### PR TITLE
Create path joining util

### DIFF
--- a/libnnpdf/src/NNPDF/utils.h
+++ b/libnnpdf/src/NNPDF/utils.h
@@ -13,6 +13,8 @@
 #include <string>
 #include <fstream>
 #include <array>
+#include <iterator>
+#include <initializer_list>
 
 /** @defgroup utils Utils
  * \brief libnnpdf utility functions
@@ -24,6 +26,51 @@
 
 namespace NNPDF
 {
+
+// This is all so we can call both joinpath({"a", "b", "c"}) which
+// requires a special treatment and auto v = vector<string>{"a", "b", "c"}; joinpath(v). See
+// https://stackoverflow.com/questions/4757614/why-doesnt-my-template-accept-an-initializer-list#4763493
+namespace
+{
+template <typename T> inline std::string joinpath_inner(const T &list)
+{
+  // This is implemented following
+  // https://github.com/python/cpython/blob/05d68a8bd84cb141be9f9335f5b3540f15a989c4/Lib/posixpath.py#L75
+  const auto sep = '/';
+  auto path = std::string{""};
+
+  for (const auto &it : list) {
+    //TODO: Use this in C++17
+    //if (std::empty(it)) {
+    if (it.empty()) {
+      continue;
+    }
+    if (*std::cbegin(it) == sep) {
+      path = it;
+    } else if (path.empty() || *std::crbegin(path) == sep) {
+      path += it;
+    } else {
+      path += sep + it;
+    }
+  }
+  return path;
+}
+}
+
+/**
+ * @brief Produce a UNIX path from a container of string-like objects.
+ * @param A iterable of objects that can be joined with strings and iterated over.
+ * @return A string representing a joined path.
+ *
+ * The resuts should be the same as os.path.join in Python (on POSIX), except
+ * that an empty string is returned from an empty iterable.
+ */
+template <typename T> std::string joinpath(const T &list)
+{
+  return joinpath_inner(list);
+}
+std::string joinpath(const std::initializer_list<std::string> &list);
+
   /**
    * @brief untargz Decompress tar.gz files in istream.
    * @param filename the input filename

--- a/libnnpdf/src/utils.cc
+++ b/libnnpdf/src/utils.cc
@@ -26,6 +26,10 @@
 
 namespace NNPDF
 {
+std::string joinpath(const std::initializer_list<std::string> &list)
+{
+  return joinpath_inner(list);
+}
   //__________________________________________________________________
   class archive_wrapper_read
   {

--- a/libnnpdf/tests/CMakeLists.txt
+++ b/libnnpdf/tests/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_executable(catch_test EXCLUDE_FROM_ALL main.cc experiment_test.cc)
+add_executable(catch_test EXCLUDE_FROM_ALL main.cc experiment_test.cc test_utils.cc)
 target_link_libraries(catch_test nnpdf ${LibArchive_LIBRARIES})

--- a/libnnpdf/tests/test_utils.cc
+++ b/libnnpdf/tests/test_utils.cc
@@ -1,0 +1,16 @@
+#include "catch.hpp"
+#include "utils.h"
+
+using namespace NNPDF;
+
+TEST_CASE("Test joinpath", "[utils]"){
+    REQUIRE(joinpath({""}) == "");
+    REQUIRE(joinpath({}) == "");
+    REQUIRE(joinpath({"a","b","cd"}) == "a/b/cd");
+    REQUIRE(joinpath({"a","","b"}) == "a/b");
+    REQUIRE(joinpath({"a","/b","c/"}) == "/b/c/");
+    REQUIRE(joinpath({"/a","b","c/"}) == "/a/b/c/");
+	auto comps = std::vector<std::string>{"a", "b", "c"};
+	REQUIRE(joinpath(comps) == "a/b/c");
+
+}


### PR DESCRIPTION
Fixes #49. This hopefully works in most corner cases and avoids
having to care about trailing / all over the place. In particular,
this is meant to solve the frequent problems where certain
configuration paths are required to have a trailing / for various
pieces of code to work, or, otherwise, to implement this logic
everywhere.