### PR TITLE
Fixmacinstall

### DIFF
--- a/libnnpdf/wrapper/CMakeLists.txt
+++ b/libnnpdf/wrapper/CMakeLists.txt
@@ -39,12 +39,7 @@ if (${CMAKE_VERSION} VERSION_LESS "3.8.0")
 else()
     swig_add_library(nnpdf LANGUAGE python SOURCES ./src/nnpdf.i)
 endif()
-
-if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-    swig_link_libraries(nnpdf ${PROJECT_NAME} ${PYTHON_EXTENSION_LINKFLAGS})
-else()
-    swig_link_libraries(nnpdf ${PROJECT_NAME} ${PYTHON_LIBRARIES})
-endif()
+swig_link_libraries(nnpdf ${PROJECT_NAME} ${PYTHON_EXTENSION_LINKFLAGS})
 
 set(LIBNNPDF_WRAPPER_PREFIX ${PYTHON_SITE_PACKAGES}/NNPDF)
 install(TARGETS _nnpdf DESTINATION ${LIBNNPDF_WRAPPER_PREFIX})


### PR DESCRIPTION
As per an email exchange between @ldd69 and @Zaharid last night I have added some lines to the libnnpdf/wrapper/CMakeList.txt which see if you are compiling with a mac and then perform slightly different actions, else does the same as before. Tested on both Luigi and my Mac and it fixes the installation problem, thought it would be worth adding to the master... Provided that I've done the change in a sensible way