### PR TITLE
Fix `plot_phi` function

### DIFF
--- a/validphys2/src/validphys/plots.py
+++ b/validphys2/src/validphys/plots.py
@@ -61,7 +61,7 @@ def plot_phi(experiments, experiments_phi):
     """
     phi = experiments_phi
     xticks = [experiment.name for experiment in experiments]
-    fig, ax = plotutils.barplot(phi, collabels=xticks, datalabels=pdf.name)
+    fig, ax = plotutils.barplot(phi, collabels=xticks, datalabels=[r'$\phi$'])
     ax.set_title(r"$\phi$ for each experiment")
     return fig
 


### PR DESCRIPTION
Before implementphi into master I stupidly changed the datalabel in `plot_phi` to be `pdf.name` as in `plot_phi_pdfs` even though pdf is never defined or imported in the `plot_phi` function and so that function doesn't work.

 I have fixed this by reverting the datalabel in `plot_phi` to something more generic which I think is fine because there is no legend on the plot.

This was overlooked because I was focusing on `plot_phi_pdfs` at the point of merging