### PR TITLE
Add the commit hash to conda version

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
     name: nnpdf
-    version: "{{ GIT_DESCRIBE_TAG }}.{{ GIT_DESCRIBE_NUMBER }}"
+    version: "{{ GIT_DESCRIBE_TAG }}.{{ GIT_DESCRIBE_NUMBER }}+{{ GIT_DESCRIBE_HASH }}"
 
 source:
     git_url: ../


### PR DESCRIPTION
Indicate the git hash in the version of the conda package. This makes
it easier to identify a package with a commit at a glance.

We uses the PEP 440 syntax by prefixing the parts of the version that
are not to be compared with a plus sign.