### PR TITLE
Continue trying if some index is not available

### DIFF
--- a/validphys2/src/validphys/loader.py
+++ b/validphys2/src/validphys/loader.py
@@ -506,7 +506,10 @@ class RemoteLoader(LoaderBase):
     def remote_files(self, urls, index, thing='files'):
         d = {}
         for url in urls:
-            d.update(self._remote_files_from_url(url, index, thing))
+            try:
+                d.update(self._remote_files_from_url(url, index, thing))
+            except RemoteLoaderError as e:
+                log.error(e)
         return d
 
     @property


### PR DESCRIPTION
This is a nicer way of falling back when an index or a repository
cannot be reached than falling altogether as in #103. Instead we
simply log the error and continue for the rest of the indexes. If no
indexes are found we do fail finally.