### PR TITLE
Add basic kinematic information to positivity plots

### DIFF
--- a/validphys2/src/validphys/plots.py
+++ b/validphys2/src/validphys/plots.py
@@ -1134,12 +1134,14 @@ def plot_positivity(pdfs, positivity_predictions_for_pdfs, posdataset, pos_use_k
 
     posset = posdataset.load()
     ndata  = posset.GetNData()
-    xvals = np.arange(ndata)
-    ax.set_xlabel('idat')
+    xvals = []
 
     if pos_use_kin:
         ax.set_xlabel('kin1')
         xvals = [posset.GetKinematics(i, 0) for i in range(0, ndata)]
+    else:
+        ax.set_xlabel('idat')
+        xvals - np.arange(ndata)
 
     offsets = plotutils.offset_xcentered(len(pdfs), ax)
     minscale = np.inf


### PR DESCRIPTION
Allow the use of the first kinematic variable in positivity plots.