### PR TITLE
Remove plotfiles argument in check_commondata call

### DIFF
--- a/validphys2/src/validphys/loader.py
+++ b/validphys2/src/validphys/loader.py
@@ -187,11 +187,8 @@ class Loader(LoaderBase):
                   "Folder '%s' not found") % (theoryID, theopath) )
         return TheoryIDSpec(theoryID, theopath)
 
-    def get_commondata(self, setname, sysnum, plotfiles=None):
-        """Get a Commondata from the set name and number.
-           The plotfiles argument is accepted to keep symmetry with
-           the commondataSpec,
-           returned by check_commondata, but it doesn't do anything."""
+    def get_commondata(self, setname, sysnum):
+        """Get a Commondata from the set name and number."""
         cd = self.check_commondata(setname, sysnum)
         return cd.load()
 


### PR DESCRIPTION
So, this argument is breaking the loader for me, the code is calling `check_commondata` with a third argument which `check_commondata` isn't expecting and doesn't do anything with.

Here I just remove the argument from the call which fixes the problem for me. But I don't know if @Zaharid has some other plans here.