### PR TITLE
Export PDF value grid before running APFEL

### DIFF
--- a/libnnpdf/src/NNPDF/pdfset.h
+++ b/libnnpdf/src/NNPDF/pdfset.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <array>
 #include <string>
 #include "common.h"
 
@@ -36,6 +37,8 @@ namespace NNPDF
 
         // LHA-style flavour basis
         enum {TBAR,BBAR,CBAR,SBAR,UBAR,DBAR,GLUON,D,U,S,C,B,T,PHT};
+        const std::array<std::string, 14> fl_labels = {"TBAR","BBAR","CBAR","SBAR","UBAR","DBAR","GLUON","D","U","S","C","B","T","PHT"};
+
         // NNPDF-style EVLN basis
         enum evlnBasis {  EVLN_GAM, EVLN_SNG, EVLN_GLU, EVLN_VAL, EVLN_V3,
                           EVLN_V8, EVLN_V15, EVLN_V24, EVLN_V35,  EVLN_T3,

--- a/nnpdfcpp/src/nnfit/inc/fitpdfset.h
+++ b/nnpdfcpp/src/nnfit/inc/fitpdfset.h
@@ -50,8 +50,9 @@ public:
   }
 
   void InitPDFSet() const;
-  void ExportPDF(int const& rep, real const& erf_val, real const& erf_trn, real const& chi2, bool posVeto);
-  string ExportPDF(int const& rep);
+  void ExportPDF(int const& rep);  //!< Export LHAPDF grid
+  void ExportGrid(int const& rep); //!< Export initial-value pdf grid
+  void ExportMeta(int const& rep, real const& erf_val, real const& erf_trn, real const& chi2, bool posVeto);
 
   bool ComputeIntegrals( int const& mem ); //!< Compute all associated integrals and sum rules
   void ComputeSumRules();                  //!< Compute preprocessing sum rule constraints over all members
@@ -64,8 +65,6 @@ public:
   void SortMembers(real*);
 
   void SetBestFit(int const&);
-  void ClearPDFs (int const&);
-
   real GetEbf()         { return fEbf; }
   void SetEbf( real const& e) {fEbf = e;} //!< Sets the new best fit error function
 

--- a/nnpdfcpp/src/nnfit/src/fitpdfset.cc
+++ b/nnpdfcpp/src/nnfit/src/fitpdfset.cc
@@ -164,30 +164,6 @@ void FitPDFSet::SortMembers(real* chi2)
 }
 
 /**
- * @brief Clear all unused members
- * @param indx the index to be removed
- */
-void FitPDFSet::ClearPDFs(int const& indx)
-{
-  if ((int) fPDFs.size() > fMembers)
-  {
-    for (size_t i=fMembers; i<fPDFs.size(); i++)
-    {
-      for (int fl = 0; fl<fNfl; fl++)
-        delete fPDFs[i][fl];
-
-      delete[] fPDFs[i];
-      delete[] fPreprocParam[i];
-    }
-
-    fPDFs.erase(fPDFs.begin()+fMembers, fPDFs.end());
-    fPreprocParam.erase(fPreprocParam.begin()+fMembers, fPreprocParam.end());
-  }
-
-  return;
-}
-
-/**
  * @brief Compute integrals and preprocessing for an individual member
  */
 bool FitPDFSet::ComputeIntegrals( int const& i )
@@ -356,14 +332,14 @@ real FitPDFSet::GetPDF(real const& x, const real &Q2, int const& n, int const& f
 }
 
 /**
- * @brief Prototype LHGrid output
+ * @brief Export fit metadata
  * @param rep the replica
  * @param erf_val the validation error function
  * @param erf_trn the training error function
  * @param chi2 the chi2
- * Print to file a partial LHgrid for the current replica
+ * Print to file information on the fit
  */
-void FitPDFSet::ExportPDF( int const& rep, real const& erf_val, real const& erf_trn, real const& chi2, bool posVeto)
+void FitPDFSet::ExportMeta( int const& rep, real const& erf_val, real const& erf_trn, real const& chi2, bool posVeto)
 {
   // Printing fitinfo to file
   cout << Colour::FG_BLUE << "\n- Writing fitinfo file..." << Colour::FG_DEFAULT << endl;
@@ -381,6 +357,7 @@ void FitPDFSet::ExportPDF( int const& rep, real const& erf_val, real const& erf_
     fitinfo << "POS_VETO"<<endl;
   else
     fitinfo << "POS_PASS"<<endl;
+
   // Arclengths
   cout << Colour::FG_BLUE << "- Computing arclengths..." << Colour::FG_DEFAULT << endl;
   fitinfo.precision(8);
@@ -452,6 +429,18 @@ void FitPDFSet::ExportPDF( int const& rep, real const& erf_val, real const& erf_
 
   params.close();
 
+}
+
+/**
+ * @brief Prototype LHGrid output
+ * @param rep the replica
+ * @param erf_val the validation error function
+ * @param erf_trn the training error function
+ * @param chi2 the chi2
+ * Print to file a partial LHgrid for the current replica
+ */
+void FitPDFSet::ExportPDF( int const& rep )
+{
   // Preparing settings from APFELSingleton
   cout << Colour::FG_BLUE <<"- Writing out LHAPDF grid: "<< fSettings.GetPDFName() << Colour::FG_DEFAULT << endl;
 
@@ -580,62 +569,129 @@ void FitPDFSet::ExportPDF( int const& rep, real const& erf_val, real const& erf_
   cout << Colour::FG_GREEN << "\n- LHAPDF successful writeout!" << Colour::FG_DEFAULT << endl << endl;
 }
 
-/**
- * @brief FitPDFSet::ExportPDF
- * @param rep
- * Export PDFs for each generation
- */
-string FitPDFSet::ExportPDF(int const& rep)
-{
-  // Settings
-  const int nf = std::max(APFELSingleton::getNFpdf(),APFELSingleton::getNFas());
-  vector<double> xgrid = APFELSingleton::getX();
 
-  if (fSettings.Get("debug").as<bool>())
-    cout << "- Printing grid to grid file: " << fSettings.GetPDFName() <<endl;
+/**
+ * @brief FitPDFSet::ExportGrid
+ * @param rep the replica ID
+ * Export initial scale PDF on a grid in x
+ */
+void FitPDFSet::ExportGrid(int const& rep)
+{
+  // Largest x-grid admissible in APFEL
+  const vector<double> xgrid =
+    {
+      1.000000000000000e-09, 1.297084823439570e-09, 1.682429034742569e-09,
+      2.182253154205826e-09, 2.830567417398188e-09, 3.671485978929410e-09,
+      4.762228629353150e-09, 6.177014273761803e-09, 8.012111098984379e-09,
+      1.039238706072454e-08, 1.347980640738050e-08, 1.748445036917782e-08,
+      2.267881188811028e-08, 2.941633703008346e-08, 3.815547465958784e-08,
+      4.949087072321288e-08, 6.419382957083709e-08, 8.326479519868589e-08,
+      1.080014229938285e-07, 1.400868730811297e-07, 1.817043317937722e-07,
+      2.356855515453774e-07, 3.057035125953233e-07, 3.965223098417466e-07,
+      5.143212572365697e-07, 6.671152451366758e-07, 8.652999229731433e-07,
+      1.122358752414873e-06, 1.455779955476825e-06, 1.888245605146129e-06,
+      2.449173524549460e-06, 3.176716500287171e-06, 4.120354152327973e-06,
+      5.344252657520903e-06, 6.931618978063155e-06, 8.990342582381449e-06,
+      1.166030301122581e-05, 1.512283122887690e-05, 1.961295293492122e-05,
+      2.543522071345024e-05, 3.298416834359921e-05, 4.277070539720159e-05,
+      5.545612481058487e-05, 7.189583136325140e-05, 9.319542279796139e-05,
+      1.207823677313300e-04, 1.564972094665545e-04, 2.027089363284954e-04,
+      2.624597993319508e-04, 3.396452441689850e-04, 4.392344430004219e-04,
+      5.675356601045333e-04, 7.325076157255367e-04, 9.441121054524513e-04,
+      1.214693176869783e-03, 1.559353061182245e-03, 1.996274511413378e-03,
+      2.546914937365516e-03, 3.235975102131256e-03, 4.091034365095647e-03,
+      5.141759770839620e-03, 6.418650960623169e-03, 7.951379403063506e-03,
+      9.766899996240997e-03, 1.188761392513640e-02, 1.432989476439189e-02,
+      1.710322794602712e-02, 2.021007339250794e-02, 2.364639713695425e-02,
+      2.740269157283572e-02, 3.146525061324443e-02, 3.581748292824286e-02,
+      4.044110601633167e-02, 4.531713439738071e-02, 5.042663479500688e-02,
+      5.575126100843393e-02, 6.127360193905193e-02, 6.697738294982548e-02,
+      7.284755899865170e-02, 7.887033222927267e-02, 8.503311978014517e-02,
+      9.132449102786790e-02, 9.773408797837715e-02, 1.042525382086388e-01,
+      1.108713665472371e-01, 1.175829093728782e-01, 1.243802338015993e-01,
+      1.312570629450312e-01, 1.382077077072888e-01, 1.452270051356506e-01,
+      1.523102630659852e-01, 1.594532106521559e-01, 1.666519542939869e-01,
+      1.739029384555782e-01, 1.812029108733327e-01, 1.885488916790972e-01,
+      1.959381459991933e-01, 2.033681596297647e-01, 2.108366174291031e-01,
+      2.183413841065613e-01, 2.258804871240649e-01, 2.334521014595030e-01,
+      2.410545360116810e-01, 2.486862214527622e-01, 2.563456993587234e-01,
+      2.640316124686842e-01, 2.717426959427826e-01, 2.794777695041488e-01,
+      2.872357303648326e-01, 2.950155468476644e-01, 3.028162526268661e-01,
+      3.106369415195031e-01, 3.184767627680818e-01, 3.263349167616716e-01,
+      3.342106511491565e-01, 3.421032573036267e-01, 3.500120671016855e-01,
+      3.579364499855710e-01, 3.658758102796432e-01, 3.738295847359622e-01,
+      3.817972402864939e-01, 3.897782719819471e-01, 3.977722010992863e-01,
+      4.057785734023404e-01, 4.137969575406706e-01, 4.218269435745480e-01,
+      4.298681416141745e-01, 4.379201805632053e-01, 4.459827069569899e-01,
+      4.540553838875619e-01, 4.621378900076507e-01, 4.702299186071416e-01,
+      4.783311767556753e-01, 4.864413845060586e-01, 4.945602741533477e-01,
+      5.026875895451769e-01, 5.108230854390865e-01, 5.189665269032351e-01,
+      5.271176887569979e-01, 5.352763550484283e-01, 5.434423185656607e-01,
+      5.516153803797675e-01, 5.597953494166407e-01, 5.679820420558005e-01,
+      5.761752817540883e-01, 5.843748986924983e-01, 5.925807294444404e-01,
+      6.007926166639503e-01, 6.090104087923975e-01, 6.172339597824495e-01,
+      6.254631288380691e-01, 6.336977801694852e-01, 6.419377827620891e-01,
+      6.501830101583613e-01, 6.584333402519444e-01, 6.666886550930888e-01,
+      6.749488407047076e-01, 6.832137869083856e-01, 6.914833871596969e-01,
+      6.997575383922505e-01, 7.080361408699164e-01, 7.163190980467328e-01,
+      7.246063164340254e-01, 7.328977054742707e-01, 7.411931774214037e-01,
+      7.494926472270083e-01, 7.577960324322238e-01, 7.661032530649272e-01,
+      7.744142315419215e-01, 7.827288925758362e-01, 7.910471630864785e-01,
+      7.993689721163776e-01, 8.076942507502913e-01, 8.160229320384573e-01,
+      8.243549509233821e-01, 8.326902441699869e-01, 8.410287502988437e-01,
+      8.493704095226000e-01, 8.577151636849855e-01, 8.660629562026835e-01,
+      8.744137320097212e-01, 8.827674375042057e-01, 8.911240204974589e-01,
+      8.994834301652264e-01, 9.078456170010206e-01, 9.162105327713991e-01,
+      9.245781304731123e-01, 9.329483642920292e-01, 9.413211895637338e-01,
+      9.496965627357548e-01, 9.580744413312983e-01, 9.664547839144387e-01,
+      9.748375500567046e-01, 9.832227003049778e-01, 9.916101961506623e-01,
+      1.000000000000000e+00
+    };
+
+  stringstream gridfilename;
+  gridfilename << fSettings.GetResultsDirectory() << "/nnfit/replica_" << rep << "/"
+               << fSettings.GetPDFName() <<".gridvalues";
+  cout << "- Printing grid to file: " << gridfilename.str() <<endl;
+
+  ofstream gridfile(gridfilename.str());
+  gridfile << scientific << setprecision(14);
+  gridfile << "{" << std::endl
+           << "\"replica\": "<< rep << "," << std::endl
+           << "\"q20\": " << fQ20 << ","<<std::endl
+           << "\"xgrid\": ["<<xgrid[0];
+  for (size_t ix=1; ix < xgrid.size(); ix++)
+    gridfile <<", "<< xgrid[ix];
+  gridfile << "]," <<std::endl;
 
   // Write out the contents of the xfxvals array to the LHgrid
-  real *pdf = new real[14];
-  const int nx = xgrid.size();
-  vector<real*> res;
-
-  for (int ix = 0; ix < nx; ix++)
+  vector<real*> pdf_grid;
+  for (auto x : xgrid)
     {
-      real *lha = new real[14];
-      GetPDF(xgrid[ix], fQ20, 0, pdf);
+      real *pdf = new real[14]();
+      real *lha = new real[14]();
+      GetPDF(x, fQ20, 0, pdf);
       PDFSet::EVLN2LHA(pdf, lha);
-      res.push_back(lha);
+      pdf_grid.push_back(lha);
+      delete[] pdf;
     }
 
-  delete[] pdf;
+  // Print pdf grid to file
+  for (int ipdf = 0; ipdf < 14; ipdf++)
+  {
+    gridfile << "\""<<PDFSet::fl_labels[ipdf]<<"\": ["
+             << pdf_grid[0][ipdf];
+    for (size_t ix = 1; ix < pdf_grid.size(); ix++)
+        gridfile << ", " << pdf_grid[ix][ipdf];
+    gridfile << "]";
+    if (ipdf < 13) gridfile << ",";
+    gridfile << std::endl;
+  }
 
-  // print the replica
-  stringstream lhaout;
-  lhaout << scientific << setprecision(7);
-  lhaout << "PdfType: replica\nFormat: lhagrid1\nFromMCReplica: " << rep << "\n---" << std::endl;
+  for (size_t ix=0; ix<pdf_grid.size(); ix++)
+    delete[] pdf_grid[ix];
 
-  for (int ix = 0; ix < nx; ix++)
-    lhaout << xgrid[ix] << " ";
-  lhaout << endl;
-
-  lhaout << sqrt(fQ20) << endl;
-
-  for (int i = -nf; i <= nf; i++)
-    if (i == 0) lhaout << 21 << " ";
-    else lhaout << i << " ";
-  lhaout << endl;
-
-  const int floffset = 6-nf;
-  for (int ix = 0; ix < nx; ix++)
-    {
-      lhaout << " ";
-      for (int fl = floffset; fl <= 12-floffset; fl++)
-        lhaout << setw(14) << res[ix][fl] << " ";
-      lhaout << std::endl;
-    }
-  lhaout << "---" << std::endl;
-
-  return lhaout.str();
+  gridfile << "}" <<std::endl;
+  gridfile.close();
 }
 
 /**

--- a/nnpdfcpp/src/nnfit/src/nnfit.cc
+++ b/nnpdfcpp/src/nnfit/src/nnfit.cc
@@ -282,10 +282,7 @@ int main(int argc, char **argv)
         }
 
         if (i % 100 == 0)
-          {
             LogChi2(settings,fitset,pos,training,validation,Exp);
-            LogPDF(settings,fitset,replica);
-          }
       }
 
       state = FIT_END;
@@ -388,8 +385,10 @@ int main(int argc, char **argv)
       }
       pos.clear();
 
-      // Export LHgrid part
-      fitset->ExportPDF(replica, erf_val/dofval, erf_trn/doftrn, chi2/dof, posVeto);
+      // Export fit results
+      fitset->ExportMeta(replica, erf_val/dofval, erf_trn/doftrn, chi2/dof, posVeto);
+      fitset->ExportGrid(replica);
+      fitset->ExportPDF(replica);
 
       // Export Logs
       delete minim;
@@ -518,14 +517,6 @@ void LogChi2(NNPDFSettings const& settings,
     }
 
   return;
-}
-
-void LogPDF(NNPDFSettings const& settings,
-            FitPDFSet* pdf,
-            int replica)
-{
-  if (settings.Get("closuretest","printpdf4gen").as<bool>())
-    LogManager::AddLogEntry("PDFgenerations",pdf->ExportPDF(replica));
 }
 
 void TrainValidSplit(NNPDFSettings const& settings,


### PR DESCRIPTION
Given #151 it's probably a good idea to write out some representation of the best-fit PDFs before APFEL is called for anything. In this way everything isn't lost if APFEL crashes.