### PR TITLE
adding extra brackets for std::array initialization

### DIFF
--- a/libnnpdf/src/NNPDF/pdfset.h
+++ b/libnnpdf/src/NNPDF/pdfset.h
@@ -37,7 +37,7 @@ namespace NNPDF
 
         // LHA-style flavour basis
         enum {TBAR,BBAR,CBAR,SBAR,UBAR,DBAR,GLUON,D,U,S,C,B,T,PHT};
-        const std::array<std::string, 14> fl_labels = {"TBAR","BBAR","CBAR","SBAR","UBAR","DBAR","GLUON","D","U","S","C","B","T","PHT"};
+        const std::array<std::string, 14> fl_labels = {{"TBAR","BBAR","CBAR","SBAR","UBAR","DBAR","GLUON","D","U","S","C","B","T","PHT"}};
 
         // NNPDF-style EVLN basis
         enum evlnBasis {  EVLN_GAM, EVLN_SNG, EVLN_GLU, EVLN_VAL, EVLN_V3,


### PR DESCRIPTION
My gcc5 does not accept inline initialization of `std::array<string,14>` without a double bracket.