### PR TITLE
Improve posfit error for corrupted replicas

### DIFF
--- a/validphys2/src/validphys/scripts/postfit.py
+++ b/validphys2/src/validphys/scripts/postfit.py
@@ -65,6 +65,9 @@ class PostfitError(Exception):
     """Exception raised when postfit cannot suceed and knows why"""
     pass
 
+class FatalPostfitError(Exception):
+    """Excption raised when some corrupted input is detected"""
+    pass
 
 def filter_replicas(postfit_path, nnfit_path, fitname):
     """ Find the paths of all replicas passing the standard NNPDF fit vetoes
@@ -85,8 +88,9 @@ def filter_replicas(postfit_path, nnfit_path, fitname):
         try:
             fitinfo.append(fitdata.load_fitinfo(pathlib.Path(path), fitname))
         except Exception as e:
-            raise PostfitError(
-                f"Corrupted replica replica at {path}: {e}") from e
+            raise FatalPostfitError(
+                f"Corrupted replica replica at {path}. "
+                f"Error when loading replica information:\n {e}") from e
     fit_vetoes = fitveto.determine_vetoes(fitinfo)
     fitveto.save_vetoes(fit_vetoes, postfit_path / 'veto_count.json')
 
@@ -194,6 +198,13 @@ def main():
     except PostfitError as e:
         log.error(f"Error in postfit:\n{e}")
         sys.exit(1)
+    except FatalPostfitError as e:
+        log.error(f"Corrupted input encountered")
+        print(
+            colors.color_exception(e.__class__, e, e.__traceback__),
+            file=sys.stderr)
     except Exception as e:
         log.critical(f"Bug in postfit ocurred. Please report it.")
-        raise
+        print(
+            colors.color_exception(e.__class__, e, e.__traceback__),
+            file=sys.stderr)


### PR DESCRIPTION
This uglifies the code a little bit to catch the error and wrap it in
an useful error message.

Closes #176.