### PR TITLE
Fix bug in chi2 bar plots

### DIFF
--- a/validphys2/src/validphys/plots.py
+++ b/validphys2/src/validphys/plots.py
@@ -500,8 +500,8 @@ def plot_datasets_chi2(experiments, experiments_chi2,each_dataset_chi2):
 
 def _plot_chis_df(df):
     chilabel = df.columns.get_level_values(1)[1]
-    data = data = df.iloc[:, df.columns.get_level_values(1)==chilabel].T.as_matrix()
-    fitnames = df.columns.levels[0]
+    data = df.iloc[:, df.columns.get_level_values(1)==chilabel].T.as_matrix()
+    fitnames = df.columns.get_level_values(0).unique()
     expnames = list(df.index.get_level_values(0))
     fig, ax = plotutils.barplot(data, expnames, fitnames)
     ax.grid(False)


### PR DESCRIPTION
The ordering of the columns was not guaranteed to match the order of
the categories we infer (i.e. for the legend). The issue is, as way
too often, the handling of pandas MultiIndexes.  The 'levels' property
stores the unique values in each levels, but they are not guaranteed
to be ordered in any way. Order is recovered by using the 'labels'
property.

See:
https://stackoverflow.com/a/24489283/1007990

Instead we get the values for all the atomic columns and select the
unique items, which should correspond to fit names.