### PR TITLE
Avoid exception when color cycle overflows

### DIFF
--- a/validphys2/src/validphys/plots.py
+++ b/validphys2/src/validphys/plots.py
@@ -12,6 +12,7 @@ from types import SimpleNamespace
 from collections import defaultdict, Sequence
 import copy
 import numbers
+import itertools
 
 import numpy as np
 import numpy.linalg as la
@@ -292,8 +293,9 @@ def _plot_fancy_impl(results, commondata, cutlist,
             #Use black for the first iteration (data),
             #and follow the cycle for
             #the rest.
-            color = '#262626'
-            for i, (res, lb) in enumerate(zip(results, labellist)):
+            next_color = itertools.chain(['#262626'], plotutils.color_iter())
+
+            for i, (res, lb, color) in enumerate(zip(results, labellist, next_color)):
 
                 if labels:
                     if lb:
@@ -316,7 +318,6 @@ def _plot_fancy_impl(results, commondata, cutlist,
                      zorder=1000,
                      transform=next(offset_iter))
 
-                color = 'C'+str(i)
 
                 #We 'plot' the empty lines to get the labels. But
                 #if everything is rmpty we skip the plot.

--- a/validphys2/src/validphys/plotutils.py
+++ b/validphys2/src/validphys/plotutils.py
@@ -8,6 +8,8 @@ Created on Thu Apr 21 18:41:43 2016
 import functools
 import itertools
 from collections import namedtuple
+import logging
+
 import scipy.stats as stats
 
 import numpy as np
@@ -18,6 +20,8 @@ from matplotlib  import transforms
 from matplotlib.markers import MarkerStyle
 
 from reportengine.floatformatting import format_number
+
+log = logging.getLogger(__name__)
 
 def ax_or_gca(f):
     """A decorator. When applied to a function, the keyword argument  ``ax``
@@ -129,6 +133,18 @@ def marker_iter_plot():
     returns kwargs to be passed to ``plt.plot()``"""
     for ms in marker_iter_scatter():
         yield {'marker':ms.get_marker(),'fillstyle': ms.get_fillstyle()}
+
+
+def color_iter():
+    """Yield the colors in the cycle defined in the matplotlib style.  When the
+    colores are exhausted a warning will be logged and the cycle will be
+    repeated infinitely. Therefore this avoids the overflow error at runtime
+    when using matplotlib's ``f'C{i}'`` color specification (equivalent to
+    ``colors[i]``) when ``i>len(colors)`` """
+    color_list = [prop['color'] for prop in plt.rcParams['axes.prop_cycle']]
+    yield from color_list
+    log.warning("Color cycle exhausted. Will repeat colors.")
+    yield from itertools.cycle(color_list)
 
 
 HandlerSpec = namedtuple('HandelrSpec', ["color", "alpha", "hatch", "outer"])


### PR DESCRIPTION
As it turns out, matplotlib's color specification is rather useless in
a programmatic setting, as we need to know how many colors we have to
use it properly (or use something like f'C{i%len(color_cycle)}') which
sort of defeats the purpose. Instead introduce a function that cycles
infinitely, but that will warn after the first cycle. Although ideally
we would make it a check that fires before computation is actually done.

Closes #250.