### PR TITLE
Replace log.warn -> log.warning

### DIFF
--- a/validphys2/src/validphys/app.py
+++ b/validphys2/src/validphys/app.py
@@ -131,8 +131,11 @@ including the contents of the following file:
 
     def run(self):
         if sys.version_info < (3, 6):
-            log.warn("validphys 2 is discontinued on Python<3.6 and will not be longer updated. Please run\n"
-                     "conda install python=3.6\n\n If you have any problems, please ask Zahari.")
+            log.warning("validphys 2 is discontinued on Python<3.6 and will "
+                    "not be longer updated. Please run\n"
+                     "conda install python=3.6\n\n"
+                     "If you have any problems, please open an issue "
+                     "on https://github.com/NNPDF/nnpdf/issues.")
         with self.upload_context(self.args['upload'], self.args['output']):
             super().run()
 

--- a/validphys2/src/validphys/config.py
+++ b/validphys2/src/validphys/config.py
@@ -302,7 +302,7 @@ class CoreConfig(configparser.Config):
             #normalize=True should check for more stuff
             get_info(ds, normalize=True)
             if not ds.commondata.plotfiles:
-                log.warn("Plotting files not found for: %s" % (ds,))
+                log.warning(f"Plotting files not found for: {ds}")
         return ds
 
 

--- a/validphys2/src/validphys/dataplots.py
+++ b/validphys2/src/validphys/dataplots.py
@@ -35,7 +35,8 @@ def plot_chi2dist(results, dataset, abs_chi2_data, chi2_stats, pdf):
     alldata, central, npoints = abs_chi2_data
     if not isinstance(alldata, MCStats):
         ax.set_facecolor("#ffcccc")
-        log.warn("Chi² distribution plots have a different meaning for non MC sets.")
+        log.warning("Chi² distribution plots have a "
+                "different meaning for non MC sets.")
         label += " (%s!)" % pdf.ErrorType
     label += '\n'+ '\n'.join(str(chi2_stat_labels[k])+(' %.2f' % v) for (k,v) in chi2_stats.items())
     ax.set_title(r"$\chi^2$ distribution for %s" % setlabel)

--- a/validphys2/src/validphys/fitdata.py
+++ b/validphys2/src/validphys/fitdata.py
@@ -34,19 +34,19 @@ def check_nnfit_results_path(path):
     """ Returns True if the requested path is a valid results directory,
     i.e if it is a directory and has a 'nnfit' subdirectory"""
     if not path.is_dir():
-        log.warn('Path is not a directory %s' % path)
+        log.warning(f"Path is not a directory {path}")
         return False
     if not (path / 'nnfit').is_dir():
-        log.warn('Path %s is not a directory' % (str(path/'nnfit')))
+        log.warning("Path {path/'nnfit'} is not a directory")
         return False
     return True
 
 def check_lhapdf_info(results_dir, fitname):
     """ Check that an LHAPDF info metadata file is
     present in the fit results """
-    info_path = results_dir.joinpath('nnfit', '%s.info' % fitname)
+    info_path = results_dir.joinpath('nnfit', f'{fitname}.info')
     if not info_path.is_file():
-        log.warn('Cannot find info file at %s' % info_path)
+        log.warning(f"Cannot find info file at {info_path}")
         return False
     return True
 
@@ -58,21 +58,21 @@ def check_replica_files(replica_path, prefix):
 
     path = pathlib.Path(replica_path)
     if not path.is_dir():
-        log.warn("Invalid directory for replica %s" % path)
+        log.warning(f"Invalid directory for replica {path}")
         return False
     valid = True
     for f in LITERAL_FILES:
         test_path = path/f
         if not test_path.is_file():
-            log.warn("Missing file: %s" % test_path)
+            log.warning(f"Missing file: {test_path}")
             valid = False
     for f in REPLICA_FILES:
         test_path = (path/prefix).with_suffix(f)
         if not test_path.is_file():
-            log.warn("Missing file: %s" % test_path)
+            log.warning(f"Missing file: {test_path}")
             valid = False
     if not valid:
-        log.warn("Found invalid replica %s" % path)
+        log.warning(f"Found invalid replica {path}")
     return valid
 
 FitInfo = namedtuple("FitInfo", ("nite", 'training', 'validation', 'chi2', 'is_positive', 'arclengths'))

--- a/validphys2/src/validphys/fitveto.py
+++ b/validphys2/src/validphys/fitveto.py
@@ -68,7 +68,7 @@ def determine_vetoes(fitinfos: list):
 def save_vetoes(veto_dict: dict, filepath):
     """ Saves a fit veto dictionary to file """
     if filepath.exists():
-        log.warn("Warning: veto file {filepath} already exists. Overwriting file")
+        log.warning(f"Veto file {filepath} already exists. Overwriting file")
     with open(str(filepath), 'w') as f:
         veto_dict_tolist = {key: val.tolist() for key, val in veto_dict.items()}
         json.dump(veto_dict_tolist, f)

--- a/validphys2/src/validphys/lhio.py
+++ b/validphys2/src/validphys/lhio.py
@@ -111,7 +111,7 @@ def write_replica(rep, set_root, header, subgrids):
     suffix = str(rep).zfill(4)
     target_file = set_root / f'{set_root.name}_{suffix}.dat'
     if target_file.is_file():
-        log.warn(f"Overwriting replica file {target_file}")
+        log.warning(f"Overwriting replica file {target_file}")
     with open(target_file, 'wb') as out:
         _rep_to_buffer(out, header, subgrids)
 

--- a/validphys2/src/validphys/loader.py
+++ b/validphys2/src/validphys/loader.py
@@ -220,12 +220,12 @@ class Loader(LoaderBase):
 
                 if fit not in self._old_commondata_fits:
                     self._old_commondata_fits.add(fit)
-                    log.warn(
+                    log.warning(
                         f"Found fit using old commondata export settings: "
                         f"'{fit}'. The commondata that are used in this run "
                         "will be updated now."
                         "Please consider re-uploading it.")
-                    log.warn(
+                    log.warning(
                         f"Points that do not pass the cuts are set to zero!")
 
                 log.info(f"Upgrading filtered commondata. Writing {newpath}")
@@ -431,7 +431,7 @@ class Loader(LoaderBase):
         try:
             vpcache = self._vp_cache()
         except KeyError as e:
-            log.warn("Entry validphys_cache_path expected but not found "
+            log.warning("Entry validphys_cache_path expected but not found "
                      "in the nnprofile.")
         else:
             extra_paths = (*extra_paths, vpcache)
@@ -673,9 +673,10 @@ class RemoteLoader(LoaderBase):
 
 
         if lhaindex.isinstalled(fitname):
-            log.warn("The PDF corresponding to the downloaded fit '%s' "
-             "exists in the LHAPDF path."
-             " Will be erased and replaced with the new one.", fitname)
+            log.warning(
+                f"The PDF corresponding to the downloaded fit '{fitname}' "
+                "exists in the LHAPDF path."
+                " Will be erased and replaced with the new one.")
             p = pathlib.Path(lhaindex.finddir(fitname))
             if p.is_symlink():
                 p.unlink()
@@ -692,7 +693,7 @@ class RemoteLoader(LoaderBase):
         if gridpath.is_dir():
             p.symlink_to(gridpath, target_is_directory=True)
         else:
-            log.warn(f"Cannot find {gridpath}. Falling back to old behaviour")
+            log.warning(f"Cannot find {gridpath}. Falling back to old behaviour")
             p.symlink_to(gridpath_old, target_is_directory=True)
 
 

--- a/validphys2/src/validphys/pdfplots.py
+++ b/validphys2/src/validphys/pdfplots.py
@@ -64,8 +64,9 @@ class PDFPlotter(metaclass=abc.ABCMeta):
 
             #Handle division by zero more quietly
             def fp_error(tp, flag):
-                log.warn("Invalid values found computing normalization to %s: "
-                 "Floating point error (%s).", normalize_pdf, tp)
+                log.warning("Invalid values found computing "
+                    f"normalization to {normalize_pdf}: "
+                    f"Floating point error ({tp}).")
                 #Show warning only once
                 np.seterr(all='ignore')
 
@@ -172,8 +173,8 @@ class PDFPlotter(metaclass=abc.ABCMeta):
 def _warn_pdf_not_montecarlo(pdf):
     et = pdf.ErrorType
     if et != 'replicas':
-        log.warn("Plotting members of a non-Monte Carlo PDF set:"
-        " %s with error type '%s'.", pdf.name, et)
+        log.warning("Plotting members of a non-Monte Carlo PDF set:"
+        f" {pdf.name} with error type '{et}'.")
 
 #Cant't add the lru_cache here because pdfs is not hashable at the moment
 @make_argcheck

--- a/validphys2/src/validphys/plotoptions/core.py
+++ b/validphys2/src/validphys/plotoptions/core.py
@@ -148,7 +148,7 @@ class PlotInfo:
                 #We might need to use reportengine.namespaces.resolve here
                 plot_params = plot_params.new_child(config_params['normalize'])
             if not 'dataset_label' in plot_params:
-                log.warn("'dataset_label' key not found in %s", file)
+                log.warning(f"'dataset_label' key not found in {file}")
                 plot_params['dataset_label'] = commondata.name
 
         else:

--- a/validphys2/src/validphys/results.py
+++ b/validphys2/src/validphys/results.py
@@ -205,7 +205,7 @@ def experiment_result_table(experiments, pdf, experiments_index):
                                  ]))
 
     if not result_records:
-        log.warn("Empty records for experiment results")
+        log.warning("Empty records for experiment results")
         return pd.DataFrame()
     df =  pd.DataFrame(result_records, columns=result_records[0].keys(),
                        index=experiments_index)

--- a/validphys2/src/validphys/scripts/postfit.py
+++ b/validphys2/src/validphys/scripts/postfit.py
@@ -119,11 +119,11 @@ def postfit(results: str, nrep: int):
         raise PostfitError('Postfit cannot find a valid LHAPDF info file')
 
     nrep = int(nrep)
-    log.warn("Postfit aiming for %d replicas" % nrep)
+    log.warning(f"Postfit aiming for {nrep} replicas")
 
     # Generate postfit and LHAPDF directory
     if final_postfit_path.is_dir():
-        log.warn(f"WARNING: Removing existing postfit directory: {postfit_path}")
+        log.warning(f"Removing existing postfit directory: {postfit_path}")
         shutil.rmtree(final_postfit_path)
     os.mkdir(LHAPDF_path)
 


### PR DESCRIPTION
I have no idea why this got deprecated but it is rather annoying that it
shows in the test logs so much. Change all the instances to use
log.warning instead.

Also take the opportunity to use f-strings in more places.