### PR TITLE
Remove useless dependency

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -24,7 +24,6 @@ requirements:
     run:
         - lhapdf
         - sqlite
-        - libgcc # [linux]
         - gsl
         - numpy
         - libarchive


### PR DESCRIPTION
This was needed before the compiler packages took care of the
appropriate runtime dependencies.