### PR TITLE
Splitting DIS into DIS NC and DIS CC

### DIFF
--- a/validphys2/src/validphys/theorycovariance.py
+++ b/validphys2/src/validphys/theorycovariance.py
@@ -176,8 +176,8 @@ commondata_experiments = collect('commondata', ['experiments', 'experiment'])
 def process_lookup(commondata_experiments):
     """Produces a dictionary with keys corresponding to dataset names
     and values corresponding to process types. Process types are
-    regrouped into the four categories 'Drell-Yan', 'Heavy Quarks', Jets'
-    and 'DIS'."""
+    regrouped into the five categories 'Drell-Yan', 'Heavy Quarks', Jets',
+    'DIS NC' and 'DIS CC'."""
     d = {commondata.name: get_info(commondata).process_description
          for commondata in commondata_experiments}
     for key, value in d.items():


### PR DESCRIPTION
I've split up the process categorisation for DIS into CC and NC manually. It's obviously continuing with the hack for splitting processes we already had, so not ideal.

We need this change for all our future testing so it'd be good to merge it into master and then pull the changes to covmat_cuts2 and other branches asap 

