### PR TITLE
Remove LHAPDF warnings from output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,13 @@ if (LHAPDF_CONFIG)
     OUTPUT_VARIABLE LHAPDF_LIBRARIES
   )
   set(LHAPDF_LIBRARIES ${LHAPDF_LIBRARIES} CACHE STRING INTERNAL)
+  #This is to stop the LHAPDF specific warnings from spamming the output
+  exec_program(${LHAPDF_CONFIG}
+    ARGS --incdir
+    OUTPUT_VARIABLE LHAPDF_INCLUDES
+  )
+  set(LHAPDF_INCLUDES ${LHAPDF_INCLUDES} CACHE STRING INTERNAL)
+  include_directories(SYSTEM ${LHAPDF_INCLUDES})
 endif(LHAPDF_CONFIG)
 
 # APFEL

--- a/libnnpdf/CMakeLists.txt
+++ b/libnnpdf/CMakeLists.txt
@@ -26,7 +26,10 @@ configure_file(
 # add preprocessor flag
 add_definitions(-DDEFAULT_NNPDF_PROFILE_PATH="${prefix}/share/NNPDF/nnprofile.yaml")
 
-include_directories(src/NNPDF src ${GSL_INCLUDE_DIRS} ${YAML_INCLUDE_DIRS})
+# Note that BEFORE is important here: Otherwise we might be reading
+# the headers from a previous installation.
+include_directories(BEFORE src/NNPDF src)
+include_directories(${GSL_INCLUDE_DIRS} ${YAML_INCLUDE_DIRS})
 FILE(GLOB_RECURSE Headers "src/NNPDF/*.h")
 add_library(nnpdf SHARED src/common.cc
                          src/commondata.cc


### PR DESCRIPTION
These are repetitive, annoying and prevent us from focusing on the
warnings specific to our code.