### PR TITLE
remove loading of experiment from experiments_index

### DIFF
--- a/validphys2/src/validphys/results.py
+++ b/validphys2/src/validphys/results.py
@@ -155,7 +155,7 @@ def experiments_index(experiments):
                 ndata = dataset.commondata.ndata
             for idat in range(ndata):
                 records.append(
-                    OrderedDict(
+                    dict(
                         [('experiment', str(experiment.name)),
                          ('dataset', str(dataset.name)),
                          ('id', idat),]))


### PR DESCRIPTION
closes #415 

Perhaps I have missed the point here but I simplified `experiments_index` quite a bit and use the dataset cuts the get the data point indices. Possibly a slightly faster way to contruct the multiindex such as `from_arrays` method however this is very readable and not too slow