### PR TITLE
Fix exception in get_remote_keywords

### DIFF
--- a/validphys2/src/validphys/scripts/vp_comparefits.py
+++ b/validphys2/src/validphys/scripts/vp_comparefits.py
@@ -21,7 +21,9 @@ def get_remote_keywords():
     root = loader.Loader().nnprofile['reports_root_url']
     url = urljoin(root, 'index.json')
     try:
-        keyobjs= requests.get(url).json()['keywords']
+        resp = requests.get(url)
+        resp.raise_for_status()
+        keyobjs  = resp.json()['keywords']
         l = [k[0] for k in keyobjs]
     except requests.RequestException:
         l = []


### PR DESCRIPTION
We did not test for the status code explicitly, and then the error one
gets when calling response.json() is not a RequestsException. As
a consequence the traceback would leak outside, instead of being ignored
silently when the validphys server cannot be reached.