### PR TITLE
Fix bug in different cuts

### DIFF
--- a/validphys2/src/validphys/fitdata.py
+++ b/validphys2/src/validphys/fitdata.py
@@ -264,11 +264,11 @@ def test_for_same_cuts(fits, match_datasets_by_name):
         if first.cuts:
             c1 = first.cuts.load()
         else:
-            c1 = ['Allpass']
+            c1 = np.arange(first.commondata.ndata)
         if second.cuts:
             c2 = second.cuts.load()
         else:
-            c2 = ['Allpass']
+            c2 = np.arange(second.commondata.ndata)
         if not np.array_equal(c1, c2):
             msg = "Cuts for %s are not the same:\n%s:\n%s\n\n%s:\n%s" % (ds, first_fit, c1, second_fit, c2)
             log.info(msg)


### PR DESCRIPTION
Fix  bug where we would get that the cuts are different if a mask with
all the data had been written for one of the fits and not for the other.
For example, this would report that the cuts are different:

```
use_cuts: fromfit
fits:
  - 190310-tg-nlo-DIS
  - 181126-si-nlo-central_DISonly

template_text: |
    {@print_different_cuts@}

actions_:
    - report(main=True)
```

even if they aren't. The reason why this bug existed in the first place
was the willingness to avoid loading datasets just to check the actual
number of datapoints, given that that is expensive. That has been worked
around since.