### PR TITLE
Fix logic in produce_fitthcovmat

### DIFF
--- a/validphys2/src/validphys/config.py
+++ b/validphys2/src/validphys/config.py
@@ -693,38 +693,40 @@ class CoreConfig(configparser.Config):
         res.__name__ = 'theory_covmat'
         return res
 
-    def produce_fitthcovmat(self, use_theorycovmat: bool = True, fit: (str, type(None)) = None):
-        """If a `fit` is specified and `use_theorycovmat` is `True` then returns the corresponding
-        covariance matrix for the given fit if it exists. If the fit doesn't have a theory
-        covariance matrix then returns `False`. If no fit is specified then returns `False`, and
-        warns the user if `use_theorycovmat` was `True`
+    def produce_fitthcovmat(
+            self, use_thcovmat_if_present: bool = True, fit: (str, type(None)) = None):
+        """If a `fit` is specified and `use_thcovmat_if_present` is `True` then returns the
+        corresponding covariance matrix for the given fit if it exists. If the fit doesn't have a
+        theory covariance matrix then returns `False`. If no fit is specified then returns the user
+        must manually set `use_thcovmat_if_present` to be False, or provide an appropriate fit.
         """
+        if not isinstance(use_thcovmat_if_present, bool):
+            raise ConfigError("use_thcovmat_if_present should be a boolean, by default it is True")
 
-        if not use_theorycovmat:
-            pass
-        elif not fit:
-            raise ConfigError("`use_theorycovmat` was true but no `fit` was specified.")
-        elif use_theorycovmat and fit:
+        if use_thcovmat_if_present and not fit:
+            raise ConfigError("`use_thcovmat_if_present` was true but no `fit` was specified.")
+
+        if use_thcovmat_if_present and fit:
             try:
-                use_theorycovmat = fit.as_input()['theorycovmatconfig']['use_thcovmat_in_fitting']
+                use_thcovmat_if_present = fit.as_input()[
+                    'theorycovmatconfig']['use_thcovmat_in_fitting']
             except KeyError:
                 #assume covmat wasn't used and fill in key accordingly but warn user
-                log.warning("use_theorycovmat was true but the flag `use_thcovmat_in_fitting` "
-                            f"didn't exist in the runcard for {fit.name}. Theory covariance "
-                            "matrix will not be used in any statistical estimators.")
-                use_theorycovmat = False
+                log.warning("use_thcovmat_if_present was true but the flag "
+                            "`use_thcovmat_in_fitting` didn't exist in the runcard for "
+                            f"{fit.name}. Theory covariance matrix will not be used "
+                            "in any statistical estimators.")
+                use_thcovmat_if_present = False
             #Now set as expected path and check it exists
-            if use_theorycovmat:
-                use_theorycovmat = (
+            if use_thcovmat_if_present:
+                use_thcovmat_if_present = (
                     fit.path/'tables'/'datacuts_theory_theorycovmatconfig_theory_covmat.csv')
-                if not os.path.exists(use_theorycovmat):
+                if not os.path.exists(use_thcovmat_if_present):
                     raise ConfigError(
                         "Fit appeared to use theory covmat in fit but the file was not at the "
-                        f"usual location: {use_theorycovmat}.")
-                use_theorycovmat = ThCovMatSpec(use_theorycovmat)
-        else:
-            raise ConfigError("use_theorycovmat should be a boolean, by default it is True")
-        return use_theorycovmat
+                        f"usual location: {use_thcovmat_if_present}.")
+                use_thcovmat_if_present = ThCovMatSpec(use_thcovmat_if_present)
+        return use_thcovmat_if_present
 
     def parse_speclabel(self, label:(str, type(None))):
         """A label for a dataspec. To be used in some plots"""

--- a/validphys2/src/validphys/scripts/vp_comparefits.py
+++ b/validphys2/src/validphys/scripts/vp_comparefits.py
@@ -127,9 +127,7 @@ class CompareFitApp(App):
         return [k.strip() for k in kwinp.split(',') if k]
 
     def interactive_theory_cov(self):
-        """Interactively fill in the `use_theorycovmat` runcard flag. Only booleans are permitted
-        at present, since the option to pass a path to `use_theorycovmat` has a high possibility of
-        producing incorrect results or errors, and has very specific use cases.
+        """Interactively fill in the `use_thcovmat_if_present` runcard flag. Which is True by default
         """
         message = ("Do you want to use the fitted covariance matrix (including theory covariance\n"
                    "matrix) to calculate the statistical estimators? ")
@@ -180,7 +178,7 @@ class CompareFitApp(App):
             },
             'speclabel': 'Reference Fit'
         }
-        autosettings['use_theorycovmat'] = args['theory_cov']
+        autosettings['use_thcovmat_if_present'] = args['theory_cov']
         return autosettings
 
 


### PR DESCRIPTION
closes #433 

Before one couldn't set `use_theorycovmat` to False. This removes the option to set as string since that was messy and improves the logic so that one cat set `use_theorycovmat` and if you do then you don't need to provide a `fit` either