### PR TITLE
add escape backslash to plotting files with double quotes

### DIFF
--- a/nnpdfcpp/data/commondata/PLOTTING_ATLASTOPDIFF8TEVTTMNORM.yaml
+++ b/nnpdfcpp/data/commondata/PLOTTING_ATLASTOPDIFF8TEVTTMNORM.yaml
@@ -1,4 +1,4 @@
-dataset_label: "ATLAS $t\\bar{t}$ rapidity $m_{t\bar{t}}$"
+dataset_label: "ATLAS $t\\bar{t}$ rapidity $m_{t\\bar{t}}$"
 x: k1
 y_label: '$(1/\sigma_{t\bar{t}})d\sigma_{t\bar{t}}/dm_{t\bar{t}}$ (fb/GeV)'
 figure_by:

--- a/nnpdfcpp/data/commondata/PLOTTING_ATLASTOPDIFF8TEVTTRAPNORM.yaml
+++ b/nnpdfcpp/data/commondata/PLOTTING_ATLASTOPDIFF8TEVTTRAPNORM.yaml
@@ -1,4 +1,4 @@
-dataset_label: "ATLAS $t\\bar{t}$ rapidity $y_{t\bar{t}}$"
+dataset_label: "ATLAS $t\\bar{t}$ rapidity $y_{t\\bar{t}}$"
 x: k1
 y_label: '$(1/\sigma_{t\bar{t}})d\sigma_{t\bar{t}}/dy_{t\bar{t}}$ (fb)'
 figure_by:

--- a/nnpdfcpp/data/commondata/PLOTTING_CMSTOPDIFF8TEVTTMNORM.yaml
+++ b/nnpdfcpp/data/commondata/PLOTTING_CMSTOPDIFF8TEVTTMNORM.yaml
@@ -1,4 +1,4 @@
-dataset_label: "CMS $t\\bar{t}$ rapidity $m_{t\bar{t}}$"
+dataset_label: "CMS $t\\bar{t}$ rapidity $m_{t\\bar{t}}$"
 x: k1
 y_label: '$(1/\sigma_{t\bar{t}})d\sigma_{t\bar{t}}/dm_{t\bar{t}}$ (fb/GeV)'
 figure_by:

--- a/nnpdfcpp/data/commondata/PLOTTING_CMSTOPDIFF8TEVTTRAPNORM.yaml
+++ b/nnpdfcpp/data/commondata/PLOTTING_CMSTOPDIFF8TEVTTRAPNORM.yaml
@@ -1,4 +1,4 @@
-dataset_label: "CMS $t\\bar{t}$ rapidity $y_{t\bar{t}}$"
+dataset_label: "CMS $t\\bar{t}$ rapidity $y_{t\\bar{t}}$"
 x: k1
 y_label: '$(1/\sigma_{t\bar{t}})d\sigma_{t\bar{t}}/dy_{t\bar{t}}$ (fb)'
 figure_by:


### PR DESCRIPTION
closes #444 

simple fix, just add extra escaping backslash as suggested by @Zaharid 

@enocera if you plan on running global reports tonight you might need to use this or else `vp-comparefits` errors at the point of doing data plots.

I tested quickly that the data plots worked for a global fit which previously was erroring for me and it seems to work fine for me, requires a recompile to replace the `PLOTTING_*` files for offending datasets for anyone wanting to test this