### PR TITLE
Fix provider declaration in vp_setupfit

### DIFF
--- a/validphys2/src/validphys/scripts/vp_setupfit.py
+++ b/validphys2/src/validphys/scripts/vp_setupfit.py
@@ -47,7 +47,7 @@ SETUPFIT_FIXED_CONFIG = dict(
     ])
 
 SETUPFIT_PROVIDERS = ['validphys.filters',
-                      'validphys.theorycovariance',
+                      'validphys.theorycovariance.construction',
                       'validphys.results',]
 
 SETUPFIT_DEFAULTS = dict(


### PR DESCRIPTION
closes  #460

vp-setupfit now will run on a theory covmat fit

I am wondering why it wasn't ok before - perhaps there is a better way to get this working?