### PR TITLE
Use NNPDF servers to upload packages

### DIFF
--- a/.ciscripts/build-deploy-linux.sh
+++ b/.ciscripts/build-deploy-linux.sh
@@ -27,14 +27,14 @@ fi
 #This seems to be needed for "artifacts" to work.
 cp /root/miniconda3/conda-bld/linux-64/*.tar.bz2 .
 
-echo "Uploading package to zigzah"
+echo "Uploading package to the NNPDF server"
 KEY=$( mktemp )
 #This is defined in the Travis environment variables.
-echo "$ZIGZAH_SSH_KEY" | base64 --decode > "$KEY"
+echo "$NNPDF_SSH_KEY" | base64 --decode > "$KEY"
 
 scp -i "$KEY" -o StrictHostKeyChecking=no\
     /root/miniconda3/conda-bld/linux-64/*.tar.bz2 \
-    dummy@zigzah.com:~/conda-pkgs-private/linux-64 
+    dummy@packages.nnpdf.science:~/packages/conda-private/linux-64
 
 if [ $? == 0 ]; then
 	echo "Upload suceeded"

--- a/.ciscripts/build-deploy-osx.sh
+++ b/.ciscripts/build-deploy-osx.sh
@@ -19,15 +19,15 @@ set the UPLOAD_NON_MASTER variable."
 	exit 0
 fi
 
-echo "Uploading package to zigzah"
+echo "Uploading package to the NNPDF server"
 #Idiotic mac mktemp
 KEY=$( mktemp  "${TMPDIR:-/tmp}/key.XXXXXXXXX" )
 #This is defined in the Gitlab variables, under the Settings Menu.
-echo "$ZIGZAH_SSH_KEY" | base64 --decode > "$KEY"
+echo "$NNPDF_SSH_KEY" | base64 --decode > "$KEY"
 
 scp -i "$KEY" -o StrictHostKeyChecking=no\
     ${CONDAPATH}/conda-bld/${OUTPUT_ARCH}/*.tar.bz2 \
-    dummy@zigzah.com:~/${OUTPUT_CHANNEL}/${OUTPUT_ARCH}
+    dummy@packages.nnpdf.science:~/packages/${OUTPUT_CHANNEL}/${OUTPUT_ARCH}
 
 if [ $? == 0 ]; then
 	echo "Upload suceeded"

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
   global:
     - CONDAPATH="/Users/travis/miniconda3"
     - OUTPUT_ARCH=osx-64
-    - OUTPUT_CHANNEL=conda-pkgs-private
+    - OUTPUT_CHANNEL=conda-private
     - UPLOAD_NON_MASTER="false"
 
   matrix:
@@ -58,7 +58,7 @@ before_install:
      fi
     - >
      if [[ "$TRAVIS_OS_NAME" == "linux" ]];
-     then docker exec build bash -c "echo ZIGZAH_SSH_KEY=$ZIGZAH_SSH_KEY >> /root/.bashrc"  ;
+     then docker exec build bash -c "echo NNPDF_SSH_KEY=$NNPDF_SSH_KEY >> /root/.bashrc"  ;
      fi
     - >
      if [[ "$TRAVIS_OS_NAME" == "linux" ]];

--- a/docker/dockerfile
+++ b/docker/dockerfile
@@ -33,8 +33,7 @@ RUN wget "$CONDA_URL"      && \
 ENV PATH /root/miniconda3/bin:$PATH
 
 RUN conda config --append channels conda-forge                                    && \
-    conda config --prepend channels https://zigzah.com/static/conda-pkgs/         && \
-    conda config --prepend channels https://zigzah.com/static/conda-pkgs-private/ && \
+    conda config --prepend channels https://packages.nnpdf.science/conda/         && \
     conda config --set show_channel_urls true                                     && \
     conda install conda-build --yes
 


### PR DESCRIPTION
Upload packages to <packages.nnpdf.science> rather than to my personal server. This is working now, but every user will have to change the channels, as well as the other repos and the installer scripts, so it may be good to merge all at once. I have kept the old key in travis so it is still working as before at the moment.

Closes #407.