### PR TITLE
Add fit description to comparefits

### DIFF
--- a/validphys2/src/validphys/comparefittemplates/comparecard.yaml
+++ b/validphys2/src/validphys/comparefittemplates/comparecard.yaml
@@ -78,6 +78,9 @@ template: report.md
 positivity:
       from_: fit
 
+description:
+    from_: fit
+
 dataspecs:
   - experiments:
       from_: fit

--- a/validphys2/src/validphys/comparefittemplates/report.md
+++ b/validphys2/src/validphys/comparefittemplates/report.md
@@ -1,7 +1,14 @@
-%NNPDF Report for fit {@ current fit @}
+%NNPDF Report for fit {@ current fit_id @}
 
-Fit summary 
-------------------
+Fit summary
+------------
+
+We are comparing:
+
+  - {@ current fit @} (`{@ current fit_id @}`): {@ current description @}
+  - {@ reference fit @} (`{@ reference fit_id @}`): {@ reference description @}
+
+
 {@ summarise_fits @}
 
 Theory Covariance Summary

--- a/validphys2/src/validphys/config.py
+++ b/validphys2/src/validphys/config.py
@@ -689,6 +689,9 @@ class CoreConfig(configparser.Config):
         """Return a string containing the PDF's LHAPDF ID"""
         return pdf.name
 
+    def produce_fit_id(self, fit) -> str:
+        """Return a string containing the ID of the fit"""
+        return fit.name
 
     @element_of('lumi_channels')
     def parse_lumi_channel(self, ch:str):


### PR DESCRIPTION
It can be very difficult to understand which fits are being compared by
just looking at the report.

This adds the description entered in the fit runcard as well as the
actual ids at the top.