### PR TITLE
Clean up imports

### DIFF
--- a/validphys2/src/validphys/MCgen_checks.py
+++ b/validphys2/src/validphys/MCgen_checks.py
@@ -6,20 +6,16 @@ Tools to check the pseudo-data MC generation.
 """
 from __future__ import generator_stop
 
-from collections import OrderedDict, namedtuple, Sequence
 import itertools
 import logging
 
 import matplotlib.pyplot as plt
 import numpy as np
-import scipy.linalg as la
 import pandas as pd
 
-from NNPDF import CommonData, Experiment
-from reportengine.checks import require_one, remove_outer, check_not_empty
+from NNPDF import Experiment
 from reportengine.table import table
 from reportengine.figure import figure
-from reportengine import collect
 
 log = logging.getLogger(__name__)
 

--- a/validphys2/src/validphys/arclength.py
+++ b/validphys2/src/validphys/arclength.py
@@ -3,7 +3,8 @@ arclength.py
 
 Module for the computation and presentation of arclengths.
 """
-from collections import namedtuple, Sequence
+from collections import namedtuple
+from collections.abc import Sequence
 import numbers
 
 import numpy as np

--- a/validphys2/src/validphys/dataplots.py
+++ b/validphys2/src/validphys/dataplots.py
@@ -6,7 +6,8 @@ from __future__ import generator_stop
 
 import logging
 import itertools
-from collections import defaultdict, Sequence
+from collections import defaultdict
+from collections.abc import Sequence
 
 import numpy as np
 import numpy.linalg as la

--- a/validphys2/src/validphys/paramfits/config.py
+++ b/validphys2/src/validphys/paramfits/config.py
@@ -1,6 +1,8 @@
-
+"""
+Configuration class for the paramfits module
+"""
 import re
-from collections import Mapping, Sequence, ChainMap
+from collections.abc import Mapping, Sequence
 
 from reportengine.configparser import Config, ConfigError, element_of
 

--- a/validphys2/src/validphys/results.py
+++ b/validphys2/src/validphys/results.py
@@ -6,7 +6,8 @@ Tools to obtain theory predictions and basic statistical estimators.
 """
 from __future__ import generator_stop
 
-from collections import OrderedDict, namedtuple, Sequence
+from collections import OrderedDict, namedtuple
+from collections.abc import Sequence
 import itertools
 import logging
 


### PR DESCRIPTION
Move

from collections import <ABC>

to

from collections.abc import <ABC>

since the former is deprecated (for no particularly good reason).

Also remove various unused imports.