### PR TITLE
Implementing tab autocomplete

### DIFF
--- a/autocomplete.py
+++ b/autocomplete.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 import sys
-from os import path
 
 from importlib import import_module
+from os import path
 
 from reportengine.utils import get_providers
 from validphys.app import providers


### PR DESCRIPTION
So @Zaharid and I thought it'd be cool to have tab autocomplete such that you could do
```
validphys --help <Tab> <Tab>
```
and get autocomplete functionality for all the VP providers, hence this PR. Currently only works for `bash` but I'll look into the implementing it for `fish` as well since that's what Zahari and myself use.

To get this working, in a bash shell, enter 
```
complete -C ./autocomplete.py validphys
```

I don't really know where to put the `autocomplete.py` file. And to avoid having to type the `complete` command, we should really put that line in a file called `validphys` inside `/usr/share/bash-completion/completions/` but I don't know how to do that automagically on install.

Finally, it may be better to compile a list of all the providers on install to avoid having to import the providers every time you press `<Tab>`