### PR TITLE
Remove lhapdf from n3fit-evolven3fit cmake 

### DIFF
--- a/n3fit/evolven3fit/CMakeLists.txt
+++ b/n3fit/evolven3fit/CMakeLists.txt
@@ -23,11 +23,11 @@ add_executable(evolven3fit ${PROJECT_SOURCE_DIR}/n3fit/evolven3fit/evolven3fit.c
         ${PROJECT_SOURCE_DIR}/nnpdfcpp/src/nnfit/src/evolgrid.cc )
 
 # Set all flags
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${NNPDF_LDFLAGS} ${LHAPDF_LIBRARIES} ${GSL_LDFLAGS} ${APFEL_LIBRARIES} ${YAML_LDFLAGS}")
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${NNPDF_LDFLAGS} ${GSL_LDFLAGS} ${APFEL_LIBRARIES} ${YAML_LDFLAGS}")
 
 # I am pretty sure this should not be a thing
 string(REPLACE ";" " " CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS}")
-target_link_libraries(evolven3fit nnpdf ${LHAPDF_LIBRARIES} ${YAML_LDFLAGS} ${APFEL_LIBRARIES} ${GSL_LDFLAGS})
+target_link_libraries(evolven3fit nnpdf ${YAML_LDFLAGS} ${APFEL_LIBRARIES} ${GSL_LDFLAGS})
 
 install(TARGETS evolven3fit DESTINATION bin
         PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ


### PR DESCRIPTION
It doesn't seem to be necessary and I was getting a crash due to lhapdf when I use `evolven3fit`.

If travis is able to compile it then it means it is indeed not necessary. If travis fails I will remove this PR and investigate why does it fail in my computer.