### PR TITLE
Add tools to both fit and analyse fits with regularised covmats

### DIFF
--- a/n3fit/src/n3fit/fit.py
+++ b/n3fit/src/n3fit/fit.py
@@ -15,7 +15,7 @@ log = logging.getLogger(__name__)
 def fit(
     fitting,
     experiments,
-    experiments_covariance_matrix,
+    t0set,
     replica,
     replica_path,
     output_path,
@@ -46,9 +46,8 @@ def fit(
         # Arguments:
             - `fitting`: dictionary with the hyperparameters of the fit
             - `experiments`: vp list of experiments to be included in the fit
-            - `experiments_covariance_matrix`: covariance matrices collected
-                                               over experiments
-            - `replica`: a list of replica numbers to run over (typically just one)
+            - `t0set`: t0set name
+            - `replica`: a list of replica numbers to run over (tipycally just one)
             - `replica_path`: path to the output of this run
             - `output_path`: name of the fit
             - `theorid`: theory id number
@@ -91,6 +90,10 @@ def fit(
     else:
         status_ok = "ok"
 
+    # Loading t0set from LHAPDF
+    if t0set is not None:
+        t0pdfset = t0set.load_t0()
+
     # First set the seed variables for
     # - Tr/Vl split
     # - Neural Network initialization
@@ -129,9 +132,9 @@ def fit(
     ##############################################################################
     all_exp_infos = [[] for _ in replica]
     # First loop over the experiments
-    for exp, exp_cov in zip(experiments, experiments_covariance_matrix):
+    for exp in experiments:
         log.info("Loading experiment: {0}".format(exp))
-        all_exp_dicts = reader.common_data_reader(exp, exp_cov, replica_seeds=mcseeds, trval_seeds=trvalseeds)
+        all_exp_dicts = reader.common_data_reader(exp, t0pdfset, replica_seeds=mcseeds, trval_seeds=trvalseeds)
         for i, exp_dict in enumerate(all_exp_dicts):
             all_exp_infos[i].append(exp_dict)
 

--- a/n3fit/src/n3fit/io/reader.py
+++ b/n3fit/src/n3fit/io/reader.py
@@ -8,7 +8,6 @@ import numpy as np
 from NNPDF import RandomGenerator
 from validphys.core import ExperimentSpec as vp_Exp
 from validphys.core import DataSetSpec as vp_Dataset
-from validphys.calcutils import regularize_covmat
 
 
 def make_tr_val_mask(datasets, exp_name, seed):
@@ -173,7 +172,7 @@ def common_data_reader_experiment(experiment_c, experiment_spec):
     return parsed_datasets
 
 
-def common_data_reader(spec, covmat, replica_seeds=None, trval_seeds=None):
+def common_data_reader(spec, t0pdfset, replica_seeds=None, trval_seeds=None):
     """
     Wrapper to read the information from validphys object
     This function receives either a validphyis experiment or dataset objects
@@ -215,6 +214,7 @@ def common_data_reader(spec, covmat, replica_seeds=None, trval_seeds=None):
     spec_c = spec.load()
     ndata = spec_c.GetNData()
     expdata_true = spec_c.get_cv().reshape(1, ndata)
+    spec_c.SetT0(t0pdfset)
     base_mcseed = int(hashlib.sha256(str(spec).encode()).hexdigest(), 16) % 10 ** 8
 
     if replica_seeds:
@@ -246,6 +246,7 @@ def common_data_reader(spec, covmat, replica_seeds=None, trval_seeds=None):
         )
 
     exp_name = spec.name
+    covmat = spec_c.get_covmat()
 
     # Now it is time to build the masks for the training validation split
     all_dict_out = []

--- a/n3fit/src/n3fit/n3fit.py
+++ b/n3fit/src/n3fit/n3fit.py
@@ -17,15 +17,14 @@ from validphys.config import EnvironmentError_, ConfigError
 from reportengine import colors
 from reportengine.compat import yaml
 
-# Set use_t0 true here for backwards compatibility. Causes fit covmats to
-# use t0 prescription
+
 N3FIT_FIXED_CONFIG = dict(
     use_cuts = 'internal',
     use_t0 = True,
     actions_ = ['datacuts::theory fit']
 )
 
-N3FIT_PROVIDERS = ["n3fit.fit", "validphys.results"]
+N3FIT_PROVIDERS = ["n3fit.fit"]
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
After @Zaharid 's talk we want to escalate studies into unstable covmats. This will involve being able to regularize the covariance matrices using the proposed method on a more industrial scale.

Actions can be added for various analyses, just the base level function has been added to calcutils

Also since the tools will be available in the validphys structure, it is pretty trivial to add the possibility of modifying the covmats at the level of a fit (in the new fitting code)

The implementation of regularizing covmats in the fit needs to be done in a more flexible/sensible way, not hardcoded as it is now.