### PR TITLE
Drop support for Python 3.6

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,14 +12,6 @@ variables:
   GIT_DEPTH: 1000
 
 ## Run the configure and make tests
-job1:
-    stage: build-deploy
-    script:
-      - ".ciscripts/build-deploy-linux.sh"
-    variables:
-        CONDA_PY: "36"
-    artifacts:
-        untracked: True
 job2:
     stage: build-deploy
     script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ env:
     - CONDA_BUILD_SYSROOT="${CONDAPATH}/MacOSX10.9.sdk"
 
   matrix:
-    - CONDA_PY=36
     - CONDA_PY=37
 
 before_install:


### PR DESCRIPTION
Remove testing and packaging for Python 3.6, making it effectively
unsupported. 3.7 has been around for enough time now, so it should be
easy to manage.

Closes #567.