### PR TITLE
added DIS Processes in APFEL to apfelcomb.md

### DIFF
--- a/doc/sphinx/source/tutorials/apfelcomb.md
+++ b/doc/sphinx/source/tutorials/apfelcomb.md
@@ -118,9 +118,12 @@ Each subgrid entry has the following fields:
 - **fktarget**	- The name of the FK table this subgrid belongs to
 - **operators** - A list of operators to handle certain special cases (see Subgrid operators).
 For DIS there is one additional field:
-- **process**	- The process string of the observable (e.g DIS\_F2P, see DIS Processes in APFEL)
+- **process**	- The process string of the observable (e.g DIS\_F2P, see DIS Processes in APFEL below)
 
 ### DIS Processes in APFEL
+
+For DIS processes and since the coefficient functions are computed solely with APFEL, one needs to specify the process of the observable, in `dis_subgrids` following `APFEL`'s nomenclature.
+The list of processes below can be found in `apfel/src/DIS/FKObservables.f` in the headers corresponding to the different observables called.
 
 **Deep Inelastic Scattering Structure Functions**:
 - DIS_F2L: [EM] Light structure function F2light (electron-proton)


### PR DESCRIPTION
This contains the list of DIS processes by key used for FKtables production and what their specifications.

@Zaharid, I know you said to locate this in` tools.md`, but I made the call to put them here since they fell logically after the `process` key explanation in the FK tables tutorial.  
Feel free to move them for any more convenient location.