### PR TITLE
Added a all_positivity_from_dataspecs key to get the union of positivity datasets

### DIFF
--- a/validphys2/src/validphys/config.py
+++ b/validphys2/src/validphys/config.py
@@ -558,6 +558,38 @@ class CoreConfig(configparser.Config):
         res.sort(key=lambda x: (x['posdataset_name']))
         return res
 
+    def produce_all_positivity_from_dataspecs(self, dataspecs):
+        """Like produce_matched_positivity_from_dataspecs but takes the union of the
+        positivity datasets of all inputs instead of the intersection"""
+        self._check_dataspecs_type(dataspecs)
+        all_names = []
+        for spec in dataspecs:
+            with self.set_context(ns=self._curr_ns.new_child(spec)):
+                _, pos = self.parse_from_(None, 'posdatasets', write=False)
+                names = {(p.name):(p) for p in pos}
+                all_names.append(names)
+        used_set = set.union(*(set(d) for d in all_names))
+
+        res = []
+        for k in used_set:
+            inres = {'posdataset_name': k}
+            l = inres['dataspecs'] = []
+            for ispec, spec in enumerate(dataspecs):
+                #Passing spec by referene
+                try:
+                    getspec = all_names[ispec][k]
+                except:
+                    continue
+                d = ChainMap({
+                    'posdataset': getspec,
+
+                    },
+                    spec)
+                l.append(d)
+            res.append(inres)
+        res.sort(key=lambda x: (x['posdataset_name']))
+        return res
+
     def produce_dataspecs_with_matched_cuts(self, dataspecs):
         """Take a list of namespaces (dataspecs), resolve ``dataset`` within
         each of them, and return another list of dataspecs where the datasets


### PR DESCRIPTION
As discussed in #593 it would be nice to have a feature enabling the possibility of doing a comparefit where the two fits were done with a different set of positivity datasets. I've done so by creating a `produce_all_positivity_from_dataspecs` method akin to `produce_matched_positivity_from_dataspecs`.

This new feature can be used with the key `all_positivity_from_dataspecs`.

An example report in which this has been used can be found here: https://vp.nnpdf.science/UM6m_h28Thuf18ocrJENjg==/ where each report use a different positivity set.

Note: this is also a textbook example of [cargo cult programming](https://en.wikipedia.org/wiki/Cargo_cult_programming) as I don't fully comprehend the logic behind `produce_matched_positivity_from_dataspecs`, in particular this loop:

```
for ispec, spec in enumerate(dataspecs):            
    #Passing spec by referene                       
    d = ChainMap({                                  
        'posdataset':       all_names[ispec][k],    
                                                    
        },                                          
        spec)                                       
    l.append(d)   
```


