### PR TITLE
Stop mac builds from breaking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -98,7 +98,7 @@ install:
      conda config --add channels https://packages.nnpdf.science/conda;
      conda config --add channels https://packages.nnpdf.science/conda-private;
      conda config --set show_channel_urls true;
-     conda install --yes conda-build;
+     conda install --yes conda-build=3.18.9;
      fi
 
 script:


### PR DESCRIPTION
Hopefully a temp fix to #597 by fixing `conda-build` to `3.18.9` (let's see what happens with CI)

should close issue once this gets fixed upstream