### PR TITLE
Removing wrong space

### DIFF
--- a/validphys2/src/validphys/lhio.py
+++ b/validphys2/src/validphys/lhio.py
@@ -104,7 +104,7 @@ def _rep_to_buffer(out, header, subgrids):
         #Reshape so printing is easy
         reshaped = g.values.reshape((len(g.groupby(level=1))*len(g.groupby(level=2)),
                               len(g.groupby(level=3))))
-        np.savetxt(out, reshaped, delimiter=" ", newline="\n ", fmt='%14.7E')
+        np.savetxt(out, reshaped, delimiter=" ", newline="\n", fmt='%14.7E')
         out.write(sep)
 
 def write_replica(rep, set_root, header, subgrids):


### PR DESCRIPTION
I've been tearing my hair out over this. It prevents `replica 0` from being read in fully using `load_replica` which in turn completely messes up `load_all_replicas`. Removing this space fixes all of these.