### PR TITLE
Add documentation on CI

### DIFF
--- a/doc/sphinx/source/ci/index.md
+++ b/doc/sphinx/source/ci/index.md
@@ -1,0 +1,93 @@
+```eval_rst
+.. _CI:
+```
+# Continuous integration and deployment
+
+The NNPDF code base makes use of externally hosted services, to aid development
+and testing. These are typically called *Continuous integration (CI)* or
+*Continuous deployment* services. Their main task is to execute automated tests
+on the code and produce [binary builds](conda) which allow it to be
+automatically deployed. The services are configured so that they react to
+[git](git) pushes to the GitHub server.
+
+Currently we are using actively [Travis CI](https://travis-ci.com/).  We benefit
+from using it for free (because we asked nicely), but it is typically paid for
+private repositories. The [Gitlab CI service hosted at
+CERN](https://gitlab.cern.ch/) was used in the past, but support was
+discontinued due to the burden of requiring everyone to have a CERN account.
+
+## Operation of CI tools
+
+Our CI service works roughly as follows:
+
+ 1. Every time a commit is made to a given branch, a request to process the
+    code in that branch is made automatically.
+ 2. The code for the branch is downloaded to the CI server, and some action is
+    taken based on configuration found both in the git repository itself and in
+    the settings on the CI service. These actions include:
+      * Compiling the code.
+	  * Running the tests.
+	  * Possibly, uploading the compiled binaries and documentation to the
+	    [NNPDF server](server).
+	We use [Conda-build](https://docs.conda.io/projects/conda-build/en/latest/)
+	to
+	do much of the heavy lifting for these actions.
+ 3. The CI service reports whether it has *succeeded* or *failed* to the GitHub
+	server, which displays that information next to the relevant pull request or
+	commit. Some logs are generated, which can aid in determining the cause of
+	errors.
+
+The progress reports of the various jobs at Travis CI, as well as the
+corresponding logs are available at <https://travis-ci.com/>, upon logging in
+with an authorized GitHub account.
+
+
+## Configuration of Travis CI
+
+Travis CI uses both files found in the NNPDF repository and settings stored in
+the Travis configuration itself.
+
+```eval_rst
+.. _travis-variables:
+```
+### Secrets stored in the Travis CI configuration
+
+To build and upload the packages Travis CI needs to be able to access some
+secrets, which should not be stored in the git repository. These are represented
+as environment variables, under the [Travis CI settings for the NNPDF
+repository](https://travis-ci.com/NNPDF/nnpdf/settings). The secrets are encoded
+using `base64` because Travis does not easily accept multiline variables. To use
+them, do something like `echo "$<SECRET VARIABLE>" | base64 --decode`.
+
+The secrets are.
+
+  - `NETRC_FILE` a base64 encoded string containing a `~/.netrc` file with
+	the [credentials](server-access) to the private conda repository
+	<https://packages.nnpdf.science/conda-private/>
+  - `NNPDF_SSH_KEY` a base64 string containing a private SSH key which is
+	 authorized to access the [upload account of the NNPDF server](server-access).
+
+### Repository configuration
+
+The main entry point for Travis CI is a file called
+[`.travis.yml`](https://github.com/NNPDF/nnpdf/blob/master/.travis.yml) on the
+top level. It specifies which operating systems and versions are tested, which
+versions of Python, various required variables, or which scripts actually get
+executed under those settings.
+
+The scripts themselves live under the
+[`.ciscripts`](https://github.com/NNPDF/nnpdf/tree/master/.ciscripts) top level
+directory. They basically call `conda build` and upload the relevant packages if
+required.
+
+By default only packages corresponding to commits to the master branch get
+uploaded. For other branches, the build and testing happens, but the results are
+discarded in the end. This behavior can be changing by (temporarily) setting the
+`UPLOAD_NON_MASTER` variable in the `.travis.yml` file to true. This can be
+useful to test modifications to the uploading.
+
+
+Linux builds are executed on top of a [docker image](https://www.docker.com/)
+which is defined by the configuration file under [the `docker`
+folder](https://github.com/NNPDF/nnpdf/tree/master/docker). This is mostly for
+historical reasons.

--- a/doc/sphinx/source/get-started/git.md
+++ b/doc/sphinx/source/get-started/git.md
@@ -1,3 +1,6 @@
+```eval_rst
+.. _git:
+```
 # Git, GitHub and GitLab
 
 *Author: Cameron Voisey, 13/10/2019*

--- a/doc/sphinx/source/index.rst
+++ b/doc/sphinx/source/index.rst
@@ -15,6 +15,7 @@ NNPDF documentation
    n3fit/index
    code/index
    serverconf/index
+   ci/index
    tutorials/index
    QA/index
 

--- a/doc/sphinx/source/serverconf/index.md
+++ b/doc/sphinx/source/serverconf/index.md
@@ -29,6 +29,9 @@ We perform every Sunday a `rsync` from the `/home/nnpdf` folder
 to the `nnpdf@lxplus` account at CERN.
 
 
+```eval_rst
+.. _server-access:
+```
 Access
 ------
 
@@ -38,15 +41,15 @@ The access to the server is provided by
 `ssh`/[`vp-upload`](upload) with the following restrictions:
 
 - `ssh` access to `root` is forbidden.
-- there is a shared `nnpdf` user with low privileges. In order to login 
+- There is a shared `nnpdf` user with low privileges. In order to login 
 the user must send his public ssh key (usually in `~/.ssh/id_rsa.pub`) to SC.
 The `nnpdf` is not allowed to login with password.
 
-The `nnpdf` user shares a common `/home/nnpdf` folder 
-where all NNPDF material is stored. Public access to data is 
-available for all files in the `/home/nnpdf/WEB` folder. The 
-`validphys` reports are stored in `/home/nnpdf/WEB/validphys-reports` 
-and the wiki in `/home/nnpdf/WEB/wiki`.
+The `nnpdf` user shares a common `/home/nnpdf` folder where all NNPDF
+material is stored. Public access to data is available for all files
+in the `/home/nnpdf/WEB` folder. The `validphys` reports are stored in
+`/home/nnpdf/WEB/validphys-reports` and the wiki in
+`/home/nnpdf/WEB/wiki`.
 
 ### Access for continuous deployment tools
 
@@ -55,12 +58,28 @@ automatically uploaded to the server by the Continous Integration service
 (Travis), through an user called `dummy` which has further reduction in
 privileges (it uses the [`rssh` shell](https://linux.die.net/man/1/rssh)) and it
 is only allowed to run the `scp` command. An accepted private key is stored
-securely in the [Travis configuration](https://travis-ci.com/NNPDF/nnpdf) under
-the `NNPDF_SSH_KEY` variable. It is encoded using `base64` because Travis does
-not easily accept multiline variables. To use it, do something like `echo
-"$NNPDF_SSH_KEY" | base64 --decode`. The packages are uploaded to
-`/home/nnpdf/packages`.
+securely in the [Travis configuration](travis-variables).  The packages
+are uploaded to `/home/nnpdf/packages`.
 
+### HTTP access
+
+Tools such as [conda](conda) and [vp-get](download) require access to
+private URLs, which are password-protected, using HTTP basic_auth. The
+access is granted by a `/.netrc` file containing the user and password
+for the relevant servers. The `/.netrc` file is typically generated
+at [installation](conda) time. It should look similar to
+```
+machine vp.nnpdf.science
+    login nnpdf
+	password <PASSWORD>
+
+machine packages.nnpdf.science
+    login nnpdf
+	password <PASSWORD>
+```
+
+The relevant passwords can be found
+[here](https://www.wiki.ed.ac.uk/pages/viewpage.action?pageId=292165461).
 
 
 ```eval_rst
@@ -69,8 +88,8 @@ not easily accept multiline variables. To use it, do something like `echo
 Web Scripts
 -----------
 
-Validphys2 interacts with the NNPDF server by [Downloading Resources]
-and [Uploading the result].
+Validphys2 interacts with the NNPDF server by [downloading resources](download)
+and [uploading results](upload).
 
 The server scripts live in the validphys2
 repository under the `serverscripts` folder.


### PR DESCRIPTION
After several years, people still ask regularly what CI is. Apart from
that needing more discussion, there are things in our Travis
configuration that are completely obscure even if you knew about Travis
in general, such as how the various secrets work or which scripts get
looked at at what time. This should make it better, without being overly
specific and subject to frequent problems with synchronization.