### PR TITLE
Added cut for CMS single-jets at 8 TeV

### DIFF
--- a/validphys2/src/validphys/cuts/filters.yaml
+++ b/validphys2/src/validphys/cuts/filters.yaml
@@ -14,6 +14,13 @@
     for the NNLO jet project.
   rule: eta < 0.3
 
+- dataset: CMS_1JET_8TEV
+  reason: |
+    We keep only the bins with pTjet>74 GeV because fixed-order theory does
+    not provide a good description of the data for smalle values of the	jet
+    transverse momentum.
+  rule: "p_T2 >= 5476"
+
 - dataset: LHCBWZMU8TEV
   reason: |
     The first two bins in rapidity have unnaturally large K-factors which we


### PR DESCRIPTION
I guess that a cut on the CMS single-jets at 8 TeV was missed when the new cut layout was introduced. This PR fixes it.