### PR TITLE
Edit installation from source docs

### DIFF
--- a/doc/sphinx/source/get-started/installation-source.md
+++ b/doc/sphinx/source/get-started/installation-source.md
@@ -10,28 +10,22 @@ If you intend to work on the NNPDF code, then building from source is the recomm
 
 	Note that the user should be in the conda environment `nnpdf-dev` whenever they wish to work on NNPDF code. The conda environment can be exited using `conda deactivate`.
 
-2. Install the appropriate C++ compilers using
-		
-		conda install gxx_linux-64 
-
-	macOS users should replace `gxx_linux-64` with `clangxx_osx-64`.
-
-3. Ensure that the NNPDF repositories `nnpdf` and `apfel` are in the `nnpdfgit` directory. These are required to be able to run fits and can be obtained respectively by
+2. Ensure that the NNPDF repositories `nnpdf` and `apfel` are in the `nnpdfgit` directory. These are required to be able to run fits and can be obtained respectively by
 
 		git clone git@github.com:NNPDF/nnpdf.git
 		git clone https://github.com/scarrazza/apfel.git
 
-4. Obtain the dependencies of the code you want to build. Where to find those depends on the particular code. For example, something linking to `libnnpdf` will likely require `pkg-config`. Projects based on `autotools` (those that have a `./configure` script) will additionally require `automake` and `libtool`. Similarly projects based on `cmake` will require installing the `cmake` package. In the case of `nnpdf` itself, the build dependencies can be found in  `<nnpdf git root>/conda-recipe/meta.yaml`. We have to install the remaining ones manually:
+3. Obtain the dependencies of the code you want to build. Where to find those depends on the particular code. Projects based on `autotools` (those that have a `./configure` script) will require `automake` and `libtool`. Similarly projects based on `cmake` will require installing the `cmake` package. In the case of `nnpdf` itself, the build dependencies can be found in  `<nnpdf git root>/conda-recipe/meta.yaml`. We have to install the remaining ones manually:
 
-		conda install pkg-config swig=3.0.10 cmake
+		conda install swig=3.0.10 cmake
 
-5. We now need to make the installation prefix point to our `nnpdf-dev` environment, this can be done using:
+4. We now need to make the installation prefix point to our `nnpdf-dev` environment, this can be done using:
 
 		$CONDA_PREFIX=~/miniconda3/envs/nnpdf-dev/
 
 	this assumes `miniconda3` is installed in the default place which is the home directory.
 
-6. Navigate to the `nnpdf` directory obtained from the Github repository and create a folder called `conda-bld` by
+5. Navigate to the `nnpdf` directory obtained from the Github repository and create a folder called `conda-bld` by
 		
 		nnpdf$ mkdir conda-bld
 		nnpdf$ cd conda-bld
@@ -40,7 +34,7 @@ If you intend to work on the NNPDF code, then building from source is the recomm
 
 		nnpdf/conda-bld$ cmake .. -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX
 
-7. When the user wishes to work on the NNPDF code, they should do so in, for example, `'/nnpdfgit/nnpdf/libnnpdf'`. To compile the code navigate to the `conda-bld` directory created above and run
+6. When the user wishes to work on the NNPDF code, they should do so in, for example, `'/nnpdfgit/nnpdf/libnnpdf'`. To compile the code navigate to the `conda-bld` directory created above and run
 
 		make
 		make install


### PR DESCRIPTION
When I followed these instructions I found that one no longer needs to install the C++ compiler themselves, in particular the compiler is installed automatically when doing `conda install --only-deps nnpdf` on both linux and mac, so step 2 is no longer necessary. I also checked whether any of the packages mentioned in what was step 4 are already installed and pkg-config is, so I got rid of any mention of this.