### PR TITLE
fix bug in argparser of vp-checktheory

### DIFF
--- a/validphys2/src/validphys/scripts/vp_checktheory.py
+++ b/validphys2/src/validphys/scripts/vp_checktheory.py
@@ -72,7 +72,6 @@ def main():
     group.add_argument(
         '--fit',
         type=str,
-        nargs=1,
         help=(
             "Name of a fit from which to parse `theoryid` from, instead of "
             "supplying theoryid on command line"


### PR DESCRIPTION
closes #652 

I completely remove the keyword and it now is working properly for me.

I guess it's a bit more difficult to have tests for command line scripts? Probably I should actually run the code I write...