### PR TITLE
Adding loader method for importing experiment specs

### DIFF
--- a/validphys2/src/validphys/loader.py
+++ b/validphys2/src/validphys/loader.py
@@ -449,8 +449,29 @@ class Loader(LoaderBase):
                            fkspecs=fkspec, thspec=theoryid, cuts=cuts,
                            frac=frac, op=op, weight=weight)
 
-    def check_experiment(self, name, datasets: List[DataSetSpec]) -> ExperimentSpec:
+    def check_experiment(self, name: str, datasets: List[DataSetSpec]) -> ExperimentSpec:
+        """Loader method for instantiating ExperimentSpec objects. The NNPDF::Experiment
+        object can then be instantiated using the load method.
 
+        Parameters
+        ----------
+        name: str
+            A string denoting the name of the resulting ExperimentSpec object.
+        dataset: List[DataSetSpec]
+            A list of DataSetSpec objects pre-created by the user. Note, these too
+            will be loaded by Loader.
+
+        Returns
+        -------
+        ExperimentSpec
+
+        Example
+        -------
+        >>> from validphys.loader import Loader
+        >>> l = Loader()
+        >>> ds = l.check_dataset("NMC", theoryid=53, cuts="internal")
+        >>> exp = l.check_experiment("My ExperimentSpec Name", [ds])
+        """
         if not isinstance(datasets, list):
             raise TypeError("Must specify a list of DataSetSpec objects to use")
 


### PR DESCRIPTION
I found it weird that we could instantiate `DataSetSpec` objects from `Loader` but not `ExperimentSpec` ones.

Just a small PR implementing this which closes #661 :

```python
In [1]: from validphys.loader import Loader 
   ...: l = Loader()                                                                                                                                                     

In [2]: exp = l.check_experiment("Foo", ["NMC", "NMCPD"], theoryid=53)                                                                                                   

In [3]: loaded_exp = exp.load()                                                                                                                                          

-- Reading COMMONDATA for Dataset: NMC
nData: 292 nSys: 16
-- COMMONDATA Files for NMC successfully read.

_NMC________________________________________________________
NMC
292 Data Points 50 X points 9 active flavours

-- Reading COMMONDATA for Dataset: NMCPD
nData: 260 nSys: 5
-- COMMONDATA Files for NMCPD successfully read.

_NMCPD______________________________________________________
NMCPD_D
260 Data Points 50 X points 4 active flavours
_NMCPD______________________________________________________
NMCPD_P
260 Data Points 50 X points 5 active flavours

```