### PR TITLE
[do not merge] New Positivity tests

### DIFF
--- a/n3fit/src/n3fit/layers/NewPositivity.py
+++ b/n3fit/src/n3fit/layers/NewPositivity.py
@@ -1,0 +1,28 @@
+from n3fit.backends import MetaLayer
+
+
+class NewPositivity(MetaLayer):
+    """
+        Just a Template for now
+
+        This layer is just for testing so it is not necessariliy efficient
+        the idea is that it takes as input
+            (pdf(x), pdf(z))
+        where pdf is the positivity-scheme pdf and x is the xgrid for the target fktable
+        and returns a pdf(x) in the MSbar scheme
+
+        The x is given at instantiation time in the variable x_in.
+        For this first test we take the x and the z to be the same grid,
+        so life is easier
+    """
+
+    def __init__(self, x_in = None, **kwargs):
+        self.x_in = x_in
+        super().__init__(**kwargs)
+
+    def call(self, x):
+        pdf_in_x = x[0] # tensor with indices (i, f) where i is the index of the grid in x and f the flavour index
+        pdf_in_z = x[1]
+        # Very non-trivial operation that changes completely the PDF happens here
+        result = pdf_in_z + pdf_in_x
+        return result

--- a/n3fit/src/n3fit/layers/__init__.py
+++ b/n3fit/src/n3fit/layers/__init__.py
@@ -1,4 +1,5 @@
 from n3fit.layers.Preprocessing import Preprocessing
+from n3fit.layers.NewPositivity import NewPositivity
 from n3fit.layers.Rotation import Rotation
 from n3fit.layers.x_operations import xIntegrator, xDivide, xMultiply
 from n3fit.layers.MSR_Normalization import MSR_Normalization


### PR DESCRIPTION
The operation that needs to transform the pdf in the positivity scheme to the MS bar scheme should happen inside the NewPositivity.py layer that this branch adds. Basically at that point you get two PDFs, one of them would be the PDF you want to transform and the other is the PDF that would be inside the convoluton. For now I'm using the fktable-grid as the grid for the convolution, probably this is highly inefficient but for now it can work.

The result should be the PDF in the MSBar scheme so that in the line
```
# Very non-trivial operation that changes completely the PDF happens here
```
you want to add the transformation that you need to do.

Just to give an example, imagine the change of scheme is just changing the position of the gluon and the sigma (indices 1 and 2 if I am not mistaken) and summing to the original PDF, for that you would have to do something like this outside of the class (so it is not generated for every instance, you only need one for this case).

```
import numpy as np
import keras.backend as K
iden = np.eye(14)
iden[1,1] = 0
iden[2,2] = 0
iden[1,2] = 1
iden[2,1] = 1
tensor_rotate = K.constant(iden)
```


And inside the `__call__` method:

`     return_pdf = pdf_in_x + self.tensor_product(pdf_in_z, tensor_rotate, axes=1)`

Let me know if there are any questions.

Note: this assumes the change of scheme is done in the evolution basis, not sure whether it is what you guys had in mind but since this is not the final form I would be very much happier if tests using this branch happen there. In the file 'n3fit/layers/Rotation.py'  you can find to which flavour corresponds which index.