### PR TITLE
Improve error message when filter fails

### DIFF
--- a/validphys2/src/validphys/config.py
+++ b/validphys2/src/validphys/config.py
@@ -944,7 +944,7 @@ class CoreConfig(configparser.Config):
                 for i in filter_rules
             ]
         except RuleProcessingError as e:
-            raise ConfigError(e) from e
+            raise ConfigError(f"Error Processing filter rules: {e}") from e
 
         return rule_list
 


### PR DESCRIPTION
It can get very confusing to get a message like "Could not find dataset
<SOME DATASET NOT IN THE RUNCARD>" without context.