### PR TITLE
Add support for lockfiles to n3fit and vp-setupfit

### DIFF
--- a/n3fit/src/n3fit/n3fit.py
+++ b/n3fit/src/n3fit/n3fit.py
@@ -30,6 +30,7 @@ N3FIT_PROVIDERS = ["n3fit.performfit"]
 log = logging.getLogger(__name__)
 
 RUNCARD_COPY_FILENAME = "filter.yml"
+INPUT_FOLDER = "input"
 
 
 class N3FitError(Exception):
@@ -74,6 +75,10 @@ class N3FitEnvironment(Environment):
                 path.mkdir(exist_ok=True)
             except OSError as e:
                 raise EnvironmentError_(e) from e
+        # make lockfile input inside of replica folder
+        # avoid conflict with setupfit
+        self.input_folder = self.replica_path / INPUT_FOLDER
+        self.input_folder.mkdir(exist_ok=True)
 
     @classmethod
     def ns_dump_description(cls):

--- a/validphys2/src/validphys/scripts/vp_setupfit.py
+++ b/validphys2/src/validphys/scripts/vp_setupfit.py
@@ -62,6 +62,7 @@ RUNCARD_COPY_FILENAME = "filter.yml"
 FILTER_OUTPUT_FOLDER = "filter"
 TABLE_OUTPUT_FOLDER = "tables"
 MD5_FILENAME = "md5"
+INPUT_FOLDER = "input"
 
 
 class SetupFitError(Exception):
@@ -104,6 +105,9 @@ class SetupFitEnvironment(Environment):
         self.filter_path.mkdir(exist_ok=True)
         self.table_folder = self.output_path / TABLE_OUTPUT_FOLDER
         self.table_folder.mkdir(exist_ok=True)
+        # put lockfile input inside of filter output
+        self.input_folder = self.filter_path / INPUT_FOLDER
+        self.input_folder.mkdir(exist_ok=True)
 
     def save_md5(self):
         """Generate md5 key from file"""


### PR DESCRIPTION
input_folder is a required attribute of the environment class. To avoid conflict I have put the input_folder for n3fit inside of the replica path (`<fitname>/nnfit/input`) and inside of filter output for vp-setupfit (`<fitname>/filter/input`) just to prevent them overwriting each other

see NNPDF/reportengine#30