### PR TITLE
Add a with_cuts method to FKTableData

### DIFF
--- a/validphys2/src/validphys/coredata.py
+++ b/validphys2/src/validphys/coredata.py
@@ -83,7 +83,7 @@ class FKTableData:
         ... ds = l.check_dataset('ATLASTTBARTOT', theoryid=53, cfac=('QCD',))
         ... table = load_fktable(ds.fkspecs[0])
         ... newtable = table.with_cuts([0,1])
-        >>> assert set(newtable.sigma.index.get_level_values(0).unique()) == {0,1}
+        >>> assert set(newtable.sigma.index.get_level_values(0)) == {0,1}
         >>> assert newtable.ndata == 2
         >>> assert newtable.metadata['GridInfo'].ndata == 3
         """

--- a/validphys2/src/validphys/tests/test_fkparser.py
+++ b/validphys2/src/validphys/tests/test_fkparser.py
@@ -24,9 +24,9 @@ def test_cuts():
     table = load_fktable(ds.fkspecs[0])
     # Check explicit cuts
     newtable = table.with_cuts([0, 1])
-    assert set(newtable.sigma.index.get_level_values(0).unique()) == {0, 1}
+    assert set(newtable.sigma.index.get_level_values(0)) == {0, 1}
     assert newtable.ndata == 2
-    assert newtable.metadata['GridInfo'].ndata == 3
+    assert newtable.metadata['GridInfo'].ndata == ds.commondata.ndata
     # Check empty cuts
     assert newtable.with_cuts(None) is newtable
     # Check loaded cuts


### PR DESCRIPTION
Allow to apply cuts to the new FKtable representation in a way that the
index is kept properly matched.

This is going to be useful to get full-fledged predictions out of this
object.

It may be useful to have this functionality at the level of the parser
when we get a nicer file format (in addition to or instead of here), but
for now it is probably fine to have it here.