### PR TITLE
Add a threshold for the validation chi2

### DIFF
--- a/n3fit/runcards/Basic_hyperopt.yml
+++ b/n3fit/runcards/Basic_hyperopt.yml
@@ -81,7 +81,7 @@ hyperscan:
         max_units: 50
         activations: ['sigmoid', 'tanh']
     kfold: 
-        threshold_loss: 2.0
+        threshold: 2.0
         partitions:
             - datasets:
                 - HERACOMBCCEM

--- a/n3fit/runcards/Basic_runcard.yml
+++ b/n3fit/runcards/Basic_runcard.yml
@@ -35,30 +35,6 @@ datacuts:
 theory:
   theoryid: 53        # database id
 
-###########################################################
-hyperscan:
-    stopping:
-        min_epochs: 5e2
-        max_epochs: 40e2
-        min_patience: 0.10
-        max_patience: 0.40
-    positivity:
-        min_multiplier: 1.00000001
-        max_multiplier: 1.00000002
-        min_initial:
-        max_initial:
-    optimizer:
-        names: 'ALL' # Use all implemented optimizers
-        min_lr: 0.0005
-        max_lr: 0.5
-    architecture:
-        initializers: 'ALL'
-        max_drop: 0.15
-        n_layers: [2,3,4]
-        min_units: 5
-        max_units: 50
-        activations: ['sigmoid', 'tanh']
-
 
 ############################################################
 fitting:
@@ -86,6 +62,7 @@ fitting:
     stopping_patience: 0.30 # percentage of the number of epochs
     layer_type: 'dense'
     dropout: 0.0
+    threshold_chi2: 5.0
 
   # NN23(QED) = sng=0,g=1,v=2,t3=3,ds=4,sp=5,sm=6,(pht=7)
   # EVOL(QED) = sng=0,g=1,v=2,v3=3,v8=4,t3=5,t8=6,(pht=7)

--- a/n3fit/src/n3fit/ModelTrainer.py
+++ b/n3fit/src/n3fit/ModelTrainer.py
@@ -15,7 +15,12 @@ from n3fit.backends import MetaModel, clear_backend_state, operations
 from n3fit.stopping import Stopping
 
 log = logging.getLogger(__name__)
-HYPER_THRESHOLD = 3.0
+
+# Threshold defaults
+# Any partition with a chi2 over the threshold will discard its hyperparameters
+HYPER_THRESHOLD = 5.0
+# The stopping will not consider any run where the validation is not under this threshold
+THRESHOLD_CHI2 = 10.0
 
 
 def _fold_data(all_data, folds, k_idx, negate_fold=False):
@@ -712,6 +717,7 @@ class ModelTrainer:
                 self.all_info,
                 total_epochs=epochs,
                 stopping_patience=stopping_epochs,
+                threshold_chi2=params.get("threshold_chi2", THRESHOLD_CHI2),
                 save_weights_each=self.save_weights_each,
             )
 

--- a/n3fit/src/n3fit/stopping.py
+++ b/n3fit/src/n3fit/stopping.py
@@ -329,6 +329,7 @@ class Stopping:
         threshold_positivity=1e-6,
         total_epochs=0,
         stopping_patience=7000,
+        threshold_chi2=10.0,
         dont_stop=False,
         save_weights_each=None,
     ):
@@ -346,6 +347,7 @@ class Stopping:
         self.history = FitHistory(self.validation, save_weights_each=save_weights_each)
 
         # Initialize internal variables for the stopping
+        self.threshold_chi2 = threshold_chi2
         self.dont_stop = dont_stop
         self.stop_now = False
         self.stopping_patience = stopping_patience
@@ -439,7 +441,7 @@ class Stopping:
 
         # Step 4. Check whether this is a better fit
         #         this means improving vl_chi2 and passing positivity
-        if self.positivity(fitstate):
+        if self.positivity(fitstate) and vl_chi2 < self.threshold_chi2:
             if vl_chi2 < self.history.best_vl():
                 # Set the new best
                 self.history.best_epoch = epoch

--- a/n3fit/src/n3fit/tests/regressions/hyper-quickcard.yml
+++ b/n3fit/src/n3fit/tests/regressions/hyper-quickcard.yml
@@ -60,10 +60,13 @@ hyperscan:
         max_units: 50
         activations: ['sigmoid', 'tanh']
     kfold: # if given a number k, k partitions will be generated automatically
-        threshold_loss: 2.0
+        threshold: 2.0
         partitions:
             - datasets:
                 - NMC
+            - datasets:
+                - SLACP
+                - CMSZDIFF12
 
 ############################################################
 fitting:

--- a/n3fit/src/n3fit/tests/regressions/quickcard.yml
+++ b/n3fit/src/n3fit/tests/regressions/quickcard.yml
@@ -39,32 +39,6 @@ datacuts:
 theory:
   theoryid: 162        # database id
 
-hyperscan:
-    stopping:
-        min_epochs: 2e1
-        max_epochs: 5e1
-        min_patience: 0.10
-        max_patience: 0.40
-    positivity:
-        min_multiplier: 1.01
-        max_multiplier: 1.10
-    optimizer:
-        names: ['Adadelta', 'Adam', 'RMSprop']
-        min_lr: 0.008
-        max_lr: 0.07
-    architecture:
-        initializers: ['glorot_normal', 'glorot_uniform']
-        max_drop: 0.15
-        n_layers: [2,3,4,5]
-        min_units: 10
-        max_units: 50
-        activations: ['sigmoid', 'tanh']
-    kfold: # if given a number k, k partitions will be generated automatically
-        threshold_loss: 2.0
-        partitions:
-            - datasets:
-                - NMC
-
 ############################################################
 fitting:
   genrep: True    # on = generate MC replicas, False = use real data
@@ -85,6 +59,7 @@ fitting:
     stopping_patience: 0.30 # percentage of the number of epochs
     layer_type: 'dense'
     dropout: 0.0
+    threshold_chi2: 50.0
 
   # NN23(QED) = sng=0,g=1,v=2,t3=3,ds=4,sp=5,sm=6,(pht=7)
   # EVOL(QED) = sng=0,g=1,v=2,v3=3,v8=4,t3=5,t8=6,(pht=7)

--- a/n3fit/src/n3fit/tests/test_fit.py
+++ b/n3fit/src/n3fit/tests/test_fit.py
@@ -15,6 +15,9 @@ import os
 
 # this is needed for Travis to pass the test in mac
 os.environ["KMP_DUPLICATE_LIB_OK"] = "True"
+# make sure the GPU is not used
+os.environ["CUDA_VISIBLE_DEVICES"] = ""
+
 import pytest
 import shutil
 import pathlib


### PR DESCRIPTION
Every now and then you can hit a plateau where the validation chi2 does not improve for some number of epochs, then the fit finishes early with a really bad chi2. This `threshold` (which can be added to the fitting parameters) will force `n3fit` not to consider the run as acceptable until the threshold has not been reached.

This feature was in the first versions of `n3fit` (when the `alpha` and `beta` exponents were fitted) and the fit rarely stopped too early so I removed it (I think it went away with the refactoring of the stopping). Now that most of the runs are done with `trainable: False` this seems to be more of a problem. I imagine the fixed exponents can give the NN a hard time at times.

The documentation of this new feature of the runcard will be in #767 