### PR TITLE
Upload a conda package per branch 

### DIFF
--- a/.ciscripts/build-deploy-linux.sh
+++ b/.ciscripts/build-deploy-linux.sh
@@ -9,8 +9,15 @@ set -v
 #Set up netrc file for uploading/downloading
 echo "$NETRC_FILE" | base64 --decode > ~/.netrc
 
+# If upload non master, add an extra string to the build
+APPEND_BUILD=''
+if [ "${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}" != 'master'  ] && [ "$UPLOAD_NON_MASTER" == true ];
+then
+    APPEND_BUILD=--append-file conda-recipe/non_master.yml
+fi
+
 #Build package
-CONDA_PY=$CONDA_PY conda build -q conda-recipe
+CONDA_PY=$CONDA_PY conda build -q conda-recipe ${APPEND_BUILD}
 if [ $? != 0 ]; then
 	echo failed to build
 	exit 1

--- a/.ciscripts/build-deploy-osx.sh
+++ b/.ciscripts/build-deploy-osx.sh
@@ -5,7 +5,14 @@ set -v
 #Set up netrc file for uploading/downloading
 echo "$NETRC_FILE" | base64 --decode > ~/.netrc
 
-conda build -q conda-recipe
+# If upload non master, add an extra string to the build
+APPEND_BUILD=''
+if [ "${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}" != 'master'  ] && [ "$UPLOAD_NON_MASTER" == true ];
+then
+    APPEND_BUILD=--append-file conda-recipe/non_master.yml
+fi
+
+conda build -q conda-recipe ${APPEND_BUILD}
 if [ $? != 0 ]; then
 	echo failed to build
 	exit 1

--- a/conda-recipe/non_master.yml
+++ b/conda-recipe/non_master.yml
@@ -1,0 +1,4 @@
+build:    
+    string: "PR"
+    track_features:
+      - non-master


### PR DESCRIPTION
This is the cleanest way I could think of for having several nnpdf builds in the server when the upload_non_master flag is set to true.

Things to note:

- I haven't tested it (it works locally though)
- When you use append-file you cannot use jinja
- I am very surprised conda has no `provides` or `priority` flags??

I guess what's missing is to take the branch name automatically but the second point prevents me from doing it... opening the PR in case someone has an easy solution for that wants to do something else (I don't think I will because I don't use conda and even if I did, on testing this locally I think I would prefer to build the package locally and then "scp it" wherever rather than waiting for Travis).

Addresses #780.

