### PR TITLE
Changing empty systematics test from test_commondataparser.py

### DIFF
--- a/validphys2/src/validphys/tests/test_commondataparser.py
+++ b/validphys2/src/validphys/tests/test_commondataparser.py
@@ -17,6 +17,12 @@ def test_basic_commondata_loading():
     assert res.nsys == 25
     assert isinstance(res.systype_table, pd.DataFrame)
 
+    # Test a dataset with no systematics
+    emptysyscd = l.check_posset(theoryID=162, setname='POSDYCBD', postlambda=1e-10)
+    emptysysres = load_commondata(emptysyscd.commondataspec)
+    assert emptysysres.nsys == 0
+    assert emptysysres.systype_table.empty is True
+
 
 def test_commondata_with_cuts():
     l = Loader()


### PR DESCRIPTION
#807 added systematics for `CMSWCHARMRAT` and now no other dataset suffers from the `nsys=0` problem.

I think we should discourage having tests that rely on the number of datapoints/systematics in the future (imho).

Also, we should probably figure out a way to auto rebase whenever a new test gets added after a branching point