### PR TITLE
Kinematic tables

### DIFF
--- a/validphys2/src/validphys/kinematics.py
+++ b/validphys2/src/validphys/kinematics.py
@@ -159,3 +159,16 @@ def xq2map_with_cuts(experiment, commondata, cuts):
     return XQ2Map(experiment, commondata, fitted_kintable, empty)
 
 experiments_xq2map = collect(xq2map_with_cuts, ('experiments', 'experiment'))
+
+
+@table
+def kinematics_table(commondata, kinlimits):
+    """
+    Table containing the kinematics of a commondata object,
+    indexed by their datapoint id.
+    """
+    ld_cd = commondata.load()
+    labels = [kinlimits[kin] for kin in ('k1', 'k2', 'k3')]
+    res = pd.DataFrame(ld_cd.get_kintable(), columns=labels)
+
+    return res


### PR DESCRIPTION
A small action that returns a table containing information about the kinematics of a commondata object.

Example runcard:

```yaml
experiments:
- experiment: NTVDMN
  datasets:
  - {dataset: NTVNUDMNFe, frac: 0.5, cfac: [MAS]}
  - {dataset: NTVNBDMNFe, frac: 0.5, cfac: [MAS]}
- experiment: ATLAS
  datasets:
  - {dataset: ATLASWZRAP11CC, frac: 1.0, cfac: [QCD]}
  - {dataset: ATLASWZRAP11CF, frac: 1.0, cfac: [QCD]}
  - {dataset: ATLASWZRAP11, frac: 0.5, cfac: [QCD]}
  - {dataset: ATLAS_WCHARM_WP_DIFF_7TEV, frac: 1.0, sys: 10}
  - {dataset: ATLAS_WCHARM_WM_DIFF_7TEV, frac: 1.0, sys: 10}


theoryid: 53

use_cuts: nocuts

template_text: |
  {@with experiments@}
  {@with experiment@}
  # {@dataset_input@}
  {@kinematics_table@}
  {@endwith@}
  {@endwith@}

actions_:
  - report(main=True)

```