### PR TITLE
Releasing GIL for C++ methods

### DIFF
--- a/libnnpdf/wrapper/CMakeLists.txt
+++ b/libnnpdf/wrapper/CMakeLists.txt
@@ -48,6 +48,7 @@ set_source_files_properties(./src/nnpdf.i PROPERTIES CPLUSPLUS ON)
 include_directories(../src)
 
 # Add swig module
+SET(CMAKE_SWIG_FLAGS "-threads")
 if (${CMAKE_VERSION} VERSION_LESS "3.8.0")
     swig_add_module(nnpdf python ./src/nnpdf.i)
 else()


### PR DESCRIPTION
Not too sure if what I've done is correct, but it _seems_ to be having the desired effect. Essentially it now releases the python GIL when you call a swig method.

I now see a marked improvement since I can run `MakeReplica` using `concurrent.futures.ThreadPoolExecutor` almost twice as fast.

See https://github.com/swig/swig/issues/927 and section 2.6 of http://www.swig.org/Doc3.0/SWIGDocumentation.pdf