### PR TITLE
Adding back action for dataset index

### DIFF
--- a/validphys2/src/validphys/theorycovariance/construction.py
+++ b/validphys2/src/validphys/theorycovariance/construction.py
@@ -36,10 +36,8 @@ collected_theoryids = collect('theoryids',
 def dataset_index_byprocess(groups_index):
     """Return a multiindex with index
        per dataset per point, ordered by process"""
-    dsnames = []
     ids = groups_index.get_level_values("id")
-    for dsname in groups_index.get_level_values("dataset"):
-        dsnames.append(dsname)
+    dsnames = list(groups_index.get_level_values("dataset"))
     processnames = [process_lookup(dsname) for dsname in dsnames]
     groups_index.droplevel(level="group")
     newindex = pd.MultiIndex.from_arrays([processnames, dsnames, ids],


### PR DESCRIPTION
This is a useful action which I removed in the data keyword PR, but I'm adding back an analogy with groups instead of experiments.