### PR TITLE
Re-add removed version.cmake file

### DIFF
--- a/version.cmake
+++ b/version.cmake
@@ -1,0 +1,3 @@
+execute_process(COMMAND python -c "import ${LIBRARY}.version ; print(${LIBRARY}.version.__file__)" OUTPUT_VARIABLE VERSION_PATH)
+STRING(STRIP ${VERSION_PATH} VERSION_PATH)
+file(WRITE ${VERSION_PATH} ${GIT_VERSION})


### PR DESCRIPTION
At some point this file was removed, nobody realised I think because it is only used when you do `VP_DEV=off` or `N3_DEV=off` which I guess nobody does.