### PR TITLE
fix conda build on OSX to 3.18.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ env:
     - OUTPUT_CHANNEL=conda-private
     - UPLOAD_NON_MASTER="false"
     - CONDA_BUILD_SYSROOT="${CONDAPATH}/MacOSX10.9.sdk"
-    # pin conda build on both platforms because of issue with channel name
+    # pin conda build on OSX because of issue with channel name
     # https://github.com/NNPDF/nnpdf/issues/915
     - CONDA_BUILD_VERSION=3.18.11
 


### PR DESCRIPTION
The last confirmed working version, also exists for both python 3.8 and 3.7