### PR TITLE
Use API in vp-nextfitruncard

### DIFF
--- a/validphys2/examples/effective_exponents/runcardreport.md
+++ b/validphys2/examples/effective_exponents/runcardreport.md
@@ -1,5 +1,5 @@
 % Next runcard:
 
 ```yaml
-{@next_effective_exponents_yaml@}
+{@iterated_runcard_yaml@}
 ```

--- a/validphys2/src/validphys/eff_exponents.py
+++ b/validphys2/src/validphys/eff_exponents.py
@@ -401,7 +401,7 @@ fmt = lambda a: float(significant_digits(a, 4))
 next_fit_eff_exps_table = collect("next_effective_exponents_table", ("fitpdfandbasis",))
 
 
-def next_effective_exponents_yaml(
+def iterated_runcard_yaml(
     fit: FitSpec, next_fit_eff_exps_table, _updated_description=None
 ):
     """
@@ -427,7 +427,7 @@ def next_effective_exponents_yaml(
     be written to a file e.g
 
     >>> from validphys.api import API
-    >>> yaml_output = API.next_effective_exponents_yaml(
+    >>> yaml_output = API.iterated_runcard_yaml(
     ...     fit=<fit name>,
     ...     _updated_description="My iterated fit"
     ... )

--- a/validphys2/src/validphys/scripts/vp_nextfitruncard.py
+++ b/validphys2/src/validphys/scripts/vp_nextfitruncard.py
@@ -101,7 +101,7 @@ def main():
 
     updated_description = interactive_description(description)
 
-    iterated_runcard_yaml = API.next_effective_exponents_yaml(
+    iterated_runcard_yaml = API.iterated_runcard_yaml(
         fit=input_fit, _updated_description=updated_description
     )
 

--- a/validphys2/src/validphys/tests/test_effexponents.py
+++ b/validphys2/src/validphys/tests/test_effexponents.py
@@ -25,7 +25,7 @@ def test_next_runcard():
     ite2_runcard.pop("pdf")  # Removing the PDF key, it's an artefact of as_input
 
     predicted_ite2_runcard = yaml.safe_load(
-        API.next_effective_exponents_yaml(fit=FIT)
+        API.iterated_runcard_yaml(fit=FIT)
     )
 
     # Remove all seed keys from the runcards since these are randomly generated


### PR DESCRIPTION
Just a small change on top of the really nice script from #863 

I use the API so there is no duplicated code, this should make any future updating a bit easier.

This required making a small change to the provider to use an internal variable to update description

This also has the nice effect that if you don't own the fit, it gets downloaded automatically using the remote loader. (from my perspective - actually the main reason I changed this)

I also updated the seed generation to be able to generate any unsigned long int, since this is what is used by both our internal RNG and numpy - in practice this probably makes no difference but seemed a little neater

Let me know what you think!

BTW I checked by putting a random seed in that the output is identical doing it this way (since anyway the code is basically the same) but please feel free to check!

inadvertently closes #928 