### PR TITLE
total chi2/phi use experiments

### DIFF
--- a/validphys2/src/validphys/closuretest/closure_results.py
+++ b/validphys2/src/validphys/closuretest/closure_results.py
@@ -273,7 +273,7 @@ fits_exps_bootstrap_chi2_central = collect(
     "experiments_bootstrap_chi2_central", ("fits", "fitcontext")
 )
 fits_level_1_noise = collect(
-    "total_experiments_chi2data", ("fits", "fitinputcontext", "fitunderlyinglaw")
+    "total_chi2_data", ("fits", "fitinputcontext", "fitunderlyinglaw")
 )
 
 

--- a/validphys2/src/validphys/config.py
+++ b/validphys2/src/validphys/config.py
@@ -1421,6 +1421,28 @@ class CoreConfig(configparser.Config):
                 )
             return validphys.filters.filter_closure_data_by_experiment
 
+    @configparser.explicit_node
+    def produce_total_chi2_data(self, fitthcovmat):
+        """If there is no theory covmat for the fit, then calculate the
+        total chi2 by summing the chi2 from each experiment.
+        """
+        import validphys.results
+
+        if fitthcovmat is None:
+            return validphys.results.total_chi2_data_from_experiments
+        return validphys.results.dataset_inputs_abs_chi2_data
+
+    @configparser.explicit_node
+    def produce_total_phi_data(self, fitthcovmat):
+        """If there is no theory covmat for the fit, then calculate the total
+        phi using contributions from each experiment.
+        """
+        import validphys.results
+
+        if fitthcovmat is None:
+            return validphys.results.total_phi_data_from_experiments
+        return validphys.results.dataset_inputs_phi_data
+
 
 
 class Config(report.Config, CoreConfig, ParamfitsConfig):

--- a/validphys2/src/validphys/dataplots.py
+++ b/validphys2/src/validphys/dataplots.py
@@ -30,17 +30,17 @@ from validphys.utils import sane_groupby_iter, split_ranges, scale_from_grid
 log = logging.getLogger(__name__)
 
 @figure
-def plot_chi2dist_experiments(total_experiments_chi2data, experiments_chi2_stats, pdf):
+def plot_chi2dist_experiments(total_chi2_data, experiments_chi2_stats, pdf):
     """Plot the distribution of chi²s of the members of the pdfset."""
-    fig, ax = _chi2_distribution_plots(total_experiments_chi2data, experiments_chi2_stats, pdf, "hist")
+    fig, ax = _chi2_distribution_plots(total_chi2_data, experiments_chi2_stats, pdf, "hist")
     ax.set_title(r"Experiments $\chi^2$ distribution")
     return fig
 
 
 @figure
-def kde_chi2dist_experiments(total_experiments_chi2data, experiments_chi2_stats, pdf):
+def kde_chi2dist_experiments(total_chi2_data, experiments_chi2_stats, pdf):
     """KDE plot for experiments chi2."""
-    fig, ax = _chi2_distribution_plots(total_experiments_chi2data, experiments_chi2_stats, pdf, "kde")
+    fig, ax = _chi2_distribution_plots(total_chi2_data, experiments_chi2_stats, pdf, "kde")
     ax.set_ylabel(r"Density")
     ax.set_title(r"Experiments $\chi^2 KDE plot$")
     return fig

--- a/validphys2/src/validphys/fitdata.py
+++ b/validphys2/src/validphys/fitdata.py
@@ -131,7 +131,7 @@ def replica_data(fit, replica_paths):
 
 
 @table
-def fit_summary(fit_name_with_covmat_label, replica_data, dataset_inputs_abs_chi2_data, dataset_inputs_phi_data):
+def fit_summary(fit_name_with_covmat_label, replica_data, total_chi2_data, total_phi_data):
     """ Summary table of fit properties
         - Central chi-squared
         - Average chi-squared
@@ -149,15 +149,15 @@ def fit_summary(fit_name_with_covmat_label, replica_data, dataset_inputs_abs_chi
 
     """
     nrep = len(replica_data)
-    ndata = dataset_inputs_abs_chi2_data.ndata
-    central_chi2 = dataset_inputs_abs_chi2_data.central_result / ndata
-    member_chi2 = dataset_inputs_abs_chi2_data.replica_result.error_members() / ndata
+    ndata = total_chi2_data.ndata
+    central_chi2 = total_chi2_data.central_result / ndata
+    member_chi2 = total_chi2_data.replica_result.error_members() / ndata
 
     nite = [x.nite for x in replica_data]
     etrain = [x.training for x in replica_data]
     evalid = [x.validation for x in replica_data]
 
-    phi, _ = dataset_inputs_phi_data
+    phi, _ = total_phi_data
     phi_err = np.std(member_chi2)/(2.0*phi*np.sqrt(nrep))
 
     VET = ValueErrorTuple


### PR DESCRIPTION
provided no theory covmat is being used. I don't see an imminent issue with this and it significantly speeds up comp fits

@tgiani please can you run a compfits using this and check the numbers are the same in particular in the fit summary table and the total row of the chi2 table?

Note I also changed the provider name for some plot functions which I guess we never use because the providers were non-existent before. Hopefully they work now.

Finally I also added a small fix for a bug I guess was introduced in #862 where a function relied on an import of `linalg` but the import didn't exist @RosalynLP can you check you agree with that? (EDIT: specifically in `results.py` with `experiments_invcovmat`)

closes #860 closes #924 