### PR TITLE
Add a __cause__ to default exception

### DIFF
--- a/validphys2/src/validphys/config.py
+++ b/validphys2/src/validphys/config.py
@@ -243,8 +243,8 @@ class CoreConfig(configparser.Config):
             try:
                 with self.set_context(ns=self._curr_ns.new_child({"theoryid": thid})):
                     _, data_val = self.parse_from_("fit", data_key, write=False)
-            except ConfigError:
-                raise e
+            except ConfigError as inner_error:
+                raise e from inner_error
         # now fill in a unique key "data_input" regardless of new or old fit
         # for uniformity
         data_input = self.produce_data_input(**{data_key: data_val})


### PR DESCRIPTION
This makes it easier to find the underlying problems in issues
like #936. E.g. by running vp-comparefits --debug -i.