### PR TITLE
Change formatting of Training length hist and T/V scatter plots

### DIFF
--- a/validphys2/src/validphys/dataplots.py
+++ b/validphys2/src/validphys/dataplots.py
@@ -686,8 +686,8 @@ def plot_training_validation(fit, replica_data, replica_filters=None):
 
     ax.set_title(fit.label)
 
-    ax.set_xlabel(r"$\chi^2/N_{dat}$ train")
-    ax.set_ylabel(r"$\chi^2/N_{dat}$ valid")
+    ax.set_xlabel(r"$\chi^2/N_{dat}$ training")
+    ax.set_ylabel(r"$\chi^2/N_{dat}$ validation")
 
     min_max_lims = [
         min([*ax.get_xlim(), *ax.get_ylim()]),


### PR DESCRIPTION
Before: https://vp.nnpdf.science/qa-7Pw-lSzGK8kVK2UOU_Q==/

 - TL plot was "density" hist but I personally don't think we want a PDF here because it includes bin width in integral and instead I think a PMF of proprtion of replicas in each bar is more useful scale.
 - T/V scatter has different x and y axis so "skewness" comparisons are hard to make

After: https://vp.nnpdf.science/4rY-pmBMRX-n3SSL7HgP_g==/

 - TL plot changed as described above, now can instantly see e.g that ~10% of replicas went to ~max training length
 - T/V scatter now has equal axis, I set height and width to default width so it's a bit taller and I add a line of y=x for reference

Is there a historical reason for doing this? Otherwise does anyone hate it? I think it's easier to understand.