### PR TITLE
Fix closure_results to account for data keyword

### DIFF
--- a/validphys2/examples/closure_templates/report.md
+++ b/validphys2/examples/closure_templates/report.md
@@ -71,9 +71,9 @@ Training validation
 -------------------
 {@fits plot_training_validation@}
 
-$\chi^2$ by experiment
+$\chi^2$ by {@processed_metadata_group@}
 ----------------------
-{@plot_fits_experiments_chi2@}
+{@plot_fits_groups_data_chi2@}
 
 $\chi^2$ by dataset comparisons
 -------------------------------

--- a/validphys2/examples/closure_templates/runcard.yaml
+++ b/validphys2/examples/closure_templates/runcard.yaml
@@ -6,8 +6,8 @@ meta:
     author: Lazy Person
 
 closure:
-    fit: {id: 071018-edi-001}
-    pdf: {id: 071018-edi-001, label: "test closures"}
+    fit: {id: 191015-mw-001}
+    pdf: {id: 191015-mw-001, label: "test closures"}
     theory:
       from_: fit
     theoryid:
@@ -66,9 +66,6 @@ pdf_uncertainty_report:
 
 template: report.md
 
-experiments:
-    from_: fit
-
 dataspecs:
   - theoryid:
       from_: closure
@@ -78,12 +75,16 @@ dataspecs:
       from_: closure
     speclabel:
       from_: closure
+    data_input:
+      from_: fitinputcontext
    
 normalize:
   normalize_to: 1
 
 datanorm:
     normalize_to: data
+
+metadata_group: experiment
 
 actions_:
   - report(main=true)

--- a/validphys2/src/validphys/compareclosuretemplates/comparecard.yaml
+++ b/validphys2/src/validphys/compareclosuretemplates/comparecard.yaml
@@ -45,33 +45,8 @@ pdf_report:
     meta: Null
     template: pdf.md
 
-experiments:
-    from_: fit
-
 description:
     from_: fit
-
-dataspecs:
-  - fit:
-      from_: current
-    pdf:
-      from_: current
-    theory:
-      from_: current
-    theoryid:
-      from_: current
-    speclabel:
-      from_: current
-  - fit:
-      from_: reference
-    pdf:
-      from_: reference
-    theory:
-      from_: reference
-    theoryid:
-      from_: reference
-    speclabel:
-      from_: reference
 
 pdfnormalize:
     - normtitle: Absolute


### PR DESCRIPTION
Now you can actually use the closure estimators for a single closure fit

I've just changed the collects here and made sure `experiments` key isn't in the report

Here is an old comp fits I ran ages and ages ago: https://vp.nnpdf.science/fweyXKx9RQWbBcofOgF2cw==/

Here I check the numbers are reproduced: https://vp.nnpdf.science/BtNgsoMESXWdf6oeJHhiqw==/

I'm satisfied that the numbers are reproduced. The discrepancies are small and in functions which bootstrap and at any rate are consistent up to bootstrap error.