### PR TITLE
bump version of matplotlib to 3.3.0+

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -36,7 +36,7 @@ requirements:
         - pkg-config
         - python # requirements for validphys
         - reportengine >=0.28 # see https://github.com/NNPDF/reportengine
-        - matplotlib >=2.0.1,<3 | >=3.0.2
+        - matplotlib >=3.3.0
         - blessings
         - scipy >=0.19.1
         - pandas =1.0


### PR DESCRIPTION
I'm slightly concerned by the convoluted versioning that this is replacing. I think it was something to do with

matplotlib/matplotlib#13276

NNPDF/reportengine#17

It seems to be fixed now anyway?