### PR TITLE
Fix CMSDY2D11 filter info

### DIFF
--- a/buildmaster/filters/CMS.cc
+++ b/buildmaster/filters/CMS.cc
@@ -224,16 +224,16 @@ void CMSWMASY47FBFilter::ReadData()
 }
 
 
-/*******   CMS DY 2D Z > ll 7 TeV 4.5 fb^{-1} data ***
- *******   ABSOLUTE VALUE dMll/dY distribution     ***
+/*******   CMS DY 2D Z > \mu \mu 7 TeV 4.5 fb^{-1} data ***
+ *******   ABSOLUTE VALUE dM_{\mu \mu}/dY distribution  ***
  * Check data and writes it in a common format
  *
  * data/CMSDY2D45FB/DATA_CMSDY2DABS45FB.dat
  * data/CMSDY2D45FB/COVMAT_CMSDYABS45FB.dat
  *
- * Double differential Drell-Yan cross section in the combined di-electron and
- * di-muon channels, from Z decay with 4.5 fb^-1 from the 2011 dataset
- * ArXiv:1301.7291
+ * Double differential Drell-Yan cross section in the dimuon channel,
+ * from Z decay with 4.5 fb^{-1} from the 2011 dataset
+ * ArXiv:1310.7291
  * Raw data from JR's root files obtained from CMS experimentalists
  */
 


### PR DESCRIPTION
Small fixes to the info on CMSDY2D11 in the filter. Firstly, I believe the measurement is in the dimuon channel rather than the combined channel. From the paper:

“This analysis measures the DY dimuon and dielectron invariant mass spectra, dσ/dm, in the range 15 to 1500 GeV, and then corrects them for detector geometrical acceptance and kinematic requirements to obtain the spectra corresponding to the full phase space. The double differential cross section d2σ/dm d|y| is measured in the dimuon channel within the detector acceptance in the range of absolute dimuon rapidity from 0 to 2.4 and dimuon invariant mass from 20 to 1500 GeV. A d2σ/dm d|y| analysis of the electron channel has not been performed.”

Secondly, the arXiv number is fixed