### PR TITLE
Add __cause__ to produce_data_input

### DIFF
--- a/validphys2/src/validphys/config.py
+++ b/validphys2/src/validphys/config.py
@@ -232,7 +232,7 @@ class CoreConfig(configparser.Config):
         _, theory = self.parse_from_("fit", "theory", write=False)
         thid = theory["theoryid"]
 
-        data_input = self.parse_data_input_from_(
+        data_input = self._parse_data_input_from_(
             "fit", {"theoryid": thid}
         )
         return {"theoryid": thid, "data_input": data_input}
@@ -1206,7 +1206,7 @@ class CoreConfig(configparser.Config):
         # TODO: get rid of libnnpdf Experiment
         return DataGroupSpec(name=group_name, datasets=datasets, dsinputs=data_input)
 
-    def parse_data_input_from_(
+    def _parse_data_input_from_(
         self,
         parse_from_value: (str, type(None)),
         additional_context: (dict, type(None)) = None,
@@ -1266,7 +1266,7 @@ class CoreConfig(configparser.Config):
 
         """
         # parse from current namespace with no additional context.
-        return self.parse_data_input_from_(None)
+        return self._parse_data_input_from_(None)
 
     def parse_metadata_group(self, group: str):
         """User specified key to group data by. The key must exist in the


### PR DESCRIPTION
After #937 I thought it would be good if we also got a cause when trying to produce `data_input` so I extracted the underlying function which raises the inner error from the outer one and then call it in both `fitinputcontext` and `data_input` production rules.

This is slightly gross but I tried to add decent amount of docstring so that it's at least vaguely clear to other people