### PR TITLE
sort hyperopt dataframe by loss

### DIFF
--- a/validphys2/src/validphys/hyperoptplot.py
+++ b/validphys2/src/validphys/hyperoptplot.py
@@ -456,6 +456,7 @@ def hyperopt_table(hyperopt_dataframe):
     filters set in the commandline arguments.
     """
     dataframe, _ = hyperopt_dataframe
+    dataframe.sort_values(by=['loss'], inplace=True)
     return dataframe
 
 


### PR DESCRIPTION
This seemed more sensible than sorting by 'iteration'. 