### PR TITLE
Print best epoch instead of stop epoch to fitinfo file

### DIFF
--- a/n3fit/src/n3fit/io/writer.py
+++ b/n3fit/src/n3fit/io/writer.py
@@ -76,7 +76,7 @@ class WriterWrapper:
             replica_path_set,
             fitname,
             self.q2,
-            self.stopping_object.stop_epoch,
+            self.stopping_object.e_best_chi2,
             vl_chi2,
             tr_chi2,
             true_chi2,

--- a/n3fit/src/n3fit/stopping.py
+++ b/n3fit/src/n3fit/stopping.py
@@ -371,8 +371,13 @@ class Stopping:
 
     @property
     def e_best_chi2(self):
-        """ Epoch of the best chi2 """
-        return self.history.best_epoch
+        """ Epoch of the best chi2, if there is no best epoch
+        return the last epoch"""
+        be = self.history.best_epoch
+        if be is None:
+            return self.stop_epoch
+        return be
+
 
     @property
     def stop_epoch(self):
@@ -551,30 +556,6 @@ Total: training = {total_tr_loss} validation = {total_vl_loss}
 """
             file_list.append(strout)
         return file_list
-
-    def to_dict(self, model_trainer):
-        """ Generates a dict with all the information about the stopping.
-        It needs a ``model_trainer`` object to compute the chi2 of
-        the training and experimental models after the best weights are updated.
-
-        It generates a dictionary with:
-            - epoch of the stop
-            - epoch of best fit
-            - status of the positivity
-            - tr chi2
-            - vl chi2
-            - exp chi2
-        """
-        tr_chi2, val_chi2, exp_chi2 = model_trainer.evaluate(self)
-        dict_out = {
-                "vl_chi2" : val_chi2,
-                "tr_chi2" : tr_chi2,
-                "exp_chi2" : exp_chi2,
-                "stop_epoch" : self.stop_epoch,
-                "epoch_of_best_fit" : self.e_best_chi2,
-                "positivity_status" : self.positivity_status()
-                }
-        return dict_out
 
 
 class Validation:

--- a/n3fit/src/n3fit/tests/regressions/quickcard_1.json
+++ b/n3fit/src/n3fit/tests/regressions/quickcard_1.json
@@ -1,7 +1,7 @@
 {
   "preprocessing": "",
   "stop_epoch": 1000,
-  "best_epoch": null,
+  "best_epoch": 1000,
   "erf_tr": 33.213114420572914,
   "erf_vl": 28.218009317727912,
   "chi2": 21.431137768190297,

--- a/n3fit/src/n3fit/tests/test_fit.py
+++ b/n3fit/src/n3fit/tests/test_fit.py
@@ -51,7 +51,7 @@ def load_data(info_file):
             lines = f.readlines()
             # Line 2 contains epochs, val, tr, exp, POS
             sp_lineone = lines[0].split()
-            ret["stop_epoch"] = int(sp_lineone[0])
+            ret["best_epoch"] = int(sp_lineone[0])
             ret["erf_vl"] = float(sp_lineone[1])
             ret["erf_tr"] = float(sp_lineone[2])
             ret["chi2"] = float(sp_lineone[3])


### PR DESCRIPTION
So that the TL shows the same information for `n3fit` and `nnfit`.

Example fit: https://vp.nnpdf.science/di9KFNx9TWGPIHoFPJ2LDw==/

Closes #989 