### PR TITLE
update tests to data keyword, where appropriate

### DIFF
--- a/validphys2/src/validphys/tests/conftest.py
+++ b/validphys2/src/validphys/tests/conftest.py
@@ -22,17 +22,11 @@ def tmp(tmpdir):
 
 # Here define the default config items like the PDF, theory and experiment specs
 
-EXPERIMENTS = [
-    {
-        'experiment': 'NMC',
-        'datasets': [{'dataset': 'NMC'}]},
-    {
-        'experiment': 'ATLASTTBARTOT',
-        'datasets': [{'dataset': 'ATLASTTBARTOT', 'cfac':['QCD']}]},
-    {
-        'experiment': 'CMSZDIFF12',
-        'datasets': [{'dataset': 'CMSZDIFF12', 'cfac':('QCD', 'NRM'), 'sys':10}]}
-    ]
+DATA = [
+    {'dataset': 'NMC'},
+    {'dataset': 'ATLASTTBARTOT', 'cfac':['QCD']},
+    {'dataset': 'CMSZDIFF12', 'cfac':('QCD', 'NRM'), 'sys':10}
+]
 
 # Experiments which have non trivial correlations between their datasets
 CORR_DATA = [
@@ -53,13 +47,9 @@ SINGLE_EXP = [
             {'dataset': 'CMSZDIFF12', 'cfac':('QCD', 'NRM'), 'sys':10}]}]
 
 WEIGHTED_DATA = [
-    {
-        'experiment': 'NMC Experiment',
-        'datasets': [{'dataset': 'NMC'}]},
-    {
-        'experiment': 'Weighted',
-        'datasets': [{'dataset': 'NMC', 'weight': 100}]},
-    ]
+    {'dataset': 'NMC'},
+    {'dataset': 'NMC', 'weight': 100},
+]
 
 PDF = "NNPDF31_nnlo_as_0118"
 HESSIAN_PDF = "NNPDF31_nnlo_as_0118_hessian"
@@ -70,7 +60,7 @@ FIT_ITERATED = "191015-mw-001_for_testing_iterated"
 base_config = dict(
         pdf=PDF,
         use_cuts='nocuts',
-        experiments=EXPERIMENTS,
+        dataset_inputs=DATA,
         theoryid=THEORYID,
         use_fitthcovmat=False
     )
@@ -96,13 +86,13 @@ def data_witht0_config():
 @pytest.fixture(scope='module')
 def data_singleexp_witht0_config(data_witht0_config):
     config_dict = dict(data_witht0_config)
+    config_dict.pop("dataset_inputs")
     config_dict.update({'experiments': SINGLE_EXP})
     return config_dict
 
 @pytest.fixture(scope='module')
 def data_with_correlations_config():
     corr_dict = dict(base_config)
-    corr_dict.pop("experiments")
     corr_dict.update(dataset_inputs=CORR_DATA)
     return corr_dict
 
@@ -115,7 +105,7 @@ def data_with_correlations_internal_cuts_config(data_with_correlations_config):
 @pytest.fixture(scope='module')
 def weighted_data_witht0_config(data_witht0_config):
     config_dict = dict(data_witht0_config)
-    config_dict.update({'experiments': WEIGHTED_DATA})
+    config_dict.update({'dataset_inputs': WEIGHTED_DATA})
     return config_dict
 
 def pytest_runtest_setup(item):

--- a/validphys2/src/validphys/tests/test_covmats.py
+++ b/validphys2/src/validphys/tests/test_covmats.py
@@ -135,7 +135,7 @@ def test_sqrt_covmat(data_config):
         # a ValueError
         sqrt_covmat(np.array([]))
 
-    exps = API.experiments(**data_config)
+    exps = API.experiments_data(**data_config)
 
     for exp in exps:
         ld_exp = exp.load()

--- a/validphys2/src/validphys/tests/test_plots.py
+++ b/validphys2/src/validphys/tests/test_plots.py
@@ -19,23 +19,21 @@ def test_plotpdfs():
 @pytest.mark.linux
 @pytest.mark.mpl_image_compare
 def test_dataspecschi2():
-    experiments = [
-        {
-            'experiment': 'NMCexp',
-            'datasets': [{'dataset': 'NMC'}]},
-        {
-            'experiment': 'ATLASxp',
-            'datasets': [{'dataset': 'ATLASTTBARTOT', 'cfac':['QCD']}]},
-        {
-            'experiment': 'CMSexp',
-            'datasets': [{'dataset': 'CMSZDIFF12', 'cfac':('QCD', 'NRM'), 'sys':10}]}
-        ]
+    dsinpts = [
+        {'dataset': 'NMC'},
+        {'dataset': 'ATLASTTBARTOT', 'cfac':['QCD']},
+        {'dataset': 'CMSZDIFF12', 'cfac':('QCD', 'NRM'), 'sys':10}
+    ]
     dataspecs = [
         {'pdf': PDF, 'theoryid': THEORYID, 'speclabel': 'no t0'},
         {'pdf': PDF, 'theoryid': THEORYID, 'use_t0': False, 'speclabel': 'with t0'}
     ]
     return API.plot_dataspecs_datasets_chi2(
-        experiments=experiments, dataspecs=dataspecs, use_cuts='nocuts', metadata_group='experiment')
+        dataset_inputs=dsinpts,
+        dataspecs=dataspecs,
+        use_cuts='nocuts',
+        metadata_group='experiment'
+    )
 
 @pytest.mark.linux
 @pytest.mark.mpl_image_compare

--- a/validphys2/src/validphys/tests/test_rebuilddata.py
+++ b/validphys2/src/validphys/tests/test_rebuilddata.py
@@ -25,7 +25,7 @@ REGRESSION_FOLDER = pathlib.Path(__file__).with_name("regressions")
 
 
 def parse_test_output(filename):
-    """Parse a dump of a matrix like experiments_covmat."""
+    """Parse the output of groups_data_values."""
     df = sane_load(filename, header=0, index_col=[0, 1, 2])
     return df
 

--- a/validphys2/src/validphys/tests/test_regressions.py
+++ b/validphys2/src/validphys/tests/test_regressions.py
@@ -55,7 +55,7 @@ def make_table_comp(loader_func):
 def test_expcovmat(data_config):
     mat = API.groups_covmat_no_table(**data_config)
     covmats = []
-    for exp in API.experiments(**data_config):
+    for exp in API.experiments_data(**data_config):
         cd = exp.datasets[0].commondata.load()
         covmats.append(NNPDF.ComputeCovMat(cd, cd.get_cv()))
     othermat = la.block_diag(*covmats)

--- a/validphys2/src/validphys/tests/test_weights.py
+++ b/validphys2/src/validphys/tests/test_weights.py
@@ -6,9 +6,9 @@ import numpy as np
 from validphys.api import API
 
 def test_weights_have_same_commondata(weighted_data_witht0_config):
-    exps = API.experiments(**weighted_data_witht0_config)
-    normal, weighted = exps
-    normalds, weightedds = normal.datasets[0].load(), weighted.datasets[0].load()
+    data = API.data(**weighted_data_witht0_config)
+    normal, weighted = data.datasets
+    normalds, weightedds = normal.load(), weighted.load()
     assert normalds.GetSys(0, 0).mult == weightedds.GetSys(0, 0).mult
     assert normalds.GetSys(0, 0).add == weightedds.GetSys(0, 0).add
 


### PR DESCRIPTION
As per title. I left pseudodata tests and single exp tests, the latter are technically a bit redundant now anyway but I can't be bothered to work out exactly how and I just wanted to separate this out from #1052 