### PR TITLE
Fix some typos in docs 

### DIFF
--- a/doc/sphinx/source/tutorials/closureestimators.rst
+++ b/doc/sphinx/source/tutorials/closureestimators.rst
@@ -27,7 +27,7 @@ These are:
 -  variance
 
    The mean across replicas of the :math:`\chi^2` between predictions
-   from a single replica and the central replica predictions. Can be
+   from a single replica and the central replica. Can be
    thought of as the variance of the replica predictions normalised by
    the covariance.
 

--- a/doc/sphinx/source/tutorials/closuretest.md
+++ b/doc/sphinx/source/tutorials/closuretest.md
@@ -115,7 +115,7 @@ fitting:
 ### Summary for each level of closure test
 
 See below for the keys which specify each level of closure test, other keys
-can be chosen by user
+can be chosen by the user.
 
 #### Level 0
 
@@ -145,7 +145,7 @@ closuretest:
   ...
 ```
 
-#### Level 0
+#### Level 2
 
 ```yaml
 fitting:
@@ -171,7 +171,7 @@ vital that the data is not rebuilt until all replicas have finished running.
 
 ### With `n3fit`
 
-Running a closure test with `n3fit` will require valid `n3fit` runcard, with
+Running a closure test with `n3fit` will require a valid `n3fit` runcard, with
 the closure test settings modified as shown
 [above](#preparing-the-closure-test-runcard). The difference
 between running a closure fit in `n3fit` and a standard fit is that the user is

--- a/doc/sphinx/source/tutorials/index.rst
+++ b/doc/sphinx/source/tutorials/index.rst
@@ -15,8 +15,8 @@ Tutorials
    ./APPLgrids_comp.md
    ./apfelcomb.md
    ./datthcomp.md
-   ./closureestimators.rst
    ./closuretest.md
+   ./closureestimators.rst
    ./conda.md
    ./pseudodata.md
    ./pdfbases.rst


### PR DESCRIPTION
I was reading the CT docs and found some typos changed also the order of fit and analysis which is something that was annoying me for absolutely no good reason.