### PR TITLE
Add option to omit 1 sigma error bars in pdf plots

### DIFF
--- a/validphys2/src/validphys/pdfplots.py
+++ b/validphys2/src/validphys/pdfplots.py
@@ -481,7 +481,7 @@ def plot_pdfs(
     corresponding to the index of the PDF in the list of PDFs, or a mixture
     of both.
 
-    mc_errors (bool): Plot 1σ bands in addition to 68% errors for Monte Carlo
+    show_mc_errors (bool): Plot 1σ bands in addition to 68% errors for Monte Carlo
     PDF.
     """
     yield from BandPDFPlotter(


### PR DESCRIPTION
Produce a more minimalistic version of the PDF plots that reduces some
amount of clutter, that is relatively irrelevant outside pdf specific
comparisons.