### PR TITLE
Add a plotting style with bigger labels

### DIFF
--- a/validphys2/src/validphys/mplstyles/biglabels.mplstyle
+++ b/validphys2/src/validphys/mplstyles/biglabels.mplstyle
@@ -1,0 +1,36 @@
+axes.grid               : True
+axes.titlesize          : large
+axes.prop_cycle        : cycler('color', ['66c2a5', 'fc8d62', '8da0cb', 'e78ac3', 'a6d854', 'ffd92f', 'e5c494', 'b3b3b3'])
+axes.labelsize          : medium
+axes.formatter.limits   : -5,5
+axes.formatter.use_mathtext : True
+axes.spines.top         : False
+axes.spines.right       : False
+
+errorbar.capsize        : 2
+
+font.size               : 14
+
+figure.figsize          : 7, 4.3
+
+grid.color              : cccccc
+grid.linestyle          : -
+grid.linewidth          : 0.05
+
+legend.fontsize         : small
+legend.numpoints        : 1
+legend.scatterpoints    : 1
+legend.loc              : best
+legend.fancybox         : True
+legend.framealpha       : 0.8
+
+lines.markersize        : 4
+
+mathtext.default        : regular
+
+xtick.labelsize         : medium
+ytick.labelsize         : medium
+xtick.top               : False
+ytick.right             : False
+
+svg.fonttype            : none


### PR DESCRIPTION
The default label sizes are intended for figures that occupy all of the
page, but we often want to have them at two or three columns. In that
case the plotting text is typically way too small. Add a style file that
makes them bigger.

At the moment one needs to run with

validphys --style <path/to>/biglabels.mplstyle

but I'll make a separate change to reportengine and vp to make that
simpler.