### PR TITLE
split up iterated_runcard_yaml 

### DIFF
--- a/validphys2/src/validphys/eff_exponents.py
+++ b/validphys2/src/validphys/eff_exponents.py
@@ -441,10 +441,7 @@ def iterate_preprocessing_yaml(fit, next_fit_eff_exps_table):
     be written to a file e.g
 
     >>> from validphys.api import API
-    >>> yaml_output = API.iterated_runcard_yaml(
-    ...     fit=<fit name>,
-    ...     _updated_description="My iterated fit"
-    ... )
+    >>> yaml_output = API.iterate_preprocessing_yaml(fit=<fit name>)
     >>> with open("output.yml", "w+") as f:
     ...     f.write(yaml_output)
 


### PR DESCRIPTION
For the closure fits I want to iterate the preprocessing and description without touching the seeds, it's convenient to split up the `iterated_runcard_yaml` rather than rewrite this functionality. The code should be functionally identical. I updated the docstrings which I think had a couple of errors.

I slightly changed how the flavours were iterated because before the flavours were taken from `check_basis` whereas now they're taken from the previous runcard. I think this won't affect anything because we almost always use the default flavours of the basis but it means that now all flavours in the fit runcard definitely get iterated or an error is raised before I think that some flavours could have been left unchanged silently!