### PR TITLE
Hopefully reduce build errors

### DIFF
--- a/validphys2/src/validphys/tests/test_pseudodata.py
+++ b/validphys2/src/validphys/tests/test_pseudodata.py
@@ -29,17 +29,11 @@ pdf: pseudodata_test_fit
 experiments:
   from_: fit
 
-theory:
-  from_: fit
-
 t0pdfset:
   from_: datacuts
 
 datacuts:
   from_: fit
-
-theoryid:
-  from_: theory
 
 use_cuts: fromfit
 """


### PR DESCRIPTION
I am guessing here, but after printing the test outputs in #1072 I noticed we download theory 53, which I think we wanted to avoid. We only were downloading it because it was in the config in one of the the `test_pseudodata` tests but you don't even need to specify theory here, hopefully this speeds up the pre test downloads whch I think was the point which the builds timed out.

closes #1071 