### PR TITLE
Speedup tests

### DIFF
--- a/validphys2/src/validphys/tests/test_pseudodata.py
+++ b/validphys2/src/validphys/tests/test_pseudodata.py
@@ -62,7 +62,7 @@ def setup_dicts(request):
 
 def test_read_fit_pseudodata():
     data_generator = API.read_fit_pseudodata(
-      fit="NNPDF31_nnlo_as_0118_DISonly_pseudodata",
+      fit="dummy_pseudodata_read_test_fit",
       use_cuts="fromfit"
     )
 
@@ -79,7 +79,7 @@ def test_read_fit_pseudodata():
         # if the input fit wasn't generated
         # with the savepseudodata flag set to true
         bad_gen = API.read_fit_pseudodata(
-            fit=FIT, use_cuts="fromfit"
+            fit="dummy_pseudodata_read_failure_test_fit", use_cuts="fromfit"
         )
         next(bad_gen)
 
@@ -87,7 +87,7 @@ def test_read_fit_pseudodata():
         # Check the enforcement of use_cuts being set
         # to fromfit is in place
         API.read_fit_pseudodata(
-          fit="NNPDF31_nnlo_as_0118_DISonly_pseudodata",
+          fit="dummy_pseudodata_read_test_fit",
           use_cuts="nocuts"
         )
         assert isinstance(e_info.__cause__, CheckError)


### PR DESCRIPTION
This is a quick fix and a bit unsatisfactory. I basically copied the offending fits which had theory 53 and then changed the config (and the md5) and reuploaded for use in tests.

We should really fix #1076  and #1075 but I think we want to get this problem solved and then do the right thing later.