### PR TITLE
Let the user know there could've been some problems with the indexing

### DIFF
--- a/validphys2/src/validphys/uploadutils.py
+++ b/validphys2/src/validphys/uploadutils.py
@@ -193,9 +193,7 @@ class ArchiveUploader(FileUploader):
         l = RemoteLoader()
         resource_list = getattr(l, self._loader_name)
 
-        if resource_name in resource_list:
-            return True
-        return False
+        return  resource_name in resource_list
 
     def _check_is_indexed(self, resource_name):
         """ Check whether the fit is correctly indexed in the server


### PR DESCRIPTION
Related to the discussion yesterday.

Before discussing how to best re-index or re-upload I think it is important that at least the code doesn't give the wrong message, i.e., if don't see any errors in your terminal it should really mean there were no errors.

So this just checks whether the fit was indexed.

This is a prototype but before adding the to-dos below (which are mostly cosmetic) I would like whether you think it is worth it or not @Zaharid @scarrazza 

To do:
-Control the wait time
-Add a command line argument to skip the wait
-Follow the structure of the rest of the class instead of just having a chunk of code there in the middle.

While this doesn't truly solve #1079 it makes it less of a problem.