### PR TITLE
Clarify number_of_replicas in running fit tutorial

### DIFF
--- a/doc/sphinx/source/tutorials/run-fit.md
+++ b/doc/sphinx/source/tutorials/run-fit.md
@@ -132,9 +132,10 @@ following the points presented above you can proceed with a fit.
 
 2. The `n3fit` program takes a `runcard.yml` as input and a replica number, e.g.
 ```n3fit runcard.yml replica``` where `replica` goes from 1-n where n is the
-maximum number of desired replicas. Note that if you desire for example a 100 
-replica fit you should launch more than 100 replicas (e.g. 130) because not 
-all the replicas will pass the checks in `postfit` ([see here](the-postfit-selection-criteria) for more info).
+maximum number of desired replicas. Note that if you desire, for example, a 100
+replica fit you should launch more than 100 replicas (e.g. 130) because not
+all of the replicas will pass the checks in `postfit`
+([see here](postfit-selection-criteria) for more info).
 
 3. Wait until you have fit results. Then run the `evolven3fit` program once to
 evolve all replicas using DGLAP. The arguments are `evolven3fit runcard_folder
@@ -143,7 +144,7 @@ above example), rather than the number you desire in the final fit.
 
 4. Wait until you have results, then use `postfit number_of_replicas
 runcard_folder` to finalize the PDF set by applying post selection criteria.
-This will produce a set of `number_of_replicas + 1` replicas. This time the 
+This will produce a set of `number_of_replicas + 1` replicas. This time the
 number of replicas should be that which you desire in the final fit (100 in the
 above example). Note that the
 standard behaviour of `postfit` can be modified by using various flags.

--- a/doc/sphinx/source/vp/scripts.rst
+++ b/doc/sphinx/source/vp/scripts.rst
@@ -38,6 +38,8 @@ Note that the command will still fail if fewer than the requested amount meet th
 flag can be useful when, for example, processing many fits simultaneously, where a specific number
 of replicas is not required, but instead at least a certain amount.
 
+.. _postfit-selection-criteria:
+
 The :code:`postfit` selection criteria
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
The expression `number_of_replicas` is used here for the number of replicas to launch, the number to evolve using `evolven3fit `and the number to give to `postfit`, whereas these would ordinarily not be the same. I just added some clarifying sentences so this is clearer to new members.