### PR TITLE
Add example runcard for future tests

### DIFF
--- a/validphys2/examples/future_test_example.yaml
+++ b/validphys2/examples/future_test_example.yaml
@@ -22,8 +22,8 @@ future:
     from_: theory
 
 present:
-  pdf: {id: 210219-n3fit-FD04, label: "PreHera"}
-  fit: {id: 210219-n3fit-FD04, label: "PreHera"}
+  pdf: {id: 210219-n3fit-FD04, label: "PreLHC"}
+  fit: {id: 210219-n3fit-FD04, label: "PreLHC"}
 
   speclabel: "PreLHC fit"
   description:


### PR DESCRIPTION
I think it would be good to have a basic/standard runcard for future tests in the examples folder of the repository. It also serves as an example for the custom grouping (https://vp.nnpdf.science/dC6D9MChTYSrEIrdmXaCLw==/)

Pointing to that branch as it is needed for this.

Edit: updated the example link so that it points to a correct one.