### PR TITLE
Fix check for c in n3fit/checks.py

### DIFF
--- a/n3fit/src/n3fit/checks.py
+++ b/n3fit/src/n3fit/checks.py
@@ -347,7 +347,7 @@ def check_consistent_basis(fitting, theoryid):
     # Check that the basis given in the runcard is one of those defined in validphys.pdfbases
     basis = check_basis(fitbasis, flavs)["basis"]
     # Now check that basis and theory id are consistent
-    has_c = basis.has_element("c") or basis.has_element("T15")
+    has_c = basis.has_element("c") or basis.has_element("T15") or basis.has_element("cp")
     if theoryid.get_description()["IC"] and not has_c:
         raise CheckError(f"{theoryid} (intrinsic charm) is incompatible with basis {fitbasis}")
     if not theoryid.get_description()["IC"] and has_c:

--- a/validphys2/src/validphys/pdfbases.py
+++ b/validphys2/src/validphys/pdfbases.py
@@ -550,7 +550,7 @@ NN31IC = LinearBasis.from_mapping(
     },
     aliases={
         'gluon': 'g', 'singlet': r'\Sigma', 'sng': r'\Sigma', 'sigma': r'\Sigma', 'cp': r'c^+',
-        'c': r'c^+', 'v': 'V', 'v3': 'V3', 'v8': 'V8', 't3': 'T3', 't8': 'T8'},
+        'v': 'V', 'v3': 'V3', 'v8': 'V8', 't3': 'T3', 't8': 'T8'},
     default_elements=(r'\Sigma', 'gluon', 'V', 'V3', 'V8', 'T3', 'T8', r'c^+', ))
 
 NN31PC = LinearBasis.from_mapping(


### PR DESCRIPTION
Fixes the check since it was only looking for cp and should be looking for c as well.

<s>I realised that we had only two basis using charm and they used a different definition (c vs cp) so I've added an alias so that one can use "c" in both if one wishes (unless  we want to enforce that distinction for some reason).</s>