### PR TITLE
Add clarification on APPLgrid versions to docs

### DIFF
--- a/doc/sphinx/source/tutorials/APPLgrids.md
+++ b/doc/sphinx/source/tutorials/APPLgrids.md
@@ -30,12 +30,11 @@ versions that have been tested):
 * [FastJet](http://fastjet.fr/) (3.3.1 onwards, from external/fastjet-3.3.1)
 
 The APPLgrid source code is
-* [APPLgrid](https://applgrid.hepforge.org/) (
-  [applgridphoton](https://github.com/scarrazza/applgridphoton), which can also
-  be accessed from [external](https://github.com/NNPDF/external)). Note that
-  only versions of APPLgrid that can be found in external should be used, as
-  opposed to those found on the APPLgrid website, since only the former are
-  supported by NNPDF.
+* [applgridphoton](https://github.com/scarrazza/applgridphoton), which can also
+  be accessed from [external](https://github.com/NNPDF/external). Note that
+  applgridphoton is a slightly modified version of the
+  [APPLgrid](https://applgrid.hepforge.org/) code, which is recommended
+  for usage with the NNPDF code.
 
 If the user is able to run the nnpdf code, LHAPDF should already be available 
 on their system. Likewise, if they are able to run apfelcomb, ROOT and APPLgrid


### PR DESCRIPTION
Closes https://github.com/NNPDF/nnpdf/issues/1119

Is this what you had in mind @Zaharid? Note that this doesn't mention applgrid-1.4.70-nnpdf, which can also be found in external (https://github.com/NNPDF/external/tree/master/applgrid-1.4.70-nnpdf) and I've used and found to work. What's the policy on that? Should we mention it in the docs? Are there cases when one would choose to use applgrid-1.4.70-nnpdf instead of applgridphoton? @enocera 