### PR TITLE
Add pdfs_noband option to lumi plots

### DIFF
--- a/doc/sphinx/source/tutorials/plot_pdfs.rst
+++ b/doc/sphinx/source/tutorials/plot_pdfs.rst
@@ -198,13 +198,13 @@ Luminosity plots
 
 	PDFscalespecs:
 	  - xscale: log
-	    xscaletitle: Log
+	    Xscaletitle: Log
 	  - xscale: linear
-	    xscaletitle: Linear
+	    Xscaletitle: Linear
 
 	template_text: |
 	  {@with PDFscalespecs@}
-	  {@xscaletitle@} scale
+	  {@Xscaletitle@} scale
 	  =====================
 	  {@plot_lumi1d@}
 	  {@plot_lumi1d_uncertainties@}
@@ -227,5 +227,10 @@ Luminosity plots
   found `here <https://github.com/NNPDF/nnpdf/blob/c20f1892767632f4764ada12bc106c04d5b739d4/validphys2/src/validphys/gridvalues.py>`_.
   Note further that a set of channels can be given by
   specifying ``lumi_channels`` followed by a list of channels.
-- The square root of centre of mass energy, \\(\\sqrt{s}\\), in GeV must also
+- The square root of centre of mass energy, √s, in GeV must also
   be provided via ``sqrts``. This is instead of ``Q``.
+- The options ``ymin`` and ``ymax`` can be supplied to control the vertical
+  range of the plot, while ``mxmin`` and ``mxmax`` (in GeV) control the
+  horizontal axis of invariant masses.
+- Other options for the band plots, such as ``pdfs_noband`` and
+  ``show_mc_errors`` work for ``plot_lumi1d``.

--- a/validphys2/src/validphys/pdfplots.py
+++ b/validphys2/src/validphys/pdfplots.py
@@ -524,6 +524,7 @@ def plot_flavours(pdf, xplotting_grid, xscale:(str,type(None))=None,
 
 @figure
 @check_pdf_normalize_to
+@check_pdfs_noband
 def plot_lumi1d(
     pdfs,
     pdfs_lumis,
@@ -533,6 +534,7 @@ def plot_lumi1d(
     show_mc_errors: bool = True,
     ymin: (numbers.Real, type(None)) = None,
     ymax: (numbers.Real, type(None)) = None,
+    pdfs_noband=None,
 ):
     """Plot PDF luminosities at a given center of mass energy.
     sqrts is the center of mass energy (GeV).
@@ -543,7 +545,8 @@ def plot_lumi1d(
     central value of some of the PDFs. `ymin` and `ymax` can be used to set
     exact bounds for the scale. `show_mc_errors` controls whether the 1σ error
     bands are shown in addition to the 68% confidence intervals for Monte Carlo
-    PDFs.
+    PDFs. A list `pdfs_noband` can be passed to supress the error bands for
+    certain PDFs and plot the central values only.
     """
 
     fig, ax = plt.subplots()
@@ -554,7 +557,6 @@ def plot_lumi1d(
         norm = 1
         ylabel = r"$\mathcal{L} (GeV^{-2})$"
 
-    # For plotting
     hatchit = plotutils.hatch_iter()
     pcycler = plotutils.color_iter()
     handles = []
@@ -573,6 +575,14 @@ def plot_lumi1d(
         hatch = next(hatchit)
 
         alpha = 0.5
+
+        (central_line,) = ax.plot(mx, cv / norm, color=color)
+
+        if pdfs_noband and pdf in pdfs_noband:
+            handles.append(central_line)
+            labels.append(pdf.label)
+            continue
+
         ax.fill_between(
             mx, err68down / norm, err68up / norm, color=color, alpha=alpha, zorder=1
         )
@@ -586,8 +596,6 @@ def plot_lumi1d(
             hatch=hatch,
             zorder=1,
         )
-
-        ax.plot(mx, cv / norm, color=color)
 
         if isinstance(gv, MCStats) and show_mc_errors:
             ax.plot(mx, errstddown / norm, linestyle="--", color=color)


### PR DESCRIPTION
This comes in handy sometimes when we want to show central values only.
The logic is the same as for PDF plots.