### PR TITLE
Remove combocuts check

### DIFF
--- a/validphys2/src/validphys/filters.py
+++ b/validphys2/src/validphys/filters.py
@@ -49,14 +49,6 @@ def default_filter_rules_input():
 
 
 @make_argcheck
-def check_combocuts(combocuts: str):
-    """Check combocuts content"""
-    check(
-        combocuts == "NNPDF31",
-        "Invalid combocut. Must be NNPDF31 (or implement it yourself).",
-    )
-
-@make_argcheck
 def check_rngalgo(rngalgo: int):
     """Check rngalgo content"""
     check(0 <= rngalgo < 17,
@@ -135,8 +127,7 @@ def filter_real_data(filter_path, data):
     return _filter_real_data(filter_path, data)
 
 
-@check_combocuts
-def filter(filter_data, combocuts):
+def filter(filter_data):
     """Summarise filters applied to all datasets"""
     total_data, total_cut_data = np.atleast_2d(filter_data).sum(axis=0)
     log.info(f'Summary: {total_cut_data}/{total_data} datapoints passed kinematic cuts.')


### PR DESCRIPTION
This option has not been used for years now and was only checked for
compatibility with pre-3.1 code, now completely obsolete.

See #1146 
cc @enocera  