### PR TITLE
Update bot reference and add upload check

### DIFF
--- a/.github/workflows/rules.yml
+++ b/.github/workflows/rules.yml
@@ -72,7 +72,7 @@ jobs:
         do
           sleep 30s
           res=$(vp-upload $RUNCARD 2>&1)
-        enddo
+        done
         url=$( echo "${res}" | grep https )
         echo "FIT_URL=$url" >> $GITHUB_ENV
     # running validphys report


### PR DESCRIPTION
Since #1081 effectively changes the seed for the bot, it was a good idea to update it.
Also, since #1083 adds an ERROR msg when the fit fails to upload, now it re-uploads when it happens.