### PR TITLE
Remove style specification for plot

### DIFF
--- a/validphys2/src/validphys/dataplots.py
+++ b/validphys2/src/validphys/dataplots.py
@@ -375,7 +375,6 @@ def _plot_fancy_impl(results, commondata, cutlist,
                 cv = line_data[('cv', i)].values
                 err = line_data[('err', i)].values
                 ax.errorbar(x, cv, yerr=err,
-                     linestyle='--',
                      lw=0.25,
                      label= label,
                      #elinewidth = 2,


### PR DESCRIPTION
This now should have very little visible effect as dotted lines look
continuous (need to look into that).

But it allows the option to be controlled be the lines.linestyle option
which can be set externally, which allows to for example disable lines
by setting the option to `'none'`.