### PR TITLE
Add cache to SimilarityCuts

### DIFF
--- a/validphys2/src/validphys/core.py
+++ b/validphys2/src/validphys/core.py
@@ -410,6 +410,7 @@ class SimilarCuts(TupleComp):
         self.threshold = threshold
         super().__init__(self.inputs, self.threshold)
 
+    @functools.lru_cache()
     def load(self):
         # TODO: Update this when a suitable interace becomes available
         from validphys.convolution import central_predictions


### PR DESCRIPTION
The similarity cuts slow down the code considerably: They use a code
path for loading data that should become standard but now doesn't use
caches and is not used anywhere else in the "main" paths. Moreover it is
a good candidate for having a cache regardless since it needs to be
loaded at least twice (and in practice a few more times on a typical run).