### PR TITLE
Add scalar log formatter function

### DIFF
--- a/validphys2/src/validphys/plotutils.py
+++ b/validphys2/src/validphys/plotutils.py
@@ -171,7 +171,7 @@ def scalar_log_formatter():
     def formatter(y, _pos):
         decimalplaces = int(np.maximum(-np.log10(y), 0))  # =0 for numbers >=1
         # Insert that number into a format string
-        formatstring = "{{:.{:1d}f}}".format(decimalplaces)
+        formatstring = f"{{:.{decimalplaces}f}}"
         # Return the formatted tick label
         return formatstring.format(y)
 


### PR DESCRIPTION
Matplotlib format numbers in log scale using exponential notation, which
doesn't always look so good, particularly when formatting things like
10^0. Add a function that displays the numbers using scalar notation
instead, so 0.1, 1, 10 instead of 10^-1, 10^0, 10^1.