### PR TITLE
Defaults for datasets

### DIFF
--- a/validphys2/src/validphys/config.py
+++ b/validphys2/src/validphys/config.py
@@ -319,7 +319,10 @@ class CoreConfig(configparser.Config):
         return spec_defaults_mapping
 
 
-    def produce_dataset_input_with_defaults(self, setname: str, dataset_defaults_spec, all_dataset_defaults, theoryid):
+    def produce_dataset_input_with_defaults(
+        self, setname: str, dataset_defaults_spec, all_dataset_defaults, theoryid
+    ):
+
         pto = theoryid.get_description()['PTO']
         pto_string = 'N' * pto + 'LO'
 

--- a/validphys2/src/validphys/config.py
+++ b/validphys2/src/validphys/config.py
@@ -363,6 +363,8 @@ class CoreConfig(configparser.Config):
         if dataset_defaults_spec is not None:
             setname = dataset['dataset']
             with self.set_context(ns=self._curr_ns.new_child({'setname': setname})):
+                # Override the mapping in the runcard from the presaved defaults
+                log.debug("Overriding runcard mapping with defaults")
                 _, dataset = self.parse_from_(None, 'dataset_input_with_defaults', write=False)
 
         sysnum = dataset.get("sys")

--- a/validphys2/src/validphys/config.py
+++ b/validphys2/src/validphys/config.py
@@ -307,7 +307,10 @@ class CoreConfig(configparser.Config):
 
     @record_from_defaults
     def produce_default_dataset_settings(self):
-        spec_file_mapping = {'40': '40_dataset_defaults.yaml'}
+        spec_file_mapping = {
+                '31': '31_dataset_defaults.yaml',
+                '40': '40_dataset_defaults.yaml',
+                }
         spec_defaults_mapping = {}
         for spec, file in spec_file_mapping.items():
             spec_defaults_mapping[spec] = yaml.safe_load(

--- a/validphys2/src/validphys/config.py
+++ b/validphys2/src/validphys/config.py
@@ -327,7 +327,17 @@ class CoreConfig(configparser.Config):
         pto_string = 'N' * pto + 'LO'
 
         dataset_defaults_spec = str(dataset_defaults_spec)
-        pto_defaults_mapping = all_dataset_defaults[dataset_defaults_spec]
+        try:
+            pto_defaults_mapping = all_dataset_defaults[dataset_defaults_spec]
+        except KeyError:
+            alternatives = all_dataset_defaults.keys()
+            raise ConfigError(
+                    f"Dataset defaults not found for spec {dataset_defaults_spec}",
+                    bad_item=dataset_defaults_spec,
+                    alternatives=alternatives,
+                    display_alternatives='best'
+            )
+
         try:
             dataset_defaults_mapping = pto_defaults_mapping[pto_string]
         except KeyError:
@@ -338,6 +348,7 @@ class CoreConfig(configparser.Config):
                     alternatives=alternatives,
                     display_alternatives='best'
             )
+
         try:
             defaults = dataset_defaults_mapping[setname]
         except KeyError as e:

--- a/validphys2/src/validphys/config.py
+++ b/validphys2/src/validphys/config.py
@@ -347,7 +347,13 @@ class CoreConfig(configparser.Config):
                      display_alternatives='best'
                 )
 
-            dataset = dataset_defaults[name]
+            try:
+                dataset = dataset_defaults[name]
+            except KeyError as e:
+                raise KeyError(
+                        f"Dataset {name} not found in "
+                        f"the dataset defaults mapping: {dataset_defaults_spec}."
+                ) from e
 
         sysnum = dataset.get("sys")
         cfac = dataset.get("cfac", tuple())

--- a/validphys2/src/validphys/dataset_defaults/31_dataset_defaults.yaml
+++ b/validphys2/src/validphys/dataset_defaults/31_dataset_defaults.yaml
@@ -1,0 +1,139 @@
+NMCPD:
+  frac: 0.5
+NMC:
+  frac: 0.5
+SLACP:
+  frac: 0.5
+SLACD:
+  frac: 0.5
+BCDMSP:
+  frac: 0.5
+BCDMSD:
+  frac: 0.5
+CHORUSNU:
+  frac: 0.5
+CHORUSNB:
+  frac: 0.5
+NTVNUDMN:
+  frac: 0.5
+NTVNBDMN:
+  frac: 0.5
+HERACOMBNCEM:
+  frac: 0.5
+HERACOMBNCEP460:
+  frac: 0.5
+HERACOMBNCEP575:
+  frac: 0.5
+HERACOMBNCEP820:
+  frac: 0.5
+HERACOMBNCEP920:
+  frac: 0.5
+HERACOMBCCEM:
+  frac: 0.5
+HERACOMBCCEP:
+  frac: 0.5
+HERAF2CHARM:
+  frac: 0.5
+H1HERAF2B:
+  frac: 1.0
+ZEUSHERAF2B:
+  frac: 1.0
+DYE886R:
+  frac: 1.0
+DYE886P:
+  frac: 0.5
+  cfac: [QCD]
+DYE605:
+  frac: 0.5
+  cfac: [QCD]
+CDFZRAP:
+  frac: 1.0
+  cfac: [QCD]
+CDFR2KT:
+  frac: 0.5
+  sys: 10
+D0ZRAP:
+  frac: 1.0
+  cfac: [QCD]
+D0WEASY:
+  frac: 1.0
+  cfac: [QCD]
+D0WMASY:
+  frac: 1.0
+  cfac: [QCD]
+ATLASWZRAP36PB:
+  frac: 1.0
+  cfac: [QCD]
+ATLASZHIGHMASS49FB:
+  frac: 1.0
+  cfac: [QCD]
+ATLASLOMASSDY11EXT:
+  frac: 1.0
+  cfac: [QCD]
+ATLASWZRAP11:
+  frac: 0.5
+  cfac: [QCD]
+ATLASR04JETS36PB:
+  frac: 0.5
+  sys: 10
+ATLASR04JETS2P76TEV:
+  frac: 0.5
+  sys: 10
+ATLAS1JET11:
+  frac: 0.5
+  sys: 10
+ATLASZPT8TEVMDIST:
+  frac: 0.5
+  cfac: [QCD]
+  sys: 10
+ATLASZPT8TEVYDIST:
+  frac: 0.5
+  cfac: [QCD]
+  sys: 10
+ATLASTTBARTOT:
+  frac: 1.0
+  cfac: [QCD]
+ATLASTOPDIFF8TEVTRAPNORM:
+  frac: 1.0
+  cfac: [QCD]
+CMSWEASY840PB:
+  frac: 1.0
+  cfac: [QCD]
+CMSWMASY47FB:
+  frac: 1.0
+  cfac: [QCD]
+CMSDY2D11:
+  frac: 0.5
+  cfac: [QCD]
+CMSWMU8TEV:
+  frac: 1.0
+  cfac: [QCD]
+CMSJETS11:
+  frac: 0.5
+  sys: 10
+CMS1JET276TEV:
+  frac: 0.5
+  sys: 10
+CMSZDIFF12:
+  frac: 1.0
+  cfac: [QCD,NRM]
+  sys: 10
+CMSTTBARTOT:
+  frac: 1.0
+  cfac: [QCD]
+CMSTOPDIFF8TEVTTRAPNORM:
+  frac: 1.0
+  cfac: [QCD]
+LHCBZ940PB:
+  frac: 1.0
+  cfac: [QCD]
+LHCBZEE2FB:
+  frac: 1.0
+  cfac: [QCD]
+LHCBWZMU7TEV:
+  frac: 1.0
+  cfac: [NRM,QCD]
+LHCBWZMU8TEV:
+  frac: 1.0
+  cfac: [NRM,QCD]
+

--- a/validphys2/src/validphys/dataset_defaults/31_dataset_defaults.yaml
+++ b/validphys2/src/validphys/dataset_defaults/31_dataset_defaults.yaml
@@ -1,139 +1,252 @@
-NMCPD:
-  frac: 0.5
-NMC:
-  frac: 0.5
-SLACP:
-  frac: 0.5
-SLACD:
-  frac: 0.5
-BCDMSP:
-  frac: 0.5
-BCDMSD:
-  frac: 0.5
-CHORUSNU:
-  frac: 0.5
-CHORUSNB:
-  frac: 0.5
-NTVNUDMN:
-  frac: 0.5
-NTVNBDMN:
-  frac: 0.5
-HERACOMBNCEM:
-  frac: 0.5
-HERACOMBNCEP460:
-  frac: 0.5
-HERACOMBNCEP575:
-  frac: 0.5
-HERACOMBNCEP820:
-  frac: 0.5
-HERACOMBNCEP920:
-  frac: 0.5
-HERACOMBCCEM:
-  frac: 0.5
-HERACOMBCCEP:
-  frac: 0.5
-HERAF2CHARM:
-  frac: 0.5
-H1HERAF2B:
-  frac: 1.0
-ZEUSHERAF2B:
-  frac: 1.0
-DYE886R:
-  frac: 1.0
-DYE886P:
-  frac: 0.5
-  cfac: [QCD]
-DYE605:
-  frac: 0.5
-  cfac: [QCD]
-CDFZRAP:
-  frac: 1.0
-  cfac: [QCD]
-CDFR2KT:
-  frac: 0.5
-  sys: 10
-D0ZRAP:
-  frac: 1.0
-  cfac: [QCD]
-D0WEASY:
-  frac: 1.0
-  cfac: [QCD]
-D0WMASY:
-  frac: 1.0
-  cfac: [QCD]
-ATLASWZRAP36PB:
-  frac: 1.0
-  cfac: [QCD]
-ATLASZHIGHMASS49FB:
-  frac: 1.0
-  cfac: [QCD]
-ATLASLOMASSDY11EXT:
-  frac: 1.0
-  cfac: [QCD]
-ATLASWZRAP11:
-  frac: 0.5
-  cfac: [QCD]
-ATLASR04JETS36PB:
-  frac: 0.5
-  sys: 10
-ATLASR04JETS2P76TEV:
-  frac: 0.5
-  sys: 10
-ATLAS1JET11:
-  frac: 0.5
-  sys: 10
-ATLASZPT8TEVMDIST:
-  frac: 0.5
-  cfac: [QCD]
-  sys: 10
-ATLASZPT8TEVYDIST:
-  frac: 0.5
-  cfac: [QCD]
-  sys: 10
-ATLASTTBARTOT:
-  frac: 1.0
-  cfac: [QCD]
-ATLASTOPDIFF8TEVTRAPNORM:
-  frac: 1.0
-  cfac: [QCD]
-CMSWEASY840PB:
-  frac: 1.0
-  cfac: [QCD]
-CMSWMASY47FB:
-  frac: 1.0
-  cfac: [QCD]
-CMSDY2D11:
-  frac: 0.5
-  cfac: [QCD]
-CMSWMU8TEV:
-  frac: 1.0
-  cfac: [QCD]
-CMSJETS11:
-  frac: 0.5
-  sys: 10
-CMS1JET276TEV:
-  frac: 0.5
-  sys: 10
-CMSZDIFF12:
-  frac: 1.0
-  cfac: [QCD,NRM]
-  sys: 10
-CMSTTBARTOT:
-  frac: 1.0
-  cfac: [QCD]
-CMSTOPDIFF8TEVTTRAPNORM:
-  frac: 1.0
-  cfac: [QCD]
-LHCBZ940PB:
-  frac: 1.0
-  cfac: [QCD]
-LHCBZEE2FB:
-  frac: 1.0
-  cfac: [QCD]
-LHCBWZMU7TEV:
-  frac: 1.0
-  cfac: [NRM,QCD]
-LHCBWZMU8TEV:
-  frac: 1.0
-  cfac: [NRM,QCD]
+NNLO:
+  NMCPD:
+    frac: 0.5
+  NMC:
+    frac: 0.5
+  SLACP:
+    frac: 0.5
+  SLACD:
+    frac: 0.5
+  BCDMSP:
+    frac: 0.5
+  BCDMSD:
+    frac: 0.5
+  CHORUSNU:
+    frac: 0.5
+  CHORUSNB:
+    frac: 0.5
+  NTVNUDMN:
+    frac: 0.5
+  NTVNBDMN:
+    frac: 0.5
+  HERACOMBNCEM:
+    frac: 0.5
+  HERACOMBNCEP460:
+    frac: 0.5
+  HERACOMBNCEP575:
+    frac: 0.5
+  HERACOMBNCEP820:
+    frac: 0.5
+  HERACOMBNCEP920:
+    frac: 0.5
+  HERACOMBCCEM:
+    frac: 0.5
+  HERACOMBCCEP:
+    frac: 0.5
+  HERAF2CHARM:
+    frac: 0.5
+  H1HERAF2B:
+    frac: 1.0
+  ZEUSHERAF2B:
+    frac: 1.0
+  DYE886R:
+    frac: 1.0
+  DYE886P:
+    frac: 0.5
+    cfac: [QCD]
+  DYE605:
+    frac: 0.5
+    cfac: [QCD]
+  CDFZRAP:
+    frac: 1.0
+    cfac: [QCD]
+  CDFR2KT:
+    frac: 0.5
+    sys: 10
+  D0ZRAP:
+    frac: 1.0
+    cfac: [QCD]
+  D0WEASY:
+    frac: 1.0
+    cfac: [QCD]
+  D0WMASY:
+    frac: 1.0
+    cfac: [QCD]
+  ATLASWZRAP36PB:
+    frac: 1.0
+    cfac: [QCD]
+  ATLASZHIGHMASS49FB:
+    frac: 1.0
+    cfac: [QCD]
+  ATLASLOMASSDY11EXT:
+    frac: 1.0
+    cfac: [QCD]
+  ATLASWZRAP11:
+    frac: 0.5
+    cfac: [QCD]
+  ATLASR04JETS36PB:
+    frac: 0.5
+    sys: 10
+  ATLASR04JETS2P76TEV:
+    frac: 0.5
+    sys: 10
+  ATLAS1JET11:
+    frac: 0.5
+    sys: 10
+  ATLASZPT8TEVMDIST:
+    frac: 0.5
+    cfac: [QCD]
+    sys: 10
+  ATLASZPT8TEVYDIST:
+    frac: 0.5
+    cfac: [QCD]
+    sys: 10
+  ATLASTTBARTOT:
+    frac: 1.0
+    cfac: [QCD]
+  ATLASTOPDIFF8TEVTRAPNORM:
+    frac: 1.0
+    cfac: [QCD]
+  CMSWEASY840PB:
+    frac: 1.0
+    cfac: [QCD]
+  CMSWMASY47FB:
+    frac: 1.0
+    cfac: [QCD]
+  CMSDY2D11:
+    frac: 0.5
+    cfac: [QCD]
+  CMSWMU8TEV:
+    frac: 1.0
+    cfac: [QCD]
+  CMSJETS11:
+    frac: 0.5
+    sys: 10
+  CMS1JET276TEV:
+    frac: 0.5
+    sys: 10
+  CMSZDIFF12:
+    frac: 1.0
+    cfac: [QCD,NRM]
+    sys: 10
+  CMSTTBARTOT:
+    frac: 1.0
+    cfac: [QCD]
+  CMSTOPDIFF8TEVTTRAPNORM:
+    frac: 1.0
+    cfac: [QCD]
+  LHCBZ940PB:
+    frac: 1.0
+    cfac: [QCD]
+  LHCBZEE2FB:
+    frac: 1.0
+    cfac: [QCD]
+  LHCBWZMU7TEV:
+    frac: 1.0
+    cfac: [NRM,QCD]
+  LHCBWZMU8TEV:
+    frac: 1.0
+    cfac: [NRM,QCD]
 
+NLO:
+  NMCPD:
+    frac: 0.5
+  NMC:
+    frac: 0.5
+  SLACP:
+    frac: 0.5
+  SLACD:
+    frac: 0.5
+  BCDMSP:
+    frac: 0.5
+  BCDMSD:
+    frac: 0.5
+  CHORUSNU:
+    frac: 0.5
+  CHORUSNB:
+    frac: 0.5
+  NTVNUDMN:
+    frac: 0.5
+  NTVNBDMN:
+    frac: 0.5
+  HERACOMBNCEM:
+    frac: 0.5
+  HERACOMBNCEP460:
+    frac: 0.5
+  HERACOMBNCEP575:
+    frac: 0.5
+  HERACOMBNCEP820:
+    frac: 0.5
+  HERACOMBNCEP920:
+    frac: 0.5
+  HERACOMBCCEM:
+    frac: 0.5
+  HERACOMBCCEP:
+    frac: 0.5
+  HERAF2CHARM:
+    frac: 0.5
+  H1HERAF2B:
+    frac: 1.0
+  ZEUSHERAF2B:
+    frac: 1.0
+  DYE886R:
+    frac: 1.0
+  DYE886P:
+    frac: 0.5
+  DYE605:
+    frac: 0.5
+  CDFZRAP:
+    frac: 1.0
+  CDFR2KT:
+    frac: 0.5
+  D0ZRAP:
+    frac: 1.0
+  D0WEASY:
+    frac: 1.0
+  D0WMASY:
+    frac: 1.0
+  ATLASWZRAP36PB:
+    frac: 1.0
+  ATLASZHIGHMASS49FB:
+    frac: 1.0
+  ATLASLOMASSDY11EXT:
+    frac: 1.0
+  ATLASWZRAP11:
+    frac: 0.5
+  ATLASR04JETS36PB:
+    frac: 0.5
+  ATLASR04JETS2P76TEV:
+    frac: 0.5
+  ATLAS1JET11:
+    frac: 0.5
+  ATLASZPT8TEVMDIST:
+    frac: 0.5
+  ATLASZPT8TEVYDIST:
+    frac: 0.5
+  ATLASTTBARTOT:
+    frac: 1.0
+  ATLASTOPDIFF8TEVTRAPNORM:
+    frac: 1.0
+  CMSWEASY840PB:
+    frac: 1.0
+  CMSWMASY47FB:
+    frac: 1.0
+  CMSWCHARMTOT:
+    frac: 1.0
+  CMSWCHARMRAT:
+    frac: 1.0
+  CMSDY2D11:
+    frac: 0.5
+  CMSWMU8TEV:
+    frac: 1.0
+  CMSJETS11:
+    frac: 0.5
+  CMS1JET276TEV:
+    frac: 0.5
+  CMSZDIFF12:
+    frac: 1.0
+    cfac: [NRM]
+  CMSTTBARTOT:
+    frac: 1.0
+  CMSTOPDIFF8TEVTTRAPNORM:
+    frac: 1.0
+  LHCBZ940PB:
+    frac: 1.0
+  LHCBZEE2FB:
+    frac: 1.0
+  LHCBWZMU7TEV:
+    frac: 1.0
+    cfac: [NRM]
+  LHCBWZMU8TEV:
+    frac: 1.0
+    cfac: [NRM]

--- a/validphys2/src/validphys/dataset_defaults/40_dataset_defaults.yaml
+++ b/validphys2/src/validphys/dataset_defaults/40_dataset_defaults.yaml
@@ -35,9 +35,9 @@ HERACOMBCCEM:
 HERACOMBCCEP:
   frac: 0.75
 HERACOMB_SIGMARED_C:
-  frac: 0.75   # N
+  frac: 0.75
 HERACOMB_SIGMARED_B:
-  frac: 0.75   # N
+  frac: 0.75
 DYE886R:
   frac: 1.0
 DYE886P:
@@ -66,22 +66,22 @@ ATLASLOMASSDY11EXT:
   cfac: [QCD]
 ATLASWZRAP11CC:
   frac: 0.75
-  cfac: [QCD]               # N
+  cfac: [QCD]
 ATLASWZRAP11CF:
   frac: 0.75
-  cfac: [QCD]               # N
+  cfac: [QCD]
 ATLASDY2D8TEV:
   frac: 0.75
-  cfac: [QCDEWK]             # N
+  cfac: [QCDEWK]
 ATLAS_WZ_TOT_13TEV:
   frac: 1.0
-  cfac: [NRM, QCD]      # N
+  cfac: [NRM, QCD]
 ATLAS_WP_JET_8TEV_PT:
   frac: 0.75
-  cfac: [QCD]         # N
+  cfac: [QCD]
 ATLAS_WM_JET_8TEV_PT:
   frac: 0.75
-  cfac: [QCD]         # N
+  cfac: [QCD]
 ATLASZPT8TEVMDIST:
   frac: 0.75
   cfac: [QCD]
@@ -95,40 +95,40 @@ ATLASTTBARTOT:
   cfac: [QCD]
 ATLAS_TTB_DIFF_8TEV_LJ_TRAPNORM:
   frac: 1.0
-  cfac: [QCD]       # N
+  cfac: [QCD]
 ATLAS_TTB_DIFF_8TEV_LJ_TTRAPNORM:
   frac: 1.0
-  cfac: [QCD]      # N
+  cfac: [QCD]
 ATLAS_TOPDIFF_DILEPT_8TEV_TTRAPNORM:
   frac: 1.0
-  cfac: [QCD]   # N
+  cfac: [QCD]
 ATLAS_1JET_8TEV_R06_DEC:
   frac: 0.75
-  cfac: [QCD]   # N
+  cfac: [QCD]
 ATLAS_2JET_7TEV_R06:
   frac: 0.75
-  cfac: [QCD]   # N
+  cfac: [QCD]
 ATLASPHT15:
   frac: 0.75
-  cfac: [QCD, EWK]  # N
+  cfac: [QCD, EWK]
 ATLAS_SINGLETOP_TCH_R_7TEV:
   frac: 1.0
-  cfac: [QCD]                     # N
+  cfac: [QCD]
 ATLAS_SINGLETOP_TCH_R_13TEV:
   frac: 1.0
-  cfac: [QCD]                    # N
+  cfac: [QCD]
 ATLAS_SINGLETOP_TCH_DIFF_7TEV_T_RAP_NORM:
   frac: 1.0
-  cfac: [QCD]       # N
+  cfac: [QCD]
 ATLAS_SINGLETOP_TCH_DIFF_7TEV_TBAR_RAP_NORM:
   frac: 1.0
-  cfac: [QCD]    # N
+  cfac: [QCD]
 ATLAS_SINGLETOP_TCH_DIFF_8TEV_T_RAP_NORM:
   frac: 0.75
-  cfac: [QCD]       # N
+  cfac: [QCD]
 ATLAS_SINGLETOP_TCH_DIFF_8TEV_TBAR_RAP_NORM:
   frac: 0.75
-  cfac: [QCD]    # N
+  cfac: [QCD]
 CMSWEASY840PB:
   frac: 1.0
   cfac: [QCD]
@@ -147,10 +147,10 @@ CMSZDIFF12:
   sys: 10
 CMS_2JET_7TEV:
   frac: 0.75
-  cfac: [QCD]      # N 
+  cfac: [QCD]
 CMS_2JET_3D_8TEV:
   frac: 0.75
-  cfac: [QCD]   # N
+  cfac: [QCD]
 CMSTTBARTOT:
   frac: 1.0
   cfac: [QCD]
@@ -159,25 +159,25 @@ CMSTOPDIFF8TEVTTRAPNORM:
   cfac: [QCD]
 CMSTTBARTOT5TEV:
   frac: 1.0
-  cfac: [QCD]                   # N
+  cfac: [QCD]
 CMS_TTBAR_2D_DIFF_MTT_TRAP_NORM:
   frac: 1.0
-  cfac: [QCD]   # N
+  cfac: [QCD]
 CMS_TTB_DIFF_13TEV_2016_2L_TRAP:
   frac: 1.0
-  cfac: [QCD]   # N
+  cfac: [QCD]
 CMS_TTB_DIFF_13TEV_2016_LJ_TRAP:
   frac: 1.0
-  cfac: [QCD]   # N
+  cfac: [QCD]
 CMS_SINGLETOP_TCH_TOT_7TEV:
   frac: 1.0
-  cfac: [QCD]   # N
+  cfac: [QCD]
 CMS_SINGLETOP_TCH_R_8TEV:
   frac: 1.0
-  cfac: [QCD]     # N
+  cfac: [QCD]
 CMS_SINGLETOP_TCH_R_13TEV:
   frac: 1.0
-  cfac: [QCD]    # N
+  cfac: [QCD]
 LHCBZ940PB:
   frac: 1.0
   cfac: [QCD]
@@ -192,7 +192,7 @@ LHCBWZMU8TEV:
   cfac: [NRM, QCD]
 LHCB_Z_13TEV_DIMUON:
   frac: 1.0
-  cfac: [QCD]       # N
+  cfac: [QCD]
 LHCB_Z_13TEV_DIELECTRON:
   frac: 1.0
-  cfac: [QCD]   # N
+  cfac: [QCD]

--- a/validphys2/src/validphys/dataset_defaults/40_dataset_defaults.yaml
+++ b/validphys2/src/validphys/dataset_defaults/40_dataset_defaults.yaml
@@ -1,0 +1,198 @@
+NMCPD:
+  frac: 0.75
+NMC:
+  frac: 0.75
+SLACP:
+  frac: 0.75
+SLACD:
+  frac: 0.75
+BCDMSP:
+  frac: 0.75
+BCDMSD:
+  frac: 0.75
+CHORUSNUPb:
+  frac: 0.75
+CHORUSNBPb:
+  frac: 0.75
+NTVNUDMNFe:
+  frac: 0.75
+  cfac: [MAS]
+NTVNBDMNFe:
+  frac: 0.75
+  cfac: [MAS]
+HERACOMBNCEM:
+  frac: 0.75
+HERACOMBNCEP460:
+  frac: 0.75
+HERACOMBNCEP575:
+  frac: 0.75
+HERACOMBNCEP820:
+  frac: 0.75
+HERACOMBNCEP920:
+  frac: 0.75
+HERACOMBCCEM:
+  frac: 0.75
+HERACOMBCCEP:
+  frac: 0.75
+HERACOMB_SIGMARED_C:
+  frac: 0.75   # N
+HERACOMB_SIGMARED_B:
+  frac: 0.75   # N
+DYE886R:
+  frac: 1.0
+DYE886P:
+  frac: 0.75
+  cfac: [QCD]
+DYE605:
+  frac: 0.75
+  cfac: [QCD]
+CDFZRAP:
+  frac: 1.0
+  cfac: [QCD]
+D0ZRAP:
+  frac: 1.0
+  cfac: [QCD]
+D0WMASY:
+  frac: 1.0
+  cfac: [QCD]
+ATLASWZRAP36PB:
+  frac: 1.0
+  cfac: [QCD]
+ATLASZHIGHMASS49FB:
+  frac: 1.0
+  cfac: [QCD]
+ATLASLOMASSDY11EXT:
+  frac: 1.0
+  cfac: [QCD]
+ATLASWZRAP11CC:
+  frac: 0.75
+  cfac: [QCD]               # N
+ATLASWZRAP11CF:
+  frac: 0.75
+  cfac: [QCD]               # N
+ATLASDY2D8TEV:
+  frac: 0.75
+  cfac: [QCDEWK]             # N
+ATLAS_WZ_TOT_13TEV:
+  frac: 1.0
+  cfac: [NRM, QCD]      # N
+ATLAS_WP_JET_8TEV_PT:
+  frac: 0.75
+  cfac: [QCD]         # N
+ATLAS_WM_JET_8TEV_PT:
+  frac: 0.75
+  cfac: [QCD]         # N
+ATLASZPT8TEVMDIST:
+  frac: 0.75
+  cfac: [QCD]
+  sys: 10
+ATLASZPT8TEVYDIST:
+  frac: 0.75
+  cfac: [QCD]
+  sys: 10
+ATLASTTBARTOT:
+  frac: 1.0
+  cfac: [QCD]
+ATLAS_TTB_DIFF_8TEV_LJ_TRAPNORM:
+  frac: 1.0
+  cfac: [QCD]       # N
+ATLAS_TTB_DIFF_8TEV_LJ_TTRAPNORM:
+  frac: 1.0
+  cfac: [QCD]      # N
+ATLAS_TOPDIFF_DILEPT_8TEV_TTRAPNORM:
+  frac: 1.0
+  cfac: [QCD]   # N
+ATLAS_1JET_8TEV_R06_DEC:
+  frac: 0.75
+  cfac: [QCD]   # N
+ATLAS_2JET_7TEV_R06:
+  frac: 0.75
+  cfac: [QCD]   # N
+ATLASPHT15:
+  frac: 0.75
+  cfac: [QCD, EWK]  # N
+ATLAS_SINGLETOP_TCH_R_7TEV:
+  frac: 1.0
+  cfac: [QCD]                     # N
+ATLAS_SINGLETOP_TCH_R_13TEV:
+  frac: 1.0
+  cfac: [QCD]                    # N
+ATLAS_SINGLETOP_TCH_DIFF_7TEV_T_RAP_NORM:
+  frac: 1.0
+  cfac: [QCD]       # N
+ATLAS_SINGLETOP_TCH_DIFF_7TEV_TBAR_RAP_NORM:
+  frac: 1.0
+  cfac: [QCD]    # N
+ATLAS_SINGLETOP_TCH_DIFF_8TEV_T_RAP_NORM:
+  frac: 0.75
+  cfac: [QCD]       # N
+ATLAS_SINGLETOP_TCH_DIFF_8TEV_TBAR_RAP_NORM:
+  frac: 0.75
+  cfac: [QCD]    # N
+CMSWEASY840PB:
+  frac: 1.0
+  cfac: [QCD]
+CMSWMASY47FB:
+  frac: 1.0
+  cfac: [QCD]
+CMSDY2D11:
+  frac: 0.75
+  cfac: [QCD]
+CMSWMU8TEV:
+  frac: 1.0
+  cfac: [QCD]
+CMSZDIFF12:
+  frac: 1.0
+  cfac: [QCD, NRM]
+  sys: 10
+CMS_2JET_7TEV:
+  frac: 0.75
+  cfac: [QCD]      # N 
+CMS_2JET_3D_8TEV:
+  frac: 0.75
+  cfac: [QCD]   # N
+CMSTTBARTOT:
+  frac: 1.0
+  cfac: [QCD]
+CMSTOPDIFF8TEVTTRAPNORM:
+  frac: 1.0
+  cfac: [QCD]
+CMSTTBARTOT5TEV:
+  frac: 1.0
+  cfac: [QCD]                   # N
+CMS_TTBAR_2D_DIFF_MTT_TRAP_NORM:
+  frac: 1.0
+  cfac: [QCD]   # N
+CMS_TTB_DIFF_13TEV_2016_2L_TRAP:
+  frac: 1.0
+  cfac: [QCD]   # N
+CMS_TTB_DIFF_13TEV_2016_LJ_TRAP:
+  frac: 1.0
+  cfac: [QCD]   # N
+CMS_SINGLETOP_TCH_TOT_7TEV:
+  frac: 1.0
+  cfac: [QCD]   # N
+CMS_SINGLETOP_TCH_R_8TEV:
+  frac: 1.0
+  cfac: [QCD]     # N
+CMS_SINGLETOP_TCH_R_13TEV:
+  frac: 1.0
+  cfac: [QCD]    # N
+LHCBZ940PB:
+  frac: 1.0
+  cfac: [QCD]
+LHCBZEE2FB:
+  frac: 1.0
+  cfac: [QCD]
+LHCBWZMU7TEV:
+  frac: 1.0
+  cfac: [NRM, QCD]
+LHCBWZMU8TEV:
+  frac: 1.0
+  cfac: [NRM, QCD]
+LHCB_Z_13TEV_DIMUON:
+  frac: 1.0
+  cfac: [QCD]       # N
+LHCB_Z_13TEV_DIELECTRON:
+  frac: 1.0
+  cfac: [QCD]   # N

--- a/validphys2/src/validphys/dataset_defaults/40_dataset_defaults.yaml
+++ b/validphys2/src/validphys/dataset_defaults/40_dataset_defaults.yaml
@@ -1,198 +1,199 @@
-NMCPD:
-  frac: 0.75
-NMC:
-  frac: 0.75
-SLACP:
-  frac: 0.75
-SLACD:
-  frac: 0.75
-BCDMSP:
-  frac: 0.75
-BCDMSD:
-  frac: 0.75
-CHORUSNUPb:
-  frac: 0.75
-CHORUSNBPb:
-  frac: 0.75
-NTVNUDMNFe:
-  frac: 0.75
-  cfac: [MAS]
-NTVNBDMNFe:
-  frac: 0.75
-  cfac: [MAS]
-HERACOMBNCEM:
-  frac: 0.75
-HERACOMBNCEP460:
-  frac: 0.75
-HERACOMBNCEP575:
-  frac: 0.75
-HERACOMBNCEP820:
-  frac: 0.75
-HERACOMBNCEP920:
-  frac: 0.75
-HERACOMBCCEM:
-  frac: 0.75
-HERACOMBCCEP:
-  frac: 0.75
-HERACOMB_SIGMARED_C:
-  frac: 0.75
-HERACOMB_SIGMARED_B:
-  frac: 0.75
-DYE886R:
-  frac: 1.0
-DYE886P:
-  frac: 0.75
-  cfac: [QCD]
-DYE605:
-  frac: 0.75
-  cfac: [QCD]
-CDFZRAP:
-  frac: 1.0
-  cfac: [QCD]
-D0ZRAP:
-  frac: 1.0
-  cfac: [QCD]
-D0WMASY:
-  frac: 1.0
-  cfac: [QCD]
-ATLASWZRAP36PB:
-  frac: 1.0
-  cfac: [QCD]
-ATLASZHIGHMASS49FB:
-  frac: 1.0
-  cfac: [QCD]
-ATLASLOMASSDY11EXT:
-  frac: 1.0
-  cfac: [QCD]
-ATLASWZRAP11CC:
-  frac: 0.75
-  cfac: [QCD]
-ATLASWZRAP11CF:
-  frac: 0.75
-  cfac: [QCD]
-ATLASDY2D8TEV:
-  frac: 0.75
-  cfac: [QCDEWK]
-ATLAS_WZ_TOT_13TEV:
-  frac: 1.0
-  cfac: [NRM, QCD]
-ATLAS_WP_JET_8TEV_PT:
-  frac: 0.75
-  cfac: [QCD]
-ATLAS_WM_JET_8TEV_PT:
-  frac: 0.75
-  cfac: [QCD]
-ATLASZPT8TEVMDIST:
-  frac: 0.75
-  cfac: [QCD]
-  sys: 10
-ATLASZPT8TEVYDIST:
-  frac: 0.75
-  cfac: [QCD]
-  sys: 10
-ATLASTTBARTOT:
-  frac: 1.0
-  cfac: [QCD]
-ATLAS_TTB_DIFF_8TEV_LJ_TRAPNORM:
-  frac: 1.0
-  cfac: [QCD]
-ATLAS_TTB_DIFF_8TEV_LJ_TTRAPNORM:
-  frac: 1.0
-  cfac: [QCD]
-ATLAS_TOPDIFF_DILEPT_8TEV_TTRAPNORM:
-  frac: 1.0
-  cfac: [QCD]
-ATLAS_1JET_8TEV_R06_DEC:
-  frac: 0.75
-  cfac: [QCD]
-ATLAS_2JET_7TEV_R06:
-  frac: 0.75
-  cfac: [QCD]
-ATLASPHT15:
-  frac: 0.75
-  cfac: [QCD, EWK]
-ATLAS_SINGLETOP_TCH_R_7TEV:
-  frac: 1.0
-  cfac: [QCD]
-ATLAS_SINGLETOP_TCH_R_13TEV:
-  frac: 1.0
-  cfac: [QCD]
-ATLAS_SINGLETOP_TCH_DIFF_7TEV_T_RAP_NORM:
-  frac: 1.0
-  cfac: [QCD]
-ATLAS_SINGLETOP_TCH_DIFF_7TEV_TBAR_RAP_NORM:
-  frac: 1.0
-  cfac: [QCD]
-ATLAS_SINGLETOP_TCH_DIFF_8TEV_T_RAP_NORM:
-  frac: 0.75
-  cfac: [QCD]
-ATLAS_SINGLETOP_TCH_DIFF_8TEV_TBAR_RAP_NORM:
-  frac: 0.75
-  cfac: [QCD]
-CMSWEASY840PB:
-  frac: 1.0
-  cfac: [QCD]
-CMSWMASY47FB:
-  frac: 1.0
-  cfac: [QCD]
-CMSDY2D11:
-  frac: 0.75
-  cfac: [QCD]
-CMSWMU8TEV:
-  frac: 1.0
-  cfac: [QCD]
-CMSZDIFF12:
-  frac: 1.0
-  cfac: [QCD, NRM]
-  sys: 10
-CMS_2JET_7TEV:
-  frac: 0.75
-  cfac: [QCD]
-CMS_2JET_3D_8TEV:
-  frac: 0.75
-  cfac: [QCD]
-CMSTTBARTOT:
-  frac: 1.0
-  cfac: [QCD]
-CMSTOPDIFF8TEVTTRAPNORM:
-  frac: 1.0
-  cfac: [QCD]
-CMSTTBARTOT5TEV:
-  frac: 1.0
-  cfac: [QCD]
-CMS_TTBAR_2D_DIFF_MTT_TRAP_NORM:
-  frac: 1.0
-  cfac: [QCD]
-CMS_TTB_DIFF_13TEV_2016_2L_TRAP:
-  frac: 1.0
-  cfac: [QCD]
-CMS_TTB_DIFF_13TEV_2016_LJ_TRAP:
-  frac: 1.0
-  cfac: [QCD]
-CMS_SINGLETOP_TCH_TOT_7TEV:
-  frac: 1.0
-  cfac: [QCD]
-CMS_SINGLETOP_TCH_R_8TEV:
-  frac: 1.0
-  cfac: [QCD]
-CMS_SINGLETOP_TCH_R_13TEV:
-  frac: 1.0
-  cfac: [QCD]
-LHCBZ940PB:
-  frac: 1.0
-  cfac: [QCD]
-LHCBZEE2FB:
-  frac: 1.0
-  cfac: [QCD]
-LHCBWZMU7TEV:
-  frac: 1.0
-  cfac: [NRM, QCD]
-LHCBWZMU8TEV:
-  frac: 1.0
-  cfac: [NRM, QCD]
-LHCB_Z_13TEV_DIMUON:
-  frac: 1.0
-  cfac: [QCD]
-LHCB_Z_13TEV_DIELECTRON:
-  frac: 1.0
-  cfac: [QCD]
+NNLO:
+  NMCPD:
+    frac: 0.75
+  NMC:
+    frac: 0.75
+  SLACP:
+    frac: 0.75
+  SLACD:
+    frac: 0.75
+  BCDMSP:
+    frac: 0.75
+  BCDMSD:
+    frac: 0.75
+  CHORUSNUPb:
+    frac: 0.75
+  CHORUSNBPb:
+    frac: 0.75
+  NTVNUDMNFe:
+    frac: 0.75
+    cfac: [MAS]
+  NTVNBDMNFe:
+    frac: 0.75
+    cfac: [MAS]
+  HERACOMBNCEM:
+    frac: 0.75
+  HERACOMBNCEP460:
+    frac: 0.75
+  HERACOMBNCEP575:
+    frac: 0.75
+  HERACOMBNCEP820:
+    frac: 0.75
+  HERACOMBNCEP920:
+    frac: 0.75
+  HERACOMBCCEM:
+    frac: 0.75
+  HERACOMBCCEP:
+    frac: 0.75
+  HERACOMB_SIGMARED_C:
+    frac: 0.75
+  HERACOMB_SIGMARED_B:
+    frac: 0.75
+  DYE886R:
+    frac: 1.0
+  DYE886P:
+    frac: 0.75
+    cfac: [QCD]
+  DYE605:
+    frac: 0.75
+    cfac: [QCD]
+  CDFZRAP:
+    frac: 1.0
+    cfac: [QCD]
+  D0ZRAP:
+    frac: 1.0
+    cfac: [QCD]
+  D0WMASY:
+    frac: 1.0
+    cfac: [QCD]
+  ATLASWZRAP36PB:
+    frac: 1.0
+    cfac: [QCD]
+  ATLASZHIGHMASS49FB:
+    frac: 1.0
+    cfac: [QCD]
+  ATLASLOMASSDY11EXT:
+    frac: 1.0
+    cfac: [QCD]
+  ATLASWZRAP11CC:
+    frac: 0.75
+    cfac: [QCD]
+  ATLASWZRAP11CF:
+    frac: 0.75
+    cfac: [QCD]
+  ATLASDY2D8TEV:
+    frac: 0.75
+    cfac: [QCDEWK]
+  ATLAS_WZ_TOT_13TEV:
+    frac: 1.0
+    cfac: [NRM, QCD]
+  ATLAS_WP_JET_8TEV_PT:
+    frac: 0.75
+    cfac: [QCD]
+  ATLAS_WM_JET_8TEV_PT:
+    frac: 0.75
+    cfac: [QCD]
+  ATLASZPT8TEVMDIST:
+    frac: 0.75
+    cfac: [QCD]
+    sys: 10
+  ATLASZPT8TEVYDIST:
+    frac: 0.75
+    cfac: [QCD]
+    sys: 10
+  ATLASTTBARTOT:
+    frac: 1.0
+    cfac: [QCD]
+  ATLAS_TTB_DIFF_8TEV_LJ_TRAPNORM:
+    frac: 1.0
+    cfac: [QCD]
+  ATLAS_TTB_DIFF_8TEV_LJ_TTRAPNORM:
+    frac: 1.0
+    cfac: [QCD]
+  ATLAS_TOPDIFF_DILEPT_8TEV_TTRAPNORM:
+    frac: 1.0
+    cfac: [QCD]
+  ATLAS_1JET_8TEV_R06_DEC:
+    frac: 0.75
+    cfac: [QCD]
+  ATLAS_2JET_7TEV_R06:
+    frac: 0.75
+    cfac: [QCD]
+  ATLASPHT15:
+    frac: 0.75
+    cfac: [QCD, EWK]
+  ATLAS_SINGLETOP_TCH_R_7TEV:
+    frac: 1.0
+    cfac: [QCD]
+  ATLAS_SINGLETOP_TCH_R_13TEV:
+    frac: 1.0
+    cfac: [QCD]
+  ATLAS_SINGLETOP_TCH_DIFF_7TEV_T_RAP_NORM:
+    frac: 1.0
+    cfac: [QCD]
+  ATLAS_SINGLETOP_TCH_DIFF_7TEV_TBAR_RAP_NORM:
+    frac: 1.0
+    cfac: [QCD]
+  ATLAS_SINGLETOP_TCH_DIFF_8TEV_T_RAP_NORM:
+    frac: 0.75
+    cfac: [QCD]
+  ATLAS_SINGLETOP_TCH_DIFF_8TEV_TBAR_RAP_NORM:
+    frac: 0.75
+    cfac: [QCD]
+  CMSWEASY840PB:
+    frac: 1.0
+    cfac: [QCD]
+  CMSWMASY47FB:
+    frac: 1.0
+    cfac: [QCD]
+  CMSDY2D11:
+    frac: 0.75
+    cfac: [QCD]
+  CMSWMU8TEV:
+    frac: 1.0
+    cfac: [QCD]
+  CMSZDIFF12:
+    frac: 1.0
+    cfac: [QCD, NRM]
+    sys: 10
+  CMS_2JET_7TEV:
+    frac: 0.75
+    cfac: [QCD]
+  CMS_2JET_3D_8TEV:
+    frac: 0.75
+    cfac: [QCD]
+  CMSTTBARTOT:
+    frac: 1.0
+    cfac: [QCD]
+  CMSTOPDIFF8TEVTTRAPNORM:
+    frac: 1.0
+    cfac: [QCD]
+  CMSTTBARTOT5TEV:
+    frac: 1.0
+    cfac: [QCD]
+  CMS_TTBAR_2D_DIFF_MTT_TRAP_NORM:
+    frac: 1.0
+    cfac: [QCD]
+  CMS_TTB_DIFF_13TEV_2016_2L_TRAP:
+    frac: 1.0
+    cfac: [QCD]
+  CMS_TTB_DIFF_13TEV_2016_LJ_TRAP:
+    frac: 1.0
+    cfac: [QCD]
+  CMS_SINGLETOP_TCH_TOT_7TEV:
+    frac: 1.0
+    cfac: [QCD]
+  CMS_SINGLETOP_TCH_R_8TEV:
+    frac: 1.0
+    cfac: [QCD]
+  CMS_SINGLETOP_TCH_R_13TEV:
+    frac: 1.0
+    cfac: [QCD]
+  LHCBZ940PB:
+    frac: 1.0
+    cfac: [QCD]
+  LHCBZEE2FB:
+    frac: 1.0
+    cfac: [QCD]
+  LHCBWZMU7TEV:
+    frac: 1.0
+    cfac: [NRM, QCD]
+  LHCBWZMU8TEV:
+    frac: 1.0
+    cfac: [NRM, QCD]
+  LHCB_Z_13TEV_DIMUON:
+    frac: 1.0
+    cfac: [QCD]
+  LHCB_Z_13TEV_DIELECTRON:
+    frac: 1.0
+    cfac: [QCD]


### PR DESCRIPTION
Let's you do stuff like
```yaml
dataset_defaults_spec: 40

dataset_inputs:
- {dataset: ATLASDY2D8TEV}
- {dataset: LHCB_Z_13TEV_DIELECTRON}

theoryid: 53

use_cuts: internal

template_text: |
  {@groups_covmat@}

actions_:
- report(main=True)
```

And it will apply the `cfac`, `sys` etc. as per the `NNPDF40_nnlo_as_0118` runcard