### PR TITLE
Readd impose sumrules to msr

### DIFF
--- a/n3fit/src/n3fit/model_gen.py
+++ b/n3fit/src/n3fit/model_gen.py
@@ -563,7 +563,7 @@ def pdfNN_layer_generator(
 
     # Impose sumrule if necessary
     if impose_sumrule:
-        layer_pdf, integrator_input = msr_constraints.msr_impose(layer_fitbasis, layer_pdf, scaler=scaler)
+        layer_pdf, integrator_input = msr_constraints.msr_impose(layer_fitbasis, layer_pdf, scaler=scaler, mode=impose_sumrule)
         model_input.append(integrator_input)
     else:
         integrator_input = None


### PR DESCRIPTION
In one of the merges it disappeared. Thankfully it happened after the flavour fits so "that's fine"