### PR TITLE
Update readme with link to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ This project contains the following components:
 - nnpdfcpp: programs used in the NNPDF fitting framework. 
 - validphys2: the fit result analysis framework.
 
-
 **Table of Contents**
   * [Installation](#installation)
     * [Binary packages](#binary-packages)


### PR DESCRIPTION
I noticed the readme didn't link to the docs and instead linked to the old vp guide, so I've added in the right links.