### PR TITLE
Fix bug in thcovmat construction

### DIFF
--- a/validphys2/src/validphys/theorycovariance/construction.py
+++ b/validphys2/src/validphys/theorycovariance/construction.py
@@ -177,15 +177,10 @@ def total_covmat_procs(procs_results_theory, fivetheories: (str, type(None)) = N
 commondata_procs = collect("commondata", ["group_dataset_inputs_by_process", "data"])
 
 
-def dataset_names(commondata_procs):
+def dataset_names(data_input):
     """Returns a list of the names of the datasets, in the same order as
     they are inputted in the runcard"""
-    names = []
-    for commondata in commondata_procs:
-        name = commondata.name
-        if name not in names:
-            names.append(name)
-    return names
+    return [el.name for el in data_input]
 
 
 ProcessInfo = namedtuple("ProcessInfo", ("theory", "namelist", "sizes"))


### PR DESCRIPTION
Since the post data keyword update to the theory covariance matrix there was a bug in constructing the theory covmat. This is because` commondata_procs` also collected over `group_dataset_inputs_by_process` so you end up with N_proc iterations of the datasets which messes up the indexing of the th covmat down the line.

I've sorted this out by only using the unique datasets from `commondata_procs` when constructing `dataset_names`. I think this is one of the main issues affecting #991.