### PR TITLE
Pin yaml-cpp more strictly

### DIFF
--- a/conda-recipe/conda_build_config.yaml
+++ b/conda-recipe/conda_build_config.yaml
@@ -7,5 +7,5 @@ pin_run_as_build:
     lhapdf: x.x.x
     apfel: x.x.x.x
     gsl: x.x.x
-    yaml-cpp: x.x
+    yaml-cpp: x.x.x
     libarchive: x.x


### PR DESCRIPTION
This is intended to fix an issue where a fresh
installation would fail with something like

```
(base) zk261@mn01:~> vp-list pdfs
Traceback (most recent call last):
  File "/home/zk261/miniconda3/bin/vp-list", line 10, in <module>
    sys.exit(main())
  File "/home/zk261/miniconda3/lib/python3.8/site-packages/validphys/scripts/vp_list.py", line 127, in main
    l = L()
  File "/home/zk261/miniconda3/lib/python3.8/site-packages/validphys/loader.py", line 71, in __init__
    datapath = nnpath.get_data_path()
  File "/home/zk261/miniconda3/lib/python3.8/site-packages/NNPDF/nnpdf.py", line 1564, in get_data_path
    return _nnpdf.get_data_path()
RuntimeError: [pathlib] error: 'data_path' key not found in profile file '/home/zk261/miniconda3/share/NNPDF/nnprofile.yaml'
```

Turns out this fixes itself by downgrading to the version we actually
built and tested with. It was installing version 0.6.3 from conda forge
where we use one from the old days in our channel. Hopefully this fix
will make it work out of the box.