### PR TITLE
Added cut to remove the first data point of the ATLAS W+jet pT measur…

### DIFF
--- a/validphys2/src/validphys/cuts/filters.yaml
+++ b/validphys2/src/validphys/cuts/filters.yaml
@@ -98,6 +98,14 @@
   PTO: NNLO
   rule: "fabs(central_value) >= 0.03"
 
+- dataset: ATLAS_WP_JET_8TEV_PT
+  reason: Avoid the region where small-pT resummation effects become important.
+  rule: "p_T >= 30"
+
+- dataset: ATLAS_WM_JET_8TEV_PT
+  reason: Avoid the region where small-pT resummation effects become important.
+  rule: "p_T >= 30"
+
 - dataset: ATLASZPT7TEV
   reason: Avoid the region where resummation effects become important.
   rule: "p_T2 >= 30**2"


### PR DESCRIPTION
This PR implements a cut on the pT distribution for the ATLAS W+jet measurement. The cut removes two data points (one for W+ and one for W-) at the smallest pT, where resummation effects may be large. Note that here the K-factor is indeed ~30% for these points. Although this data sets has been fitted for quite some time now - and the cut won't possibly change anything - I believe that it's neater to have it. 