### PR TITLE
Add option to use same trvl seed for all replicas

### DIFF
--- a/doc/sphinx/source/n3fit/runcard_detailed.rst
+++ b/doc/sphinx/source/n3fit/runcard_detailed.rst
@@ -105,6 +105,16 @@ The fraction of events that are considered for the training and validation sets 
 
 It is possible to run a fit with no validation set by setting the fraction to ``1.0``, in this case the training set will be used as validation set.
 
+The random seed for the training/validation split is defined by the variable ``trvlseed``.
+By default the seed is further modified by the replica index, but it is possible
+to fix it such that it is the same for all replicas with ``same_trvl_per_replica``
+(``false`` by default).
+
+.. code-block:: yaml
+
+    trvlseed: 7
+    same_trvl_per_replica: true
+
 
 .. _networkarch-label:
 

--- a/validphys2/src/validphys/n3fit_data.py
+++ b/validphys2/src/validphys/n3fit_data.py
@@ -25,11 +25,13 @@ from validphys.n3fit_data_utils import (
 
 log = logging.getLogger(__name__)
 
-def replica_trvlseed(replica, trvlseed):
+def replica_trvlseed(replica, trvlseed, same_trvl_per_replica=False):
     """Generates the ``trvlseed`` for a ``replica``."""
     # TODO: move to the new infrastructure
     # https://numpy.org/doc/stable/reference/random/index.html#introduction
     np.random.seed(seed=trvlseed)
+    if same_trvl_per_replica:
+        return np.random.randint(0, pow(2, 31))
     for _ in range(replica):
         res = np.random.randint(0, pow(2, 31))
     return res


### PR DESCRIPTION
Added an option to the runcard (`same_trvl_per_replica`, I was not sure about the name) so that the training validation split is the same for all replicas.

Closes #1244 