### PR TITLE
Ignore autogenerated files in documentation

### DIFF
--- a/doc/sphinx/.gitignore
+++ b/doc/sphinx/.gitignore
@@ -1,2 +1,3 @@
 # Ignore auto generated module references
-./source/modules
+source/modules
+source/theories.csv


### PR DESCRIPTION
Fix the syntax so the modules are actually ignored and ignore the newer
theories csv.