### PR TITLE
Set minimum version of Sphinx

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -46,7 +46,7 @@ requirements:
         - requests
         - prompt_toolkit
         - validobj
-        - sphinx # documentation
+        - sphinx >=4.0.2 # documentation. Needs pinning becasue https://github.com/sphinx-doc/sphinx/issues/9216
         - recommonmark
         - sphinx_rtd_theme >0.5
         - sphinxcontrib-bibtex


### PR DESCRIPTION
The documentation fails to build because the Sphinx package that we are
getting from defaults has incorrectly specified dependencies. See

https://github.com/sphinx-doc/sphinx/issues/9216

Instead pull a newer version, from conda forge that has this fixed.