### PR TITLE
Compile buildmaster with asan

### DIFF
--- a/buildmaster/CMakeLists.txt
+++ b/buildmaster/CMakeLists.txt
@@ -47,6 +47,7 @@ pkg_search_module(LIBARCHIVE REQUIRED libarchive)
 set(DEFAULT_CXX_OPTIONS "-Wall -Wextra -march=nocona -mtune=haswell \
                          -fvisibility-inlines-hidden -fmessage-length=0 \
                          -ftree-vectorize -fPIC -fstack-protector-strong \
+                         -fsanitize=address \
                          -O2 -pipe")
 
 # Get rid of annoying semi colon in pkg_config output - slightly hacky way


### PR DESCRIPTION
This code is not performance critical at all and instead is very prone
to have various kinds of off by one errors. Some of them can be found
with the address sanitizer, and so it seems a good idea to have it on by
default.