### PR TITLE
Fix vp-deltachi2 by changing experiments to datasets inputs

### DIFF
--- a/validphys2/src/validphys/scripts/vp_deltachi2.py
+++ b/validphys2/src/validphys/scripts/vp_deltachi2.py
@@ -63,7 +63,7 @@ class HyperoptPlotApp(App):
             "theory": {"from_": "fit"},
             "theoryid": {"from_": "theory"},
             "use_cuts": "fromfit",
-            "experiments": {"from_": "fit"},
+            "dataset_inputs": {"from_": "fit"},
             "normalize_to": fit,
         }
 


### PR DESCRIPTION
I'm seeing the following error 
```
[ERROR]: Bad configuration encountered:
Could not retrieve element experiments from namespace. No such key
```

Steps to reproduce the error:

```bash
vp-get fit 210219-01-rs-nnpdf40-baseline
mc2hessian 210219-01-rs-nnpdf40-baseline 50 2
mv 210219-01-rs-nnpdf40-baseline_hessian_50/ $(lhapdf-config --datadir)/
vp-deltachi2 210219-01-rs-nnpdf40-baseline 210219-01-rs-nnpdf40-baseline_hessian_50
```

I think this line change should fix it, not sure whether I'll be breaking other things (or whether that's not what it should be doing ofc) so if someone can have a look it would be appreciated.
