### PR TITLE
Plot higher mx data by default

### DIFF
--- a/validphys2/src/validphys/pdfgrids.py
+++ b/validphys2/src/validphys/pdfgrids.py
@@ -152,7 +152,7 @@ def lumigrid1d(
     pdf: PDF,
     lumi_channel,
     sqrts: numbers.Real,
-    nbins_m: int = 30,
+    nbins_m: int = 40,
     mxmin: numbers.Real = 10,
     mxmax: (type(None), numbers.Real) = None,
     scale="log",
@@ -171,7 +171,7 @@ def lumigrid1d(
     """
     s = sqrts*sqrts
     if mxmax is None:
-        mxmax = sqrts/10
+        mxmax = sqrts/3
     if scale=="log":
         mxs = np.logspace(np.log10(mxmin), np.log10(mxmax), nbins_m)
     elif scale=="linear":


### PR DESCRIPTION
The default limit for Mx was sqrts/10, which is alleged to be too low.
Change it to sqrts/3 and add a few more points by default to compensate.

Closes #1309 