### PR TITLE
Modify vp-comparefits interface

### DIFF
--- a/validphys2/src/validphys/scripts/vp_comparefits.py
+++ b/validphys2/src/validphys/scripts/vp_comparefits.py
@@ -61,17 +61,15 @@ class CompareFitApp(App):
         mandatory.add_argument('--author', help="The author of the report.")
         mandatory.add_argument(
             '--keywords', nargs='+', help="keywords to index the report with.")
-        mandatory.add_argument(
+
+        parser.add_argument(
             '--thcovmat_if_present',
-            dest='thcovmat_if_present',
             action='store_true',
             help="Use theory cov mat for calculating statistical estimators if available.")
-        mandatory.add_argument(
+        parser.add_argument(
             '--no-thcovmat_if_present',
-            dest='thcovmat_if_present',
-            action='store_false',
-            help="Do not use theory cov mat for calculating statistical estimators.")
-
+            action='store_true',
+            help="DEPRECATED: does nothing")
         parser.add_argument(
             '--current_fit_label',
             nargs='?',
@@ -94,7 +92,7 @@ class CompareFitApp(App):
             help="Use the closure comparison template.",
             action='store_true')
 
-        parser.set_defaults(thcovmat_if_present=None)
+        parser.set_defaults()
 
     def try_complete_args(self):
         args = self.args


### PR DESCRIPTION
vp-comparefits requires a number of arguments to be added when ran from command-line, however the `--help` doesn't really help on knowing which they are. I've grouped them so that one can quickly know which are mandatory:

```
mandatory:
  Mandatory command line arguments

  --title TITLE         The title that will be indexed with the report.
  --author AUTHOR       The author of the report.
  --keywords KEYWORDS [KEYWORDS ...]
                        keywords to index the report with.

```

Then there're the flags `th_covmat_if_present` and `no-thcovmat_if_present` which are both the same one. I guess there might be a good reason why having one of the two was made mandatory but I think it makes more sense to be `false` by default and use it if needed?  I've put as reviewer people who modified this file just in case I broke something important...

Note: I've separated the thcovmat and the groupping commits so I can revert the thcovmat if there's a good reason for making it mandatory.