### PR TITLE
update matplotlib hatch style

### DIFF
--- a/validphys2/src/validphys/plotutils.py
+++ b/validphys2/src/validphys/plotutils.py
@@ -111,7 +111,7 @@ def hatch_iter():
     """An infinite iterator that yields increasingly denser patterns of
     hatches suitable for passing as the ``hatch`` argument of matplotlib
     functions."""
-    hatches = "/ \\ - + o 0".split()
+    hatches = "/ \\ - + o O".split()
     i = 1
     while True:
         for hatch in hatches:


### PR DESCRIPTION
> MatplotlibDeprecationWarning: hatch must consist of a string of "*+-./OX\ox|" or None, but found the following invalid values "0". Passing invalid values is deprecated since 3.4 and will become an error two minor releases later.

https://matplotlib.org/devdocs/gallery/shapes_and_collections/hatch_style_reference.html#hatch-style-reference