### PR TITLE
Add metadata groups to closure tables

### DIFF
--- a/validphys2/src/validphys/closuretest/multiclosure.py
+++ b/validphys2/src/validphys/closuretest/multiclosure.py
@@ -650,7 +650,25 @@ experiments_bootstrap_bias_variance = collect(
 )
 
 
-def experiments_bootstrap_ratio(experiments_bootstrap_bias_variance):
+def total_bootstrap_ratio(experiments_bootstrap_bias_variance):
+    """Calculate the total bootstrap ratio for all data. Leverages the
+    fact that the covariance matrix is block diagonal in experiments so
+
+        Total ratio = sum(bias) / sum(variance)
+
+    Which is valid provided there are no inter-experimental correlations.
+
+    Returns
+    -------
+    bias_var_total: tuple
+        tuple of the total bias and variance
+
+    """
+    bias_tot, var_tot = np.sum(experiments_bootstrap_bias_variance, axis=0)
+    return bias_tot, var_tot
+
+
+def experiments_bootstrap_ratio(experiments_bootstrap_bias_variance, total_bootstrap_ratio):
     """Returns a bootstrap resampling of the ratio of bias/variance for
     each experiment and total. Total is calculated as sum(bias)/sum(variance)
     where each sum refers to the sum across experiments.
@@ -664,13 +682,8 @@ def experiments_bootstrap_ratio(experiments_bootstrap_bias_variance):
         resampled.
 
     """
-    bias_tot, var_tot = experiments_bootstrap_bias_variance[0]
-    # add first ratio to list
-    ratios = [bias_tot / var_tot]
-    for bias, var in experiments_bootstrap_bias_variance[1:]:
-        bias_tot += bias
-        var_tot += var
-        ratios.append(bias / var)
+    ratios = [bias / var for bias, var in experiments_bootstrap_bias_variance]
+    bias_tot, var_tot = total_bootstrap_ratio
     ratios.append(bias_tot / var_tot)
     return ratios
 
@@ -678,7 +691,6 @@ def experiments_bootstrap_ratio(experiments_bootstrap_bias_variance):
 def experiments_bootstrap_sqrt_ratio(experiments_bootstrap_ratio):
     """Square root of experiments_bootstrap_ratio"""
     return np.sqrt(experiments_bootstrap_ratio)
-
 
 
 def experiments_bootstrap_expected_xi(experiments_bootstrap_sqrt_ratio):
@@ -693,7 +705,24 @@ def experiments_bootstrap_expected_xi(experiments_bootstrap_sqrt_ratio):
     estimated_integral = special.erf(n_sigma_in_variance / np.sqrt(2))
     return estimated_integral
 
+groups_bootstrap_bias_variance = collect(
+    "fits_bootstrap_data_bias_variance", ("group_dataset_inputs_by_metadata",)
+)
 
+
+def groups_bootstrap_ratio(groups_bootstrap_bias_variance, total_bootstrap_ratio):
+    """Like :py:func:`experiments_bootstrap_ratio` but for metadata groups."""
+    return experiments_bootstrap_ratio(groups_bootstrap_bias_variance, total_bootstrap_ratio)
+
+
+def groups_bootstrap_sqrt_ratio(groups_bootstrap_ratio):
+    """Like :py:func:`experiments_bootstrap_sqrt_ratio` but for metadata groups."""
+    return experiments_bootstrap_sqrt_ratio(groups_bootstrap_ratio)
+
+
+def groups_bootstrap_expected_xi(groups_bootstrap_sqrt_ratio):
+    """Like :py:func:`experiments_bootstrap_expected_xi` but for metadata groups."""
+    return experiments_bootstrap_expected_xi(groups_bootstrap_sqrt_ratio)
 
 
 @check_multifit_replicas
@@ -743,6 +772,10 @@ def total_bootstrap_xi(experiments_bootstrap_xi):
 
     """
     return np.concatenate(experiments_bootstrap_xi, axis=1)
+
+groups_bootstrap_xi = collect(
+    "fits_bootstrap_data_xi", ("group_dataset_inputs_by_metadata",))
+
 
 def dataset_fits_bias_replicas_variance_samples(
     internal_multiclosure_dataset_loader,

--- a/validphys2/src/validphys/closuretest/multiclosure_output.py
+++ b/validphys2/src/validphys/closuretest/multiclosure_output.py
@@ -661,6 +661,20 @@ def experiments_bootstrap_sqrt_ratio_table(
 
 
 @table
+def groups_bootstrap_sqrt_ratio_table(
+    groups_bootstrap_sqrt_ratio, groups_data
+):
+    """Like :py:func:`experiments_bootstrap_sqrt_ratio_table` but for
+    metadata groups.
+    """
+    df = experiments_bootstrap_sqrt_ratio_table(
+        groups_bootstrap_sqrt_ratio, groups_data
+    )
+    idx = df.index.rename("group")
+    return df.set_index(idx)
+
+
+@table
 def experiments_bootstrap_expected_xi_table(
     experiments_bootstrap_expected_xi, experiments_data
 ):
@@ -680,6 +694,16 @@ def experiments_bootstrap_expected_xi_table(
     ]
     return df
 
+
+@table
+def groups_bootstrap_expected_xi_table(groups_bootstrap_expected_xi, groups_data):
+    """Like :py:func:`experiments_bootstrap_expected_xi_table` but for metadata
+    groups.
+    """
+    df = experiments_bootstrap_expected_xi_table(
+        groups_bootstrap_expected_xi, groups_data)
+    idx = df.index.rename("group")
+    return df.set_index(idx)
 
 @table
 def experiments_bootstrap_xi_table(
@@ -706,6 +730,17 @@ def experiments_bootstrap_xi_table(
 
 
 @table
+def groups_bootstrap_xi_table(
+    groups_bootstrap_xi, groups_data, total_bootstrap_xi
+):
+    """Like :py:func:`experiments_bootstrap_xi_table` but for metadata groups."""
+    df = experiments_bootstrap_xi_table(
+        groups_bootstrap_xi, groups_data, total_bootstrap_xi)
+    idx = df.index.rename("group")
+    return df.set_index(idx)
+
+
+@table
 def experiments_bootstrap_xi_comparison(
     experiments_bootstrap_xi_table, experiments_bootstrap_expected_xi_table
 ):
@@ -717,6 +752,18 @@ def experiments_bootstrap_xi_comparison(
     return pd.concat(
         (experiments_bootstrap_xi_table, experiments_bootstrap_expected_xi_table),
         axis=1,
+    )
+
+
+@table
+def groups_bootstrap_xi_comparison(
+    groups_bootstrap_xi_table, groups_bootstrap_expected_xi_table
+):
+    """Like :py:func:`experiments_bootstrap_xi_comparison` but for metadata
+    groups.
+    """
+    return experiments_bootstrap_xi_comparison(
+        groups_bootstrap_xi_table, groups_bootstrap_expected_xi_table
     )
 
 


### PR DESCRIPTION
Without spending more time on this, this was the best I could do. There seems to be a fair amount of redundancy but I think there isn't a better way to do it without getting rid of backwards compat.

Example report: https://vp.nnpdf.science/6oHHKWGkSw-d-LxFX59Fig==

the groups are much smaller so there are bigger fluctuations. The worst one is probably jets which actually has a fair amount of data. Anyway people asked for it, so here it is.