### PR TITLE
Improved reading of fit pseudodata

### DIFF
--- a/validphys2/src/validphys/pseudodata.py
+++ b/validphys2/src/validphys/pseudodata.py
@@ -5,7 +5,6 @@ networks during the fitting.
 """
 from collections import namedtuple
 import logging
-import os
 import pathlib
 
 import numpy as np


### PR DESCRIPTION
Just a quick PR that refines the way we read the pseudodata files from a fit. This builds on the production rules of  #1328, which now allows for an easier way to handle the postfit pseudodata reshuffling.

Tests will fail for now. Blocked by #1333 