### PR TITLE
add isort configuration file

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,12 @@
+[settings]
+# overview cofiguration options: https://pycqa.github.io/isort/docs/configuration/options.html
+default_section = THIRDPARTY
+known_first_party = validphys,n3fit,reportengine
+sections = FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
+multi_line_output=3
+include_trailing_comma=True
+line_length=100
+lines_after_imports=1
+remove_redundant_aliases=True
+force_alphabetical_sort_within_sections=True
+


### PR DESCRIPTION
I think pylint also contains rules for this, but since that output is such a chaotic mess (see #1338 ), I thought we might use isort to get some consistency between files when it comes to the imports.

@Zaharid what do you think?