### PR TITLE
Correcting kinematics override for DY datasets

### DIFF
--- a/nnpdfcpp/data/commondata/PLOTTING_ATLASDY2D8TEV.yaml
+++ b/nnpdfcpp/data/commondata/PLOTTING_ATLASDY2D8TEV.yaml
@@ -6,5 +6,7 @@ figure_by:
 
 x_label: '$|y_{\ell\ell}|$'
 
+kinematics_override: ewk_rap_sqrt_scale
+
 experiment: "ATLAS"
 nnpdf31_process: DY

--- a/nnpdfcpp/data/commondata/PLOTTING_ATLASZHIGHMASS49FB.yaml
+++ b/nnpdfcpp/data/commondata/PLOTTING_ATLASZHIGHMASS49FB.yaml
@@ -3,6 +3,8 @@ x: k2
 y_label: '$d\sigma_{Z/\gamma^{*}}/dM_{ll}$ (fb)' 
 y_scale: log
 
+kinematics_override: ewk_mll_sqrt_scale
+
 experiment: "ATLAS"
 
 nnpdf31_process: DY

--- a/nnpdfcpp/data/commondata/PLOTTING_CMSDY2D11.yaml
+++ b/nnpdfcpp/data/commondata/PLOTTING_CMSDY2D11.yaml
@@ -4,6 +4,8 @@ y_label: '$d\sigma_{Z/\gamma^{*}}/dy$ (fb)'
 figure_by:
   - k2 
 
+kinematics_override: ewk_mll_sqrt_scale
+
 experiment: "CMS"
 
 nnpdf31_process: DY


### PR DESCRIPTION
I believe these weren't set so kinematic coverage plots looked weird