### PR TITLE
'poslambda' to 'maxlambda' in docs

### DIFF
--- a/doc/sphinx/source/tutorials/thcov_tutorial.rst
+++ b/doc/sphinx/source/tutorials/thcov_tutorial.rst
@@ -229,13 +229,13 @@ It can be found `here <https://github.com/NNPDF/nnpdf/tree/master/validphys2/exa
 	############################################################
 	positivity:
 	  posdatasets:
-	  - {dataset: POSF2U, poslambda: 1e6}        # Positivity Lagrange Multiplier
-	  - {dataset: POSF2DW, poslambda: 1e6}
-	  - {dataset: POSF2S, poslambda: 1e6}
-	  - {dataset: POSFLL, poslambda: 1e6}
-	  - {dataset: POSDYU, poslambda: 1e10}
-	  - {dataset: POSDYD, poslambda: 1e10}
-	  - {dataset: POSDYS, poslambda: 1e10}
+	  - {dataset: POSF2U, maxlambda: 1e6}        # Positivity Lagrange Multiplier
+	  - {dataset: POSF2DW, maxlambda: 1e6}
+	  - {dataset: POSF2S, maxlambda: 1e6}
+	  - {dataset: POSFLL, maxlambda: 1e6}
+	  - {dataset: POSDYU, maxlambda: 1e10}
+	  - {dataset: POSDYD, maxlambda: 1e10}
+	  - {dataset: POSDYS, maxlambda: 1e10}
 
 	############################################################
 	closuretest:

--- a/doc/sphinx/source/vp/custom_pipelines.rst
+++ b/doc/sphinx/source/vp/custom_pipelines.rst
@@ -68,7 +68,7 @@ resource we are providing does. The docstring will be seen in
 
 	def parse_posdataset(self, posset:dict, * ,theoryid):
 	    """An observable used as positivity constrain in the fit.
-	    It is a mapping containing 'dataset' and 'poslambda'."""
+	    It is a mapping containing 'dataset' and 'maxlambda'."""
 	    ...
 
 
@@ -165,10 +165,10 @@ The `PositivitySetSpec` could be defined roughly like:
 .. code:: python
 
 	 class PositivitySetSpec():
-	     def __init__(self, commondataspec, fkspec, poslambda, thspec):
+	     def __init__(self, commondataspec, fkspec, maxlambda, thspec):
 		 self.commondataspec = commondataspec
 		 self.fkspec = fkspec
-		 self.poslambda = poslambda
+		 self.maxlambda = maxlambda
 		 self.thspec = thspec
 
 	     @property
@@ -182,7 +182,7 @@ The `PositivitySetSpec` could be defined roughly like:
 	     def load(self):
 		 cd = self.commondataspec.load()
 		 fk = self.fkspec.load()
-		 return PositivitySet(cd, fk, self.poslambda)
+		 return PositivitySet(cd, fk, self.maxlambda)
 
 Here `PositivitySet` is the `libnnpdf` object. It is generally better
 to pass around the spec objects because they are lighter and have more
@@ -194,21 +194,21 @@ With this, our parser method could look like this:
 
 	def parse_posdataset(self, posset:dict, * ,theoryid):
 	    """An observable used as positivity constrain in the fit.
-	    It is a mapping containing 'dataset' and 'poslambda'."""
+	    It is a mapping containing 'dataset' and 'maxlambda'."""
 	    bad_msg = ("posset must be a mapping with a name ('dataset') and "
-		       "a float multiplier(poslambda)")
+		       "a float multiplier(maxlambda)")
 
 	    theoryno, theopath = theoryid
 	    try:
 		name = posset['dataset']
-		poslambda = float(posset['poslambda'])
+		maxlambda = float(posset['maxlambda'])
 	    except KeyError as e:
 		raise ConfigError(bad_msg, e.args[0], posset.keys()) from e
 	    except ValueError as e:
 		raise ConfigError(bad_msg) from e
 
 	    try:
-		return self.loader.check_posset(theoryno, name, poslambda)
+		return self.loader.check_posset(theoryno, name, maxlambda)
 	    except FileNotFoundError as e:
 		raise ConfigError(e) from e
 


### PR DESCRIPTION
Doesn't correspond to an issue, but I noticed this had not yet been updated. 