### PR TITLE
Restructuring data kws docs

### DIFF
--- a/doc/sphinx/source/vp/dataspecification.rst
+++ b/doc/sphinx/source/vp/dataspecification.rst
@@ -3,79 +3,15 @@
 Data specification
 ==================
 
+.. _datasetspec-core-label:
 
-At a glance: what do I need to change in my runcards?
------------------------------------------------------
+``DataSetSpec`` - Core dataset object
+-------------------------------------
 
 The data specification has been updated from a more rigid structure based on 
 experiments to a flatter structure based on individual datasets, which can be
 grouped in a more flexible way for different purposes. This grouping is specified
 by ``metadata_group``, and the default grouping is by ``experiment``.
-
-Efforts have been made to ensure a degree of backwards compatibility, however
-there are two main things which may need to be changed in old runcards.
-
-1. For theorycovariance runcards, you must add a line with
-``metadata_group: nnpdf31_process``, or else the prescriptions for scale
-variations will not vary scales coherently for data
-within the same process type, as usually desired, but rather for data within
-the same experiment.
-
-2. Many actions which were based on experiments have changed names as they are
-now based on arbitrary groupings given by ``metadata_group``. The table below gives
-the old name alongside the new one. These need to be updated for the runcards to 
-continue to work.
-
-.. list-table:: Updated names for old actions
-   :widths: 25 25
-   :header-rows: 1
-
-   * - Old name
-     - New name
-   * - plot_fits_experiments_phi
-     - plot_fits_groups_data_phi
-   * - plot_phi_experiment_dist
-     - plot_dataset_inputs_phi_dist
-   * - plot_experiments_chi2
-     - plot_groups_data_chi2
-   * - plot_fits_experiments_chi2
-     - plot_fits_groups_data_chi2
-   * - experiment_result_table
-     - group_result_table
-   * - experiment_result_table_68cl
-     - group_result_table_68cl
-   * - experiments_covmat
-     - groups_covmat
-   * - experiments_sqrtcovmat
-     - groups_sqrtcovmat
-   * - experiments_invcovmat
-     - groups_invcovmat
-   * - experiments_normcovmat
-     - groups_normcovmat
-   * - experiments_corrmat
-     - groups_corrmat
-   * - experiment_results
-     - dataset_inputs_results
-   * - experiments_chi2_table
-     - groups_chi2_table
-   * - fits_experiments_chi2_table
-     - fits_groups_chi2_table
-   * - fits_experiments_phi_table
-     - fits_groups_phi_table
-   * - dataspecs_experiments_chi2_table
-     - dataspecs_groups_chi2_table
-   * - experiments_central_values
-     - groups_central_values
-   * - experiments_chi2_table_theory
-     - groups_chi2_table_theory
-   * - experiments_chi2_table_diagtheory
-     - groups_chi2_table_diagtheory
-
-
-.. _datasetspec-core-label:
-
-``DataSetSpec`` - Core dataset object
--------------------------------------
 
 The core dataset object in ``validphys`` is the
 :py:mod:`validphys.core.DataSetSpec` which is responsible for loading the
@@ -484,3 +420,65 @@ always require ``experiments`` to be specified in the runcard.
   group will contain all of the datasets from the fit - which is incorrect.
   This is regarded as a bug, the relevant issue is:
   https://github.com/NNPDF/reportengine/issues/38
+
+At a glance: what do I need to change in my runcards?
+-----------------------------------------------------
+
+Efforts have been made to ensure a degree of backwards compatibility, however
+there are two main things which may need to be changed in old runcards.
+
+1. For theorycovariance runcards, you must add a line with
+``metadata_group: nnpdf31_process``, or else the prescriptions for scale
+variations will not vary scales coherently for data
+within the same process type, as usually desired, but rather for data within
+the same experiment.
+
+2. Many actions which were based on experiments have changed names as they are
+now based on arbitrary groupings given by ``metadata_group``. The table below gives
+the old name alongside the new one. These need to be updated for the runcards to 
+continue to work.
+
+.. list-table:: Updated names for old actions
+   :widths: 25 25
+   :header-rows: 1
+
+   * - Old name
+     - New name
+   * - plot_fits_experiments_phi
+     - plot_fits_groups_data_phi
+   * - plot_phi_experiment_dist
+     - plot_dataset_inputs_phi_dist
+   * - plot_experiments_chi2
+     - plot_groups_data_chi2
+   * - plot_fits_experiments_chi2
+     - plot_fits_groups_data_chi2
+   * - experiment_result_table
+     - group_result_table
+   * - experiment_result_table_68cl
+     - group_result_table_68cl
+   * - experiments_covmat
+     - groups_covmat
+   * - experiments_sqrtcovmat
+     - groups_sqrtcovmat
+   * - experiments_invcovmat
+     - groups_invcovmat
+   * - experiments_normcovmat
+     - groups_normcovmat
+   * - experiments_corrmat
+     - groups_corrmat
+   * - experiment_results
+     - dataset_inputs_results
+   * - experiments_chi2_table
+     - groups_chi2_table
+   * - fits_experiments_chi2_table
+     - fits_groups_chi2_table
+   * - fits_experiments_phi_table
+     - fits_groups_phi_table
+   * - dataspecs_experiments_chi2_table
+     - dataspecs_groups_chi2_table
+   * - experiments_central_values
+     - groups_central_values
+   * - experiments_chi2_table_theory
+     - groups_chi2_table_theory
+   * - experiments_chi2_table_diagtheory
+     - groups_chi2_table_diagtheory

--- a/doc/sphinx/source/vp/dataspecification.rst
+++ b/doc/sphinx/source/vp/dataspecification.rst
@@ -124,15 +124,16 @@ Here we are obtaining the result from the production rule
 are ``dataset_input``, ``cuts`` and ``theoryid``.
 
 .. note::
-    It seems odd to require theory settings such as a `theoryid` in the
-    `dataset_input` in order to load data. However, this is a relic of the
+
+    It seems odd to require theory settings such as a ``theoryid`` in the
+    ``dataset_input`` in order to load data. However, this is a relic of the
     underlying C++ code that performs the loading of data, which intrinsically
     groups together the commondata (CSVs containing data central values and
     uncertainties) and :ref:`fktables`.
 
     Clearly there is a big margin for error when manually entering
-    `dataset_input` and so there is a
-    [project](https://github.com/NNPDF/nnpdf/issues/226) that aims to have a
+    ``dataset_input`` and so there is a
+    `project <https://github.com/NNPDF/nnpdf/issues/226>`_ that aims to have a
     stable way of filling many of these settings with correct default values.
 
 The ``DataSetSpec`` contains all of the information used to construct it, e.g.

--- a/doc/sphinx/source/vp/dataspecification.rst
+++ b/doc/sphinx/source/vp/dataspecification.rst
@@ -9,8 +9,8 @@ Data specification
 -------------------------------------
 
 The declaration of dataset specifications within the ``validphys`` framework
-is handled using the ``dataset_input`` (or ``dataset_inputs`` namespace
-list for a collection of datasets) key. Through this keyword the user
+is handled using the ``dataset_input``  key, or ``dataset_inputs`` namespace
+list for a collection of datasets. Through this keyword the user
 is provided a granular degree of customizability for each dataset considered
 in the runcard; in particular the handling of K-factors, systematic uncertainties,
 training fraction, or dataset weight can be modified in this declaration. Moreover,
@@ -426,7 +426,7 @@ always require ``experiments`` to be specified in the runcard.
   This is regarded as a bug, the relevant issue is:
   https://github.com/NNPDF/reportengine/issues/38
 
-At a glance: what do I need to change in my runcards?
+What do I need to change in my runcards?
 -----------------------------------------------------
 
 Efforts have been made to ensure a degree of backwards compatibility, however

--- a/doc/sphinx/source/vp/dataspecification.rst
+++ b/doc/sphinx/source/vp/dataspecification.rst
@@ -8,10 +8,15 @@ Data specification
 ``DataSetSpec`` - Core dataset object
 -------------------------------------
 
-The data specification has been updated from a more rigid structure based on 
-experiments to a flatter structure based on individual datasets, which can be
-grouped in a more flexible way for different purposes. This grouping is specified
-by ``metadata_group``, and the default grouping is by ``experiment``.
+The declaration of dataset specifications within the ``validphys`` framework
+is handled using the ``dataset_input`` (or ``dataset_inputs`` namespace
+list for a collection of datasets) key. Through this keyword the user
+is provided a granular degree of customizability for each dataset considered
+in the runcard; in particular the handling of K-factors, systematic uncertainties,
+training fraction, or dataset weight can be modified in this declaration. Moreover,
+the ``metadata_group`` keyword allows for a flexible grouping of a collection of
+datasets, organizing them into disjoint subsets depending on, for example, the
+experiment class to which they belong or their process type.
 
 The core dataset object in ``validphys`` is the
 :py:mod:`validphys.core.DataSetSpec` which is responsible for loading the


### PR DESCRIPTION
I spotted a couple of formatting typos, which have been fixed. I also moved the at a glance section to the end of the document such that it reads after the section on backwards compatibility. Closes #1354