### PR TITLE
Revert correlated shift functionality

### DIFF
--- a/validphys2/src/validphys/dataplots.py
+++ b/validphys2/src/validphys/dataplots.py
@@ -22,7 +22,7 @@ from reportengine.floatformatting import format_number
 from reportengine import collect
 
 from validphys.core import MCStats, cut_mask, CutsPolicy
-from validphys.results import chi2_stat_labels, get_shifted_results
+from validphys.results import chi2_stat_labels
 from validphys.plotoptions import get_info, kitable, transform_result
 from validphys import plotutils
 from validphys.utils import sane_groupby_iter, split_ranges, scale_from_grid
@@ -198,7 +198,7 @@ def check_normalize_to(ns, **kwargs):
 #TODO: This interface is horrible. We need to think how to adapt libnnpdf
 #to make this use case easier
 def _plot_fancy_impl(results, commondata, cutlist,
-               normalize_to:(int,type(None)) = None, labellist=None, withshifts=False):
+               normalize_to:(int,type(None)) = None, labellist=None):
 
     """Implementation of the data-theory comparison plots. Providers are
     supposed to call (yield from) this.
@@ -218,9 +218,6 @@ def _plot_fancy_impl(results, commondata, cutlist,
     labellist : list or None
         The labesl that will appear in the plot. They sill be deduced
         (from the PDF names) if None is given.
-    withshifts: bool
-        Add the correlated shifts to the theory predctions based on 
-        eq.84 of arXiv:1709.04922
     Returns
     -------
     A generator over figures.
@@ -272,50 +269,6 @@ def _plot_fancy_impl(results, commondata, cutlist,
             table[('err', i)] = err/norm_cv
         cvcols.append(cvcol)
 
-    ### Computing correlated shifts according to the paper: arXiv:1709.04922
-    if withshifts:
-        for i, (result, cuts) in enumerate(zip(results, cutlist)):
-            if i==0: continue
-
-            cd = commondata.load()
-            mask = cut_mask(cuts)
-
-            ## fill uncertainties
-            Ndat = len(table[('cv', i)])
-            Nsys = cd.GetNSys()
-
-            uncorrE = np.zeros(Ndat) # square root of sum of uncorrelated uncertainties
-            corrE = np.zeros((Ndat, Nsys)) # table of all the correlated uncertainties
-            lambda_sys = np.zeros(Nsys) # nuisance parameters
-
-            for idat in range(Ndat):
-                convi = table[('cv', 0)][idat]/cd.GetData(idat) # conversion constant
-                uncorrE[idat] = cd.GetUncE(idat)*convi
-                for isys in range(Nsys):
-                    if cd.GetSys(idat, isys).name != "UNCORR":
-                        corrE[idat, isys] = cd.GetSys(idat, isys).add*convi
-
-            ## applying cuts
-            uncorrE=uncorrE[mask]
-            corrE=corrE[mask]
-            data = table[('cv', 0)][mask]
-            theory = table[('cv', i)][mask]
-
-            ## isys is equivalent to alpha index and lsys to delta in eq.85
-            if np.any(uncorrE == 0):
-                temp_shifts = np.zeros(Ndat)
-            else:
-                f1 = (data - theory)/uncorrE # first part of eq.85
-                A = np.diag(np.diag(np.ones((Nsys, Nsys)))) + \
-                    np.einsum('ik,il,i->kl', corrE, corrE, 1./uncorrE**2) # eq.86
-                f2 = np.einsum('kl,il,i->ik', np.linalg.inv(A), corrE, 1./uncorrE) # second part of eq.85
-                lambda_sys= np.einsum('i,ik->k', f1,f2) #nuisance parameter
-                temp_shifts = np.einsum('ik,k->i',corrE,lambda_sys) # the shift
-
-                shifts = np.full(Ndat, np.nan)
-                shifts[mask] = temp_shifts
-
-                table[('cv', i)] += shifts
 
     figby = sane_groupby_iter(table, info.figure_by)
 
@@ -429,7 +382,7 @@ def _plot_fancy_impl(results, commondata, cutlist,
 @check_normalize_to
 @figuregen
 def plot_fancy(one_or_more_results, commondata, cuts,
-               normalize_to: (int, str, type(None)) = None, withshifts=False):
+               normalize_to: (int, str, type(None)) = None):
     """
     Read the PLOTTING configuration for the dataset and generate the
     corrspondig data theory plot.
@@ -443,23 +396,10 @@ def plot_fancy(one_or_more_results, commondata, cuts,
     result (0 for the data, and i for the ith pdf). None means plotting
     absolute values.
 
-    withshifts: bool
-        Add the correlated shifts to the theory predctions based on 
-        eq.84 of arXiv:1709.04922
 
     See docs/plotting_format.md for details on the format of the PLOTTING
     files.
     """
-    if withshifts:
-        one_or_more_results, shifted = get_shifted_results(results=one_or_more_results,
-                                               commondata=commondata,
-                                               cutlist=cutlist)
-        for ilabel in range(len(labellist)): 
-            if ilabel == 0:
-                continue
-            if shifted[ilabel-1]:
-                labellist[ilabel] += " (shifted)"
-
 
     yield from _plot_fancy_impl(results=one_or_more_results,
                                 commondata=commondata,
@@ -493,10 +433,13 @@ def _check_dataspec_normalize_to(normalize_to, dataspecs):
 @_check_same_dataset_name
 @_check_dataspec_normalize_to
 @figuregen
-def plot_fancy_dataspecs(dataspecs_results, dataspecs_commondata,
-                         dataspecs_cuts, dataspecs_speclabel,
-                         normalize_to:(str, int, type(None))=None,
-                         withshifts=False):
+def plot_fancy_dataspecs(
+    dataspecs_results,
+    dataspecs_commondata,
+    dataspecs_cuts,
+    dataspecs_speclabel,
+    normalize_to: (str, int, type(None)) = None,
+):
     """
     General interface for data-theory comparison plots.
 
@@ -522,10 +465,6 @@ def plot_fancy_dataspecs(dataspecs_results, dataspecs_commondata,
 
         - or None (default) to plot absolute values.
 
-    withshifts: bool
-        Add the correlated shifts to the theory predctions based on 
-        eq.84 of arXiv:1709.04922
-
     A limitation at the moment is that the data cuts and errors will be taken
     from the first specifiaction.
     """
@@ -538,16 +477,6 @@ def plot_fancy_dataspecs(dataspecs_results, dataspecs_commondata,
     cutlist = [dataspecs_cuts[0], *dataspecs_cuts]
     commondata = dataspecs_commondata[0]
     labellist = [None, *dataspecs_speclabel]
-
-    if withshifts:
-        results, shifted = get_shifted_results(results=results,
-                                               commondata=commondata,
-                                               cutlist=cutlist)
-        for ilabel in range(len(labellist)):
-            if ilabel == 0:
-                continue
-            if shifted[ilabel-1]:
-                labellist[ilabel] += " (shifted)"
 
     yield from _plot_fancy_impl(results = results, commondata=commondata,
                                 cutlist=cutlist, labellist=labellist,


### PR DESCRIPTION
This was broken on some code paths, seemed to incorrectly duplicate the
computation on others, and it is affected by very significative
conceptual limitations (see e.g.
https://github.com/NNPDF/nnpdf/pull/825#issuecomment-655331325) while it
is perhaps not so obvious what problem did it solve in the first place
(see e.g. https://github.com/NNPDF/nnpdf/issues/506#issuecomment-509213007).

It was not used in the 4.0 paper, and as a matter of empirical fact,
that did not cause the galaxy to be sucked into a black hole. The
coding related aspects could be improved upon, but that could benefit
from a fresh start. The algorithmic code lives in history and it is easy
enough to recover if needed.

Closes #1171.