### PR TITLE
fix default value in postfit help

### DIFF
--- a/validphys2/src/validphys/scripts/postfit.py
+++ b/validphys2/src/validphys/scripts/postfit.py
@@ -224,7 +224,7 @@ def main():
         nargs='?',
         default=NSIGMA_DISCARD_CHI2,
         help="The number of standard deviations in the chi2, calculated over PDF replicas, "
-             " above which the replicas are cut. The default is four.",
+             f" above which the replicas are cut. The default is {NSIGMA_DISCARD_CHI2}.",
         type=float,
     )
     parser.add_argument(
@@ -232,7 +232,7 @@ def main():
         nargs='?',
         default=NSIGMA_DISCARD_ARCLENGTH,
         help="The number of standard deviations in the arclength, calculated over PDF replicas, "
-             " above which the replicas are cut. The default is four.",
+             f" above which the replicas are cut. The default is {NSIGMA_DISCARD_ARCLENGTH}.",
         type=float,
     )
     parser.add_argument(
@@ -240,7 +240,7 @@ def main():
         nargs='?',
         default=INTEG_THRESHOLD,
         help="The maximum value allowed for integrable distributions at small-x. "
-             "The default is 1e-2.",
+             f"The default is {INTEG_THRESHOLD}.",
         type=float,
     )
     parser.add_argument(


### PR DESCRIPTION
The default value for the integrability threshold was incorrectly stated in the --help string (it's 0.5 instead of 1e-2). This way the same mistake won't happen again if a value is changed. 