### PR TITLE
Adding spider plot for dataspecs groups

### DIFF
--- a/validphys2/src/validphys/dataplots.py
+++ b/validphys2/src/validphys/dataplots.py
@@ -495,6 +495,11 @@ def _scatter_marked(ax, x, y, marked_dict, *args, **kwargs):
         kwargs['s'] += 10
 
 @figure
+def plot_dataspecs_groups_chi2_spider(dataspecs_groups_chi2_table):
+    fig, ax = _plot_chi2s_spider_df(dataspecs_groups_chi2_table)
+    return fig
+
+@figure
 def plot_fits_chi2_spider(fits, fits_groups_chi2,
                           fits_groups_data, processed_metadata_group):
     """Plots the chi²s of all groups of datasets


### PR DESCRIPTION
Supersedes #1366, @enocera, can you check the following runcard I took from the other PR? I don't believe it is working yet because I get a chi2 of ~ 4.0 for the di-jet production. I also noticed e.g `ATLAS_WMU_8TEV` is in the runcard you provided, but not in either of the fits.

Also would you mind checking the cfactors for the NLO datasets are correct

```yaml
meta:
    title: χ2 spider plots by group
    keywords: [spider, chi2, nnpdf40]
    author: Emanuele R. Nocera

metadata_group: custom_group 

use_cuts: internal

NLOdatasets: &NLOdatasets
  - {dataset: NMCPD_dw_ite, frac: 0.75, custom_group: Fixed-target DIS}
  - {dataset: NMC, frac: 0.75, custom_group: Fixed-target DIS}
  - {dataset: SLACP_dwsh, frac: 0.75, custom_group: Fixed-target DIS}
  - {dataset: SLACD_dw_ite, frac: 0.75, custom_group: Fixed-target DIS}
  - {dataset: BCDMSP_dwsh, frac: 0.75, custom_group: Fixed-target DIS}
  - {dataset: BCDMSD_dw_ite, frac: 0.75, custom_group: Fixed-target DIS}
  - {dataset: CHORUSNUPb_dw_ite, frac: 0.75, custom_group: Fixed-target DIS}
  - {dataset: CHORUSNBPb_dw_ite, frac: 0.75, custom_group: Fixed-target DIS}
  - {dataset: NTVNUDMNFe_dw_ite, frac: 0.75, custom_group: Fixed-target DIS}
  - {dataset: NTVNBDMNFe_dw_ite, frac: 0.75, custom_group: Fixed-target DIS}
  - {dataset: HERACOMBNCEM, frac: 0.75, custom_group: Collider DIS}
  - {dataset: HERACOMBNCEP460, frac: 0.75, custom_group: Collider DIS}
  - {dataset: HERACOMBNCEP575, frac: 0.75, custom_group: Collider DIS}
  - {dataset: HERACOMBNCEP820, frac: 0.75, custom_group: Collider DIS}
  - {dataset: HERACOMBNCEP920, frac: 0.75, custom_group: Collider DIS}
  - {dataset: HERACOMBCCEM, frac: 0.75, custom_group: Collider DIS}
  - {dataset: HERACOMBCCEP, frac: 0.75, custom_group: Collider DIS}
  - {dataset: HERACOMB_SIGMARED_C, frac: 0.75, custom_group: Collider DIS}   
  - {dataset: HERACOMB_SIGMARED_B, frac: 0.75, custom_group: Collider DIS}   
  - {dataset: DYE886R_dw_ite, frac: 0.75, custom_group: Fixed-target DY}
  - {dataset: DYE886P, frac: 0.75, custom_group: Fixed-target DY}
  - {dataset: DYE605_dw_ite, frac: 0.75, custom_group: Fixed-target DY}
  - {dataset: DYE906R_dw_ite, frac: 0.75, cfac: [ACC], custom_group: Fixed-target DY}
  - {dataset: CDFZRAP_NEW, frac: 0.75, custom_group: Collider gauge boson production}
  - {dataset: D0ZRAP_40, frac: 0.75, custom_group: Collider gauge boson production}
  - {dataset: D0WMASY, frac: 0.75, custom_group: Collider gauge boson production}
  - {dataset: ATLASWZRAP36PB, frac: 0.75, custom_group: Collider gauge boson production}
  - {dataset: ATLASZHIGHMASS49FB, frac: 0.75, custom_group: Collider gauge boson production}
  - {dataset: ATLASLOMASSDY11EXT, frac: 0.75, custom_group: Collider gauge boson production}
  - {dataset: ATLASWZRAP11CC, frac: 0.75, custom_group: Collider gauge boson production}               
  - {dataset: ATLASWZRAP11CF, frac: 0.75, custom_group: Collider gauge boson production}
  - {dataset: ATLAS_WMU_8TEV, frac: 0.75, custom_group: Collider gauge boson production}
  - {dataset: ATLASDY2D8TEV, frac: 0.75, custom_group: Collider gauge boson production}
  - {dataset: ATLAS_DY_2D_8TEV_LOWMASS, frac: 0.75, custom_group: Collider gauge boson production} 
  - {dataset: ATLAS_WZ_TOT_13TEV, frac: 0.75, cfac: [NRM], custom_group: Collider gauge boson production}       
  - {dataset: ATLAS_WP_JET_8TEV_PT, frac: 0.75, custom_group: Collider gauge boson production+jet}         
  - {dataset: ATLAS_WM_JET_8TEV_PT, frac: 0.75, custom_group: Collider gauge boson production+jet}         
  - {dataset: ATLASZPT8TEVMDIST, frac: 0.75, sys: 10, custom_group: Z transverse momentum}
  - {dataset: ATLASZPT8TEVYDIST, frac: 0.75, sys: 10, custom_group: Z transverse momentum}
  - {dataset: ATLASTTBARTOT7TEV, frac: 0.75, custom_group: Top-quark pair production}
  - {dataset: ATLASTTBARTOT8TEV, frac: 0.75, custom_group: Top-quark pair production}
  - {dataset: ATLAS_TTBARTOT_13TEV_FULLLUMI, frac: 0.75, custom_group: Top-quark pair production}
  - {dataset: ATLAS_TTB_DIFF_8TEV_LJ_TRAPNORM, frac: 0.75, custom_group: Top-quark pair production}                 
  - {dataset: ATLAS_TTB_DIFF_8TEV_LJ_TTRAPNORM, frac: 0.75, custom_group: Top-quark pair production}                
  - {dataset: ATLAS_TOPDIFF_DILEPT_8TEV_TTRAPNORM, frac: 0.75, custom_group: Top-quark pair production}             
  - {dataset: ATLAS_1JET_8TEV_R06_DEC, frac: 0.75, custom_group: Single-inclusive jet production}                        
  - {dataset: ATLAS_2JET_7TEV_R06, frac: 0.75, custom_group: Di-jet production}                            
  - {dataset: ATLASPHT15, frac: 0.75, cfac: [EWK], custom_group: Direct photon production}                                
  - {dataset: ATLAS_SINGLETOP_TCH_R_7TEV, frac: 0.75, custom_group: Single top-quark production}                      
  - {dataset: ATLAS_SINGLETOP_TCH_R_13TEV, frac: 0.75, custom_group: Single top-quark production}                     
  - {dataset: ATLAS_SINGLETOP_TCH_DIFF_7TEV_T_RAP_NORM, frac: 0.75, custom_group: Single top-quark production}        
  - {dataset: ATLAS_SINGLETOP_TCH_DIFF_7TEV_TBAR_RAP_NORM, frac: 0.75, custom_group: Single top-quark production}     
  - {dataset: ATLAS_SINGLETOP_TCH_DIFF_8TEV_T_RAP_NORM, frac: 0.75, custom_group: Single top-quark production}       
  - {dataset: ATLAS_SINGLETOP_TCH_DIFF_8TEV_TBAR_RAP_NORM, frac: 0.75, custom_group: Single top-quark production}
  - {dataset: ATLAS_WCHARM_WP_DIFF_7TEV, frac: 0.75, cfac: [], custom_group: Collider gauge boson production}
  - {dataset: ATLAS_WCHARM_WM_DIFF_7TEV, frac: 0.75, cfac: [], custom_group: Collider gauge boson production}
  - {dataset: CMSWEASY840PB, frac: 0.75, custom_group: Collider gauge boson production}
  - {dataset: CMSWMASY47FB, frac: 0.75, custom_group: Collider gauge boson production}
  - {dataset: CMSDY2D11, frac: 0.75, custom_group: Collider gauge boson production}
  - {dataset: CMSWMU8TEV, frac: 0.75, custom_group: Collider gauge boson production}
  - {dataset: CMSZDIFF12, frac: 0.75, cfac: [NRM], sys: 10, custom_group: Z transverse momentum}
  - {dataset: CMS_2JET_7TEV, frac: 0.75, custom_group: Di-jet production}                                   
  - {dataset: CMS_2JET_3D_8TEV, frac: 0.75, custom_group: Di-jet production}                               
  - {dataset: CMSTTBARTOT7TEV, frac: 0.75, custom_group: Top-quark pair production}
  - {dataset: CMSTTBARTOT8TEV, frac: 0.75, custom_group: Top-quark pair production}
  - {dataset: CMSTTBARTOT13TEV, frac: 0.75, custom_group: Top-quark pair production}
  - {dataset: CMSTOPDIFF8TEVTTRAPNORM, frac: 0.75, custom_group: Top-quark pair production}
  - {dataset: CMSTTBARTOT5TEV, frac: 0.75, custom_group: Top-quark pair production}                                 
  - {dataset: CMS_TTBAR_2D_DIFF_MTT_TRAP_NORM, frac: 0.75, custom_group: Top-quark pair production}                 
  - {dataset: CMS_TTB_DIFF_13TEV_2016_2L_TRAP, frac: 0.75, custom_group: Top-quark pair production}                 
  - {dataset: CMS_TTB_DIFF_13TEV_2016_LJ_TRAP, frac: 0.75, custom_group: Top-quark pair production}                 
  - {dataset: CMS_SINGLETOP_TCH_TOT_7TEV, frac: 0.75, custom_group: Single top-quark production}                      
  - {dataset: CMS_SINGLETOP_TCH_R_8TEV, frac: 0.75, custom_group: Single top-quark production}                        
  - {dataset: CMS_SINGLETOP_TCH_R_13TEV, frac: 0.75, custom_group: Single top-quark production}
  - {dataset: CMSWCHARMTOT, frac: 0.75, custom_group: Collider gauge boson production}
  - {dataset: CMSWCHARMRAT, frac: 0.75, custom_group: Collider gauge boson production}
  - {dataset: CMS_WCHARM_DIFF_UNNORM_13TEV, frac: 0.75, custom_group: Collider gauge boson production}
  - {dataset: LHCBZ940PB, frac: 0.75, custom_group: Collider gauge boson production}
  - {dataset: LHCBZEE2FB_40, frac: 0.75, custom_group: Collider gauge boson production}
  - {dataset: LHCBWZMU7TEV, frac: 0.75, cfac: [NRM], custom_group: Collider gauge boson production}
  - {dataset: LHCBWZMU8TEV, frac: 0.75, cfac: [NRM], custom_group: Collider gauge boson production}
  - {dataset: LHCB_Z_13TEV_DIMUON, frac: 0.75, custom_group: Collider gauge boson production}                             
  - {dataset: LHCB_Z_13TEV_DIELECTRON, frac: 0.75, custom_group: Collider gauge boson production} 


NNLOdatasets: &NNLOdatasets
  - {dataset: NMCPD_dw_ite, frac: 0.75, custom_group: Fixed-target DIS}
  - {dataset: NMC, frac: 0.75, custom_group: Fixed-target DIS}
  - {dataset: SLACP_dwsh, frac: 0.75, custom_group: Fixed-target DIS}
  - {dataset: SLACD_dw_ite, frac: 0.75, custom_group: Fixed-target DIS}
  - {dataset: BCDMSP_dwsh, frac: 0.75, custom_group: Fixed-target DIS}
  - {dataset: BCDMSD_dw_ite, frac: 0.75, custom_group: Fixed-target DIS}
  - {dataset: CHORUSNUPb_dw_ite, frac: 0.75, custom_group: Fixed-target DIS}
  - {dataset: CHORUSNBPb_dw_ite, frac: 0.75, custom_group: Fixed-target DIS}
  - {dataset: NTVNUDMNFe_dw_ite, frac: 0.75, cfac: [MAS], custom_group: Fixed-target DIS}
  - {dataset: NTVNBDMNFe_dw_ite, frac: 0.75, cfac: [MAS], custom_group: Fixed-target DIS}
  - {dataset: HERACOMBNCEM, frac: 0.75, custom_group: Collider DIS}
  - {dataset: HERACOMBNCEP460, frac: 0.75, custom_group: Collider DIS}
  - {dataset: HERACOMBNCEP575, frac: 0.75, custom_group: Collider DIS}
  - {dataset: HERACOMBNCEP820, frac: 0.75, custom_group: Collider DIS}
  - {dataset: HERACOMBNCEP920, frac: 0.75, custom_group: Collider DIS}
  - {dataset: HERACOMBCCEM, frac: 0.75, custom_group: Collider DIS}
  - {dataset: HERACOMBCCEP, frac: 0.75, custom_group: Collider DIS}
  - {dataset: HERACOMB_SIGMARED_C, frac: 0.75, custom_group: Collider DIS}   
  - {dataset: HERACOMB_SIGMARED_B, frac: 0.75, custom_group: Collider DIS}   
  - {dataset: DYE886R_dw_ite, frac: 0.75, cfac: [QCD], custom_group: Fixed-target DY}
  - {dataset: DYE886P, frac: 0.75, cfac: [QCD], custom_group: Fixed-target DY}
  - {dataset: DYE605_dw_ite, frac: 0.75, cfac: [QCD], custom_group: Fixed-target DY}
  - {dataset: DYE906R_dw_ite, frac: 0.75, cfac: [ACC,QCD], custom_group: Fixed-target DY}
  - {dataset: CDFZRAP_NEW, frac: 0.75, cfac: [QCD], custom_group: Collider gauge boson production}
  - {dataset: D0ZRAP_40, frac: 0.75, cfac: [QCD], custom_group: Collider gauge boson production}
  - {dataset: D0WMASY, frac: 0.75, cfac: [QCD], custom_group: Collider gauge boson production}
  - {dataset: ATLASWZRAP36PB, frac: 0.75, cfac: [QCD], custom_group: Collider gauge boson production}
  - {dataset: ATLASZHIGHMASS49FB, frac: 0.75, cfac: [QCD], custom_group: Collider gauge boson production}
  - {dataset: ATLASLOMASSDY11EXT, frac: 0.75, cfac: [QCD], custom_group: Collider gauge boson production}
  - {dataset: ATLASWZRAP11CC, frac: 0.75, cfac: [QCD], custom_group: Collider gauge boson production}               
  - {dataset: ATLASWZRAP11CF, frac: 0.75, cfac: [QCD], custom_group: Collider gauge boson production}
  - {dataset: ATLAS_WMU_8TEV, frac: 0.75, cfac: [QCD], custom_group: Collider gauge boson production}
  - {dataset: ATLASDY2D8TEV, frac: 0.75, cfac: [QCDEWK], custom_group: Collider gauge boson production}
  - {dataset: ATLAS_DY_2D_8TEV_LOWMASS, frac: 0.75, cfac: [QCD], custom_group: Collider gauge boson production} 
  - {dataset: ATLAS_WZ_TOT_13TEV, frac: 0.75, cfac: [NRM, QCD], custom_group: Collider gauge boson production}       
  - {dataset: ATLAS_WP_JET_8TEV_PT, frac: 0.75, cfac: [QCD], custom_group: Collider gauge boson production+jet}         
  - {dataset: ATLAS_WM_JET_8TEV_PT, frac: 0.75, cfac: [QCD], custom_group: Collider gauge boson production+jet}         
  - {dataset: ATLASZPT8TEVMDIST, frac: 0.75, cfac: [QCD], sys: 10, custom_group: Z transverse momentum}
  - {dataset: ATLASZPT8TEVYDIST, frac: 0.75, cfac: [QCD], sys: 10, custom_group: Z transverse momentum}
  - {dataset: ATLASTTBARTOT7TEV, frac: 0.75, cfac: [QCD], custom_group: Top-quark pair production}
  - {dataset: ATLASTTBARTOT8TEV, frac: 0.75, cfac: [QCD], custom_group: Top-quark pair production}
  - {dataset: ATLAS_TTBARTOT_13TEV_FULLLUMI, frac: 0.75, cfac: [QCD], custom_group: Top-quark pair production}
  - {dataset: ATLAS_TTB_DIFF_8TEV_LJ_TRAPNORM, frac: 0.75, cfac: [QCD], custom_group: Top-quark pair production}                 
  - {dataset: ATLAS_TTB_DIFF_8TEV_LJ_TTRAPNORM, frac: 0.75, cfac: [QCD], custom_group: Top-quark pair production}                
  - {dataset: ATLAS_TOPDIFF_DILEPT_8TEV_TTRAPNORM, frac: 0.75, cfac: [QCD], custom_group: Top-quark pair production}             
  - {dataset: ATLAS_1JET_8TEV_R06_DEC, frac: 0.75, cfac: [QCD], custom_group: Single-inclusive jet production}                        
  - {dataset: ATLAS_2JET_7TEV_R06, frac: 0.75, cfac: [QCD], custom_group: Di-jet production}                            
  - {dataset: ATLASPHT15, frac: 0.75, cfac: [QCD, EWK], custom_group: Direct photon production}                                
  - {dataset: ATLAS_SINGLETOP_TCH_R_7TEV, frac: 0.75, cfac: [QCD], custom_group: Single top-quark production}                      
  - {dataset: ATLAS_SINGLETOP_TCH_R_13TEV, frac: 0.75, cfac: [QCD], custom_group: Single top-quark production}                     
  - {dataset: ATLAS_SINGLETOP_TCH_DIFF_7TEV_T_RAP_NORM, frac: 0.75, cfac: [QCD], custom_group: Single top-quark production}        
  - {dataset: ATLAS_SINGLETOP_TCH_DIFF_7TEV_TBAR_RAP_NORM, frac: 0.75, cfac: [QCD], custom_group: Single top-quark production}     
  - {dataset: ATLAS_SINGLETOP_TCH_DIFF_8TEV_T_RAP_NORM, frac: 0.75, cfac: [QCD], custom_group: Single top-quark production}       
  - {dataset: ATLAS_SINGLETOP_TCH_DIFF_8TEV_TBAR_RAP_NORM, frac: 0.75, cfac: [QCD], custom_group: Single top-quark production}
  - {dataset: ATLAS_WCHARM_WP_DIFF_7TEV, frac: 0.75, cfac: [], custom_group: Collider gauge boson production}
  - {dataset: ATLAS_WCHARM_WM_DIFF_7TEV, frac: 0.75, cfac: [], custom_group: Collider gauge boson production}
  - {dataset: CMSWEASY840PB, frac: 0.75, cfac: [QCD], custom_group: Collider gauge boson production}
  - {dataset: CMSWMASY47FB, frac: 0.75, cfac: [QCD], custom_group: Collider gauge boson production}
  - {dataset: CMSDY2D11, frac: 0.75, cfac: [QCD], custom_group: Collider gauge boson production}
  - {dataset: CMSWMU8TEV, frac: 0.75, cfac: [QCD], custom_group: Collider gauge boson production}
  - {dataset: CMSZDIFF12, frac: 0.75, cfac: [QCD, NRM], sys: 10, custom_group: Z transverse momentum}
  - {dataset: CMS_2JET_7TEV, frac: 0.75, cfac: [QCD], custom_group: Di-jet production}                                   
  - {dataset: CMS_2JET_3D_8TEV, frac: 0.75, cfac: [QCD], custom_group: Di-jet production}                               
  - {dataset: CMSTTBARTOT7TEV, frac: 0.75, cfac: [QCD], custom_group: Top-quark pair production}
  - {dataset: CMSTTBARTOT8TEV, frac: 0.75, cfac: [QCD], custom_group: Top-quark pair production}
  - {dataset: CMSTTBARTOT13TEV, frac: 0.75, cfac: [QCD], custom_group: Top-quark pair production}
  - {dataset: CMSTOPDIFF8TEVTTRAPNORM, frac: 0.75, cfac: [QCD], custom_group: Top-quark pair production}
  - {dataset: CMSTTBARTOT5TEV, frac: 0.75, cfac: [QCD], custom_group: Top-quark pair production}                                 
  - {dataset: CMS_TTBAR_2D_DIFF_MTT_TRAP_NORM, frac: 0.75, cfac: [QCD], custom_group: Top-quark pair production}                 
  - {dataset: CMS_TTB_DIFF_13TEV_2016_2L_TRAP, frac: 0.75, cfac: [QCD], custom_group: Top-quark pair production}                 
  - {dataset: CMS_TTB_DIFF_13TEV_2016_LJ_TRAP, frac: 0.75, cfac: [QCD], custom_group: Top-quark pair production}                 
  - {dataset: CMS_SINGLETOP_TCH_TOT_7TEV, frac: 0.75, cfac: [QCD], custom_group: Single top-quark production}                      
  - {dataset: CMS_SINGLETOP_TCH_R_8TEV, frac: 0.75, cfac: [QCD], custom_group: Single top-quark production}                        
  - {dataset: CMS_SINGLETOP_TCH_R_13TEV, frac: 0.75, cfac: [QCD], custom_group: Single top-quark production}
  - {dataset: CMSWCHARMTOT, frac: 0.75, custom_group: Collider gauge boson production}
  - {dataset: CMSWCHARMRAT, frac: 0.75, custom_group: Collider gauge boson production}
  - {dataset: CMS_WCHARM_DIFF_UNNORM_13TEV, frac: 0.75, custom_group: Collider gauge boson production}
  - {dataset: LHCBZ940PB, frac: 0.75, cfac: [QCD], custom_group: Collider gauge boson production}
  - {dataset: LHCBZEE2FB_40, frac: 0.75, cfac: [QCD], custom_group: Collider gauge boson production}
  - {dataset: LHCBWZMU7TEV, frac: 0.75, cfac: [NRM, QCD], custom_group: Collider gauge boson production}
  - {dataset: LHCBWZMU8TEV, frac: 0.75, cfac: [NRM, QCD], custom_group: Collider gauge boson production}
  - {dataset: LHCB_Z_13TEV_DIMUON, frac: 0.75, cfac: [QCD], custom_group: Collider gauge boson production}                             
  - {dataset: LHCB_Z_13TEV_DIELECTRON, frac: 0.75, cfac: [QCD], custom_group: Collider gauge boson production} 

dataspecs:
  - pdf: 210713-theory-001
    speclabel: NNPDF4.0 NLO
    theoryid: 208
    dataset_inputs: *NLOdatasets

  - pdf: 210713-n3fit-001
    speclabel: NNPDF4.0 NNLO
    theoryid: 200
    dataset_inputs: *NNLOdatasets

template_text: |
    # Spider plot for χ2
    {@plot_dataspecs_groups_chi2_spider@}
    
    
actions_:
  - report(main=true)
```