### PR TITLE
Bump reportengine version

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -40,7 +40,7 @@ requirements:
         - apfel
         - pkg-config
         - python # requirements for validphys
-        - reportengine >=0.30.18 # see https://github.com/NNPDF/reportengine
+        - reportengine >=0.30.25 # see https://github.com/NNPDF/reportengine
         - matplotlib >=3.3.0
         - blessings >=1.7
         - scipy >=0.19.1


### PR DESCRIPTION
Apparently there are even more bugs when dealing with complicated namespaces. The latest version patches the latest known one.