### PR TITLE
Add sysroot to installation instruction

### DIFF
--- a/doc/sphinx/source/get-started/installation.rst
+++ b/doc/sphinx/source/get-started/installation.rst
@@ -171,7 +171,14 @@ explained above, if the user has not already done so.
 
    .. code::
 
-       conda install pkg-config swig=3.0.10 cmake
+       conda install pkg-config swig cmake
+      
+   When working on a Linux system it is `currently 
+   <https://github.com/NNPDF/nnpdf/pull/1280>`_ also needed to run
+   
+   .. code::
+   
+       conda install sysroot_linux-64
 
 5. We now need to make the installation prefix point to our
    ``nnpdf-dev`` environment. Fortunately, when you activate the environment,

--- a/doc/sphinx/source/get-started/installation.rst
+++ b/doc/sphinx/source/get-started/installation.rst
@@ -178,7 +178,7 @@ explained above, if the user has not already done so.
    
    .. code::
    
-       conda install sysroot_linux-64
+       conda install sysroot_linux-64=2.17
 
 5. We now need to make the installation prefix point to our
    ``nnpdf-dev`` environment. Fortunately, when you activate the environment,


### PR DESCRIPTION
This has been a built dependency since #1280 and we can't seem to get rid of it. People are finding (see #1290) that following the current instructions gives errors so we should add it until we can remove it.

Closes #1290.