### PR TITLE
Collecting over cuts context for pseudodata

### DIFF
--- a/validphys2/src/validphys/config.py
+++ b/validphys2/src/validphys/config.py
@@ -253,6 +253,18 @@ class CoreConfig(configparser.Config):
         replicas = fitted_replica_indexes(pdf)
         return NSList(replicas, nskey='replica')
 
+    def produce_fitcontextwithcuts(self, fit, fitinputcontext):
+        """Like fitinputcontext but setting the cuts policy.
+        """
+        theoryid = fitinputcontext['theoryid']
+        data_input = fitinputcontext['data_input']
+
+        return {
+            "dataset_inputs": data_input,
+            "theoryid": theoryid,
+            "use_cuts": CutsPolicy.FROMFIT,
+        }
+
     def produce_fitenvironment(self, fit, fitinputcontext):
         """Like fitcontext, but additionally forcing various other
         parameters, such as the cuts policy and Monte Carlo seeding to be

--- a/validphys2/src/validphys/pseudodata.py
+++ b/validphys2/src/validphys/pseudodata.py
@@ -77,6 +77,12 @@ def read_replica_pseudodata(fit, context_index, replica):
     try:
         tr = pd.read_csv(training_path, index_col=[0, 1, 2], sep="\t", header=0)
         val = pd.read_csv(validation_path, index_col=[0, 1, 2], sep="\t", header=0)
+    except FileNotFoundError:
+        # Old 3.1 style fits had pseudodata called training.dat and validation.dat
+        training_path = replica_path / "training.dat"
+        validation_path = replica_path / "validation.dat"
+        tr = pd.read_csv(training_path, index_col=[0, 1, 2], sep="\t", names=[f"replica {replica}"])
+        val = pd.read_csv(validation_path, index_col=[0, 1, 2], sep="\t", names=[f"replica {replica}"])
     except FileNotFoundError as e:
         raise FileNotFoundError(
             "Could not find saved training and validation data files. "

--- a/validphys2/src/validphys/pseudodata.py
+++ b/validphys2/src/validphys/pseudodata.py
@@ -21,8 +21,8 @@ log = logging.getLogger(__name__)
 DataTrValSpec = namedtuple('DataTrValSpec', ['pseudodata', 'tr_idx', 'val_idx'])
 
 context_index = collect("groups_index", ("fitcontext",))
-read_fit_pseudodata = collect('read_replica_pseudodata', ('fitreplicas', 'fitenvironment'))
-read_pdf_pseudodata = collect('read_replica_pseudodata', ('pdfreplicas', 'fitenvironment'))
+read_fit_pseudodata = collect('read_replica_pseudodata', ('fitreplicas', 'fitcontextwithcuts'))
+read_pdf_pseudodata = collect('read_replica_pseudodata', ('pdfreplicas', 'fitcontextwithcuts'))
 
 def read_replica_pseudodata(fit, context_index, replica):
     """Function to handle the reading of training and validation splits for a fit that has been


### PR DESCRIPTION
The reason the bug in https://github.com/NNPDF/nnpdf/issues/1414 happened was because we were collecting over an environment that was over specified. This does beg the question whether we still want to fix the point raised in #1414 in light of #1413