### PR TITLE
Fix to `check_cuts_considered`

### DIFF
--- a/validphys2/src/validphys/checks.py
+++ b/validphys2/src/validphys/checks.py
@@ -106,7 +106,7 @@ def check_cuts_fromfit(use_cuts):
 
 @make_argcheck
 def check_cuts_considered(use_cuts):
-    if use_cuts not in CutsPolicy or use_cuts == CutsPolicy.NOCUTS:
+    if use_cuts == CutsPolicy.NOCUTS:
         raise CheckError(f"Cuts must be computed for this action, but they are set to {use_cuts.value}")
 
 

--- a/validphys2/src/validphys/checks.py
+++ b/validphys2/src/validphys/checks.py
@@ -106,7 +106,7 @@ def check_cuts_fromfit(use_cuts):
 
 @make_argcheck
 def check_cuts_considered(use_cuts):
-    if use_cuts not in (CutsPolicy.FROMFIT, CutsPolicy.INTERNAL):
+    if use_cuts not in CutsPolicy or use_cuts == CutsPolicy.NOCUTS:
         raise CheckError(f"Cuts must be computed for this action, but they are set to {use_cuts.value}")
 
 


### PR DESCRIPTION
At some point `check_cuts_considered` started being used for the fits, resulting in the following error when running the NLO runcards for instance.

```
~$ n3fit n3fit/runcards/reproduce_nnpdf40/NNPDF40_nlo_as_01180.yml 1
[WARNING]: Using q2min from runcard                                                                                                                                                                                                          
[WARNING]: Using w2min from runcard                                                                                                                                                                                                          
[ERROR]: Cannot process a resource:                                                                                                                                                                                                          
Could not process the resource 'dataset_t0_predictions', required by:                                                                                                                                                                        
 - dataset_inputs_t0_predictions                                                                                                                                                                                                             
 - dataset_inputs_t0_covmat_from_systematics                                                                                                                                                                                                 
 - fitting_data_dict                                                                                                                                                                                                                         
 - exps_fitting_data_dict                                                                                                                                                                                                                    
 - replica_nnseed_fitting_data_dict                                                                                                                                                                                                          
 - replicas_nnseed_fitting_data_dict                                                                                  
 - performfit                                                                                                                                                                                                                                
Cuts must be computed for this action, but they are set to fromsimilarpredictions
```

The check was only accepting fromfit and internal, now it accepts anything that isn't "nocuts". 

Maybe it wasn't a bug but a feature though.