### PR TITLE
Update git tutorial

### DIFF
--- a/doc/sphinx/source/get-started/git.md
+++ b/doc/sphinx/source/get-started/git.md
@@ -67,10 +67,8 @@ into which you clone the desired repositories. This way all code related to NNPD
 mkdir nnpdfgit
 cd nnpdfgit
 
-git clone git@github.com:NNPDF/nnpdf.git          # The main body of NNPDF code
+git clone git@github.com:NNPDF/nnpdf.git          # The main body of NNPDF code: validphys, n3fit and buildmaster
 git clone https://github.com/scarrazza/apfel.git  # Handles the DGLAP PDF evolution as well as the production of NNLO DIS predictions
-git clone git@github.com:NNPDF/buildmaster.git    # Where experimental data are turned into a format suitable for NNPDF fits
-git clone git@github.com:NNPDF/external.git 	  # Codes written outside of NNPDF that are required to produce theoretical predictions (i.e. APPLgrids)
 git clone git@github.com:NNPDF/applgrids.git 	  # Where APPLgrids get stored
 git clone git@github.com:NNPDF/apfelcomb.git 	  # Turns APPLgrids into FK tables
 git clone git@github.com:NNPDF/reportengine.git   # A framework for data analysis that validphys relies on


### PR DESCRIPTION
Remove `buildmaster` (which is part of nnpdf now) and `external` from the list of links in the git tutorial.

Thanks @AleCandido for noticing.