### PR TITLE
Fixing buildmaster compilation

### DIFF
--- a/buildmaster/filters/INT.cc
+++ b/buildmaster/filters/INT.cc
@@ -14,7 +14,7 @@ void register_integrability(vector<unique_ptr<CommonData>>& list)
     "INTEGXV_543",
     "INTEGXV3_543",
     "INTEGXV8_543"};
-  const std::array<std::string, 2>  INTsets = {
+  const std::array<std::string, 5>  INTsets = {
     "INTEGXT3",
     "INTEGXT8",
     "INTEGXV",


### PR DESCRIPTION
@Zaharid This should fix #1452 . It seems that some additional integrability sets have been added and that there was a mismatch in the number of sets added. @RoyStegeman I have a vague recollection that you added some integrability sets for the feature scaling paper. Are these sets mirrored in the relevant theories? Let me check.