### PR TITLE
Enable python 3.9 and mamba build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,7 +8,7 @@ on:
 
 # some general variables
 env:
-  CONDA_PY: 38
+  CONDA_PY: 39
   IMAGE_NAME: nnpdf
 
 jobs:
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.8]
+        python-version: [3.9]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/fitbot.yml
+++ b/.github/workflows/fitbot.yml
@@ -111,7 +111,7 @@ jobs:
         url=$(vp-upload output/ 2>&1 | grep https)
         echo "REPORT_URL=$url" >> $GITHUB_ENV
     - name: Save the package if something fails
-      if: ${{ failure }}
+      if: failure()
       shell: bash -l ${0}
       run: |
         scp /usr/share/miniconda/envs/test/conda-bld/linux-64/nnpdf*.tar.bz2  nnpdf.fisica.unimi.it:debug_pkgs/

--- a/.github/workflows/fitbot.yml
+++ b/.github/workflows/fitbot.yml
@@ -11,7 +11,7 @@ env:
   N3FIT_MAXNREP: 20 # total number of replicas to fit
   POSTFIT_NREP: 16 # requested replicas for postfit
   REFERENCE_SET: NNBOT-d3034a7cc-2021-06-11 # reference set for vp
-  CONDA_PY: 38
+  CONDA_PY: 39
 
 jobs:
   build:
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.8]
+        python-version: [3.9]
     runs-on: ${{ matrix.os }}
     env:
       NETRC_FILE: ${{ secrets.NETRC_FILE }}
@@ -42,11 +42,11 @@ jobs:
         conda config --append channels conda-forge
         conda config --prepend channels https://packages.nnpdf.science/public
         conda config --set show_channel_urls true
-        conda install conda-build --yes
+        conda install boa --yes
     - name: Build recipe
       shell: bash -l {0}
       run: |
-        CONDA_PY=$CONDA_PY conda build --no-test -q conda-recipe
+        CONDA_PY=$CONDA_PY conda mambabuild --no-test -q conda-recipe
     # install local build
     - name: Installing NNPDF conda package
       shell: bash -l {0}

--- a/.github/workflows/fitbot.yml
+++ b/.github/workflows/fitbot.yml
@@ -110,6 +110,11 @@ jobs:
                     --thcovmat_if_present
         url=$(vp-upload output/ 2>&1 | grep https)
         echo "REPORT_URL=$url" >> $GITHUB_ENV
+    - name: Save the package if something fails
+      if: ${{ failure }}
+      shell: bash -l ${0}
+      run: |
+        scp /usr/share/miniconda/envs/test/conda-bld/linux-64/nnpdf*.tar.bz2  nnpdf.fisica.unimi.it:debug_pkgs/
     # write reminder
     - name: Write summary on PR
       uses: unsplash/comment-on-pr@master

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.9]
+        python-version: [3.8, 3.9]
         include:
           - os: ubuntu-latest
             CONDA_OS: linux-64

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.8]
+        python-version: [3.9]
         include:
           - os: ubuntu-latest
             CONDA_OS: linux-64
@@ -42,13 +42,13 @@ jobs:
         conda config --prepend channels https://packages.nnpdf.science/public
         conda config --set show_channel_urls true
         conda activate test
-        conda install conda-build --yes
+        conda install boa --yes
     - name: Build recipe and run tests on linux
       if: startsWith(matrix.os, 'ubuntu')
       shell: bash -l {0}
       run: |
         conda activate test
-        conda build -q conda-recipe
+        conda mambabuild -q conda-recipe
     - name: Build recipe and run tests on macOS
       if: startsWith(matrix.os, 'macOS')
       shell: bash -l {0}

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -39,7 +39,6 @@ requirements:
         - pkg-config
         - python # requirements for validphys
         - reportengine >=0.30.25 # see https://github.com/NNPDF/reportengine
-        - curio
         - matplotlib >=3.3.0
         - blessings >=1.7
         - scipy >=0.19.1
@@ -52,6 +51,7 @@ requirements:
         - sphinx_rtd_theme >0.5
         - sphinxcontrib-bibtex
         - docutils =0.16 # This dependency is not explicity needed but https://github.com/NNPDF/nnpdf/issues/1220
+        - curio >=1.0
 
 test:
     requires:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -26,8 +26,6 @@ requirements:
     run:
         # Only install tensorflow on linux. Select eigen build
         - tensorflow >=2 *eigen* # [linux]
-        - gast ==0.3.3 # Conda tensorflow uses the wrong version
-        - opt_einsum >=2.3.2 # Conda tensorflow uses the wrong version
         - psutil # to ensure n3fit affinity is with the right processors
         - hyperopt
         - seaborn

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -39,6 +39,7 @@ requirements:
         - pkg-config
         - python # requirements for validphys
         - reportengine >=0.30.25 # see https://github.com/NNPDF/reportengine
+        - curio
         - matplotlib >=3.3.0
         - blessings >=1.7
         - scipy >=0.19.1

--- a/libnnpdf/wrapper/CMakeLists.txt
+++ b/libnnpdf/wrapper/CMakeLists.txt
@@ -30,7 +30,7 @@ execute_process(
   COMMAND "${PYTHON_EXECUTABLE}" -c "if True:
     import sysconfig;
     lcom = sysconfig.get_config_var(\"LDSHARED\");
-    cc, _, flags = lcom.partition(\" \");
+    cc, _, flags = lcom.strip().partition(\" \");
     print(flags)"
     OUTPUT_VARIABLE PYTHON_EXTENSION_LINKFLAGS
 	RESULT_VARIABLE ret


### PR DESCRIPTION
As per https://github.com/NNPDF/nnpdf/issues/1458#issuecomment-958807144

If the workflow works I'll enable also 3.8 so that we have both for the time being.