### PR TITLE
Improve postfit error message

### DIFF
--- a/validphys2/src/validphys/scripts/postfit.py
+++ b/validphys2/src/validphys/scripts/postfit.py
@@ -140,7 +140,11 @@ def _postfit(results: str, nrep: int, chi2_threshold: float, arclength_threshold
         if not fitdata.check_nnfit_results_path(result_path):
             raise PostfitError('Postfit cannot find a valid results path')
         if not fitdata.check_lhapdf_info(result_path, fitname):
-            raise PostfitError('Postfit cannot find a valid LHAPDF info file')
+            raise PostfitError(
+                'Postfit cannot find a valid LHAPDF info file\n'
+                'Note: Perhaps you forgot to run evolven3fit? See\n'
+                'https://docs.nnpdf.science/tutorials/run-fit.html#running-the-fitting-code'
+            )
 
         nrep = int(nrep)
         if at_least_nrep:


### PR DESCRIPTION
A missing info file is a symptom of not having executed the evolution
code. This has cause some confusion and it is therefore useful to
suggest it as a possibility in the error message.

Closes #1479.