### PR TITLE
Fix example runcard

### DIFF
--- a/validphys2/src/validphys/closuretest/runcards/NNPDF40_closure_test.yml
+++ b/validphys2/src/validphys/closuretest/runcards/NNPDF40_closure_test.yml
@@ -99,6 +99,9 @@ trvlseed: 1727532335
 nnseed: 1737785873
 mcseed: 2123509817
 genrep: true          # true = generate MC replicas, false = use real data
+# Legacy options required by closure tests
+rngalg: 0
+seed: 4
 
 parameters: # This defines the parameter dictionary that is passed to the Model Trainer
   nodes_per_layer: [18, 24, 36, 8]

--- a/validphys2/src/validphys/closuretest/runcards/NNPDF40_closure_test.yml
+++ b/validphys2/src/validphys/closuretest/runcards/NNPDF40_closure_test.yml
@@ -99,7 +99,7 @@ trvlseed: 1727532335
 nnseed: 1737785873
 mcseed: 2123509817
 genrep: true          # true = generate MC replicas, false = use real data
-# Legacy options required by closure tests
+# Deprecated options still required by closure tests
 rngalg: 0
 seed: 4
 


### PR DESCRIPTION
This runcard in the `closuretest` folder currently doesn’t work. I’ve tried it changing it in master (because it looked trivial and that it should not affect anything) but the tests failed so I’m moving the changes to a PR to investigate…