### PR TITLE
Use python covmat in multiclosure tests

### DIFF
--- a/validphys2/src/validphys/checks.py
+++ b/validphys2/src/validphys/checks.py
@@ -22,6 +22,12 @@ import logging
 log = logging.getLogger(__name__)
 
 @make_check
+def check_use_t0(ns, **kwargs):
+    """Checks use_t0 is set to true"""
+    if not ns.get("use_t0"):
+        raise CheckError("The flag 'use_t0' needs to be set to 'true' for this action.")
+
+@make_check
 def check_pdf_is_montecarlo(ns, **kwargs):
     pdf = ns['pdf']
     etype = pdf.ErrorType

--- a/validphys2/src/validphys/closuretest/closure_checks.py
+++ b/validphys2/src/validphys/closuretest/closure_checks.py
@@ -77,6 +77,14 @@ def check_t0pdfset_matches_law(t0pdfset, fit):
             f"Underlying pdf: {t0_from_fit}, does not match t0pdfset: {t0pdfset}"
         )
 
+@make_argcheck
+def check_t0pdfset_matches_multiclosure_law(multiclosure_underlyinglaw, t0set):
+    """Checks that, if a multiclosure_underlyinglaw is present, it matches the t0set
+    Checks t0set instead of t0pdfset since different mechanisms can fill t0set
+    """
+    if str(t0set) != str(multiclosure_underlyinglaw):
+        raise CheckError(f"The underlying pdf {multiclosure_underlyinglaw} does not match t0pdfset: {t0set}")
+
 
 @make_argcheck
 def check_at_least_10_fits(fits):

--- a/validphys2/src/validphys/closuretest/closure_checks.py
+++ b/validphys2/src/validphys/closuretest/closure_checks.py
@@ -4,9 +4,12 @@ closuretest/checks.py
 Module containing checks specific to the closure tests.
 
 """
+import logging
 from collections import defaultdict
 
 from reportengine.checks import make_argcheck, CheckError
+
+log = logging.getLogger(__name__)
 
 
 @make_argcheck
@@ -83,7 +86,7 @@ def check_t0pdfset_matches_multiclosure_law(multiclosure_underlyinglaw, t0set):
     Checks t0set instead of t0pdfset since different mechanisms can fill t0set
     """
     if str(t0set) != str(multiclosure_underlyinglaw):
-        raise CheckError(f"The underlying pdf {multiclosure_underlyinglaw} does not match t0pdfset: {t0set}")
+        log.warning(f"The underlying pdf {multiclosure_underlyinglaw} does not match t0pdfset: {t0set}")
 
 
 @make_argcheck

--- a/validphys2/src/validphys/closuretest/multiclosure.py
+++ b/validphys2/src/validphys/closuretest/multiclosure.py
@@ -34,7 +34,7 @@ SAMPLING_INTERVAL = 5
 @check_fits_areclosures
 @check_fits_different_filterseed
 def internal_multiclosure_dataset_loader(
-    dataset, fits_pdf, multiclosure_underlyinglaw, fits
+    dataset, fits_pdf, multiclosure_underlyinglaw, fits, dataset_inputs_t0_covmat_from_systematics
 ):
     """Internal function for loading multiple theory predictions for a given
     dataset and a single covariance matrix using underlying law as t0 PDF,
@@ -77,12 +77,6 @@ def internal_multiclosure_dataset_loader(
     typically used in these studies.
 
     """
-    if isinstance(dataset, DataSetSpec):
-        data = dataset.load()  # just use internal loader
-    else:
-        # don't cache result
-        data = dataset.load.__wrapped__(dataset)
-
     fits_dataset_predictions = [
         ThPredictionsResult.from_convolution(pdf, dataset)
         for pdf in fits_pdf
@@ -91,25 +85,21 @@ def internal_multiclosure_dataset_loader(
         multiclosure_underlyinglaw, dataset
     )
 
-    # copy data to make t0 cov
-    loaded_data = type(data)(data)
-    loaded_data.SetT0(multiclosure_underlyinglaw.load_t0())
-    covmat = loaded_data.get_covmat()
-    sqrt_covmat = la.cholesky(covmat, lower=True)
+    sqrt_covmat = la.cholesky(dataset_inputs_t0_covmat_from_systematics, lower=True)
     # TODO: support covmat reg and theory covariance matrix
     # possibly make this a named tuple
-    return (fits_dataset_predictions, fits_underlying_predictions, covmat, sqrt_covmat)
+    return (fits_dataset_predictions, fits_underlying_predictions, dataset_inputs_t0_covmat_from_systematics, sqrt_covmat)
 
 
 @check_fits_underlying_law_match
 @check_fits_areclosures
 @check_fits_different_filterseed
 def internal_multiclosure_data_loader(
-    data, fits_pdf, multiclosure_underlyinglaw, fits
+    data, fits_pdf, multiclosure_underlyinglaw, fits, dataset_inputs_t0_covmat_from_systematics
 ):
     """Like `internal_multiclosure_dataset_loader` except for all data"""
     return internal_multiclosure_dataset_loader(
-        data, fits_pdf, multiclosure_underlyinglaw, fits
+        data, fits_pdf, multiclosure_underlyinglaw, fits, dataset_inputs_t0_covmat_from_systematics
     )
 
 

--- a/validphys2/src/validphys/closuretest/multiclosure.py
+++ b/validphys2/src/validphys/closuretest/multiclosure.py
@@ -15,7 +15,6 @@ from reportengine import collect
 
 from validphys.results import ThPredictionsResult
 from validphys.calcutils import calc_chi2
-from validphys.core import DataSetSpec
 from validphys.closuretest.closure_checks import (
     check_at_least_10_fits,
     check_multifit_replicas,
@@ -23,6 +22,7 @@ from validphys.closuretest.closure_checks import (
     check_fits_areclosures,
     check_fits_different_filterseed,
 )
+from validphys.checks import check_use_t0
 
 # bootstrap seed default
 DEFAULT_SEED = 9689372
@@ -33,6 +33,7 @@ SAMPLING_INTERVAL = 5
 @check_fits_underlying_law_match
 @check_fits_areclosures
 @check_fits_different_filterseed
+@check_use_t0
 def internal_multiclosure_dataset_loader(
     dataset, fits_pdf, multiclosure_underlyinglaw, fits, dataset_inputs_t0_covmat_from_systematics
 ):
@@ -94,6 +95,7 @@ def internal_multiclosure_dataset_loader(
 @check_fits_underlying_law_match
 @check_fits_areclosures
 @check_fits_different_filterseed
+@check_use_t0
 def internal_multiclosure_data_loader(
     data, fits_pdf, multiclosure_underlyinglaw, fits, dataset_inputs_t0_covmat_from_systematics
 ):

--- a/validphys2/src/validphys/closuretest/multiclosure.py
+++ b/validphys2/src/validphys/closuretest/multiclosure.py
@@ -21,6 +21,7 @@ from validphys.closuretest.closure_checks import (
     check_fits_underlying_law_match,
     check_fits_areclosures,
     check_fits_different_filterseed,
+    check_t0pdfset_matches_multiclosure_law
 )
 from validphys.checks import check_use_t0
 
@@ -34,6 +35,7 @@ SAMPLING_INTERVAL = 5
 @check_fits_areclosures
 @check_fits_different_filterseed
 @check_use_t0
+@check_t0pdfset_matches_multiclosure_law
 def internal_multiclosure_dataset_loader(
     dataset, fits_pdf, multiclosure_underlyinglaw, fits, dataset_inputs_t0_covmat_from_systematics
 ):
@@ -95,6 +97,7 @@ def internal_multiclosure_dataset_loader(
 @check_fits_underlying_law_match
 @check_fits_areclosures
 @check_fits_different_filterseed
+@check_t0pdfset_matches_multiclosure_law
 @check_use_t0
 def internal_multiclosure_data_loader(
     data, fits_pdf, multiclosure_underlyinglaw, fits, dataset_inputs_t0_covmat_from_systematics

--- a/validphys2/src/validphys/config.py
+++ b/validphys2/src/validphys/config.py
@@ -913,11 +913,16 @@ class CoreConfig(configparser.Config):
         return do_use_t0
 
     # TODO: Find a good name for this
-    def produce_t0set(self, use_t0=False, t0pdfset=None):
+    def produce_t0set(self, use_t0=False, t0pdfset=None, multiclosure_underlyinglaw=None):
         """Return the t0set if use_t0 is True and None otherwise. Raises an
-        error if t0 is requested but no t0set is given."""
+        error if t0 is requested but no t0set is given.
+        For multiclosure tests, take the set from the underlyinglaw of all closure fits
+        which will be ensured to be the same. t0pdfset takes precedence
+        """
         if use_t0:
             if not t0pdfset:
+                if multiclosure_underlyinglaw is not None:
+                    return multiclosure_underlyinglaw
                 raise ConfigError("Setting use_t0 requires specifying a valid t0pdfset")
             return t0pdfset
         else:

--- a/validphys2/src/validphys/config.py
+++ b/validphys2/src/validphys/config.py
@@ -10,7 +10,6 @@ import functools
 import inspect
 import numbers
 import copy
-import glob
 from importlib.resources import read_text, contents
 
 from collections import ChainMap, defaultdict
@@ -913,20 +912,15 @@ class CoreConfig(configparser.Config):
         return do_use_t0
 
     # TODO: Find a good name for this
-    def produce_t0set(self, use_t0=False, t0pdfset=None, multiclosure_underlyinglaw=None):
+    def produce_t0set(self, use_t0=False, t0pdfset=None):
         """Return the t0set if use_t0 is True and None otherwise. Raises an
         error if t0 is requested but no t0set is given.
-        For multiclosure tests, take the set from the underlyinglaw of all closure fits
-        which will be ensured to be the same. t0pdfset takes precedence
         """
         if use_t0:
             if not t0pdfset:
-                if multiclosure_underlyinglaw is not None:
-                    return multiclosure_underlyinglaw
                 raise ConfigError("Setting use_t0 requires specifying a valid t0pdfset")
             return t0pdfset
-        else:
-            return None
+        return None
 
     def _parse_lagrange_multiplier(self, kind, theoryid, setdict):
         """ Lagrange multiplier constraints are mappings


### PR DESCRIPTION
This closes issue #1486 while dealing with another of the not-trivial cases of #1475. And the last preventing me from working on #1475 because I've decided not to touch the filter at this stage.

This "fix" is very tricky because there are no examples or tests where I can check what the intended behavior is exactly. Thanks to @tgiani I have at least a runcard that uses the function:
```
fit: 210326-mw-001

theoryid: 200
use_cuts: internal
q2min: 3.49                        # Q2 minimum
w2min: 12.5                        # W2 minimum

dataset_inputs:
# ATLAS
- {dataset: DYE906R_dw_ite, frac: 0.75, cfac: [ACC,QCD]}
- { dataset: ATLASWZRAP11CF, frac: 0.75, cfac: [QCD] } # N

meta:
 author: TG
 keywords: [test]
 title: Test plot_data_fits_bias_variance

diag_ns:
 - diagonal_basis: True
 - diagonal_basis: False

template_text: |
 # Results with 25 fits

 ## Central diff histogram
 {@with diag_ns@}
 # Diagonal: {@diagonal_basis@}
 {@plot_data_fits_bias_variance@}
 {@endwith@}

use_t0: true

fits:
- 210326-mw-001
- 210326-mw-002

actions_:
 - report(main=True)
```

Honestly, I would've like not to have modified `config.py` or force people to have to use `use_t0` when before it wasn't the case, however due to https://github.com/NNPDF/nnpdf/blob/b44ae914ef494049f9456c8c0fdd267e8386446e/validphys2/src/validphys/closuretest/multiclosure.py#L49 just calling `dataset_inputs_t0_covmat_from_systematics` is non-trivial, doable, but complicates quite a bit the logic (unless there's some shortcut I haven't found).

### Fix
Just using `dataset_inputs_t0_covmat_from_systematics`. I've checked that for the above runcard the results are completely equivalent. This also simplifies the function since it no longer have to take care of doing the loading of the data and setting the t0 set etc (which included a copy not sure why)

### Backwards compatibility
Since this breaks previously working runcards (in that now the user has to add one extra flag) and in that the usage of the t0 covmat is not happening in the dark in some function but done by validphys I've added two checks:
- `use_t0` just telling the user the runcard should be updated
- Ensure that the user doesn't mistakenly set a `t0set` different from the `multiclosure_law`.

### Tests and examples
It would be nice if someone could add tests to this module which is currently lacking. I honestly don't know what to test other than it runs. I'll add the runcard @tgiani gave me but for the tests someone else should do another PR that takes care of this because I'm mostly guessing how things should work so I don't think I'm qualified to write a test specifying _how really_ things should work.

Anyway this is ready for review.