### PR TITLE
do what genrep says in makereplica

### DIFF
--- a/validphys2/src/validphys/pseudodata.py
+++ b/validphys2/src/validphys/pseudodata.py
@@ -101,7 +101,7 @@ def read_replica_pseudodata(fit, context_index, replica):
     return DataTrValSpec(pseudodata.drop("type", axis=1), tr.index, val.index)
 
 
-def make_replica(groups_dataset_inputs_loaded_cd_with_cuts, replica_mcseed):
+def make_replica(groups_dataset_inputs_loaded_cd_with_cuts, replica_mcseed, genrep):
     """Function that takes in a list of :py:class:`validphys.coredata.CommonData`
     objects and returns a pseudodata replica accounting for
     possible correlations between systematic uncertainties.
@@ -141,6 +141,9 @@ def make_replica(groups_dataset_inputs_loaded_cd_with_cuts, replica_mcseed):
        0.30100351, 0.31781208, 0.30827054, 0.30258217, 0.32116842,
        0.34206012, 0.31866286, 0.2790856 , 0.33257621, 0.33680007,
     """
+    if not genrep:
+        return np.concatenate([cd.central_values for cd in groups_dataset_inputs_loaded_cd_with_cuts])
+
     # Seed the numpy RNG with the seed.
     rng = np.random.default_rng(seed=replica_mcseed)
 

--- a/validphys2/src/validphys/pseudodata.py
+++ b/validphys2/src/validphys/pseudodata.py
@@ -101,7 +101,7 @@ def read_replica_pseudodata(fit, context_index, replica):
     return DataTrValSpec(pseudodata.drop("type", axis=1), tr.index, val.index)
 
 
-def make_replica(groups_dataset_inputs_loaded_cd_with_cuts, replica_mcseed, genrep):
+def make_replica(groups_dataset_inputs_loaded_cd_with_cuts, replica_mcseed, genrep=True):
     """Function that takes in a list of :py:class:`validphys.coredata.CommonData`
     objects and returns a pseudodata replica accounting for
     possible correlations between systematic uncertainties.

--- a/validphys2/src/validphys/tests/test_pythonmakereplica.py
+++ b/validphys2/src/validphys/tests/test_pythonmakereplica.py
@@ -26,6 +26,7 @@ SINGLE_SYS_DATASETS = [
     {"dataset": "CMS_SINGLETOP_TCH_R_13TEV", "cfac": ["QCD"]},
 ]
 
+
 @pytest.mark.parametrize("use_cuts", ["nocuts", "internal"])
 @pytest.mark.parametrize("dataset_inputs", [DATA, CORR_DATA, SINGLE_SYS_DATASETS])
 def test_commondata_unchanged(data_config, dataset_inputs, use_cuts):
@@ -86,3 +87,18 @@ def test_pseudodata_has_correct_ndata(data_config, dataset_inputs, use_cuts):
     rep = API.make_replica(**config)
     ndata = np.sum([cd.ndata for cd in ld_cds])
     assert len(rep) == ndata
+
+
+@pytest.mark.parametrize("use_cuts", ["nocuts", "internal"])
+@pytest.mark.parametrize("dataset_inputs", [DATA, CORR_DATA, SINGLE_SYS_DATASETS])
+def test_genrep_off(data_config, dataset_inputs, use_cuts):
+    """Check that when genrep is set to False replicas are not generated."""
+    config = dict(data_config)
+    config["dataset_inputs"] = dataset_inputs
+    config["use_cuts"] = use_cuts
+    config["replica_mcseed"] = SEED
+    config["genrep"] = False
+    ld_cds = API.dataset_inputs_loaded_cd_with_cuts(**config)
+    not_replica = API.make_replica(**config)
+    central_data = np.concatenate([d.central_values for d in ld_cds])
+    np.testing.assert_allclose(not_replica, central_data)


### PR DESCRIPTION
I've noticed `make_replica` is not honoring `genrep` (which was not an argument to `make_replica` and so the replicas were always generated). This PR fixes that.

Code that reproduce the problem:

```python
from validphys.api import API
import numpy as np
t0 = API.make_replica(
    dataset_inputs=[{"dataset":"NMC"}, {"dataset": "NMCPD"}],
    use_cuts="nocuts",
    theoryid=53,
    replica=1,
    mcseed=123,
    genrep=False,
    )
tnot = API.make_replica(
    dataset_inputs=[{"dataset":"NMC"}, {"dataset": "NMCPD"}],
    use_cuts="nocuts",
    theoryid=53,
    replica=1,
    mcseed=321,
    genrep=False,
    )
np.allclose(t0, tnot)
```
False


What was happening before if `genrep` is used is that `numpy` is seeded with `None` and then a random non-reproducible replica is generated, so basically worsts case scenario. After this PR this code returns `True` (since no replica is generated).