### PR TITLE
Access the PDF info class explicitly

### DIFF
--- a/validphys2/src/validphys/checks.py
+++ b/validphys2/src/validphys/checks.py
@@ -24,7 +24,7 @@ log = logging.getLogger(__name__)
 @make_check
 def check_pdf_is_montecarlo(ns, **kwargs):
     pdf = ns['pdf']
-    etype = pdf.ErrorType
+    etype = pdf.error_type
     if etype != 'replicas':
         raise CheckError("Error type of PDF %s must be 'replicas' and not %s"
                           % (pdf, etype))

--- a/validphys2/src/validphys/core.py
+++ b/validphys2/src/validphys/core.py
@@ -15,6 +15,7 @@ import functools
 import inspect
 import json
 import logging
+from pathlib import Path
 
 import numpy as np
 
@@ -91,24 +92,18 @@ class _PDFSETS():
 PDFSETS = _PDFSETS()
 
 class PDF(TupleComp):
+    """Base validphys PDF providing high level access to metadata.
+
+    Statistical estimators which depends on the PDF type (MC, Hessian...)
+    are exposed as a :py:class:`Stats` object through the :py:meth:`stats_class` attribute
+    The LHAPDF metadata can directly be accessed through the :py:meth:`info` attribute
+    """
 
     def __init__(self, name):
         self.name = name
         self._plotname = name
+        self._info = None
         super().__init__(name)
-
-
-    def __getattr__(self, attr):
-        #We don't even try to get reserved attributes from the info file
-        if attr.startswith('__'):
-            raise AttributeError(attr)
-        try:
-            return lhaindex.parse_info(self.name)[attr]
-        except KeyError as e:
-            raise AttributeError("'%r' has no attribute '%s'" % (type(self),
-                                                                 attr)) from e
-        except IOError as e:
-            raise PDFDoesNotExist(self.name) from e
 
     @property
     def label(self):
@@ -121,42 +116,71 @@ class PDF(TupleComp):
     @property
     def stats_class(self):
         """Return the stats calculator for this error type"""
-        error = self.ErrorType
+        error = self.error_type
         klass = STAT_TYPES[error]
-        if hasattr(self, 'ErrorConfLevel'):
-            klass = functools.partial(klass, rescale_factor=self.rescale_factor)
+        if self._has_error_conf_level():
+            klass = functools.partial(klass, rescale_factor=self._rescale_factor)
         return klass
 
-    #TODO: Make this a proper Path
     @property
     def infopath(self):
-        return lhaindex.infofilename(self.name)
+        return Path(lhaindex.infofilename(self.name))
+
+    @property
+    def info(self):
+        """Information contained in the LHAPDF .info file"""
+        if self._info is None:
+            try:
+                self._info = lhaindex.parse_info(self.name)
+            except IOError as e:
+                raise PDFDoesNotExist(self.name) from e
+        return self._info
+
+    @property
+    def q_min(self):
+        """Minimum Q as given by the LHAPDF .info file"""
+        return self.info["QMin"]
+
+    @property
+    def error_type(self):
+        """Error type as defined in the LHAPDF .info file"""
+        return self.info["ErrorType"]
+
+    def _has_error_conf_level(self):
+        """Utility method to check whether an info file contains ErrorConfLevel"""
+        return "ErrorConfLevel" in self.info
+
+    @property
+    def error_conf_level(self):
+        """Error confidence level as defined in the LHAPDF .info file
+        if no number is given in the LHAPDF .info file defaults to 68%
+        """
+        # Check possible misconfigured info file
+        if self.error_type == "replicas":
+            if self._has_error_conf_level():
+                raise ValueError(
+                    f"Attribute at {self.infopath} 'ErrorConfLevel' doesn't "
+                    "make sense with 'replicas' error type"
+                )
+            return None
+        return self.info.get("ErrorConfLevel", 68)
 
     @property
     def isinstalled(self):
         try:
-            self.infopath
+            return self.infopath.is_file()
         except FileNotFoundError:
             return False
-        else:
-            return True
 
-
-    @property
-    def rescale_factor(self):
-        #This is imported here for performance reasons.
+    def _rescale_factor(self):
+        """Compute the rescale factor for the stats class"""
+        # This is imported here for performance reasons.
         import scipy.stats
-        if hasattr(self, "ErrorConfLevel"):
-            if self.ErrorType == 'replicas':
-                raise ValueError("Attribute at %s 'ErrorConfLevel' doesn't "
-                "make sense with 'replicas' error type" % self.infopath)
-            val = scipy.stats.norm.isf((1 - 0.01*self.ErrorConfLevel)/2)
-            if np.isnan(val):
-                raise ValueError("Invalid 'ErrorConfLevel' of PDF %s: %s" %
-                                 (self, val))
-            return val
-        else:
-            return 1
+
+        val = scipy.stats.norm.isf((1 - 0.01 * self.error_conf_level) / 2)
+        if np.isnan(val):
+            raise ValueError(f"Invalid 'ErrorConfLevel' for PDF {self}: {val}")
+        return val
 
     @functools.lru_cache(maxsize=16)
     def load(self):
@@ -167,48 +191,36 @@ class PDF(TupleComp):
         """Load the PDF as a t0 set"""
         return LHAPDFSet(self.name, LHAPDFSet.erType_ER_MCT0)
 
-
     def __str__(self):
         return self.label
 
     def __len__(self):
-        return self.NumMembers
-
-
+        return self.info["NumMembers"]
 
     @property
     def nnpdf_error(self):
         """Return the NNPDF error tag, used to build the `LHAPDFSet` objeect"""
-        error = self.ErrorType
+        error = self.error_type
         if error == "replicas":
             return LHAPDFSet.erType_ER_MC
+
+        cl = self.error_conf_level
         if error == "hessian":
-            if hasattr(self, 'ErrorConfLevel'):
-                cl = self.ErrorConfLevel
-                if cl == 90:
-                    return LHAPDFSet.erType_ER_EIG90
-                elif cl == 68:
-                    return LHAPDFSet.erType_ER_EIG
-                else:
-                    raise NotImplementedError("No hessian errors with confidence"
-                                              " interval %s" % (cl,) )
-            else:
+            if cl == 90:
+                return LHAPDFSet.erType_ER_EIG90
+            elif cl == 68:
                 return LHAPDFSet.erType_ER_EIG
-
-        if error == "symmhessian":
-            if hasattr(self, 'ErrorConfLevel'):
-                cl = self.ErrorConfLevel
-                if cl == 68:
-                    return LHAPDFSet.erType_ER_SYMEIG
-                else:
-                    raise NotImplementedError("No symmetric hessian errors "
-                                              "with confidence"
-                                              " interval %s" % (cl,) )
             else:
+                raise NotImplementedError(f"No hessian errors with confidence interval {cl}")
+        if error == "symmhessian":
+            if cl == 68:
                 return LHAPDFSet.erType_ER_SYMEIG
+            else:
+                raise NotImplementedError(
+                    "No symmetric hessian errors " f"with confidence interval {cl}"
+                )
 
-        raise NotImplementedError("Error type for %s: '%s' is not implemented" %
-                                  (self.name, error))
+        raise NotImplementedError(f"Error type for {self}: '{error}' is not implemented")
 
     @property
     def grid_values_index(self):
@@ -230,7 +242,11 @@ class PDF(TupleComp):
         err = self.nnpdf_error
         if err is LHAPDFSet.erType_ER_MC:
             return range(1, len(self))
-        elif err in (LHAPDFSet.erType_ER_SYMEIG, LHAPDFSet.erType_ER_EIG, LHAPDFSet.erType_ER_EIG90):
+        elif err in (
+            LHAPDFSet.erType_ER_SYMEIG,
+            LHAPDFSet.erType_ER_EIG,
+            LHAPDFSet.erType_ER_EIG90,
+        ):
             return range(0, len(self))
         else:
             raise RuntimeError("Unknown error type")
@@ -243,10 +259,8 @@ class PDF(TupleComp):
         return len(self.grid_values_index)
 
 
-
 kinlabels_latex = CommonData.kinLabel_latex.asdict()
 _kinlabels_keys = sorted(kinlabels_latex, key=len, reverse=True)
-
 
 
 def get_plot_kinlabels(commondata):

--- a/validphys2/src/validphys/dataplots.py
+++ b/validphys2/src/validphys/dataplots.py
@@ -63,7 +63,7 @@ def _chi2_distribution_plots(chi2_data, stats, pdf, plot_type):
         ax.set_facecolor("#ffcccc")
         log.warning("Chi² distribution plots have a "
                 "different meaning for non MC sets.")
-        label += " (%s!)" % pdf.ErrorType
+        label += " (%s!)" % pdf.error_type
     label += '\n'+ '\n'.join(str(chi2_stat_labels[k])+(' %.2f' % v) for (k,v) in stats.items())
     ax.set_xlabel(r"Replica $\chi^2$")
 
@@ -828,7 +828,7 @@ def plot_replica_sum_rules(pdf, sum_rules, Q):
     fig, axes = plt.subplots(nrows=len(sum_rules), sharex=True)
     #TODO: Get rid of this nonsense
     ncomputed = len(sum_rules[0])
-    if pdf.ErrorType == 'replicas':
+    if pdf.error_type == 'replicas':
         x = np.arange(1, ncomputed + 1)
     else:
         x = np.arange(ncomputed)

--- a/validphys2/src/validphys/deltachi2.py
+++ b/validphys2/src/validphys/deltachi2.py
@@ -26,7 +26,7 @@ log = logging.getLogger(__name__)
 @make_argcheck
 def check_pdf_is_symmhessian(pdf, **kwargs):
     """Check ``pdf`` has error type of ``symmhessian``"""
-    etype = pdf.ErrorType
+    etype = pdf.error_type
     if etype != "symmhessian":
         raise CheckError(
             "Error: type of PDF %s must be 'symmhessian' and not %s" % (pdf, etype)
@@ -256,7 +256,7 @@ class PDFEpsilonPlotter(PDFPlotter):
 def check_pdfs_are_montecarlo(pdfs, **kwargs):
     """Checks that the action is applied only to a pdf consisiting of MC replicas."""
     for pdf in pdfs:
-        etype = pdf.ErrorType
+        etype = pdf.error_type
         if etype != "replicas":
             raise CheckError(
                 "Error: type of PDF %s must be 'replicas' and not '%s'" % (pdf, etype)

--- a/validphys2/src/validphys/eff_exponents.py
+++ b/validphys2/src/validphys/eff_exponents.py
@@ -339,7 +339,7 @@ def next_effective_exponents_table(
         max(2x68% c.l. upper value evaluated at x=`x1_beta` and x=`x2_beta`)
 
     """
-    Qmin = pdf.QMin
+    Qmin = pdf.q_min
 
     alpha_effs = alpha_eff(
         pdf, xmin=x1_alpha, xmax=x2_alpha, npoints=2, Q=Qmin, basis=basis, flavours=flavours)

--- a/validphys2/src/validphys/fitdata.py
+++ b/validphys2/src/validphys/fitdata.py
@@ -341,7 +341,7 @@ def summarise_theory_covmat_fits(fits_theory_covmat_summary):
 
 def _get_fitted_index(pdf, i):
     """Return the nnfit index for the replica i"""
-    p = pathlib.Path(pdf.infopath).with_name(f'{pdf.name}_{i:04d}.dat')
+    p = pdf.infopath.with_name(f'{pdf.name}_{i:04d}.dat')
     with open(p) as f:
         it = yaml.safe_load_all(f)
         metadata = next(it)

--- a/validphys2/src/validphys/lhio.py
+++ b/validphys2/src/validphys/lhio.py
@@ -169,7 +169,7 @@ def generate_replica0(pdf, kin_grids=None, extra_fields=None):
     if extra_fields is not None:
         raise NotImplementedError()
 
-    set_info = pathlib.Path(pdf.infopath)
+    set_info = pdf.infopath
     set_root = set_info.parent
     if not set_root.exists():
         raise RuntimeError(f"Target directory {set_root} does not exist")
@@ -238,7 +238,7 @@ def new_pdf_from_indexes(
 
     set_root.mkdir()
 
-    original_info = pathlib.Path(pdf.infopath)
+    original_info = pdf.infopath
     original_folder = original_info.parent
 
     new_info = set_root/(set_name + '.info')
@@ -310,8 +310,8 @@ def hessian_from_lincomb(pdf, V, set_name=None, folder = None, extra_fields=None
                 out.write(f"SetDesc: \"Hessian {pdf}_hessian\"\n")
             elif l.find("NumMembers:") >= 0:
                 out.write(f"NumMembers: {neig+1}\n")
-            elif l.find("ErrorType: replicas") >= 0:
-                out.write("ErrorType: symmhessian\n")
+            elif l.find("error_type: replicas") >= 0:
+                out.write("error_type: symmhessian\n")
             else:
                 out.write(l)
         if extra_fields is not None:

--- a/validphys2/src/validphys/mc2hessian.py
+++ b/validphys2/src/validphys/mc2hessian.py
@@ -125,14 +125,14 @@ def _compress_X(X, neig):
 
 def _pdf_normalization(pdf):
     """Extract the quantity by which we have to divide the eigenvectors to
-    get the correct errors, depending on the `ErrorType` of `pdf`."""
+    get the correct errors, depending on the `error_type` of `pdf`."""
     nrep = len(pdf) - 1
-    if pdf.ErrorType == "replicas":
+    if pdf.error_type == "replicas":
         norm = np.sqrt(nrep - 1)
-    elif pdf.ErrorType in ("hessian", "symmhessian"):
+    elif pdf.error_type in ("hessian", "symmhessian"):
         norm = 1
     else:
         raise NotImplementedError(
-            "This PDF error type is not supported." "PDF error: %s" % pdf.ErrorType
+            "This PDF error type is not supported." "PDF error: %s" % pdf.error_type
         )
     return norm

--- a/validphys2/src/validphys/pdfgrids.py
+++ b/validphys2/src/validphys/pdfgrids.py
@@ -98,7 +98,7 @@ def lumigrid2d(pdf:PDF, lumi_channel, sqrts:numbers.Real,
     The grid is sampled linearly in rapidity and logarithmically in mass.
 
     The results are computed for all relevant PDF members and wrapped in a
-    stats class, to compute statistics regardless of the ErrorType.
+    stats class, to compute statistics regardless of the error_type.
     """
     s = sqrts*sqrts
     mxs = np.logspace(1, np.log10(sqrts), nbins_m)
@@ -175,7 +175,7 @@ def lumigrid1d(
     GeV and ``mxmax`` is set based on ``sqrts``.
 
     The results are computed for all relevant PDF members and wrapped in a
-    stats class, to compute statistics regardless of the ErrorType.
+    stats class, to compute statistics regardless of the error_type.
     """
     s = sqrts * sqrts
     if mxmax is None:

--- a/validphys2/src/validphys/pdfplots.py
+++ b/validphys2/src/validphys/pdfplots.py
@@ -173,7 +173,7 @@ class PDFPlotter(metaclass=abc.ABCMeta):
 
 @functools.lru_cache()
 def _warn_pdf_not_montecarlo(pdf):
-    et = pdf.ErrorType
+    et = pdf.error_type
     if et != 'replicas':
         log.warning("Plotting members of a non-Monte Carlo PDF set:"
         f" {pdf.name} with error type '{et}'.")

--- a/validphys2/src/validphys/replica_selector.py
+++ b/validphys2/src/validphys/replica_selector.py
@@ -5,7 +5,6 @@ Tools for filtering replica sets based on criteria on the replicas.
 """
 import logging
 import numbers
-import pathlib
 import shutil
 import warnings
 import re
@@ -75,13 +74,13 @@ def alpha_s_bundle_pdf(pdf, pdfs, output_path, target_name: (str, type(None)) = 
         If ``None``, then the name of the original pdf is used
         but with ``_pdfas`` appended
     """
-    base_pdf_path = pathlib.Path(pdf.infopath).parent
+    base_pdf_path = pdf.infopath.parent
     nrep = len(pdf)
 
     target_name = target_name or pdf.name + '_pdfas'
     target_path = output_path / target_name
 
-    alphas_paths = [pathlib.Path(i.infopath).parent for i in pdfs]
+    alphas_paths = [i.infopath.parent for i in pdfs]
     alphas_replica0s = [path / f'{p}_0000.dat' for path, p in zip(alphas_paths, pdfs)]
     new_nrep = nrep + len(alphas_replica0s)
     alphas_values = [str(p.AlphaS_MZ) for p in pdfs]
@@ -111,7 +110,7 @@ def alpha_s_bundle_pdf(pdf, pdfs, output_path, target_name: (str, type(None)) = 
             yaml_obj = yaml.YAML()
             info_yaml = yaml_obj.load(stream)
         info_yaml['NumMembers'] = new_nrep
-        info_yaml['ErrorType'] += '+as'
+        info_yaml['error_type'] += '+as'
         extra_desc = '; '.join(
             f"mem={i} => alphas(MZ)={val}"
             for val, i in zip(alphas_values, range(nrep, new_nrep))

--- a/validphys2/src/validphys/scripts/vp_pdffromreplicas.py
+++ b/validphys2/src/validphys/scripts/vp_pdffromreplicas.py
@@ -93,9 +93,9 @@ def main():
     loader = FallbackLoader()
     input_pdf = loader.check_pdf(args.input_pdf)
 
-    if input_pdf.ErrorType != "replicas":
+    if input_pdf.error_type != "replicas":
         log.error(
-            "Error type of input PDF must be `replicas` not `%s`", input_pdf.ErrorType
+            "Error type of input PDF must be `replicas` not `%s`", input_pdf.error_type
         )
         sys.exit(1)
 

--- a/validphys2/src/validphys/sumrules.py
+++ b/validphys2/src/validphys/sumrules.py
@@ -221,7 +221,7 @@ def bad_replica_sumrules(pdf, sum_rules, threshold: numbers.Real = 0.01):
     farther from the correct value than ``threshold`` (in absolute value).
     """
     ncomputed = len(sum_rules[0])
-    if pdf.ErrorType == "replicas":
+    if pdf.error_type == "replicas":
         x = np.arange(1, ncomputed + 1)
     else:
         x = np.arange(ncomputed)

--- a/validphys2/src/validphys/tests/test_core.py
+++ b/validphys2/src/validphys/tests/test_core.py
@@ -1,0 +1,24 @@
+"""
+Test core functionality
+"""
+import pytest
+from validphys import core
+from validphys.tests.conftest import PDF, HESSIAN_PDF
+
+@pytest.mark.parametrize("pdf_name", [PDF, HESSIAN_PDF])
+def test_pdf(pdf_name):
+    """Check that the given PDF and their relevant attributes can be read
+    And that they don't have crazy values
+    """
+    pdf = core.PDF(pdf_name)
+    _ = pdf.q_min
+    _ = pdf.stats_class
+    assert pdf.isinstalled
+    error_type = pdf.error_type
+    if error_type == "replicas":
+        assert pdf.get_members() == (len(pdf)-1)
+        assert pdf.error_conf_level is None
+    else:
+        assert pdf.get_members() == len(pdf)
+        assert isinstance(pdf.error_conf_level, (int, float))
+    assert pdf.name == pdf._plotname == pdf_name == str(pdf)


### PR DESCRIPTION
One of the changes proposed in #1475.

This is not strictly necessarily for #destroyingc++ but it makes my life easier. Realistically the `PDF` only needs to look into the `.info` file for the error type and eventually the confidence levels of the hessian errors. Now this is done through explicit attributes. The `.info` file is still exposed through an `info` attribute, which among other things allows for the user to look at what's included instead of guessing and hoping for `__get_attr__` to find it.

Since I was effectively rewriting the `PDF` class I've also fixed a `TODO` which asked for the usage of `Path` for `infopath` and I've clean some redundant checks (for instance, `rescale_factor` is only called in one specific situation so no point on checking inside the same reason why it was being called in the first place.

The only quirk here is the fact that some hessian PDFs do not include a confidence level. Is that because it is assumed to be 68%? (@Zaharid could you comment?) I've left it such that it behaves exactly as the previous one in that case but the code could be simplified even more if this is confirmed.

Some notes on the PR itself: all the changes are to the `core.py` (and `test_core.py`) files. All the other files changed have been a sed command for the following substitutions: (`ErrorType` -> `error_type`, `QMin` -> `q_min`) and the removal of redundant `pathlib` calls.