### PR TITLE
Swap libNNPDF LHAPDFSet for a python PDF object

### DIFF
--- a/doc/sphinx/source/vp/examples.rst
+++ b/doc/sphinx/source/vp/examples.rst
@@ -69,6 +69,6 @@ NNLO pdf                             NNPDF40_nnlo_as_01180               NNPDF4.
 NNLO pdf hessian                     NNPDF40_nnlo_as_01180_hessian       NNPDF4.0 NNLO hessian PDF set generated from replicas
 NLO fit                              NNPDF40_nlo_as_01180                NNPDF4.0 NLO fit with 100 replicas (+ central replica)
 NNLO fit                             NNPDF40_nnlo_lowprecision           NNPDF4.0 NNLO low precision fit (theory 162) with 50 replicas (+ central replica)
-NNLO fit (iterated)                  NNPDF40_nnlo_lowprecision_iterated  Iteration of NNPDF40_nnlo_lowprecision
+NNLO fit (iterated)                  NNPDF40_nnlo_low_precision_iterated  Iteration of NNPDF40_nnlo_lowprecision
 fit                                  NNPDF40_example_closure_test        ``n3fit`` closure test fit with 30 replicas before and after postfit
 ===================================  =================================== ==================================================================

--- a/doc/sphinx/source/vp/pydataobjs.rst
+++ b/doc/sphinx/source/vp/pydataobjs.rst
@@ -255,3 +255,20 @@ from the API::
         "theoryid": 162
     }
     total_cov = API.dataset_inputs_covmat_from_systematics(**inp)
+
+Loading LHAPDF PDFs
+-------------------
+
+A wrapper class for LHAPDF PDFs is implemented in the :py:mod:`validphys.lhapdfset` module.
+An instance of this module will provide with a handful of useful wrappers to the underlying
+LHAPDF python interface. This is also the output of the ``pdf.load()`` method.
+
+For example, the following will return the values for all 100 members of NNPDF4.0 for
+the gluon and the d-quark, at three values of ``x`` at ``Q=91.2``.
+
+.. code-block:: python
+    from validphys.api import API
+    pdf = API.pdf(pdf="NNPDF40_nnlo_as_01180")
+    l_pdf = pdf.load()
+    alpha_s = l_pdf.central_member.alphasQ(91.2)
+    results = l_pdf.grid_values([21,1], [0.1, 0.2, 0.3], [91.2])

--- a/validphys2/src/validphys/app.py
+++ b/validphys2/src/validphys/app.py
@@ -15,6 +15,7 @@ import logging
 import contextlib
 
 
+import lhapdf
 from reportengine import app
 
 from validphys.config import Config, Environment
@@ -131,7 +132,7 @@ including the contents of the following file:
             import NNPDF
 
             NNPDF.SetVerbosity(0)
-            NNPDF.SetLHAPDFVerbosity(0)
+            lhapdf.setVerbosity(0)
 
     @staticmethod
     def upload_context(do_upload, output):

--- a/validphys2/src/validphys/checks.py
+++ b/validphys2/src/validphys/checks.py
@@ -39,7 +39,7 @@ def check_pdf_is_montecarlo(ns, **kwargs):
 def check_know_errors(ns, **kwargs):
     pdf = ns['pdf']
     try:
-        pdf.nnpdf_error
+        pdf.stats_class
     except NotImplementedError as e:
         raise CheckError(e) from e
 

--- a/validphys2/src/validphys/config.py
+++ b/validphys2/src/validphys/config.py
@@ -161,7 +161,7 @@ class CoreConfig(configparser.Config):
 
         # Check that we know how to compute errors
         try:
-            pdf.nnpdf_error
+            pdf.stats_class
         except NotImplementedError as e:
             raise ConfigError(str(e))
         return pdf

--- a/validphys2/src/validphys/core.py
+++ b/validphys2/src/validphys/core.py
@@ -84,6 +84,18 @@ class PDF(TupleComp):
     Statistical estimators which depends on the PDF type (MC, Hessian...)
     are exposed as a :py:class:`Stats` object through the :py:attr:`stats_class` attribute
     The LHAPDF metadata can directly be accessed through the :py:attr:`info` attribute
+
+
+    Examples
+    --------
+    >>> from validphys.api import API
+    >>> from validphys.convolution import predictions
+    >>> args = {"dataset_input":{"dataset": "ATLASTTBARTOT"}, "theoryid":162, "use_cuts":"internal"}
+    >>> ds = API.dataset(**args)
+    >>> pdf = API.pdf(pdf="NNPDF40_nnlo_as_01180")
+    >>> preds = predictions(ds, pdf)
+    >>> preds.shape
+    (3, 100)
     """
 
     def __init__(self, name):

--- a/validphys2/src/validphys/filters.py
+++ b/validphys2/src/validphys/filters.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Filters for NNPDF fits
 """
@@ -173,7 +172,7 @@ def _filter_closure_data(filter_path, data, fakepdfset, fakenoise, errorsize):
     """Filter closure test data."""
     total_data_points = 0
     total_cut_data_points = 0
-    fakeset = fakepdfset.load()
+    fakeset = fakepdfset.legacy_load()
     # Load data, don't cache result
     loaded_data = data.load.__wrapped__(data)
     # generate level 1 shift if fakenoise

--- a/validphys2/src/validphys/gridvalues.py
+++ b/validphys2/src/validphys/gridvalues.py
@@ -10,14 +10,8 @@ import itertools
 
 import numpy as np
 
-from NNPDF import REALDOUBLE, LHAPDFSet
-
 from validphys.core import PDF
-
-#Numpy is unhappy about downcasting double to float implicitly, so we have
-#to manually make sure all input arrays correspond to NNPDF::real.
-FLTYPE = np.int32
-REALTYPE = np.double if REALDOUBLE else np.float32
+from validphys.lhapdfset import LHAPDFSet
 
 # Canonical ordering of PDG quark flavour codes
 QUARK_FLAVOURS = (-6, -5, -4, -3, -2, -1, 1, 2, 3, 4, 5, 6)
@@ -54,9 +48,9 @@ QUARK_COMBINATIONS = {
 
 def _grid_values(lpdf, flmat, xmat, qmat):
     """Compute lpdf.grid_values with more forgiving argument types"""
-    flmat = np.atleast_1d(np.asanyarray(flmat, dtype=FLTYPE))
-    xmat = np.atleast_1d(np.asarray(xmat, dtype=REALTYPE))
-    qmat = np.atleast_1d(np.asarray(qmat, dtype=REALTYPE))
+    flmat = np.atleast_1d(np.asanyarray(flmat))
+    xmat = np.atleast_1d(np.asarray(xmat))
+    qmat = np.atleast_1d(np.asarray(qmat))
     return lpdf.grid_values(flmat, xmat, qmat)
 
 def grid_values(pdf:PDF, flmat, xmat, qmat):

--- a/validphys2/src/validphys/lhapdfset.py
+++ b/validphys2/src/validphys/lhapdfset.py
@@ -60,11 +60,6 @@ class LHAPDFSet:
         self._flavors = None
 
     @property
-    def is_monte_carlo(self):
-        """Check whether the error type is MC"""
-        return self._error_type == "replicas"
-
-    @property
     def is_t0(self):
         """Check whether we are in t0 mode"""
         return self._error_type == "t0"
@@ -83,7 +78,7 @@ class LHAPDFSet:
         """
         if self.is_t0:
             return self._lhapdf_set[0:1]
-        if self.is_monte_carlo:
+        if self._error_type == "replicas":
             return self._lhapdf_set[1:]
         return self._lhapdf_set
 
@@ -129,6 +124,6 @@ class LHAPDFSet:
         # Create an array of x and q of equal length for LHAPDF
         xarr, qarr = (g.ravel() for g in np.meshgrid(xgrid, qgrid))
         # Ask LHAPDF for the values and swap the flavours and xgrid-qgrid axes
-        raw = np.array([member.xfxQ(flavors, xarr, qarr) for member in self.members]).swapaxes(1,2)
+        raw = np.array([member.xfxQ(flavors, xarr, qarr) for member in self.members]).swapaxes(1, 2)
         # Unroll the xgrid-qgrid axes
         return raw.reshape(self.n_members, len(flavors), len(xgrid), len(qgrid))

--- a/validphys2/src/validphys/lhapdfset.py
+++ b/validphys2/src/validphys/lhapdfset.py
@@ -92,11 +92,13 @@ class LHAPDFSet:
         """Returns a reference to member 0 of the PDF list"""
         return self._lhapdf_set[0]
 
-    def xfxQ(self, x, q, member_idx, flavour):
-        """Return the PDF value for one single point for one single member"""
-        member_pdf = self.members[member_idx]
-        res = member_pdf.xfxQ(x, q)
-        return res[flavour]
+    def xfxQ(self, x, Q, n, fl):
+        """Return the PDF value for one single point for one single member
+        If the flavour is not included in the PDF (for instance top/antitop) return 0.0
+        """
+        member_pdf = self.members[n]
+        res = member_pdf.xfxQ(x, Q)
+        return res.get(fl, 0.0)
 
     @property
     def flavors(self):

--- a/validphys2/src/validphys/lhapdfset.py
+++ b/validphys2/src/validphys/lhapdfset.py
@@ -1,0 +1,155 @@
+"""
+    Module containing an LHAPDF class compatible with validphys
+    using the official lhapdf python interface.
+    It exposes an interface (almost) compatible with libNNPDF::LHAPDFSet
+    The ``.members`` and ``.central_member`` of the ``LHAPDFSet`` are
+    LHAPDF objects (the typical output from ``mkPDFs``) and can be used normally.
+    For MC PDFs the ``central_member`` is the average of all replicas (members 1-100)
+    while for Hessian PDFs the ``central_member`` is also ``member[0]``
+    Examples
+    --------
+    >>> from validphys.lhapdfset import LHAPDFSet, ER_MC
+    >>> pdf = LHAPDFSet("NNPDF40_nnlo_as_01180", ER_MC)
+    >>> pdf.get_members()
+    100
+    >>> len(pdf.members)
+    100
+    >>> pdf.central_member.alphasQ(91.19)
+    0.11800
+    >>> pdf.member[0].xfxQ2(0.5, 15625)
+    {-5: 6.983360500601136e-05,
+    -4: 0.0021818063617227604,
+    -3: 0.00172453472243952,
+    -2: 0.0010906577230485718,
+    -1: 0.0022049272225017286,
+    1: 0.020051104853608722,
+    2: 0.0954139944889494,
+    3: 0.004116641378803191,
+    4: 0.002180124185625795,
+    5: 6.922722705177504e-05,
+    21: 0.007604124516892057}
+"""
+import logging
+from typing import NamedTuple
+import numpy as np
+import lhapdf
+
+log = logging.getLogger(__name__)
+
+
+class PDFErrorType(NamedTuple):
+    """Namedtuple containing the information about the error type of the PDF"""
+
+    name: str
+    monte_carlo: bool
+    libNNPDF: int
+    t0: bool
+    description: str
+
+
+ER_NONE = PDFErrorType("erType_ER_NONE", False, 0, False, "No error info")
+ER_MC = PDFErrorType("erType_ER_MC", True, 1, False, "Monte Carlo")
+ER_MC68 = PDFErrorType("erType_ER_MC68", True, 2, False, "Monte Carlo 68pc")
+ER_MCT0 = PDFErrorType("erType_ER_MCT0", False, 3, True, "Monte Carlo t0")
+ER_EIG = PDFErrorType("erType_ER_EIG", False, 4, False, "Eigenvector 68pc")
+ER_EIG90 = PDFErrorType("erType_ER_EIG90", False, 5, False, "Eigenvector 90pc")
+ER_SYMEIG = PDFErrorType("erType_ER_SYMEIG", False, 6, False, "Symmetric eigenvectors")
+
+
+class LHAPDFSet:
+    """Wrapper for the lhapdf python interface.
+    Once instantiated this class will load the PDF set according to whether it is to be
+    treated as a T0 set (only the CV) or not.
+    For Monte Carlo sets the central value (member 0) is by default not included when taking
+    the resutls for all members (i.e., when using ``grid_values``).
+    However, it is possible to add member 0 by changing the ``include_cv`` attribute to True.
+    Temporarily: it exposes all libNNPDF error attributes that were exposed and used prior to
+    the introduction of this class
+    """
+
+    def __init__(self, name, error_type):
+        log.info("PDF: %s ErrorType: %s", name, error_type)
+        self._name = name
+        self._error_type = error_type
+        if self.is_t0:
+            # If at this point we already know this is a T0 set, load only the CV
+            self._lhapdf_set = [lhapdf.mkPDF(name)]
+        else:
+            self._lhapdf_set = lhapdf.mkPDFs(name)
+        self._flavors = None
+
+    @property
+    def is_monte_carlo(self):
+        """Check whether the error type is MC"""
+        return self._error_type == "replicas"
+
+    @property
+    def is_t0(self):
+        """Check whether we are in t0 mode"""
+        return self._error_type == "t0"
+
+    @property
+    def n_members(self):
+        """Return the number of active members in the PDF set"""
+        return len(self.members)
+
+    @property
+    def members(self):
+        """Return the members of the set, this depends on the error type:
+            t0: returns only member 0
+            MC: skip member 0
+            Hessian: return all
+        """
+        if self.is_t0:
+            return self._lhapdf_set[0:1]
+        if self.is_monte_carlo:
+            return self._lhapdf_set[1:]
+        return self._lhapdf_set
+
+    @property
+    def central_member(self):
+        """Returns a reference to member 0 of the PDF list"""
+        return self._lhapdf_set[0]
+
+    def xfxQ(self, x, q, member_idx, flavour):
+        """Return the PDF value for one single point for one single member"""
+        member_pdf = self.members[member_idx]
+        res = member_pdf.xfxQ(x, q)
+        return res[flavour]
+
+    @property
+    def flavors(self):
+        """Returns the list of accepted flavors by the LHAPDF set"""
+        if self._flavors is None:
+            self._flavors = self.members[0].flavors()
+        return self._flavors
+
+    def grid_values(self, flavors: np.ndarray, xgrid: np.ndarray, qgrid: np.ndarray):
+        """Returns the PDF values for every member for the required
+        flavours, points in x and pointx in q
+        The return shape is
+            (members, flavors, xgrid, qgrid)
+        Return
+        ------
+            ndarray of shape (members, flavors, xgrid, qgrid)
+        Examples
+        --------
+        >>> import numpy as np
+        >>> from validphys.lhapdfset import LHAPDFSet, ER_MC
+        >>> pdf = LHAPDFSet("NNPDF40_nnlo_as_01180", ER_MC)
+        >>> xgrid = np.random.rand(10)
+        >>> qgrid = np.random.rand(3)
+        >>> flavs = np.arange(-4,4)
+        >>> flavs[4] = 21
+        >>> results = pdf.grid_values(flavs, xgrid, qgrid)
+        """
+        # Grid values loop
+        ret = np.array(
+            [
+                [[member.xfxQ(flavors, x, q) for x in xgrid] for q in qgrid]
+                for member in self.members
+            ]
+        )
+
+        # Finally return in the documented shape
+        return np.transpose(ret, (0, 3, 2, 1))

--- a/validphys2/src/validphys/results.py
+++ b/validphys2/src/validphys/results.py
@@ -171,7 +171,7 @@ class ThPredictionsResult(NNPDFDataResult):
 class PositivityResult(StatsResult):
     @classmethod
     def from_convolution(cls, pdf, posset):
-        loaded_pdf = pdf.load()
+        loaded_pdf = pdf.legacy_load()
         loaded_pos = posset.load()
         data = loaded_pos.GetPredictions(loaded_pdf)
         stats = pdf.stats_class(data.T)

--- a/validphys2/src/validphys/sumrules.py
+++ b/validphys2/src/validphys/sumrules.py
@@ -13,13 +13,13 @@ import numpy as np
 import pandas as pd
 import scipy.integrate as integrate
 
-from NNPDF import LHAPDFSet
 from reportengine.table import table
 from reportengine.checks import check_positive
 from reportengine.floatformatting import format_error_value_columns
 
 from validphys.core import PDF
 from validphys.pdfbases import ALL_FLAVOURS, parse_flarr
+from validphys.lhapdfset import LHAPDFSet
 
 
 def _momentum_sum_rule_integrand(x, lpdf:LHAPDFSet, irep, Q):
@@ -125,7 +125,7 @@ KNOWN_SUM_RULES_EXPECTED = {
 
 def _sum_rules(rules_dict, lpdf, Q):
     """Compute a SumRulesGrid from the loaded PDF, at Q"""
-    nmembers = lpdf.GetMembers()
+    nmembers = lpdf.n_members()
     #TODO: Write this in something fast
     #If nothing else, at least allocate and store the result contiguously
     res = np.zeros((len(rules_dict), nmembers))

--- a/validphys2/src/validphys/sumrules.py
+++ b/validphys2/src/validphys/sumrules.py
@@ -125,7 +125,7 @@ KNOWN_SUM_RULES_EXPECTED = {
 
 def _sum_rules(rules_dict, lpdf, Q):
     """Compute a SumRulesGrid from the loaded PDF, at Q"""
-    nmembers = lpdf.n_members()
+    nmembers = lpdf.n_members
     #TODO: Write this in something fast
     #If nothing else, at least allocate and store the result contiguously
     res = np.zeros((len(rules_dict), nmembers))

--- a/validphys2/src/validphys/tests/conftest.py
+++ b/validphys2/src/validphys/tests/conftest.py
@@ -48,7 +48,7 @@ PDF = "NNPDF40_nnlo_as_01180"
 HESSIAN_PDF = "NNPDF40_nnlo_as_01180_hessian"
 THEORYID = 162
 FIT = "NNPDF40_nnlo_lowprecision"
-FIT_ITERATED = "NNPDF40_nnlo_lowprecision_iterated"
+FIT_ITERATED = "NNPDF40_nnlo_low_precision_iterated"
 
 base_config = dict(
         pdf=PDF,


### PR DESCRIPTION
Final step of #1472, with the previous changes this is just a drop-in replacement. At least from the point of view of the tests nothing changes (the test will fail because the effective exponent for `smallx` for `t3` changed).

The only thing missing from here in order to close fully #1472 is how to avoid having to run the convolution twice to get the central value for observable predictions (which is a factor of x2 every time one tries to get a prediction). See issue #1502 for more on this.

Note that a `legacy_load` is still left there because the `filter.py` uses a PDF for `MakeClosure`.