### PR TITLE
Optimize pseudodata computation

### DIFF
--- a/validphys2/src/validphys/chi2grids.py
+++ b/validphys2/src/validphys/chi2grids.py
@@ -60,10 +60,7 @@ def computed_pseudoreplicas_chi2(
     return df
 
 
-# TODO: Probably fitcontext should set all of the variables required to compute
-# this. But better setting
-# them explicitly than setting some, so we require the user to do that.
-fits_computed_pseudoreplicas_chi2 = collect(computed_pseudoreplicas_chi2, ("fits",))
+fits_computed_pseudoreplicas_chi2 = collect(computed_pseudoreplicas_chi2, ("fits", "fitenvironment", "fitpdf"))
 
 dataspecs_computed_pseudorreplicas_chi2 = collect(computed_pseudoreplicas_chi2, ("dataspecs",))
 

--- a/validphys2/src/validphys/chi2grids.py
+++ b/validphys2/src/validphys/chi2grids.py
@@ -25,6 +25,7 @@ log = logging.getLogger(__name__)
 
 def computed_pseudoreplicas_chi2(
     fitted_make_replicas,
+    fitted_replica_indexes,
     group_result_table_no_table,  # to get the results already in the form of a dataframe
     groups_sqrtcovmat,
 ):
@@ -35,7 +36,7 @@ def computed_pseudoreplicas_chi2(
     where ``nnftix_index`` is the name of the corresponding replica
     """
     # Stack the replica pseudodata to have the prediction shape
-    r_data = np.stack(fitted_make_replicas, axis=1)
+    r_data = np.stack(fitted_make_replicas[0], axis=1)
 
     # Drop data central and theory central which is not useful here
     r_prediction = group_result_table_no_table.drop(columns=["data_central", "theory_central"])
@@ -51,7 +52,7 @@ def computed_pseudoreplicas_chi2(
         its_covmat = groups_sqrtcovmat[group_level == group][group]
         chi2_per_replica = calc_chi2(its_covmat, group_diff)
         ndata = len(group_diff)
-        for i, chi2 in enumerate(chi2_per_replica):
+        for i, chi2 in zip(fitted_replica_indexes, chi2_per_replica):
             df_output.append(PseudoReplicaExpChi2Data(group, ndata, chi2, i))
 
     df = pd.DataFrame(df_output, columns=PseudoReplicaExpChi2Data._fields)
@@ -60,7 +61,9 @@ def computed_pseudoreplicas_chi2(
     return df
 
 
-fits_computed_pseudoreplicas_chi2 = collect(computed_pseudoreplicas_chi2, ("fits", "fitenvironment", "fitpdf"))
+fits_computed_pseudoreplicas_chi2 = collect(
+    computed_pseudoreplicas_chi2, ("fits", "fitenvironment", "fitpdf")
+)
 
 dataspecs_computed_pseudorreplicas_chi2 = collect(computed_pseudoreplicas_chi2, ("dataspecs",))
 

--- a/validphys2/src/validphys/chi2grids.py
+++ b/validphys2/src/validphys/chi2grids.py
@@ -67,6 +67,10 @@ fits_computed_pseudoreplicas_chi2 = collect(
 
 dataspecs_computed_pseudorreplicas_chi2 = collect(computed_pseudoreplicas_chi2, ("dataspecs",))
 
+@table
+def export_computed_pseudoreplicas_chi2(computed_pseudoreplicas_chi2):
+    return computed_pseudoreplicas_chi2
+
 
 @table
 def export_fits_computed_pseudoreplicas_chi2(fits_computed_pseudoreplicas_chi2):

--- a/validphys2/src/validphys/paramfits/config.py
+++ b/validphys2/src/validphys/paramfits/config.py
@@ -98,7 +98,7 @@ class ParamfitsConfig(Config):
         res = tableloader.combine_pseudoreplica_tables(dfs, finalnames,
                 blacklist_datasets=blacklist_datasets)
 
-        return {'fits_computed_pseudoreplicas_chi2': res}
+        return {'computed_pseudoreplicas_chi2': res}
 
 
     #TODO: autogenerate functions like this

--- a/validphys2/src/validphys/pseudodata.py
+++ b/validphys2/src/validphys/pseudodata.py
@@ -246,10 +246,10 @@ def _fitted_make_replicas(fit, groups_dataset_inputs_loaded_cd_with_cuts, genrep
     res = []
     g = groups_dataset_inputs_loaded_cd_with_cuts
     for i in range(1, num_fitted_replicas(fit) + 1):
+        log.debug(f"Computing pseudodata for replica {i} in {fit}")
         seed = replica_mcseed(i, mcseed, genrep)
         pseudodata_replica = make_replica(g, seed, genrep)
         res.append(pseudodata_replica)
-    print(res)
     return res
 
 fitted_make_replicas = collect("_fitted_make_replicas", ("fitenvironment",))

--- a/validphys2/src/validphys/pseudodata.py
+++ b/validphys2/src/validphys/pseudodata.py
@@ -14,7 +14,6 @@ import pandas as pd
 from reportengine import collect
 
 from validphys.covmats import INTRA_DATASET_SYS_NAME
-from validphys.fitdata import num_fitted_replicas
 from validphys.n3fit_data import replica_mcseed
 
 
@@ -362,14 +361,17 @@ make_replicas = collect('make_replica', ('replicas',))
 indexed_make_replicas = collect('indexed_make_replica', ('replicas',))
 
 
-def _fitted_make_replicas(fit, pseudodata_generation_data, genrep: bool, mcseed: int):
+def _fitted_make_replicas(
+    fit, pseudodata_generation_data, fitted_replica_indexes, genrep: bool, mcseed: int
+):
     res = []
-    for i in range(1, num_fitted_replicas(fit) + 1):
-        log.debug(f"Computing pseudodata for replica {i} in {fit}")
+    for order, i in enumerate(fitted_replica_indexes):
+        log.debug(f"Computing pseudodata for replica {order} in {fit}")
         seed = replica_mcseed(i, mcseed, genrep)
         pseudodata_replica = make_replica(pseudodata_generation_data, seed, genrep)
         res.append(pseudodata_replica)
     return res
+
 
 fitted_make_replicas = collect("_fitted_make_replicas", ("fitenvironment",))
 

--- a/validphys2/src/validphys/pseudodata.py
+++ b/validphys2/src/validphys/pseudodata.py
@@ -10,9 +10,12 @@ import pathlib
 import numpy as np
 import pandas as pd
 
-from validphys.covmats import INTRA_DATASET_SYS_NAME
-
 from reportengine import collect
+
+from validphys.covmats import INTRA_DATASET_SYS_NAME
+from validphys.fitdata import num_fitted_replicas
+from validphys.n3fit_data import replica_mcseed
+
 
 FILE_PREFIX = "datacuts_theory_fitting_"
 
@@ -236,8 +239,21 @@ _recreate_pdf_pseudodata = collect('indexed_make_replica', ('pdfreplicas', 'fite
 fit_tr_masks = collect('replica_training_mask_table', ('fitreplicas', 'fitenvironment'))
 pdf_tr_masks = collect('replica_training_mask_table', ('pdfreplicas', 'fitenvironment'))
 make_replicas = collect('make_replica', ('replicas',))
-fitted_make_replicas = collect('make_replica', ('pdfreplicas',))
 indexed_make_replicas = collect('indexed_make_replica', ('replicas',))
+
+
+def _fitted_make_replicas(fit, groups_dataset_inputs_loaded_cd_with_cuts, genrep: bool, mcseed: int):
+    res = []
+    g = groups_dataset_inputs_loaded_cd_with_cuts
+    for i in range(1, num_fitted_replicas(fit) + 1):
+        seed = replica_mcseed(i, mcseed, genrep)
+        pseudodata_replica = make_replica(g, seed, genrep)
+        res.append(pseudodata_replica)
+    print(res)
+    return res
+
+fitted_make_replicas = collect("_fitted_make_replicas", ("fitenvironment",))
+
 
 def recreate_fit_pseudodata(_recreate_fit_pseudodata, fitreplicas, fit_tr_masks):
     """Function used to reconstruct the pseudodata seen by each of the


### PR DESCRIPTION
The function `computed_pseudoreplicas_chi2` in chi2grids.py is unusable in the current master as well as various pseudodata replica utilities.

One showstopper involves

```
 fitted_make_replicas = collect('make_replica', ('pdfreplicas',))
```

Reportengine is unfortunately unable to deal with this very elegantly and will try to resolve all the data for each of the replicas anew. It would be nice to fix that but in the meantime, add the loop manually.

 Once that is fixed it turns out that generating a replica with `make_replica` is unbearably slow now (in fact it didn't finish for me between launching  it early this morning  and looking at it now). I am not sure if this is a old phenomenon or has to do with some regression in pandas.

(Incidentally @enocera  did you notice any problems in that phase while running the fits?)

So currently, on master calling make_replica with an unlucky input can take well in excess of a few minutes per replica. The slow parts are all pandas operations such as some trivial looking concatenation like `special_add_errors = pd.concat(special_add, axis=0, sort=True).fillna(0).to_numpy()` (hence why I think it may e a regression) which takes half a second for some reason. To address that move all these operations outside, to a separate provider so they can be shared across various inputs. With that computing a pseidodata replica takes a few seconds at worst on  my laptop.
