### PR TITLE
Add a fallback to using all points for reports that are using old fits with bad filters.

### DIFF
--- a/validphys2/src/validphys/config.py
+++ b/validphys2/src/validphys/config.py
@@ -446,6 +446,7 @@ class CoreConfig(configparser.Config):
     def parse_use_fitcommondata(self, do_use: bool):
         """Use the commondata files in the fit instead of those in the data
         directory."""
+        import ipdb; ipdb.set_trace()
         return do_use
 
     def produce_commondata(self, *, dataset_input, use_fitcommondata=False, fit=None):
@@ -473,10 +474,9 @@ class CoreConfig(configparser.Config):
 
     def _produce_fit_cuts(self, commondata):
         """Produce fit and then attempt to load cuts from that fit."""
-        name = commondata.name
         _, fit = self.parse_from_(None, "fit", write=False)
         try:
-            return self.loader.check_fit_cuts(name, fit, fallback_commondata=commondata)
+            return self.loader.check_fit_cuts(commondata, fit)
         except LoadFailedError as e:
             raise ConfigError(e) from e
 

--- a/validphys2/src/validphys/config.py
+++ b/validphys2/src/validphys/config.py
@@ -446,7 +446,6 @@ class CoreConfig(configparser.Config):
     def parse_use_fitcommondata(self, do_use: bool):
         """Use the commondata files in the fit instead of those in the data
         directory."""
-        import ipdb; ipdb.set_trace()
         return do_use
 
     def produce_commondata(self, *, dataset_input, use_fitcommondata=False, fit=None):

--- a/validphys2/src/validphys/config.py
+++ b/validphys2/src/validphys/config.py
@@ -476,7 +476,7 @@ class CoreConfig(configparser.Config):
         name = commondata.name
         _, fit = self.parse_from_(None, "fit", write=False)
         try:
-            return self.loader.check_fit_cuts(name, fit)
+            return self.loader.check_fit_cuts(name, fit, fallback_commondata=commondata)
         except LoadFailedError as e:
             raise ConfigError(e) from e
 

--- a/validphys2/src/validphys/loader.py
+++ b/validphys2/src/validphys/loader.py
@@ -266,8 +266,9 @@ class Loader(LoaderBase):
                     raise DataNotFoundError(f"Either {newpath} or {oldpath} "
                         "are needed with `use_fitcommondata`")
                 #This is to not repeat all the error handling stuff
-                basedata = self.check_commondata(setname, sysnum=sysnum).datafile
-                cuts = self.check_fit_cuts(setname, fit=fit)
+                basedata = self.check_commondata(setname, sysnum=sysnum)
+                basedata_path = basedata.datafile
+                cuts = self.check_fit_cuts(basedata, fit=fit)
 
                 if fit not in self._old_commondata_fits:
                     self._old_commondata_fits.add(fit)
@@ -280,7 +281,7 @@ class Loader(LoaderBase):
                         f"Points that do not pass the cuts are set to zero!")
 
                 log.info(f"Upgrading filtered commondata. Writing {newpath}")
-                rebuild_commondata_without_cuts(oldpath, cuts, basedata, newpath)
+                rebuild_commondata_without_cuts(oldpath, cuts, basedata_path, newpath)
             datafile = newpath
         else:
             datafile = self.commondata_folder / f'DATA_{setname}.dat'
@@ -504,7 +505,7 @@ class Loader(LoaderBase):
             if cuts is CutsPolicy.NOCUTS:
                 cuts = None
             elif cuts is CutsPolicy.FROMFIT:
-                cuts = self.check_fit_cuts(name, fit, fallback=commondata)
+                cuts = self.check_fit_cuts(commondata, fit)
             elif cuts is CutsPolicy.INTERNAL:
                 if rules is None:
                     rules = self.check_default_filter_rules(theoryid)
@@ -552,20 +553,19 @@ class Loader(LoaderBase):
     def get_pdf(self, name):
         return self.check_pdf(name).load()
 
-    def check_fit_cuts(self, setname, fit, fallback_commondata=None):
+    def check_fit_cuts(self, commondata, fit):
+        setname = commondata.name
         if fit is None:
             raise TypeError("Must specify a fit to use the cuts.")
         if not isinstance(fit, FitSpec):
             fit = self.check_fit(fit)
-        fitname, fitpath = fit
+        _, fitpath = fit
         p = (fitpath/'filter')/setname/('FKMASK_' + setname+ '.dat')
         if not p.parent.exists():
             raise CutsNotFound(f"Bad filter configuration. Could not find {p.parent}")
         if not p.exists():
-            if fallback_commondata is None:
-                raise CutsNotFound(f"Bad filter configuration, no cuts found for {setname}: {p}")
-            return Cuts.legacy(setname, fallback_commondata)
-        return Cuts(setname, p)
+            p = None
+        return Cuts(commondata, p)
 
     def check_internal_cuts(self, commondata, rules):
         return InternalCutsWrapper(commondata, rules)

--- a/validphys2/src/validphys/tests/test_commondataparser.py
+++ b/validphys2/src/validphys/tests/test_commondataparser.py
@@ -32,7 +32,7 @@ def test_commondata_with_cuts():
     cd = l.check_commondata(setname=setname)
     loaded_cd = load_commondata(cd)
 
-    fit_cuts = l.check_fit_cuts(fit=FIT, setname=setname)
+    fit_cuts = l.check_fit_cuts(fit=FIT, commondata=cd)
     internal_cuts = l.check_internal_cuts(
         cd, API.rules(theoryid=THEORYID, use_cuts="internal")
     )
@@ -57,6 +57,7 @@ def test_commondata_with_cuts():
     assert all(loaded_cd.with_cuts([1, 2, 3]).commondata_table.index - 1 == [1, 2, 3])
 
     # Check that giving cuts for another dataset raises the correct ValueError exception
-    bad_cuts = l.check_fit_cuts(fit=FIT, setname="NMCPD")
+    cd_bad = l.check_commondata(setname="NMCPD")
+    bad_cuts = l.check_fit_cuts(fit=FIT, commondata=cd_bad)
     with pytest.raises(ValueError):
         loaded_cd.with_cuts(bad_cuts)

--- a/validphys2/src/validphys/tests/test_loader.py
+++ b/validphys2/src/validphys/tests/test_loader.py
@@ -41,7 +41,7 @@ def test_rebuild_commondata_without_cuts(tmp_path_factory, arg):
     if cuts:
         cutpath = tmp / "cuts.txt"
         np.savetxt(cutpath, np.asarray(cuts, dtype=int), fmt="%u")
-        cutspec = Cuts(cd.name, cutpath)
+        cutspec = Cuts(cd, cutpath)
         lcd = type(lcd)(lcd, cuts)
     lcd.Export(str(tmp))
     # We have to reconstruct the name here...


### PR DESCRIPTION
One example (I'm using `generate_a_report.yaml` as template) that would fail in current master (because the HERACOMBNCEM cuts do not exist). With this you get a million warnings but it works.
I think many warnings is better than a failure. Fixes #1505 

```
fit: NNPDF31_nnlo_as_0118_DISonly

pdf:
  from_: "fit"

experiments:
  - experiment: TEST
    datasets:
      - {dataset: HERACOMBNCEM , frac: 0.5}

theoryid: 162

use_cuts: "fromfit"

template_text: |
  {@experiments::experiment plot_chi2dist@}

actions_:
  - report(main=True)
```