### PR TITLE
Fix callers of group_chi2_table

### DIFF
--- a/validphys2/src/validphys/results.py
+++ b/validphys2/src/validphys/results.py
@@ -660,17 +660,16 @@ def predictions_by_kinematics_table(results, kinematics_table_notable):
     tb['prediction'] = theory.central_value
     return tb
 
-groups_each_dataset_chi2 = collect("each_dataset_chi2", ("group_dataset_inputs_by_process",))
-groups_data_by_process = collect("data", ("group_dataset_inputs_by_process",))
+groups_each_dataset_chi2 = collect("each_dataset_chi2", ("group_dataset_inputs_by_metadata",))
 groups_chi2_by_process = collect("dataset_inputs_abs_chi2_data", ("group_dataset_inputs_by_process",))
-
+groups_each_dataset_chi2_by_process = collect("each_dataset_chi2", ("group_dataset_inputs_by_process",))
 
 @table
-def groups_chi2_table(groups_data_by_process, pdf, groups_chi2_by_process, groups_each_dataset_chi2):
+def groups_chi2_table(groups_data, pdf, groups_chi2, groups_each_dataset_chi2):
     """Return a table with the chi² to the groups and each dataset in
-    the groups."""
+    the groups, grouped by metadata."""
     records = []
-    for group, groupres, dsresults in zip(groups_data_by_process, groups_chi2_by_process, groups_each_dataset_chi2):
+    for group, groupres, dsresults in zip(groups_data, groups_chi2, groups_each_dataset_chi2):
         for dataset, dsres in zip(group, dsresults):
             stats = chi2_stats(dsres)
             stats["group"] = dataset.name
@@ -682,7 +681,19 @@ experiments_chi2_table = collect(
     "groups_chi2_table", ("group_dataset_inputs_by_experiment",)
 )
 
-procs_chi2_table = collect("groups_chi2_table", ("group_dataset_inputs_by_process",))
+@table
+def procs_chi2_table(
+    procs_data, pdf, groups_chi2_by_process, groups_each_dataset_chi2_by_process
+):
+    """Same as groups_chi2_table but by process"""
+    return groups_chi2_table(
+        procs_data,
+        pdf,
+        groups_chi2_by_process,
+        groups_each_dataset_chi2_by_process,
+    )
+
+#procs_chi2_table = collect("groups_chi2_table", ("group_dataset_inputs_by_process",))
 
 @check_cuts_considered
 @table

--- a/validphys2/src/validphys/results.py
+++ b/validphys2/src/validphys/results.py
@@ -660,17 +660,17 @@ def predictions_by_kinematics_table(results, kinematics_table_notable):
     tb['prediction'] = theory.central_value
     return tb
 
-groups_each_dataset_chi2 = collect("each_dataset_chi2", ("group_dataset_inputs_by_metadata",))
+groups_each_dataset_chi2 = collect("each_dataset_chi2", ("group_dataset_inputs_by_process",))
+groups_data_by_process = collect("data", ("group_dataset_inputs_by_process",))
+groups_chi2_by_process = collect("dataset_inputs_abs_chi2_data", ("group_dataset_inputs_by_process",))
+
 
 @table
-def groups_chi2_table(groups_data, pdf, groups_chi2, groups_each_dataset_chi2):
+def groups_chi2_table(groups_data_by_process, pdf, groups_chi2_by_process, groups_each_dataset_chi2):
     """Return a table with the chi² to the groups and each dataset in
     the groups."""
     records = []
-    for group, groupres, dsresults in zip(groups_data, groups_chi2, groups_each_dataset_chi2):
-        stats = chi2_stats(groupres)
-        stats["group"] = group.name
-        records.append(stats)
+    for group, groupres, dsresults in zip(groups_data_by_process, groups_chi2_by_process, groups_each_dataset_chi2):
         for dataset, dsres in zip(group, dsresults):
             stats = chi2_stats(dsres)
             stats["group"] = dataset.name

--- a/validphys2/src/validphys/results.py
+++ b/validphys2/src/validphys/results.py
@@ -678,13 +678,11 @@ def groups_chi2_table(groups_data, pdf, groups_chi2, groups_each_dataset_chi2):
     return pd.DataFrame(records)
 
 
-@table
-def procs_chi2_table(procs_data, pdf, procs_chi2, each_dataset_chi2):
-    return groups_chi2_table(procs_data, pdf, procs_chi2, each_dataset_chi2)
-    
 experiments_chi2_table = collect(
     "groups_chi2_table", ("group_dataset_inputs_by_experiment",)
 )
+
+procs_chi2_table = collect("groups_chi2_table", ("group_dataset_inputs_by_process",))
 
 @check_cuts_considered
 @table

--- a/validphys2/src/validphys/theorycovariance/output.py
+++ b/validphys2/src/validphys/theorycovariance/output.py
@@ -16,27 +16,38 @@ from matplotlib import cm, colors as mcolors
 
 from reportengine.figure import figure
 from reportengine.table import table
+from reportengine import collect
 
 from validphys import plotutils
 from validphys.results import groups_chi2_table
 
 log = logging.getLogger(__name__)
 
+abs_chi2_data_theory_dataset_by_process = collect(
+    "abs_chi2_data_theory_dataset", ("group_dataset_inputs_by_process",)
+)
+
 
 @table
 def procs_chi2_table_theory(
-    procs_data, pdf, abs_chi2_data_theory_proc, abs_chi2_data_theory_dataset
+    procs_data, pdf, abs_chi2_data_theory_proc, abs_chi2_data_theory_dataset_by_process
 ):
     """Same as groups_chi2_table but including theory covariance matrix.
     Note: we use groups_chi2_table here but provide data grouped by process."""
     return groups_chi2_table(
-        procs_data, pdf, abs_chi2_data_theory_proc, abs_chi2_data_theory_dataset
+        procs_data,
+        pdf,
+        abs_chi2_data_theory_proc,
+        abs_chi2_data_theory_dataset_by_process,
     )
 
 
 @table
 def procs_chi2_table_diagtheory(
-    procs_data, pdf, abs_chi2_data_diagtheory_proc, abs_chi2_data_diagtheory_dataset
+    procs_data,
+    pdf,
+    abs_chi2_data_diagtheory_proc,
+    abs_chi2_data_theory_dataset_by_process,
 ):
     """Same as groups_chi2_table but including diagonal theory covariance matrix.
     Note: we use groups_chi2_table here but provide data grouped by process."""
@@ -44,7 +55,7 @@ def procs_chi2_table_diagtheory(
         procs_data,
         pdf,
         abs_chi2_data_diagtheory_proc,
-        abs_chi2_data_diagtheory_dataset,
+        abs_chi2_data_theory_dataset_by_process,
     )
 
 


### PR DESCRIPTION
Commit 79604bd had introduced a level of indirection on the inputs of
groups_chi2_table to make sure that the data wasn't being reshuffled too
much. This however was not propagated to the actions that internally
made use of that functionality, of which there are three.

Fix the simpler one to use the original action with the right grouping
and add an additional collect over processes for the ones in the theory
covariance matrix module.

Closes #1520.