### PR TITLE
Bugfix hyperopt integrability penalty

### DIFF
--- a/n3fit/src/n3fit/hyper_optimization/penalties.py
+++ b/n3fit/src/n3fit/hyper_optimization/penalties.py
@@ -94,7 +94,7 @@ def patience(stopping_object=None, alpha=1e-4, **_kwargs):
     return vl_loss * np.exp(alpha * diff)
 
 
-def integrability(pdf_models=None):
+def integrability(pdf_models=None, **_kwargs):
     """Adds a penalty proportional to the value of the integrability integration
     It adds a 0-penalty when the value of the integrability is equal or less than the value
     of the threshold defined in validphys::fitveto

--- a/n3fit/src/n3fit/tests/regressions/hyper-quickcard.yml
+++ b/n3fit/src/n3fit/tests/regressions/hyper-quickcard.yml
@@ -69,6 +69,8 @@ kfold:
     target: average
     penalties:
       - saturation
+      - patience
+      - saturation
     threshold: 2.0
     partitions:
         - datasets:

--- a/n3fit/src/n3fit/tests/regressions/hyper-quickcard.yml
+++ b/n3fit/src/n3fit/tests/regressions/hyper-quickcard.yml
@@ -70,7 +70,7 @@ kfold:
     penalties:
       - saturation
       - patience
-      - saturation
+      - integrability
     threshold: 2.0
     partitions:
         - datasets:


### PR DESCRIPTION
All penatlies need to allow for unused `**kwargs`. 