### PR TITLE
Improve remote keyword functionality

### DIFF
--- a/validphys2/src/validphys/loader.py
+++ b/validphys2/src/validphys/loader.py
@@ -18,6 +18,7 @@ import os
 import os.path as osp
 import urllib.parse as urls
 import mimetypes
+from functools import cached_property
 
 from typing import List
 
@@ -789,6 +790,19 @@ class RemoteLoader(LoaderBase):
     def remote_nnpdf_pdfs(self):
         return self.remote_files(self.nnpdf_pdfs_urls, self.nnpdf_pdfs_index,
                                  thing="PDFs")
+
+    @cached_property
+    def remote_keywords(self):
+        root = self.nnprofile['reports_root_url']
+        url = urls.urljoin(root, 'index.json')
+        try:
+           req = requests.get(url)
+           req.raise_for_status()
+           keyobjs= req.json()['keywords']
+           l = [k[0] for k in keyobjs]
+        except requests.RequestException as e:
+            raise RemoteLoaderError(e) from e
+        return l
 
     @property
     def downloadable_fits(self):

--- a/validphys2/src/validphys/promptutils.py
+++ b/validphys2/src/validphys/promptutils.py
@@ -58,8 +58,8 @@ def confirm(message, default=None):
     session = PromptSession(complete_message, key_bindings=bindings)
     return session.prompt()
 
-#We need some sort of cache because prompt_toolkit calls the callable
-#every time it tries to complete.
+# We need some sort of cache because prompt_toolkit calls the callable
+# every time it tries to complete.
 class KeywordsWithCache():
     def __init__(self, loader):
         self.loader = loader
@@ -70,7 +70,7 @@ class KeywordsWithCache():
             if hasattr(self.loader, "remote_keywords"):
                 try:
                     self.words = self.loader.remote_keywords
-                # Catch a borad exception here as we don't want the completion
+                # Catch a broad exception here as we don't want the completion
                 # to break the app
                 except Exception as e:
                     self.words= []

--- a/validphys2/src/validphys/promptutils.py
+++ b/validphys2/src/validphys/promptutils.py
@@ -60,20 +60,17 @@ def confirm(message, default=None):
 
 # We need some sort of cache because prompt_toolkit calls the callable
 # every time it tries to complete.
-class KeywordsWithCache():
+class KeywordsWithCache:
     def __init__(self, loader):
         self.loader = loader
         self.words = None
 
     def __call__(self):
         if self.words is None:
-            if hasattr(self.loader, "remote_keywords"):
-                try:
-                    self.words = self.loader.remote_keywords
-                # Catch a broad exception here as we don't want the completion
-                # to break the app
-                except Exception as e:
-                    self.words= []
-            else:
+            try:
+                self.words = self.loader.remote_keywords
+            # Catch a broad exception here as we don't want the completion
+            # to break the app
+            except Exception as e:
                 self.words = []
         return self.words

--- a/validphys2/src/validphys/promptutils.py
+++ b/validphys2/src/validphys/promptutils.py
@@ -57,3 +57,23 @@ def confirm(message, default=None):
     complete_message = merge_formatted_text([message, yes_no_str(default)])
     session = PromptSession(complete_message, key_bindings=bindings)
     return session.prompt()
+
+#We need some sort of cache because prompt_toolkit calls the callable
+#every time it tries to complete.
+class KeywordsWithCache():
+    def __init__(self, loader):
+        self.loader = loader
+        self.words = None
+
+    def __call__(self):
+        if self.words is None:
+            if hasattr(self.loader, "remote_keywords"):
+                try:
+                    self.words = self.loader.remote_keywords
+                # Catch a borad exception here as we don't want the completion
+                # to break the app
+                except Exception as e:
+                    self.words= []
+            else:
+                self.words = []
+        return self.words

--- a/validphys2/src/validphys/scripts/vp_comparefits.py
+++ b/validphys2/src/validphys/scripts/vp_comparefits.py
@@ -10,6 +10,7 @@ from reportengine.compat import yaml
 from reportengine.colors import t
 
 from validphys.app import App
+from validphys.loader import RemoteLoader
 from validphys import comparefittemplates, compareclosuretemplates
 from validphys.promptutils import confirm, KeywordsWithCache
 
@@ -152,9 +153,13 @@ class CompareFitApp(App):
         return prompt_toolkit.prompt("Enter author name: ", default=default)
 
     def interactive_keywords(self):
+        if isinstance(self.environment.loader, RemoteLoader):
+            completer = WordCompleter(words=KeywordsWithCache(self.environment.loader))
+        else:
+            completer = None
         kwinp = prompt_toolkit.prompt(
             "Enter keywords: ",
-            completer=WordCompleter(words=KeywordsWithCache(self.environment.loader)),
+            completer=completer,
             complete_in_thread=True,
         )
         return [k.strip() for k in kwinp.split(',') if k]

--- a/validphys2/src/validphys/scripts/vp_comparefits.py
+++ b/validphys2/src/validphys/scripts/vp_comparefits.py
@@ -25,7 +25,9 @@ def get_remote_keywords():
     root = loader.Loader().nnprofile['reports_root_url']
     url = urljoin(root, 'index.json')
     try:
-        keyobjs= requests.get(url).json()['keywords']
+        req = requests.get(url)
+        req.raise_for_status()
+        keyobjs= req.json()['keywords']
         l = [k[0] for k in keyobjs]
     except requests.RequestException:
         l = []

--- a/validphys2/src/validphys/uploadutils.py
+++ b/validphys2/src/validphys/uploadutils.py
@@ -349,7 +349,7 @@ def interactive_meta(path):
     None
     """
     # Import here to avoid circular imports
-    from validphys.scripts.vp_comparefits import KeywordsWithCache
+    from validphys.promptutils import KeywordsWithCache
 
     title = prompt_toolkit.prompt("Enter report title: ")
 
@@ -364,7 +364,7 @@ def interactive_meta(path):
 
     kwinp = prompt_toolkit.prompt(
         "Enter keywords: ",
-        completer=WordCompleter(words=KeywordsWithCache()),
+        completer=WordCompleter(words=KeywordsWithCache(RemoteLoader())),
         complete_in_thread=True)
     keywords = [k.strip() for k in kwinp.split(",") if k]
 


### PR DESCRIPTION
`vp-comparefits` and other scripts would suggest remote keywords when in  interactive mode. The implementation had some problems as it would raise an exception whenever the user had no permission to access vp server which would in turn crash the whole app. The solution there was to issue the appropriate `raise_for_status` command. This was made worse by the fact that this particular completer would not respect the `--no-net` flag and try to connect anyway.

 While we are on it, tidy up the implementation, moving the bulk of it to RemoteLoader instead. With that make sure that comarefits only looks at that when the remote loader is in use.

cc @J-M-Moore 