### PR TITLE
Improve documentation on regularized covmats

### DIFF
--- a/doc/sphinx/source/figuresofmerit/index.rst
+++ b/doc/sphinx/source/figuresofmerit/index.rst
@@ -77,6 +77,8 @@ For a more detailed discussion of the future test formalism see e.g.
 :ref:`How to run a Future Test <futuretests>`
 
 
+.. _covmat-reg:
+
 Regularized covariance matrices
 --------------------------------------------------------------------------------
 Information about the accuracy of the experimental uncertainty is generally not
@@ -87,16 +89,23 @@ where the regularized covariance matrix comes in: it aims to provide a matrix
 which is closely related to the original experimental covariance matrix while
 avoiding the problems during optimization.
 
-The function that performs the regularization is
-:py:meth:`validphys.calcutils.regularize_l2`. A regularized covarinace marix
-cannot be generated while performing a fit as it is necesarry to produce
-corresponding :ref:`FastKernel tables<fktables>` and include it in the theory
-as a separete dataset. For instructions on how to do this see
-:ref:`tutorialfktables`
+The stability characteristic for a given dataset can be computed using the
+:py:func:`validphys.covmats.covmat_stability_characteristic`. All the dataset
+covariance matrices can be altered so that their stability characteristic is
+less than a given value by specifying such value as a `norm_threshold`
+parameter in the runcard. Adding it in an analysis results in computing a
+regularized :math:`\chi^2` that is less sensitive to inaccuracies in the
+correlation model. Adding it in a :ref:`fit runcard <runcard-detailed>` results
+in a fit with regularized covariance matrices.
+
+.. note::
+    There is currently no support for displaying regularized :math:`\chi^2`
+    values in :ref:`vp-comparefits <compare-fits>`
 
 A more detailed discussion of regularization procedure, and how it is used
 within NNPDF can be found in sections 4.2 and 8.7 of the NNPDF4.0 paper
 :cite:p:`nnpdf40`.
+
 
 
 The weighted fit method

--- a/doc/sphinx/source/n3fit/runcard_detailed.rst
+++ b/doc/sphinx/source/n3fit/runcard_detailed.rst
@@ -259,6 +259,22 @@ or ``multiplier`` keys empty and instead define a ``maxlambda`` per dataset:
 
 
 
+Regularized covariance matrices
+-------------------------------
+
+The :ref:`covariance matrix regularization <covmat-reg>` is controlled by a
+`norm_threshold` parameter. By default if the parameter is not set, no
+regularization is applied. It is found that the effect of aggressive
+correlation models can be tested by setting values of 4 (which roughly
+corresponds to the assumptions that correlations are controlled to an accuracy
+of better than 35%) or higher.
+
+
+.. code-block:: yaml
+
+    norm_threshold: 4
+
+
 .. _tensorboard-label:
 
 Inspecting and profiling the code


### PR DESCRIPTION
Clarify that one can in fact run fits with the covmat and also that
currently it is not supported in vp.

Closes #1558.

cc @J-M-Moore 