### PR TITLE
libnnpdf/wrapper: don't try to install to system PYTHONPATH

### DIFF
--- a/libnnpdf/wrapper/CMakeLists.txt
+++ b/libnnpdf/wrapper/CMakeLists.txt
@@ -17,7 +17,7 @@ endif()
 execute_process(
   COMMAND "${PYTHON_EXECUTABLE}" -c "if True:
     from distutils.sysconfig import get_python_lib;
-    print(get_python_lib())"
+    print(get_python_lib(prefix=\"${CMAKE_INSTALL_PREFIX}\"))"
     OUTPUT_VARIABLE PYTHON_SITE_PACKAGES
 	RESULT_VARIABLE ret
   OUTPUT_STRIP_TRAILING_WHITESPACE)


### PR DESCRIPTION
The standard convention is for the libraries to be installed to python
prefix relative to the installation prefix, not the system prefix. It
is the a reponsibility of the user or their package manager to
relocate the files or set the correct PYTHONPATH.

This avoids installation errors like:

    CMake Error at libnnpdf/wrapper/cmake_install.cmake:49 (file):
      file cannot create directory:
      /path/to/lib/python3.X/site-packages/NNPDF.
      Maybe need administrative privileges.
    Call Stack (most recent call first):
      libnnpdf/cmake_install.cmake:73 (include)
      cmake_install.cmake:50 (include)