### PR TITLE
Fix bugs in closuretest

### DIFF
--- a/validphys2/src/validphys/closuretest/closure_checks.py
+++ b/validphys2/src/validphys/closuretest/closure_checks.py
@@ -110,7 +110,7 @@ def check_multifit_replicas(fits_pdf, _internal_max_reps, _internal_min_reps):
     fit.
 
     """
-    n_reps = {pdf.get_members() for pdf in fits_pdf}
+    n_reps = {pdf.get_members()-1 for pdf in fits_pdf}
     if len(n_reps) != 1:
         raise CheckError(
             "all fits for multiclosure actions should have same number of replicas"

--- a/validphys2/src/validphys/closuretest/multiclosure.py
+++ b/validphys2/src/validphys/closuretest/multiclosure.py
@@ -212,7 +212,7 @@ def dataset_replica_and_central_diff(
 
     """
     closures_th, law_th, covmat, _ = internal_multiclosure_dataset_loader
-    replicas = np.asarray([th._rawdata for th in closures_th])
+    replicas = np.asarray([th.error_members for th in closures_th])
     centrals = np.mean(replicas, axis=-1)
     underlying = law_th.central_value
 
@@ -321,8 +321,9 @@ class BootstrappedTheoryResult:
     """
 
     def __init__(self, data):
-        self.rawdata = data
+        self.error_members = data
         self.central_value = data.mean(axis=1)
+        self.rawdata = np.concatenate([self.central_value.reshape(-1, 1), data], axis=-1)
 
 
 def _bootstrap_multiclosure_fits(

--- a/validphys2/src/validphys/closuretest/multiclosure_pseudodata.py
+++ b/validphys2/src/validphys/closuretest/multiclosure_pseudodata.py
@@ -54,8 +54,8 @@ def expected_data_delta_chi2(
     for i_fit, fit_th in enumerate(closures_th):
         # transpose the datasets fits cvs into the cvs for all datasets for single fit
         dt_central = np.concatenate([fits_cvs[i_fit] for fits_cvs in data_fits_cv])
-        th_replicas = fit_th._rawdata
-        th_central = np.mean(th_replicas, axis=-1)
+        th_replicas = fit_th.error_members
+        th_central = fit_th.central_value
         shift = calc_chi2(sqrt_covmat, law_central - dt_central)
         chi2_cent = calc_chi2(sqrt_covmat, th_central - dt_central)
         fits_delta_chi2.append(chi2_cent - shift)


### PR DESCRIPTION
Found bugs after merge of PR #1329, #1324 and #1321 (6th April) in `master` when calling functions from `multiclosure_output.py`. This is probably due to call of outdated functions or new behavior of already existing ones, e.g. LHAPDF loaders.