### PR TITLE
Add overfit metric to vp

### DIFF
--- a/doc/sphinx/source/tutorials/index.rst
+++ b/doc/sphinx/source/tutorials/index.rst
@@ -27,6 +27,7 @@ Analysing results
    ./plot_pdfs.rst
    ./pdfbases.rst
    ./datthcomp.md
+   ./overfit_metric.rst
 
 Adding new data
 ---------------

--- a/doc/sphinx/source/tutorials/overfit_metric.rst
+++ b/doc/sphinx/source/tutorials/overfit_metric.rst
@@ -1,0 +1,28 @@
+.. _tut_overfit_metric:
+
+=====================================================================
+Interperting the :math:`\mathcal{R}_O` overfit metric
+=====================================================================
+
+One way to define overfitting can be defined through the validation loss used to define the stopping point in the early stopping algorithm.
+Namely, since the validation and training datasets are not fully uncorrelated, a sufficiently efficient setup of hyperparameters may succeed at learning even the validation pseudodata instead of performing worse with respect to the validation data while continuing to learn only features of the training data. This renders the early stopping algorithm an insufficient tool to prevent overfitting completely.
+This insight is what will be used for the overfitting metric proposed below: if the methodology has learned features of the validation pseudodata, that indicates that the methodology is one that overfits on the data.
+
+So how do we test if the methodology has learned features from the validation pseudodata? The idea is that the :math:`N_\mathrm{rep}` pseudodatasets that go into a PDF fit form a collection of random variables that are independent and identically distributed.
+Let us consider a fit of a given PDF replica :math:`f^r` to an underlying data replica :math:`\mathcal{D}_r`, where :math:`r\in\{1,2,\ldots,N_\mathrm{rep}\}` labels the replica index.
+If a PDF replica :math:`f^r` does not contain information on the specific data replica :math:`\mathcal{D}_r`, then
+
+.. math::
+    \chi^2_{\mathrm{val},(r,r)} = \frac{1}{N_\mathrm{rep}}\sum_{r'=1}^{N_\mathrm{rep}}\chi^2_{\mathrm{val}(r,r')} \quad \mathrm{if} \quad N_\mathrm{rep}\rightarrow\infty,
+
+where :math:`\chi^2_{\mathrm{val}(r,r')}` is the :math:`\chi^2` for PDF replica :math:`f^r` as calculated to data replica :math:`\mathcal{D}_{r'}` but with the training validation split corresponding to replica :math:`r`.
+In this procedure the a correct treatment of the training validation split it crucial. Namely, the PDF :math:`f^r` should not depend on the validation data used during its training, as it corresponds to a test of how well the fit generalizes to non-training data. However, this is not the case for the pseudodatapoints that were in the training dataset while fitting :math:`f^r`.
+This is why when defining :math:`\chi^2_{\mathrm{val}(r,r')}` , it is important to note that the same training-validation mask is used to extract the validation datasets :math:`\mathcal{D}_{r'}` corresponding to the same experimental datapoints.
+
+Using this insight, one may define as a measure of overfitting the difference between the right hand side and the left hand side of the equation above:
+
+.. math::
+    \mathcal{R}_O=\chi^2_{\mathrm{val},(r,r)} - \frac{1}{N_\mathrm{rep}}\sum_{r'=1}^{N_\mathrm{rep}}\chi^2_{\mathrm{val}(r,r')}.
+
+If this value is negative, that is an indicator of an overfitted PDF.
+The :math:`\mathcal{R}_O` is impacted by statistical fluctuations that can be estimated using a bootstrapping method.

--- a/doc/sphinx/source/tutorials/overfit_metric.rst
+++ b/doc/sphinx/source/tutorials/overfit_metric.rst
@@ -4,25 +4,47 @@
 Interperting the :math:`\mathcal{R}_O` overfit metric
 =====================================================================
 
-One way to define overfitting can be defined through the validation loss used to define the stopping point in the early stopping algorithm.
-Namely, since the validation and training datasets are not fully uncorrelated, a sufficiently efficient setup of hyperparameters may succeed at learning even the validation pseudodata instead of performing worse with respect to the validation data while continuing to learn only features of the training data. This renders the early stopping algorithm an insufficient tool to prevent overfitting completely.
-This insight is what will be used for the overfitting metric proposed below: if the methodology has learned features of the validation pseudodata, that indicates that the methodology is one that overfits on the data.
+One way to define overfitting can be defined through the validation loss used to
+define the stopping point in the early stopping algorithm. Namely, since the 
+validation and training datasets are not fully uncorrelated, a sufficiently 
+efficient setup of hyperparameters may succeed at learning even the validation 
+pseudodata instead of performing worse with respect to the validation data while 
+continuing to learn only features of the training data. This renders the early
+stopping algorithm an insufficient tool to prevent overfitting completely. This 
+insight is what will be used for the overfitting metric proposed below: if the 
+methodology has learned features of the validation pseudodata, that indicates 
+that the methodology is one that overfits on the data.
 
-So how do we test if the methodology has learned features from the validation pseudodata? The idea is that the :math:`N_\mathrm{rep}` pseudodatasets that go into a PDF fit form a collection of random variables that are independent and identically distributed.
-Let us consider a fit of a given PDF replica :math:`f^r` to an underlying data replica :math:`\mathcal{D}_r`, where :math:`r\in\{1,2,\ldots,N_\mathrm{rep}\}` labels the replica index.
-If a PDF replica :math:`f^r` does not contain information on the specific data replica :math:`\mathcal{D}_r`, then
+So how do we test if the methodology has learned features from the validation 
+pseudodata? The idea is that the :math:`N_\mathrm{rep}` pseudodatasets that go 
+into a PDF fit form a collection of random variables that are independent and 
+identically distributed. Let us consider a fit of a given PDF replica 
+:math:`f^r` to an underlying data replica :math:`\mathcal{D}_r`, where 
+:math:`r\in\{1,2,\ldots,N_\mathrm{rep}\}` labels the replica index. If a PDF 
+replica :math:`f^r` does not contain information on the specific data replica 
+:math:`\mathcal{D}_r`, then
 
 .. math::
     \chi^2_{\mathrm{val},(r,r)} = \frac{1}{N_\mathrm{rep}}\sum_{r'=1}^{N_\mathrm{rep}}\chi^2_{\mathrm{val}(r,r')} \quad \mathrm{if} \quad N_\mathrm{rep}\rightarrow\infty,
 
-where :math:`\chi^2_{\mathrm{val}(r,r')}` is the :math:`\chi^2` for PDF replica :math:`f^r` as calculated to data replica :math:`\mathcal{D}_{r'}` but with the training validation split corresponding to replica :math:`r`.
-In this procedure the a correct treatment of the training validation split it crucial. Namely, the PDF :math:`f^r` should not depend on the validation data used during its training, as it corresponds to a test of how well the fit generalizes to non-training data. However, this is not the case for the pseudodatapoints that were in the training dataset while fitting :math:`f^r`.
-This is why when defining :math:`\chi^2_{\mathrm{val}(r,r')}` , it is important to note that the same training-validation mask is used to extract the validation datasets :math:`\mathcal{D}_{r'}` corresponding to the same experimental datapoints.
+where :math:`\chi^2_{\mathrm{val}(r,r')}` is the :math:`\chi^2` for PDF replica 
+:math:`f^r` as calculated to data replica :math:`\mathcal{D}_{r'}` but with the 
+training validation split corresponding to replica :math:`r`. In this procedure 
+the a correct treatment of the training validation split it crucial. Namely, the 
+PDF :math:`f^r` should not depend on the validation data used during its 
+training, as it corresponds to a test of how well the fit generalizes to 
+non-training data. However, this is not the case for the pseudodatapoints that
+were in the training dataset while fitting :math:`f^r`. This is why when 
+defining :math:`\chi^2_{\mathrm{val}(r,r')}` , it is important to note that the 
+same training-validation mask is used to extract the validation datasets 
+:math:`\mathcal{D}_{r'}` corresponding to the same experimental datapoints.
 
-Using this insight, one may define as a measure of overfitting the difference between the right hand side and the left hand side of the equation above:
+Using this insight, one may define as a measure of overfitting the difference
+between the right hand side and the left hand side of the equation above:
 
 .. math::
     \mathcal{R}_O=\chi^2_{\mathrm{val},(r,r)} - \frac{1}{N_\mathrm{rep}}\sum_{r'=1}^{N_\mathrm{rep}}\chi^2_{\mathrm{val}(r,r')}.
 
-If this value is negative, that is an indicator of an overfitted PDF.
-The :math:`\mathcal{R}_O` is impacted by statistical fluctuations that can be estimated using a bootstrapping method.
+If this value is negative, that is an indicator of an overfitted PDF. The 
+:math:`\mathcal{R}_O` is impacted by statistical fluctuations that can be
+estimated using a bootstrapping method.

--- a/doc/sphinx/source/tutorials/overfit_metric.rst
+++ b/doc/sphinx/source/tutorials/overfit_metric.rst
@@ -1,10 +1,10 @@
 .. _tut_overfit_metric:
 
 =====================================================================
-Interperting the :math:`\mathcal{R}_O` overfit metric
+Interpreting the :math:`\mathcal{R}_O` overfit metric
 =====================================================================
 
-One way to define overfitting can be defined through the validation loss used to
+One way to define overfitting is through the validation loss used to
 define the stopping point in the early stopping algorithm. Namely, since the 
 validation and training datasets are not fully uncorrelated, a sufficiently 
 efficient setup of hyperparameters may succeed at learning even the validation 
@@ -48,3 +48,5 @@ between the right hand side and the left hand side of the equation above:
 If this value is negative, that is an indicator of an overfitted PDF. The 
 :math:`\mathcal{R}_O` is impacted by statistical fluctuations that can be
 estimated using a bootstrapping method.
+
+The overfit metric is available in validphys through the ``overfitmetric`` action and it is a standard component of the :ref:`vp-comparefits report<compare-fits>`.

--- a/validphys2/src/validphys/app.py
+++ b/validphys2/src/validphys/app.py
@@ -54,6 +54,7 @@ providers = [
     "validphys.n3fit_data",
     "validphys.mc2hessian",
     "reportengine.report",
+    "validphys.overfit_metric"
 ]
 
 log = logging.getLogger(__name__)

--- a/validphys2/src/validphys/checks.py
+++ b/validphys2/src/validphys/checks.py
@@ -154,7 +154,7 @@ def check_have_two_pdfs(pdfs):
 
 
 @make_argcheck
-def check_at_least_two_pdfs(pdfs):
+def check_at_least_two_replicas(pdfs):
     for pdf in pdfs:
         # The get_members function also includes the central value replica, 
         # therefore we need it to be larger than 3

--- a/validphys2/src/validphys/checks.py
+++ b/validphys2/src/validphys/checks.py
@@ -153,6 +153,14 @@ def check_have_two_pdfs(pdfs):
     check(len(pdfs) == 2,'Expecting exactly two pdfs.')
 
 
+@make_argcheck
+def check_at_least_two_pdfs(pdfs):
+    for pdf in pdfs:
+        # The get_members function also includes the central value replica, 
+        # therefore we need it to be larger than 3
+        check(pdf.get_members() >= 3,'Expecting at least two replicas.')
+
+
 #The indexing to one instead of zero is so that we can be consistent with
 #how plot_fancy works, so normalize_to: 1 would normalize to the first pdf
 #for both.

--- a/validphys2/src/validphys/comparefittemplates/comparecard.yaml
+++ b/validphys2/src/validphys/comparefittemplates/comparecard.yaml
@@ -143,11 +143,30 @@ ProcessGroup:
     metadata_group: nnpdf31_process
 
 overfitmetric:
-  use_t0: True
-  datacuts:
-    from_: fit
-  t0pdfset:
-    from_: datacuts
+  - use_t0: True
+    fit:
+      from_: reference
+    datacuts:
+      from_: fit
+    t0pdfset:
+      from_: datacuts
+    theory:
+        from_: fit
+    theoryid:
+        from_: theory
+
+  - use_t0: True
+    fit:
+      from_: current
+    datacuts:
+      from_: fit
+    t0pdfset:
+      from_: datacuts
+    theory:
+        from_: fit
+    theoryid:
+        from_: theory
+
 
 actions_:
   - report(main=true)

--- a/validphys2/src/validphys/comparefittemplates/comparecard.yaml
+++ b/validphys2/src/validphys/comparefittemplates/comparecard.yaml
@@ -142,5 +142,12 @@ DataGroups:
 ProcessGroup:
     metadata_group: nnpdf31_process
 
+overfitmetric:
+  use_t0: True
+  datacuts:
+    from_: fit
+  t0pdfset:
+    from_: datacuts
+
 actions_:
   - report(main=true)

--- a/validphys2/src/validphys/comparefittemplates/report.md
+++ b/validphys2/src/validphys/comparefittemplates/report.md
@@ -71,7 +71,7 @@ Training lengths
 
 Overfit measure
 ----------------
-{@fits::fitcontext plot_deltachi2_histogram@}
+{@fits::fitcontext::overfitmetric plot_deltachi2_histogram@}
 {@summarise_deltachi2@}
 
 Training-validation

--- a/validphys2/src/validphys/comparefittemplates/report.md
+++ b/validphys2/src/validphys/comparefittemplates/report.md
@@ -72,8 +72,8 @@ Training lengths
 Overfit measure
 ----------------
 {@with overfitmetric@}
-{@plot_deltachi2_histogram@}
-{@fit_deltachi2_summary@}
+{@plot_overfitting_histogram@}
+{@fit_overfitting_summary@}
 {@endwith@}
 
 

--- a/validphys2/src/validphys/comparefittemplates/report.md
+++ b/validphys2/src/validphys/comparefittemplates/report.md
@@ -69,6 +69,11 @@ Training lengths
 ----------------
 {@fits plot_training_length@}
 
+Overfit measure
+----------------
+{@fits plot_deltachi2_histogram@}
+{@summarise_deltachi2@}
+
 Training-validation
 -------------------
 {@fits plot_training_validation@}

--- a/validphys2/src/validphys/comparefittemplates/report.md
+++ b/validphys2/src/validphys/comparefittemplates/report.md
@@ -116,17 +116,6 @@ Dataset differences and cuts
 {@print_dataset_differences@}
 {@print_different_cuts@}
 
-Overfitting metric
-------------------
-### Table
-{@summarise_deltachi2@}
-
-
-### Histogram plot
-{@with dataspecs@}
-{@plot_deltachi2_histogram@}
-{@endwith@}
-
 Code versions
 -------------
 {@fits_version_table@}

--- a/validphys2/src/validphys/comparefittemplates/report.md
+++ b/validphys2/src/validphys/comparefittemplates/report.md
@@ -111,6 +111,17 @@ Dataset differences and cuts
 {@print_dataset_differences@}
 {@print_different_cuts@}
 
+Overfitting metric
+------------------
+### Table
+{@summarise_deltachi2@}
+
+
+### Histogram plot
+{@with dataspecs@}
+{@plot_deltachi2_histogram@}
+{@endwith@}
+
 Code versions
 -------------
 {@fits_version_table@}

--- a/validphys2/src/validphys/comparefittemplates/report.md
+++ b/validphys2/src/validphys/comparefittemplates/report.md
@@ -71,7 +71,7 @@ Training lengths
 
 Overfit measure
 ----------------
-{@fits plot_deltachi2_histogram@}
+{@fits::fitcontext plot_deltachi2_histogram@}
 {@summarise_deltachi2@}
 
 Training-validation

--- a/validphys2/src/validphys/comparefittemplates/report.md
+++ b/validphys2/src/validphys/comparefittemplates/report.md
@@ -71,8 +71,11 @@ Training lengths
 
 Overfit measure
 ----------------
-{@fits::fitcontext::overfitmetric plot_deltachi2_histogram@}
-{@summarise_deltachi2@}
+{@with overfitmetric@}
+{@plot_deltachi2_histogram@}
+{@fit_deltachi2_summary@}
+{@endwith@}
+
 
 Training-validation
 -------------------

--- a/validphys2/src/validphys/overfit_metric.py
+++ b/validphys2/src/validphys/overfit_metric.py
@@ -28,7 +28,7 @@ def array_expected_delta_chi2(calculate_chi2s_per_replica, replica_data):
 
     number_pdfs = res_over.shape[0]
     list_expected_delta_chi2 = []
-    for i in range(number_pdfs * 1000):
+    for _ in range(number_pdfs * 1000):
         mask = np.random.randint(0, number_pdfs, size=int(0.95 * number_pdfs))
         res_tmp = res_over[mask][:, mask]
 
@@ -112,7 +112,7 @@ def plot_deltachi2_histogram(fit, array_expected_delta_chi2):
 
 fits_deltachi2_summary = collect("fit_deltachi2_summary", ("fits", "fitcontext"))
 
-
+@table
 def fit_deltachi2_summary(fit, array_expected_delta_chi2):
     mean = array_expected_delta_chi2.mean()
     std = array_expected_delta_chi2.std()

--- a/validphys2/src/validphys/overfit_metric.py
+++ b/validphys2/src/validphys/overfit_metric.py
@@ -15,10 +15,13 @@ import scipy.stats as stats
 import pandas as pd
 import numpy as np
 
+
 log = logging.getLogger(__name__)
 
-
 preds = collect("predictions", ("pdfs","dataset_inputs",))
+
+def foo(get_val_erf, calculate_chi2s_per_replica):
+    import ipdb; ipdb.set_trace()
 
 def array_expected_delta_chi2(calculate_chi2s_per_replica, replica_data):
 
@@ -59,7 +62,7 @@ def calculate_chi2s_per_replica(
 
     pp = []
     for i, dss in enumerate(dataset_inputs):
-        preds_witout_cv = preds[i]
+        preds_witout_cv = preds[i].drop(0, axis=1)
         df = pd.concat({dss.name: preds_witout_cv}, names=['dataset'])
         pp.append(df)
 
@@ -71,7 +74,7 @@ def calculate_chi2s_per_replica(
         prediction_filter=pdf_data_index.val_idx.droplevel(level=0)
         prediction_filter.rename(["dataset","data"], inplace=True)
         PDF_predictions_val = PDF_predictions.loc[prediction_filter]
-        PDF_predictions_val = PDF_predictions_val.values[:,enum+1]
+        PDF_predictions_val = PDF_predictions_val.values[:,enum]
 
         new_val_pseudodata_list = _create_new_val_pseudodata(pdf_data_index, recreate_pdf_pseudodata_no_table)
 

--- a/validphys2/src/validphys/overfit_metric.py
+++ b/validphys2/src/validphys/overfit_metric.py
@@ -30,12 +30,13 @@ preds = collect(
 
 
 def _create_new_val_pseudodata(pdf_data_index, fit_data_indices_list):
-    """ Loads all validation psuedodata replicas used during the fiting of the
+    """Loads all validation psuedodata replicas used during the fiting of the
     pdf replicas
 
+    Returns
     -------
     np.ndarray
-        (nrep,ndata) sized numpy array containingt the validation data used to 
+        (nrep,ndata) sized numpy array containingt the validation data used to
         fit the pdfs.
     """
     vl_data_fitrep = []
@@ -43,7 +44,7 @@ def _create_new_val_pseudodata(pdf_data_index, fit_data_indices_list):
         vl_data_fitrep.append(
             fitreplica_info.pseudodata.loc[pdf_data_index.val_idx]
         )
-    return np.array(vl_data_fitrep)[:,:,0]
+    return np.array(vl_data_fitrep)[:, :, 0]
 
 
 @check_at_least_two_pdfs
@@ -53,7 +54,7 @@ def calculate_chi2s_per_replica(
     dataset_inputs,
     groups_covmat_no_table,
 ):
-    """ Calculates the chi2 for each PDF relica to many pseudodata replicas.
+    """Calculates the chi2 for each PDF relica to many pseudodata replicas.
 
     Parameters
     ----------
@@ -70,9 +71,9 @@ def calculate_chi2s_per_replica(
     Returns
     -------
     np.ndarray
-        (Npdfs, Npdfs) sized matrix containing the chi2 of a pdf replica 
+        (Npdfs, Npdfs) sized matrix containing the chi2 of a pdf replica
         calculated to a given psuedodata replica. The diagonal values correspond
-        to the cases where the PDF replica has been fitted to the coresponding 
+        to the cases where the PDF replica has been fitted to the coresponding
         pseudodata replica
     """
     pp = []
@@ -96,7 +97,9 @@ def calculate_chi2s_per_replica(
         )
 
         invcovmat_vl = np.linalg.inv(
-            groups_covmat_no_table[pdf_data_index.val_idx].T[pdf_data_index.val_idx]
+            groups_covmat_no_table[pdf_data_index.val_idx].T[
+                pdf_data_index.val_idx
+            ]
         )
 
         tmp = PDF_predictions_val - new_val_pseudodata_list
@@ -113,7 +116,7 @@ def array_expected_overfitting(
     number_of_resamples=1000,
     resampling_fraction=0.95,
 ):
-    """ Calculates the expected difference in chi2 between:
+    """Calculates the expected difference in chi2 between:
     1. The chi2 of a PDF replica calculated using the corresponding pseudodata
         replica using during the fit
     2. The chi2 of a PDF replica calculated using an alternative i.i.d random
@@ -121,7 +124,7 @@ def array_expected_overfitting(
 
     The expected difference along with an error estimate is obtained through a
     bootstrapping consisting of `number_of_resamples` resamples per pdf replica
-    where each resampling contains a fraction `resampling_fraction` of all 
+    where each resampling contains a fraction `resampling_fraction` of all
     replicas.
 
     Parameters
@@ -129,18 +132,18 @@ def array_expected_overfitting(
     calculate_chi2s_per_replica : np.ndarray
         validation chi2 per pdf replica
     replica_data : list(vp.fitdata.FitInfo)
-        
+
     number_of_resamples : int, optional
-        _description_, by default 1000
+        number of resamples per pdf replica, by default 1000
     resampling_fraction : float, optional
-        _description_, by default 0.95
+        fraction of replcias used in the bootstrap resampling, by default 0.95
 
     Returns
     -------
     np.ndarray
-        (number_of_resamples*Npdfs,) sized array containing the mean delta chi2 
-        values per resampled list. 
-    """    
+        (number_of_resamples*Npdfs,) sized array containing the mean delta chi2
+        values per resampled list.
+    """
     fitted_val_erf = np.array([info.validation for info in replica_data])
 
     number_pdfs = calculate_chi2s_per_replica.shape[0]
@@ -162,7 +165,7 @@ def array_expected_overfitting(
 
 @figure
 def plot_overfitting_histogram(fit, array_expected_overfitting):
-    """Plots the bootrap error and central value of the overfittedness in a 
+    """Plots the bootrap error and central value of the overfittedness in a
     historgram"""
     mean = array_expected_overfitting.mean()
     std = array_expected_overfitting.std()
@@ -171,9 +174,12 @@ def plot_overfitting_histogram(fit, array_expected_overfitting):
 
     ax.hist(array_expected_overfitting, bins=50, density=True)
     ax.axvline(x=mean, color="black")
-    xrange = [array_expected_overfitting.min(), array_expected_overfitting.max()]
+    ax.axvline(x=0, color="black", linestyle="--")
+    xrange = [
+        array_expected_overfitting.min(),
+        array_expected_overfitting.max(),
+    ]
     xgrid = np.linspace(xrange[0], xrange[1], num=100)
-    ax.set_xlim(xrange[0], xrange[1])
     ax.plot(xgrid, stats.norm.pdf(xgrid, mean, std))
     ax.set_xlabel(r"$\Delta \chi^2_{\mathrm{overfit}}$")
     ax.set_ylabel("density")
@@ -189,10 +195,10 @@ fits_overfitting_summary = collect(
 
 @table
 def fit_overfitting_summary(fit, array_expected_overfitting):
-    """ Creates a table containing the overfitting information:
-        - mean chi2 difference
-        - bootstrap error
-        - sigmas away from 0  
+    """Creates a table containing the overfitting information:
+    - mean chi2 difference
+    - bootstrap error
+    - sigmas away from 0
     """
     mean = array_expected_overfitting.mean()
     std = array_expected_overfitting.std()
@@ -205,7 +211,7 @@ def fit_overfitting_summary(fit, array_expected_overfitting):
 
 @table
 def summarise_overfitting(fits_overfitting_summary):
-    """ Same as `fit_overfitting_summary`, but collected over all `fits` in the 
-    runcard 
+    """Same as `fit_overfitting_summary`, but collected over all `fits` in the
+    runcard and put in a single table.
     """
     return pd.concat(fits_overfitting_summary, axis=1)

--- a/validphys2/src/validphys/overfit_metric.py
+++ b/validphys2/src/validphys/overfit_metric.py
@@ -49,28 +49,31 @@ def _create_new_val_pseudodata(pdf_data_index, fit_data_indices_list):
 
 
 def calculate_chi2s_per_replica(
-    recreate_pdf_pseudodata,
+    recreate_pdf_pseudodata_no_table,
     preds,
     dataset_inputs,
-    groups_covmat,
+    groups_covmat_no_table,
     ):
+
+    groups_covmat = groups_covmat_no_table
 
     pp = []
     for i, dss in enumerate(dataset_inputs):
-        df = pd.concat({dss.name: preds[i]}, names=['dataset'])
+        preds_witout_cv = preds[i]
+        df = pd.concat({dss.name: preds_witout_cv}, names=['dataset'])
         pp.append(df)
 
     PDF_predictions = pd.concat(pp)
 
     chi2s_per_replica=[]
-    for enum, pdf_data_index in enumerate(recreate_pdf_pseudodata):
+    for enum, pdf_data_index in enumerate(recreate_pdf_pseudodata_no_table):
 
         prediction_filter=pdf_data_index.val_idx.droplevel(level=0)
         prediction_filter.rename(["dataset","data"], inplace=True)
         PDF_predictions_val = PDF_predictions.loc[prediction_filter]
-        PDF_predictions_val = PDF_predictions_val.values[:,enum]
+        PDF_predictions_val = PDF_predictions_val.values[:,enum+1]
 
-        new_val_pseudodata_list = _create_new_val_pseudodata(pdf_data_index, recreate_pdf_pseudodata)
+        new_val_pseudodata_list = _create_new_val_pseudodata(pdf_data_index, recreate_pdf_pseudodata_no_table)
 
         invcovmat_vl = np.linalg.inv(groups_covmat[pdf_data_index.val_idx].T[pdf_data_index.val_idx])
         

--- a/validphys2/src/validphys/overfit_metric.py
+++ b/validphys2/src/validphys/overfit_metric.py
@@ -54,8 +54,8 @@ def calculate_chi2s_per_replica(
     dataset_inputs,
     groups_covmat_no_table,
 ):
-    """Calculates, for each PDF replica, the chi2 of the validation with the pseudodata generated
-    for all other replicas in the fit
+    """Calculates, for each PDF replica, the chi2 of the validation with the
+    pseudodata generated for all other replicas in the fit
 
     Parameters
     ----------

--- a/validphys2/src/validphys/overfit_metric.py
+++ b/validphys2/src/validphys/overfit_metric.py
@@ -91,7 +91,7 @@ def calculate_chi2s_per_replica(
 
 
 @figure
-def plot_deltachi2_histogram(array_expected_delta_chi2):
+def plot_deltachi2_histogram(fit, array_expected_delta_chi2):
     mean = array_expected_delta_chi2.mean()
     std = array_expected_delta_chi2.std()
 
@@ -105,7 +105,7 @@ def plot_deltachi2_histogram(array_expected_delta_chi2):
     ax.plot(xgrid, stats.norm.pdf(xgrid, mean, std))
     ax.set_xlabel(r"$\Delta \chi^2_{\mathrm{overfit}}$")
     ax.set_ylabel("density")
-    ax.set_title(f"fitname")
+    ax.set_title(f"{fit.label}")
     plt.tight_layout()
     return f
 

--- a/validphys2/src/validphys/overfit_metric.py
+++ b/validphys2/src/validphys/overfit_metric.py
@@ -117,9 +117,9 @@ def fit_deltachi2_summary(fit, array_expected_delta_chi2):
     mean = array_expected_delta_chi2.mean()
     std = array_expected_delta_chi2.std()
     return pd.DataFrame(
-        [mean, std, abs(mean / std)],
+        [mean, std, mean / std],
         columns=[fit.label],
-        index=["mean", "bootstrap error", "abs(mean/bootsrap error)"],
+        index=["mean", "bootstrap error", "mean/bootsrap error"],
     )
 
 

--- a/validphys2/src/validphys/overfit_metric.py
+++ b/validphys2/src/validphys/overfit_metric.py
@@ -181,7 +181,7 @@ def plot_overfitting_histogram(fit, array_expected_overfitting):
     ]
     xgrid = np.linspace(xrange[0], xrange[1], num=100)
     ax.plot(xgrid, stats.norm.pdf(xgrid, mean, std))
-    ax.set_xlabel(r"$\Delta \chi^2_{\mathrm{overfit}}$")
+    ax.set_xlabel(r"$\mathcal{R}_O$")
     ax.set_ylabel("density")
     ax.set_title(f"{fit.label}")
     plt.tight_layout()

--- a/validphys2/src/validphys/overfit_metric.py
+++ b/validphys2/src/validphys/overfit_metric.py
@@ -30,13 +30,13 @@ preds = collect(
 
 
 def _create_new_val_pseudodata(pdf_data_index, fit_data_indices_list):
-    """Loads all validation psuedodata replicas used during the fiting of the
+    """Loads all validation pseudodata replicas used during the fiting of the
     pdf replicas
 
     Returns
     -------
     np.ndarray
-        (nrep,ndata) sized numpy array containingt the validation data used to
+        (nrep,ndata) sized numpy array containing the validation data used to
         fit the pdfs.
     """
     vl_data_fitrep = []
@@ -54,7 +54,8 @@ def calculate_chi2s_per_replica(
     dataset_inputs,
     groups_covmat_no_table,
 ):
-    """Calculates the chi2 for each PDF relica to many pseudodata replicas.
+    """Calculates, for each PDF replica, the chi2 of the validation with the pseudodata generated
+    for all other replicas in the fit
 
     Parameters
     ----------
@@ -118,13 +119,13 @@ def array_expected_overfitting(
 ):
     """Calculates the expected difference in chi2 between:
     1. The chi2 of a PDF replica calculated using the corresponding pseudodata
-        replica using during the fit
+        replica used during the fit
     2. The chi2 of a PDF replica calculated using an alternative i.i.d random
         pseudododata replicas
 
     The expected difference along with an error estimate is obtained through a
-    bootstrapping consisting of `number_of_resamples` resamples per pdf replica
-    where each resampling contains a fraction `resampling_fraction` of all
+    bootstrapping consisting of ``number_of_resamples`` resamples per pdf replica
+    where each resampling contains a fraction ``resampling_fraction`` of all
     replicas.
 
     Parameters
@@ -132,11 +133,10 @@ def array_expected_overfitting(
     calculate_chi2s_per_replica : np.ndarray
         validation chi2 per pdf replica
     replica_data : list(vp.fitdata.FitInfo)
-
     number_of_resamples : int, optional
         number of resamples per pdf replica, by default 1000
     resampling_fraction : float, optional
-        fraction of replcias used in the bootstrap resampling, by default 0.95
+        fraction of replicas used in the bootstrap resampling, by default 0.95
 
     Returns
     -------

--- a/validphys2/src/validphys/overfit_metric.py
+++ b/validphys2/src/validphys/overfit_metric.py
@@ -1,0 +1,119 @@
+"""
+overfit_metric.py
+
+This calculates the overfit metric
+"""
+
+import logging
+
+
+from reportengine import collect
+from reportengine.figure import figure
+from reportengine.table import table
+
+import scipy.stats as stats
+import pandas as pd
+import numpy as np
+
+log = logging.getLogger(__name__)
+
+
+preds = collect("predictions", ("pdfs","dataset_inputs",))
+
+def array_expected_delta_chi2(calculate_chi2s_per_replica, replica_data):
+
+    res_over = calculate_chi2s_per_replica
+
+    fitted_val_erf = np.array([info.validation for info in replica_data])
+
+    number_pdfs = res_over.shape[0]
+    list_expected_delta_chi2 = []
+    for i in range(number_pdfs*1000):
+        mask = np.random.randint(0, number_pdfs, size=int(0.95*number_pdfs))
+        res_tmp = res_over[mask][:,mask]
+
+        fitted_val_erf_tmp = fitted_val_erf[mask]
+        expected_val_chi2 = res_tmp.mean(axis=0)
+        delta_chi2 = fitted_val_erf_tmp - expected_val_chi2
+        expected_delta_chi2 = delta_chi2.mean()
+
+        list_expected_delta_chi2.append(expected_delta_chi2)
+    return np.array(list_expected_delta_chi2)
+
+
+def _create_new_val_pseudodata(pdf_data_index, fit_data_indices_list):
+    vl_data_fitrep = []
+    for fitreplica_info in fit_data_indices_list:
+        vl_data_fitrep.append(fitreplica_info.pseudodata.loc[pdf_data_index.val_idx])
+    return np.array(vl_data_fitrep).squeeze()
+
+
+def calculate_chi2s_per_replica(
+    recreate_pdf_pseudodata,
+    preds,
+    dataset_inputs,
+    groups_covmat,
+    ):
+
+    pp = []
+    for i, dss in enumerate(dataset_inputs):
+        df = pd.concat({dss.name: preds[i]}, names=['dataset'])
+        pp.append(df)
+
+    PDF_predictions = pd.concat(pp)
+
+    chi2s_per_replica=[]
+    for enum, pdf_data_index in enumerate(recreate_pdf_pseudodata):
+
+        prediction_filter=pdf_data_index.val_idx.droplevel(level=0)
+        prediction_filter.rename(["dataset","data"], inplace=True)
+        PDF_predictions_val = PDF_predictions.loc[prediction_filter]
+        PDF_predictions_val = PDF_predictions_val.values[:,enum]
+
+        new_val_pseudodata_list = _create_new_val_pseudodata(pdf_data_index, recreate_pdf_pseudodata)
+
+        invcovmat_vl = np.linalg.inv(groups_covmat[pdf_data_index.val_idx].T[pdf_data_index.val_idx])
+        
+        tmp = ( PDF_predictions_val - new_val_pseudodata_list)
+
+        chi2 = np.einsum("ij,jk,ik->i", tmp, invcovmat_vl, tmp) / tmp.shape[1]
+        chi2s_per_replica.append(chi2)
+
+    # array of chi2 per replica
+    return np.array(chi2s_per_replica)
+
+import matplotlib.pyplot as plt
+
+@figure
+def plot_deltachi2_histogram(array_expected_delta_chi2):
+    mean = array_expected_delta_chi2.mean()
+    std = array_expected_delta_chi2.std()
+
+    f, ax = plt.subplots(1,1)
+
+    ax.hist(array_expected_delta_chi2, bins=50, density=True);
+    ax.axvline(x=mean,color='black')
+    xrange=[array_expected_delta_chi2.min(),array_expected_delta_chi2.max()]
+    xgrid = np.linspace(xrange[0], xrange[1], num=100)
+    ax.set_xlim(xrange[0],xrange[1])
+    ax.plot(xgrid, stats.norm.pdf(xgrid, mean, std))
+    ax.set_xlabel(r"$\Delta \chi^2_{\mathrm{overfit}}$")
+    ax.set_ylabel("density")
+    ax.set_title(f"fitname")
+    plt.tight_layout()
+    return f
+
+fits_deltachi2_summary = collect('fit_deltachi2_summary', ('fits','fitcontext'))
+
+def fit_deltachi2_summary(fit,array_expected_delta_chi2):
+    mean = array_expected_delta_chi2.mean()
+    std = array_expected_delta_chi2.std()
+    return pd.DataFrame(
+        [mean, std, abs(mean/std)],
+        columns=[fit.label],
+        index=["mean", "bootstrap error", "abs(mean/bootsrap error)"]
+        )
+
+@table
+def summarise_deltachi2(fits_deltachi2_summary):
+    return pd.concat(fits_deltachi2_summary,axis=1)

--- a/validphys2/src/validphys/overfit_metric.py
+++ b/validphys2/src/validphys/overfit_metric.py
@@ -16,7 +16,7 @@ from reportengine import collect
 from reportengine.figure import figure
 from reportengine.table import table
 
-from validphys.checks import check_at_least_two_pdfs
+from validphys.checks import check_at_least_two_replicas
 
 log = logging.getLogger(__name__)
 
@@ -47,7 +47,7 @@ def _create_new_val_pseudodata(pdf_data_index, fit_data_indices_list):
     return np.array(vl_data_fitrep)[:, :, 0]
 
 
-@check_at_least_two_pdfs
+@check_at_least_two_replicas
 def calculate_chi2s_per_replica(
     recreate_pdf_pseudodata_no_table,
     preds,

--- a/validphys2/src/validphys/overfit_metric.py
+++ b/validphys2/src/validphys/overfit_metric.py
@@ -6,22 +6,19 @@ This calculates the overfit metric
 
 import logging
 
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import scipy.stats as stats
 
 from reportengine import collect
 from reportengine.figure import figure
 from reportengine.table import table
 
-import scipy.stats as stats
-import pandas as pd
-import numpy as np
-
-
 log = logging.getLogger(__name__)
 
 preds = collect("predictions", ("pdfs","dataset_inputs",))
 
-def foo(get_val_erf, calculate_chi2s_per_replica):
-    import ipdb; ipdb.set_trace()
 
 def array_expected_delta_chi2(calculate_chi2s_per_replica, replica_data):
 
@@ -31,9 +28,9 @@ def array_expected_delta_chi2(calculate_chi2s_per_replica, replica_data):
 
     number_pdfs = res_over.shape[0]
     list_expected_delta_chi2 = []
-    for i in range(number_pdfs*1000):
-        mask = np.random.randint(0, number_pdfs, size=int(0.95*number_pdfs))
-        res_tmp = res_over[mask][:,mask]
+    for i in range(number_pdfs * 1000):
+        mask = np.random.randint(0, number_pdfs, size=int(0.95 * number_pdfs))
+        res_tmp = res_over[mask][:, mask]
 
         fitted_val_erf_tmp = fitted_val_erf[mask]
         expected_val_chi2 = res_tmp.mean(axis=0)
@@ -56,31 +53,35 @@ def calculate_chi2s_per_replica(
     preds,
     dataset_inputs,
     groups_covmat_no_table,
-    ):
+):
 
     groups_covmat = groups_covmat_no_table
 
     pp = []
     for i, dss in enumerate(dataset_inputs):
         preds_witout_cv = preds[i].drop(0, axis=1)
-        df = pd.concat({dss.name: preds_witout_cv}, names=['dataset'])
+        df = pd.concat({dss.name: preds_witout_cv}, names=["dataset"])
         pp.append(df)
 
     PDF_predictions = pd.concat(pp)
 
-    chi2s_per_replica=[]
+    chi2s_per_replica = []
     for enum, pdf_data_index in enumerate(recreate_pdf_pseudodata_no_table):
 
-        prediction_filter=pdf_data_index.val_idx.droplevel(level=0)
-        prediction_filter.rename(["dataset","data"], inplace=True)
+        prediction_filter = pdf_data_index.val_idx.droplevel(level=0)
+        prediction_filter.rename(["dataset", "data"], inplace=True)
         PDF_predictions_val = PDF_predictions.loc[prediction_filter]
-        PDF_predictions_val = PDF_predictions_val.values[:,enum]
+        PDF_predictions_val = PDF_predictions_val.values[:, enum]
 
-        new_val_pseudodata_list = _create_new_val_pseudodata(pdf_data_index, recreate_pdf_pseudodata_no_table)
+        new_val_pseudodata_list = _create_new_val_pseudodata(
+            pdf_data_index, recreate_pdf_pseudodata_no_table
+        )
 
-        invcovmat_vl = np.linalg.inv(groups_covmat[pdf_data_index.val_idx].T[pdf_data_index.val_idx])
-        
-        tmp = ( PDF_predictions_val - new_val_pseudodata_list)
+        invcovmat_vl = np.linalg.inv(
+            groups_covmat[pdf_data_index.val_idx].T[pdf_data_index.val_idx]
+        )
+
+        tmp = PDF_predictions_val - new_val_pseudodata_list
 
         chi2 = np.einsum("ij,jk,ik->i", tmp, invcovmat_vl, tmp) / tmp.shape[1]
         chi2s_per_replica.append(chi2)
@@ -88,20 +89,19 @@ def calculate_chi2s_per_replica(
     # array of chi2 per replica
     return np.array(chi2s_per_replica)
 
-import matplotlib.pyplot as plt
 
 @figure
 def plot_deltachi2_histogram(array_expected_delta_chi2):
     mean = array_expected_delta_chi2.mean()
     std = array_expected_delta_chi2.std()
 
-    f, ax = plt.subplots(1,1)
+    f, ax = plt.subplots(1, 1)
 
-    ax.hist(array_expected_delta_chi2, bins=50, density=True);
-    ax.axvline(x=mean,color='black')
-    xrange=[array_expected_delta_chi2.min(),array_expected_delta_chi2.max()]
+    ax.hist(array_expected_delta_chi2, bins=50, density=True)
+    ax.axvline(x=mean, color="black")
+    xrange = [array_expected_delta_chi2.min(), array_expected_delta_chi2.max()]
     xgrid = np.linspace(xrange[0], xrange[1], num=100)
-    ax.set_xlim(xrange[0],xrange[1])
+    ax.set_xlim(xrange[0], xrange[1])
     ax.plot(xgrid, stats.norm.pdf(xgrid, mean, std))
     ax.set_xlabel(r"$\Delta \chi^2_{\mathrm{overfit}}$")
     ax.set_ylabel("density")
@@ -109,17 +109,20 @@ def plot_deltachi2_histogram(array_expected_delta_chi2):
     plt.tight_layout()
     return f
 
-fits_deltachi2_summary = collect('fit_deltachi2_summary', ('fits','fitcontext'))
 
-def fit_deltachi2_summary(fit,array_expected_delta_chi2):
+fits_deltachi2_summary = collect("fit_deltachi2_summary", ("fits", "fitcontext"))
+
+
+def fit_deltachi2_summary(fit, array_expected_delta_chi2):
     mean = array_expected_delta_chi2.mean()
     std = array_expected_delta_chi2.std()
     return pd.DataFrame(
-        [mean, std, abs(mean/std)],
+        [mean, std, abs(mean / std)],
         columns=[fit.label],
-        index=["mean", "bootstrap error", "abs(mean/bootsrap error)"]
-        )
+        index=["mean", "bootstrap error", "abs(mean/bootsrap error)"],
+    )
+
 
 @table
 def summarise_deltachi2(fits_deltachi2_summary):
-    return pd.concat(fits_deltachi2_summary,axis=1)
+    return pd.concat(fits_deltachi2_summary, axis=1)

--- a/validphys2/src/validphys/pseudodata.py
+++ b/validphys2/src/validphys/pseudodata.py
@@ -296,3 +296,8 @@ def recreate_pdf_pseudodata(_recreate_pdf_pseudodata, pdfreplicas, pdf_tr_masks)
     :py:func:`validphys.pseudodata.recreate_fit_pseudodata`
     """
     return recreate_fit_pseudodata(_recreate_pdf_pseudodata, pdfreplicas, pdf_tr_masks)
+
+pdf_tr_masks_no_table = collect('replica_training_mask', ('pdfreplicas', 'fitenvironment'))
+def recreate_pdf_pseudodata_no_table(_recreate_pdf_pseudodata, pdfreplicas, pdf_tr_masks_no_table):
+    return recreate_fit_pseudodata(_recreate_pdf_pseudodata, pdfreplicas, pdf_tr_masks_no_table)
+

--- a/validphys2/src/validphys/pseudodata.py
+++ b/validphys2/src/validphys/pseudodata.py
@@ -298,5 +298,5 @@ def recreate_pdf_pseudodata(_recreate_pdf_pseudodata, pdfreplicas, pdf_tr_masks)
     return recreate_fit_pseudodata(_recreate_pdf_pseudodata, pdfreplicas, pdf_tr_masks)
 
 pdf_tr_masks_no_table = collect('replica_training_mask', ('pdfreplicas', 'fitenvironment'))
-recreate_pdf_pseudodata_no_table = recreate_fit_pseudodata
-
+def recreate_pdf_pseudodata_no_table(_recreate_pdf_pseudodata, pdfreplicas, pdf_tr_masks_no_table):
+    return recreate_pdf_pseudodata(_recreate_pdf_pseudodata, pdfreplicas, pdf_tr_masks_no_table)

--- a/validphys2/src/validphys/pseudodata.py
+++ b/validphys2/src/validphys/pseudodata.py
@@ -298,6 +298,5 @@ def recreate_pdf_pseudodata(_recreate_pdf_pseudodata, pdfreplicas, pdf_tr_masks)
     return recreate_fit_pseudodata(_recreate_pdf_pseudodata, pdfreplicas, pdf_tr_masks)
 
 pdf_tr_masks_no_table = collect('replica_training_mask', ('pdfreplicas', 'fitenvironment'))
-def recreate_pdf_pseudodata_no_table(_recreate_pdf_pseudodata, pdfreplicas, pdf_tr_masks_no_table):
-    return recreate_fit_pseudodata(_recreate_pdf_pseudodata, pdfreplicas, pdf_tr_masks_no_table)
+recreate_pdf_pseudodata_no_table = recreate_fit_pseudodata
 

--- a/validphys2/src/validphys/tests/conftest.py
+++ b/validphys2/src/validphys/tests/conftest.py
@@ -50,6 +50,7 @@ PDF = "NNPDF40_nnlo_as_01180"
 HESSIAN_PDF = "NNPDF40_nnlo_as_01180_hessian"
 THEORYID = 162
 FIT = "NNPDF40_nnlo_lowprecision"
+FIT_3REPLICAS = "Basic_runcard_3replicas"
 FIT_ITERATED = "NNPDF40_nnlo_low_precision_iterated"
 PSEUDODATA_FIT = "pseudodata_test_fit_n3fit_220208"
 

--- a/validphys2/src/validphys/tests/test_overfit_metric.py
+++ b/validphys2/src/validphys/tests/test_overfit_metric.py
@@ -1,0 +1,27 @@
+"""
+test_loader.py
+
+Test overfit metric implementation.
+"""
+
+from validphys.api import API
+from validphys.tests.conftest import FIT_3REPLICAS
+
+config = {
+    "fit": FIT_3REPLICAS,
+    "use_t0": True,
+    "use_cuts": "fromfit",
+    "theory": {"from_": "fit"},
+    "theoryid": {"from_": "theory"},
+    "datacuts": {"from_": "fit"},
+    "t0pdfset": {"from_": "datacuts"},
+    "pdfs": [{"from_": "fit"}],
+    "dataset_inputs": {"from_": "fit"},
+}
+
+
+def test_overfit_chi2():
+    replica_info = API.replica_data(**config)
+    val_erf = [info.validation for info in replica_info]
+    chi2s_per_replica = API.calculate_chi2s_per_replica(**config)
+    assert (abs(chi2s_per_replica.diagonal() - val_erf) < 1e-4).all()


### PR DESCRIPTION
As discussed in Amsterdam I've implemented the overfit metric to vp, and included a plot and table by default in the comparefit report.

I'll open the metric per dataset grouping in a later PR.

I don't really like how it's implemented in the comparefits report, but I believe including something like `fits::fitcontext` in the loop already means that the default `use_t0=False`  is included in the loop. 

example report: https://vp.nnpdf.science/ihtLSPpKTBa45jD2UEH4bw==

Also to prevent confusion we may went to use something other than "deltachi2", but ideally also something better than "overfit metric"?