### PR TITLE
Enable positivity/integrability pineappl grids

### DIFF
--- a/validphys2/src/validphys/core.py
+++ b/validphys2/src/validphys/core.py
@@ -606,6 +606,10 @@ class LagrangeSetSpec(DataSetSpec):
         return self
 
     @functools.lru_cache()
+    def load_commondata(self):
+        return self.commondata.load()
+
+    @functools.lru_cache()
     def load(self):
         cd = self.commondata.load()
         fk = self.fkspecs[0].load()

--- a/validphys2/src/validphys/dataplots.py
+++ b/validphys2/src/validphys/dataplots.py
@@ -1039,7 +1039,7 @@ def plot_positivity(
     fig, ax = plt.subplots()
     ax.axhline(0, color="red")
 
-    posset = posdataset.load()
+    posset = posdataset.load_commondata()
     ndata = posset.GetNData()
     xvals = []
 

--- a/validphys2/src/validphys/filters.py
+++ b/validphys2/src/validphys/filters.py
@@ -199,14 +199,14 @@ def check_positivity(posdatasets):
     """Verify positive datasets are ready for the fit."""
     log.info('Verifying positivity tables:')
     for pos in posdatasets:
-        pos.load()
+        pos.load_commondata()
         log.info(f'{pos.name} checked.')
 
 def check_integrability(integdatasets):
     """Verify positive datasets are ready for the fit."""
     log.info('Verifying integrability tables:')
     for integ in integdatasets:
-        integ.load()
+        integ.load_commondata()
         log.info(f'{integ.name} checked.')
 
 class PerturbativeOrder:


### PR DESCRIPTION
Since now we have positivity/integrability grids computed with the new theory pipeline.