### PR TITLE
Evaluate only unique xgrids

### DIFF
--- a/n3fit/src/n3fit/layers/observable.py
+++ b/n3fit/src/n3fit/layers/observable.py
@@ -4,7 +4,7 @@ from abc import abstractmethod, ABC
 from n3fit.backends import operations as op
 
 
-def _is_unique(list_of_arrays):
+def is_unique(list_of_arrays):
     """Check whether the list of arrays more than one different arrays"""
     the_first = list_of_arrays[0]
     for i in list_of_arrays[1:]:
@@ -52,13 +52,13 @@ class Observable(MetaLayer, ABC):
             self.fktables.append(op.numpy_to_tensor(fk))
 
         # check how many xgrids this dataset needs
-        if _is_unique(xgrids):
+        if is_unique(xgrids):
             self.splitting = None
         else:
             self.splitting = [i.shape[1] for i in xgrids]
 
         # check how many basis this dataset needs
-        if _is_unique(basis) and _is_unique(xgrids):
+        if is_unique(basis) and is_unique(xgrids):
             self.all_masks = [self.gen_mask(basis[0])]
             self.many_masks = False
         else:

--- a/n3fit/src/n3fit/model_gen.py
+++ b/n3fit/src/n3fit/model_gen.py
@@ -9,7 +9,6 @@
 
 
 """
-from itertools import zip_longest
 from dataclasses import dataclass
 import numpy as np
 from n3fit.msr import msr_impose

--- a/n3fit/src/n3fit/model_trainer.py
+++ b/n3fit/src/n3fit/model_trainer.py
@@ -337,18 +337,18 @@ class ModelTrainer:
         #    [x1, x2, x3] (unique grids) and [0,0,0,1,1,2] (index of the grid per dataset)
         #    The pdf will then be evaluated to concatenate([x1,x2,x3]) and then split (x1, x2, x3)
         #    Then each of the experiment, looking at the indexes, will receive one of the 3 PDFs
-
-        # Clean the input list
-        inputs_hash = []
+        #    The decision whether two grids (x1 and x1) are really the same is decided below
         inputs_unique = []
         inputs_idx = []
-        for input_grid in self.input_list:
-            ghash = hash(tuple(input_grid.flatten()))
-            if ghash not in inputs_hash:
-                inputs_hash.append(ghash)
-                inputs_unique.append(input_grid)
-            inputs_idx.append(inputs_hash.index(ghash))
-
+        for igrid in self.input_list:
+            for idx, arr in enumerate(inputs_unique):
+                if igrid.size == arr.size and np.allclose(igrid, arr):
+                    inputs_idx.append(idx)
+                    break
+            else:
+                inputs_idx.append(len(inputs_unique))
+                inputs_unique.append(igrid)
+        
         # Concatenate the unique inputs
         input_arr = np.concatenate(inputs_unique, axis=1).T
         if self._scaler:


### PR DESCRIPTION
Deals with #1586 in a very generic way so that one is still allow to mix situations in which not all xgrids are equal but some of them are.

For now only done for the fit. Once tests have run and it works there, I'll try to add some kind of cache to the vp PDF so that we can avoid calling `lhapdf` once per dataset (which I cannot promise because it is both trivial to do and trivial to do it in a disastrous way).