### PR TITLE
Fixing the grouping and the thcovmat flag

### DIFF
--- a/n3fit/src/n3fit/scripts/n3fit_exec.py
+++ b/n3fit/src/n3fit/scripts/n3fit_exec.py
@@ -147,6 +147,8 @@ class N3FitConfig(Config):
             N3FIT_FIXED_CONFIG['actions_'].extend((training_action, validation_action))
         #Theorycovmat flags and defaults
         N3FIT_FIXED_CONFIG['theory_covmat_flag'] = False
+        N3FIT_FIXED_CONFIG['use_thcovmat_in_fitting'] = False
+        N3FIT_FIXED_CONFIG['use_thcovmat_in_sampling'] = False
         if (thconfig:=file_content.get('theorycovmatconfig')) is not None:
             N3FIT_FIXED_CONFIG['use_thcovmat_in_fitting'] = thconfig.get('use_thcovmat_in_fitting', True) 
             N3FIT_FIXED_CONFIG['use_thcovmat_in_sampling'] = thconfig.get('use_thcovmat_in_sampling', True) 

--- a/n3fit/src/n3fit/scripts/n3fit_exec.py
+++ b/n3fit/src/n3fit/scripts/n3fit_exec.py
@@ -148,9 +148,10 @@ class N3FitConfig(Config):
         #Theorycovmat flags and defaults
         N3FIT_FIXED_CONFIG['theory_covmat_flag'] = False
         if (thconfig:=file_content.get('theorycovmatconfig')) is not None:
-            N3FIT_FIXED_CONFIG['theory_covmat_flag'] = True
             N3FIT_FIXED_CONFIG['use_thcovmat_in_fitting'] = thconfig.get('use_thcovmat_in_fitting', True) 
-            N3FIT_FIXED_CONFIG['use_thcovmat_in_sampling'] = thconfig.get('use_thcovmat_in_sampling', True)  
+            N3FIT_FIXED_CONFIG['use_thcovmat_in_sampling'] = thconfig.get('use_thcovmat_in_sampling', True) 
+            if N3FIT_FIXED_CONFIG['use_thcovmat_in_sampling'] or N3FIT_FIXED_CONFIG['use_thcovmat_in_fitting']:
+                N3FIT_FIXED_CONFIG['theory_covmat_flag'] = True
             N3FIT_FIXED_CONFIG['use_user_uncertainties'] = thconfig.get('use_user_uncertainties', False) 
             N3FIT_FIXED_CONFIG['use_scalevar_uncertainties'] = thconfig.get('use_scalevar_uncertainties', True) 
         #Sampling flags

--- a/validphys2/src/validphys/commondata.py
+++ b/validphys2/src/validphys/commondata.py
@@ -33,6 +33,6 @@ dataset_inputs_loaded_cd_with_cuts = collect(
 )
 
 groups_dataset_inputs_loaded_cd_with_cuts = collect(
-    "loaded_commondata_with_cuts", ("group_dataset_inputs_by_fitting_group", "data_input")
+    "loaded_commondata_with_cuts", ("group_dataset_inputs_by_metadata", "data_input")
 )
 

--- a/validphys2/src/validphys/commondata.py
+++ b/validphys2/src/validphys/commondata.py
@@ -33,6 +33,6 @@ dataset_inputs_loaded_cd_with_cuts = collect(
 )
 
 groups_dataset_inputs_loaded_cd_with_cuts = collect(
-    "loaded_commondata_with_cuts", ("group_dataset_inputs_by_metadata", "data_input")
+    "loaded_commondata_with_cuts", ("group_dataset_inputs_by_fitting_group", "data_input")
 )
 

--- a/validphys2/src/validphys/config.py
+++ b/validphys2/src/validphys/config.py
@@ -1584,11 +1584,12 @@ class CoreConfig(configparser.Config):
         # somebody will want to add to this at some point e.g for th. uncertainties
         allowed = {
             "standard_report": "experiment",
+            "thcovmat_fit": "ALL"
         }
         return allowed[spec]
 
     def produce_processed_data_grouping(
-        self, data_grouping=None, data_grouping_recorded_spec_=None
+        self, use_thcovmat_in_fitting, use_thcovmat_in_sampling, data_grouping=None, data_grouping_recorded_spec_=None
     ):
         """Process the data_grouping key from the runcard, or lockfile. If
         `data_grouping_recorded_spec_` is present then its value is taken, and
@@ -1602,6 +1603,8 @@ class CoreConfig(configparser.Config):
         if data_grouping is None:
             # fallback to old default behaviour, but still record to lockfile
             data_grouping = self.parse_data_grouping("standard_report")
+            if use_thcovmat_in_fitting or use_thcovmat_in_sampling:
+                data_grouping = self.parse_data_grouping("thcovmat_fit")
         if data_grouping_recorded_spec_ is not None:
             return data_grouping_recorded_spec_[data_grouping]
         return self.load_default_data_grouping(data_grouping)
@@ -1652,17 +1655,6 @@ class CoreConfig(configparser.Config):
             {"data_input": NSList(group, nskey="dataset_input"), "group_name": name}
             for name, group in res.items()
         ]
-
-    def produce_group_dataset_inputs_by_fitting_group(
-        self, data_input, theory_covmat_flag
-    ):
-        """
-        Groups datasets all together in a group called ALL if the theory covariance matrix
-        is used in the fit, otherwise it groups them by experiment.
-        """
-        if theory_covmat_flag:
-            return self.produce_group_dataset_inputs_by_metadata(data_input, "ALL")
-        return self.produce_group_dataset_inputs_by_metadata(data_input, "experiment")
 
     def produce_fivetheories(self, point_prescription):
         if point_prescription == "5bar point":

--- a/validphys2/src/validphys/config.py
+++ b/validphys2/src/validphys/config.py
@@ -1589,7 +1589,7 @@ class CoreConfig(configparser.Config):
         return allowed[spec]
 
     def produce_processed_data_grouping(
-        self, use_thcovmat_in_fitting, use_thcovmat_in_sampling, data_grouping=None, data_grouping_recorded_spec_=None
+        self, use_thcovmat_in_fitting=False, use_thcovmat_in_sampling=False, data_grouping=None, data_grouping_recorded_spec_=None
     ):
         """Process the data_grouping key from the runcard, or lockfile. If
         `data_grouping_recorded_spec_` is present then its value is taken, and

--- a/validphys2/src/validphys/config.py
+++ b/validphys2/src/validphys/config.py
@@ -1595,8 +1595,10 @@ class CoreConfig(configparser.Config):
         `data_grouping_recorded_spec_` is present then its value is taken, and
         the runcard is assumed to be a lockfile.
 
-        If data_grouping is None, then fall back to old behaviour of grouping
-        by experiment.
+        If data_grouping is None, then, if either use_thcovmat_in_fitting or use_thcovmat_in_sampling
+        (or both) are true (which means that the fit is a thcovmat fit), group all the datasets 
+        together, otherwise fall back to the default behaviour of grouping by 
+        experiment (called standard_report).
 
         Else, the user can specfiy their own grouping, for example metadata_process.
         """

--- a/validphys2/src/validphys/n3fit_data.py
+++ b/validphys2/src/validphys/n3fit_data.py
@@ -311,7 +311,7 @@ def fitting_data_dict(
     return dict_out
 
 
-exps_fitting_data_dict = collect("fitting_data_dict", ("group_dataset_inputs_by_fitting_group",))
+exps_fitting_data_dict = collect("fitting_data_dict", ("group_dataset_inputs_by_metadata",))
 
 
 def replica_nnseed_fitting_data_dict(replica, exps_fitting_data_dict, replica_nnseed):

--- a/validphys2/src/validphys/tests/conftest.py
+++ b/validphys2/src/validphys/tests/conftest.py
@@ -58,7 +58,6 @@ base_config = dict(
         use_cuts='nocuts',
         dataset_inputs=DATA,
         theoryid=THEORYID,
-        use_fitthcovmat=False,
         Q=10,
     )
 


### PR DESCRIPTION
The grouping used in the thcovmat fit is broken because `groups_dataset_inputs_loaded_cd_with_cuts` does not use `group_dataset_inputs_by_fitting_group` and therefore is not grouped as the thcovmat (even if the groupings are similar so sometimes it happens to be correct by chance). 

Moreover, the thcovmat group is used also when both `use_thcovmat_in_sampling` and `use_thcovmat_in_fitting` are false.