### PR TITLE
Re-enable `use_t0` flag.

### DIFF
--- a/n3fit/src/n3fit/scripts/n3fit_exec.py
+++ b/n3fit/src/n3fit/scripts/n3fit_exec.py
@@ -22,6 +22,7 @@ from reportengine.namespaces import NSList
 
 N3FIT_FIXED_CONFIG = dict(
     use_cuts = 'internal',
+    use_t0 = True,
     actions_ = []
 )
 

--- a/n3fit/src/n3fit/scripts/n3fit_exec.py
+++ b/n3fit/src/n3fit/scripts/n3fit_exec.py
@@ -22,7 +22,6 @@ from reportengine.namespaces import NSList
 
 N3FIT_FIXED_CONFIG = dict(
     use_cuts = 'internal',
-    use_t0 = True,
     actions_ = []
 )
 

--- a/validphys2/src/validphys/config.py
+++ b/validphys2/src/validphys/config.py
@@ -1054,10 +1054,16 @@ class CoreConfig(configparser.Config):
         self, t0pdfset=None, use_t0_sampling=False, use_t0_fitting=False, use_t0=False
     ):
         """Return the t0set if use_t0 is True and None otherwise. Raises an
-        error if t0 is requested but no t0set is given.
-        Note that ``n3fit`` will set ``use_t0_fitting`` to `True` by default
+        error if t0 is requested but no t0set is given or if an ambiguous combination is requested
+        Note that ``n3fit`` will set ``use_t0_fitting`` to `True` by default.
         """
-        if use_t0_sampling or use_t0_fitting or use_t0:
+        if not use_t0:
+            # Check that sampling and fitting t0 are also set to False
+            if use_t0_sampling:
+                raise ConfigError("Incompatible: sampling::use_t0 is True, but use_t0 is False")
+            if use_t0_fitting:
+                raise ConfigError("Incompatible: fitting::use_t0 is True, but use_t0 is False")
+        if use_t0:
             if not t0pdfset:
                 raise ConfigError("""Setting use_t0, use_t0_sampling or use_t0_fitting
                                   requires specifying a valid t0pdfset""")

--- a/validphys2/src/validphys/config.py
+++ b/validphys2/src/validphys/config.py
@@ -1051,14 +1051,15 @@ class CoreConfig(configparser.Config):
 
     # TODO: Find a good name for this
     def produce_t0set(
-        self, t0pdfset=None, use_t0_sampling=False, use_t0_fitting=True, use_t0=True
+        self, t0pdfset=None, use_t0_sampling=False, use_t0_fitting=False, use_t0=False
     ):
         """Return the t0set if use_t0 is True and None otherwise. Raises an
         error if t0 is requested but no t0set is given.
+        Note that ``n3fit`` will set ``use_t0_fitting`` to `True` by default
         """
         if use_t0_sampling or use_t0_fitting or use_t0:
             if not t0pdfset:
-                raise ConfigError("Setting use_t0 requires specifying a valid t0pdfset")
+                raise ConfigError("Setting use_t0* requires specifying a valid t0pdfset")
             return t0pdfset
         return None
 

--- a/validphys2/src/validphys/config.py
+++ b/validphys2/src/validphys/config.py
@@ -1051,7 +1051,7 @@ class CoreConfig(configparser.Config):
 
     # TODO: Find a good name for this
     def produce_t0set(
-        self, t0pdfset=None, use_t0_sampling=False, use_t0_fitting=True, use_t0=False
+        self, t0pdfset=None, use_t0_sampling=False, use_t0_fitting=True, use_t0=True
     ):
         """Return the t0set if use_t0 is True and None otherwise. Raises an
         error if t0 is requested but no t0set is given.

--- a/validphys2/src/validphys/config.py
+++ b/validphys2/src/validphys/config.py
@@ -1059,7 +1059,8 @@ class CoreConfig(configparser.Config):
         """
         if use_t0_sampling or use_t0_fitting or use_t0:
             if not t0pdfset:
-                raise ConfigError("Setting use_t0* requires specifying a valid t0pdfset")
+                raise ConfigError("""Setting use_t0, use_t0_sampling or use_t0_fitting
+                                  requires specifying a valid t0pdfset""")
             return t0pdfset
         return None
 

--- a/validphys2/src/validphys/config.py
+++ b/validphys2/src/validphys/config.py
@@ -1051,12 +1051,12 @@ class CoreConfig(configparser.Config):
 
     # TODO: Find a good name for this
     def produce_t0set(
-        self, t0pdfset=None, use_t0_sampling=False, use_t0_fitting=True,
+        self, t0pdfset=None, use_t0_sampling=False, use_t0_fitting=True, use_t0=False
     ):
         """Return the t0set if use_t0 is True and None otherwise. Raises an
         error if t0 is requested but no t0set is given.
         """
-        if use_t0_sampling or use_t0_fitting:
+        if use_t0_sampling or use_t0_fitting or use_t0:
             if not t0pdfset:
                 raise ConfigError("Setting use_t0 requires specifying a valid t0pdfset")
             return t0pdfset


### PR DESCRIPTION
See https://github.com/NNPDF/nnpdf/pull/1489#discussion_r971613012

It is in principle a trivial change that should not do anything, adding @andreab1997 in case there was a reason why we wanted to eliminate `use_t0` that I've forgotten.