### PR TITLE
Eko from theory

### DIFF
--- a/n3fit/src/evolven3fit/evolve.py
+++ b/n3fit/src/evolven3fit/evolve.py
@@ -91,9 +91,9 @@ def evolve_fit(
     else:
         try:
             log.info(f"Loading eko from theory {theoryID}")
-            theory_eko_path = Loader().check_theoryID(theoryID).get_eko()
+            theory_eko_path = (Loader().check_theoryID(theoryID).path)/'eko.tar'
             eko_op = output.Output.load_tar(theory_eko_path)
-        except TypeError:
+        except:
             log.info(f"eko not found in theory {theoryID}, we will construct it")
             eko_op = eko_utils.construct_eko_for_fit(theory, op, log, dump_eko)
             pass   

--- a/n3fit/src/evolven3fit/evolve.py
+++ b/n3fit/src/evolven3fit/evolve.py
@@ -89,7 +89,6 @@ def evolve_fit(
         log.info(f"Loading eko from : {eko_path}")
         eko_op = output.Output.load_tar(eko_path)
     else:
-        import ipdb; ipdb.set_trace()
         try:
             log.info(f"Loading eko from theory {theoryID}")
             theory_eko_path = Loader().check_theoryID(theoryID).get_eko()

--- a/n3fit/src/evolven3fit/evolve.py
+++ b/n3fit/src/evolven3fit/evolve.py
@@ -94,7 +94,7 @@ def evolve_fit(
             theory_eko_path = Loader().check_theoryID(theoryID).get_eko()
             eko_op = output.Output.load_tar(theory_eko_path)
         except TypeError:
-            log.info(f"eko not found in theory {theoryID}: maybe it is not a pineappl theory?")
+            log.info(f"eko not found in theory {theoryID}, we will construct it")
             eko_op = eko_utils.construct_eko_for_fit(theory, op, log, dump_eko)
             pass   
     eko_op.xgrid_reshape(targetgrid=x_grid, inputgrid=x_grid)

--- a/n3fit/src/evolven3fit/evolve.py
+++ b/n3fit/src/evolven3fit/evolve.py
@@ -9,6 +9,7 @@ from ekobox import genpdf, gen_info
 from ekomark import apply
 from eko import basis_rotation as br
 from eko import output
+from validphys.loader import Loader
 
 from . import utils, eko_utils
 
@@ -88,7 +89,15 @@ def evolve_fit(
         log.info(f"Loading eko from : {eko_path}")
         eko_op = output.Output.load_tar(eko_path)
     else:
-        eko_op = eko_utils.construct_eko_for_fit(theory, op, log, dump_eko)
+        import ipdb; ipdb.set_trace()
+        try:
+            log.info(f"Loading eko from theory {theoryID}")
+            theory_eko_path = Loader().check_theoryID(theoryID).get_eko()
+            eko_op = output.Output.load_tar(theory_eko_path)
+        except TypeError:
+            log.info(f"eko not found in theory {theoryID}: maybe it is not a pineappl theory?")
+            eko_op = eko_utils.construct_eko_for_fit(theory, op, log, dump_eko)
+            pass   
     eko_op.xgrid_reshape(targetgrid=x_grid, inputgrid=x_grid)
     info = gen_info.create_info_file(theory, op, 1, info_update={})
     info["NumMembers"] = "REPLACE_NREP"

--- a/validphys2/src/validphys/core.py
+++ b/validphys2/src/validphys/core.py
@@ -801,11 +801,6 @@ class TheoryIDSpec:
         dbpath = self.path.parent/'theory.db'
         return fetch_theory(dbpath, self.id)
 
-    def get_eko(self):
-        if self.is_pineappl():
-            return self.path/'eko.tar'
-        raise TypeError(f"the requested eko does not exists because the theory {self.id} is not a pineappl theory")
-
     __slots__ = ('id', 'path')
 
     def __repr__(self):

--- a/validphys2/src/validphys/core.py
+++ b/validphys2/src/validphys/core.py
@@ -801,6 +801,11 @@ class TheoryIDSpec:
         dbpath = self.path.parent/'theory.db'
         return fetch_theory(dbpath, self.id)
 
+    def get_eko(self):
+        if self.is_pineappl():
+            return self.path/'eko.tar'
+        raise TypeError(f"the requested eko does not exists because the theory {self.id} is not a pineappl theory")
+
     __slots__ = ('id', 'path')
 
     def __repr__(self):


### PR DESCRIPTION
We want to allow `evolven3fit` to look inside the relevant theory and, if possible, load the eko needed for the evolution from there. This should actually be the default behaviour. 