### PR TITLE
Add flag for the derivative of thePDF

### DIFF
--- a/doc/sphinx/source/tutorials/plot_pdfs.rst
+++ b/doc/sphinx/source/tutorials/plot_pdfs.rst
@@ -98,6 +98,8 @@ Plotting PDFs, uncertainties and replicas
 - Here the ``PDFscalespecs`` namespace specifies two x-scales to be plotted.
 - The actions are called: ``plot_pdfs``, ``plot_uncertainties`` and
   ``plot_pdfreplicas``. Their output is fairly self-evident!
+- PDF plotting routines allow to perform the derivative of the PDFs with respect to logx
+  by using the ``derivative: N`` flag, where ``N`` is the degree of the desired derivative. [Example](https://vp.nnpdf.science/Tj8jTeWhSki5ObB17nV1BQ==/#pdf-bands-2)
 
 Plotting PDF distances
 ----------------------

--- a/validphys2/src/validphys/arclength.py
+++ b/validphys2/src/validphys/arclength.py
@@ -33,7 +33,6 @@ def arc_lengths(
     Q: numbers.Real,
     basis: (str, Basis) = "flavour",
     flavours: (list, tuple, type(None)) = None,
-    xscale: str = "linear"
 ):
     """Compute arc lengths at scale Q"""
     checked = check_basis(basis, flavours)
@@ -47,7 +46,7 @@ def arc_lengths(
     for a, b in zip(seg_min, seg_max):
         # Finite diff. step-size, x-grid
         eps = (b - a) / npoints
-        ixgrid = xgrid(a, b, xscale, npoints)
+        ixgrid = xgrid(a, b, "linear", npoints)
         # PDFs evaluated on grid, use the entire thing, the Stats class will chose later
         xfgrid = xplotting_grid(pdf, Q, ixgrid, basis, flavours).grid_values.data * ixgrid[1]
         fdiff = np.diff(xfgrid) / eps  # Compute forward differences
@@ -76,19 +75,15 @@ def arc_length_table(arc_lengths):
 @figure
 @check_pdf_normalize_to
 def plot_arc_lengths(
-    pdfs_arc_lengths: Sequence,
-    Q: numbers.Real,
-    normalize_to: (type(None), int) = None,
-    xscale: str = "linear",
+    pdfs_arc_lengths: Sequence, Q: numbers.Real, normalize_to: (type(None), int) = None
 ):
     """Plot the arc lengths of provided pdfs"""
     fig, ax = plt.subplots()
-
-    scl_txt = "" if xscale == "linear" else "log-"
     if normalize_to is not None:
-        ax.set_ylabel(f"Arc {scl_txt}length $Q={Q}$ GeV (normalised)")
+        ax.set_ylabel(f"Arc length $Q={Q}$ GeV (normalised)")
     else:
-        ax.set_ylabel(f"Arc {scl_txt}length $Q={Q}$ GeV")
+        ax.set_ylabel(f"Arc length $Q={Q}$ GeV")
+
     for ipdf, arclengths in enumerate(pdfs_arc_lengths):
         xvalues = np.array(range(len(arclengths.flavours)))
         xlabels = [

--- a/validphys2/src/validphys/arclength.py
+++ b/validphys2/src/validphys/arclength.py
@@ -33,7 +33,7 @@ def arc_lengths(
     Q: numbers.Real,
     basis: (str, Basis) = "flavour",
     flavours: (list, tuple, type(None)) = None,
-    xscale:(str,type(None)) = "linear"
+    xscale: str = "linear"
 ):
     """Compute arc lengths at scale Q"""
     checked = check_basis(basis, flavours)
@@ -79,7 +79,7 @@ def plot_arc_lengths(
     pdfs_arc_lengths: Sequence,
     Q: numbers.Real,
     normalize_to: (type(None), int) = None,
-    xscale: (str, type(None)) = "linear",
+    xscale: str = "linear",
 ):
     """Plot the arc lengths of provided pdfs"""
     fig, ax = plt.subplots()

--- a/validphys2/src/validphys/arclength.py
+++ b/validphys2/src/validphys/arclength.py
@@ -76,15 +76,19 @@ def arc_length_table(arc_lengths):
 @figure
 @check_pdf_normalize_to
 def plot_arc_lengths(
-    pdfs_arc_lengths: Sequence, Q: numbers.Real, normalize_to: (type(None), int) = None
+    pdfs_arc_lengths: Sequence,
+    Q: numbers.Real,
+    normalize_to: (type(None), int) = None,
+    xscale: (str, type(None)) = "linear",
 ):
     """Plot the arc lengths of provided pdfs"""
     fig, ax = plt.subplots()
-    if normalize_to is not None:
-        ax.set_ylabel(f"Arc length $Q={Q}$ GeV (normalised)")
-    else:
-        ax.set_ylabel(f"Arc length $Q={Q}$ GeV")
 
+    scl_txt = "" if xscale == "linear" else "log-"
+    if normalize_to is not None:
+        ax.set_ylabel(f"Arc {scl_txt}length $Q={Q}$ GeV (normalised)")
+    else:
+        ax.set_ylabel(f"Arc {scl_txt}length $Q={Q}$ GeV")
     for ipdf, arclengths in enumerate(pdfs_arc_lengths):
         xvalues = np.array(range(len(arclengths.flavours)))
         xlabels = [

--- a/validphys2/src/validphys/arclength.py
+++ b/validphys2/src/validphys/arclength.py
@@ -33,6 +33,7 @@ def arc_lengths(
     Q: numbers.Real,
     basis: (str, Basis) = "flavour",
     flavours: (list, tuple, type(None)) = None,
+    xscale:(str,type(None)) = "linear"
 ):
     """Compute arc lengths at scale Q"""
     checked = check_basis(basis, flavours)
@@ -46,7 +47,7 @@ def arc_lengths(
     for a, b in zip(seg_min, seg_max):
         # Finite diff. step-size, x-grid
         eps = (b - a) / npoints
-        ixgrid = xgrid(a, b, "linear", npoints)
+        ixgrid = xgrid(a, b, xscale, npoints)
         # PDFs evaluated on grid, use the entire thing, the Stats class will chose later
         xfgrid = xplotting_grid(pdf, Q, ixgrid, basis, flavours).grid_values.data * ixgrid[1]
         fdiff = np.diff(xfgrid) / eps  # Compute forward differences

--- a/validphys2/src/validphys/pdfgrids.py
+++ b/validphys2/src/validphys/pdfgrids.py
@@ -54,6 +54,7 @@ class XPlottingGrid:
     xgrid: np.ndarray
     grid_values: Stats
     scale: str
+    derivative_degree: int = 0 # keep track of the degree of the derivative
 
     def __post_init__(self):
         """Enforce grid_values being a Stats instance"""
@@ -79,7 +80,8 @@ class XPlottingGrid:
         """Return the derivative of the grid with respect to dlogx"""
         new_data = np.gradient(self.grid_values.data, self.xgrid, axis=-1)*self.xgrid
         gv = self.grid_values.__class__(new_data)
-        return dataclasses.replace(self, grid_values=gv)
+        nd = self.derivative_degree + 1
+        return dataclasses.replace(self, grid_values=gv, derivative_degree=nd)
 
 
 @make_argcheck(check_basis)

--- a/validphys2/src/validphys/pdfgrids.py
+++ b/validphys2/src/validphys/pdfgrids.py
@@ -77,7 +77,10 @@ class XPlottingGrid:
         return dataclasses.replace(self, grid_values=grid_values)
 
     def derivative(self):
-        """Return the derivative of the grid with respect to dlogx"""
+        """Return the derivative of the grid with respect to dlogx
+        A call to this function will return a new ``XPlottingGrid`` instance with
+        the derivative as grid values and with an increased ``derivative_degree``
+        """
         new_data = np.gradient(self.grid_values.data, self.xgrid, axis=-1)*self.xgrid
         gv = self.grid_values.__class__(new_data)
         nd = self.derivative_degree + 1

--- a/validphys2/src/validphys/pdfgrids.py
+++ b/validphys2/src/validphys/pdfgrids.py
@@ -89,7 +89,7 @@ def xplotting_grid(
     xgrid=None,
     basis: (str, Basis) = 'flavour',
     flavours: (list, tuple, type(None)) = None,
-    derivative: bool = False,
+    derivative: int = 0,
 ):
     """Return an object containing the value of the PDF at the specified values
     of x and flavour.
@@ -102,7 +102,7 @@ def xplotting_grid(
 
     Q: The PDF scale in GeV.
 
-    derivative (bool): if True, take the derivative of the PDF instead
+    derivative (int): how many derivtives of the PDF should be taken (default=0)
     """
     #Make usable outside reportengine
     checked = check_basis(basis, flavours)
@@ -123,8 +123,8 @@ def xplotting_grid(
 
     res = XPlottingGrid(Q, basis, flavours, xgrid, stats_gv, scale)
 
-    if derivative:
-        return res.derivative()
+    for _ in range(derivative):
+        res = res.derivative()
 
     return res
 

--- a/validphys2/src/validphys/pdfgrids.py
+++ b/validphys2/src/validphys/pdfgrids.py
@@ -75,10 +75,22 @@ class XPlottingGrid:
         """Create a copy of the grid with potentially a different set of values"""
         return dataclasses.replace(self, grid_values=grid_values)
 
+    def derivative(self):
+        """Return the derivative of the grid with respect to dlogx"""
+        new_data = np.gradient(self.grid_values.data, self.xgrid, axis=-1)*self.xgrid
+        gv = self.grid_values.__class__(new_data)
+        return dataclasses.replace(self, grid_values=gv)
+
 
 @make_argcheck(check_basis)
-def xplotting_grid(pdf:PDF, Q:(float,int), xgrid=None, basis:(str, Basis)='flavour',
-                   flavours:(list, tuple, type(None))=None):
+def xplotting_grid(
+    pdf: PDF,
+    Q: (float, int),
+    xgrid=None,
+    basis: (str, Basis) = 'flavour',
+    flavours: (list, tuple, type(None)) = None,
+    derivative: bool = False,
+):
     """Return an object containing the value of the PDF at the specified values
     of x and flavour.
 
@@ -89,6 +101,8 @@ def xplotting_grid(pdf:PDF, Q:(float,int), xgrid=None, basis:(str, Basis)='flavo
     If None, the defaults for that basis will be selected.
 
     Q: The PDF scale in GeV.
+
+    derivative (bool): if True, take the derivative of the PDF instead
     """
     #Make usable outside reportengine
     checked = check_basis(basis, flavours)
@@ -108,6 +122,10 @@ def xplotting_grid(pdf:PDF, Q:(float,int), xgrid=None, basis:(str, Basis)='flavo
     stats_gv = pdf.stats_class(gv.reshape(gv.shape[:-1]))
 
     res = XPlottingGrid(Q, basis, flavours, xgrid, stats_gv, scale)
+
+    if derivative:
+        return res.derivative()
+
     return res
 
 xplotting_grids = collect(xplotting_grid, ('pdfs',))

--- a/validphys2/src/validphys/pdfplots.py
+++ b/validphys2/src/validphys/pdfplots.py
@@ -89,9 +89,16 @@ class PDFPlotter(metaclass=abc.ABCMeta):
 
     def get_ylabel(self, parton_name):
         if self.normalize_to is not None:
-            return "Ratio to {}".format(self.normalize_pdf.label)
-        else:
-            return '$x{}(x)$'.format(parton_name)
+            return f"Ratio to {self.normalize_pdf.label}"
+
+        # If it is a derivative, add the operator to the plot
+        derivative_str = ""
+        if self.firstgrid.derivative_degree > 0:
+            derivative_str = r"\frac{d}{dlogx}"
+        if self.firstgrid.derivative_degree > 1:
+            derivative_str = f"({derivative_str})^{self.firstgrid.derivative_degree}"
+        
+        return f"${derivative_str} x{parton_name}(x)$"
 
     def get_title(self, parton_name):
         return f"${parton_name}$ at {self.Q} GeV"

--- a/validphys2/src/validphys/pdfplots.py
+++ b/validphys2/src/validphys/pdfplots.py
@@ -93,10 +93,10 @@ class PDFPlotter(metaclass=abc.ABCMeta):
 
         # If it is a derivative, add the operator to the plot
         derivative_str = ""
-        if self.firstgrid.derivative_degree > 0:
-            derivative_str = r"\frac{d}{dlogx}"
-        if self.firstgrid.derivative_degree > 1:
-            derivative_str = f"({derivative_str})^{self.firstgrid.derivative_degree}"
+        dg = self.firstgrid.derivative_degree
+        if dg > 0:
+            dgs = f"{dg}" if dg > 0 else ""
+            derivative_str = fr"\frac{{d^{dgs}}}{{d^{dgs}logx}}"
         
         return f"${derivative_str} x{parton_name}(x)$"
 


### PR DESCRIPTION
This PR adds the `derivative` flag to validphys which can be used to get derivatives of the xplotting_grids (so it will be used automatically by any PDF plotting routine).

Example: https://vp.nnpdf.science/Tj8jTeWhSki5ObB17nV1BQ==/#pdf-bands-2