### PR TITLE
Kinetic energy of the pdf

### DIFF
--- a/validphys2/src/validphys/pdfgrids.py
+++ b/validphys2/src/validphys/pdfgrids.py
@@ -48,13 +48,14 @@ class XPlottingGrid:
     The `grid_values` attribute corresponds to a `Stats` instance
     in order to compute statistical estimators in a sensible manner.
     """
+
     Q: float
     basis: (str, Basis)
     flavours: (list, tuple, type(None))
     xgrid: np.ndarray
     grid_values: Stats
     scale: str
-    derivative_degree: int = 0 # keep track of the degree of the derivative
+    derivative_degree: int = 0  # keep track of the degree of the derivative
 
     def __post_init__(self):
         """Enforce grid_values being a Stats instance"""
@@ -76,15 +77,41 @@ class XPlottingGrid:
         """Create a copy of the grid with potentially a different set of values"""
         return dataclasses.replace(self, grid_values=grid_values)
 
+    def process_label(self, base_label):
+        """Process the base_label used for plotting.
+        For instance, for derivatives it will add d/dlogx to the base_label.
+        """
+        if self.derivative_degree == 0:
+            return base_label
+
+        dgs = f"^{self.derivative_degree}" if self.derivative_degree > 1 else ""
+        derivative_str = fr"\frac{{d{dgs}}}{{d{dgs}logx}}"
+
+        return f"{derivative_str} {base_label}"
+
     def derivative(self):
         """Return the derivative of the grid with respect to dlogx
         A call to this function will return a new ``XPlottingGrid`` instance with
         the derivative as grid values and with an increased ``derivative_degree``
         """
-        new_data = np.gradient(self.grid_values.data, self.xgrid, axis=-1)*self.xgrid
+        new_data = np.gradient(self.grid_values.data, self.xgrid, axis=-1) * self.xgrid
         gv = self.grid_values.__class__(new_data)
         nd = self.derivative_degree + 1
         return dataclasses.replace(self, grid_values=gv, derivative_degree=nd)
+
+
+@dataclasses.dataclass
+class KineticXPlottingGrid(XPlottingGrid):
+    """Kinetic Energy version of the XPlottingGrid"""
+
+    def process_label(self, base_label):
+        """Wraps the base_label inside the kinetic energy formula"""
+        # Ask the parent class for the derivative degree
+        dlabel = super().process_label(base_label)
+        return rf"\sqrt{{ 1 + ({dlabel})^2}}"
+
+    def derivative(self):
+        raise NotImplementedError("""The Kinetic energy does not allow further derivatives""")
 
 
 @make_argcheck(check_basis)
@@ -157,7 +184,8 @@ def kinetic_xplotting_grid(
     # Compute the kinetic energy
     kinen_rawdata = np.sqrt(1 + xpg.grid_values.data**2)
     kinen_gv = pdf.stats_class(kinen_rawdata)
-    return xpg.copy_grid(kinen_gv)
+    tmp_grid = xpg.copy_grid(kinen_gv)
+    return KineticXPlottingGrid(**tmp_grid.__dict__)
 
 
 xplotting_grids = collect(xplotting_grid, ('pdfs',))

--- a/validphys2/src/validphys/pdfgrids.py
+++ b/validphys2/src/validphys/pdfgrids.py
@@ -133,9 +133,35 @@ def xplotting_grid(
 
     return res
 
+@make_argcheck(check_basis)
+def kinetic_xplotting_grid(
+    pdf: PDF,
+    Q: (float, int),
+    xgrid=None,
+    basis: (str, Basis) = 'flavour',
+    flavours: (list, tuple, type(None)) = None,
+):
+    r"""Returns an object containing the value of the kinetic energy of the PDF
+    at the specified values of x and flavour for a given Q.
+    Utilizes ``xplotting_grid``
+    The kinetic energy of the PDF is defined as:
+
+    .. math::
+
+        k = \sqrt{1 + (d/dlogx f)^2}
+    """
+    # Get the pdf derived wrt logx
+    xpg = xplotting_grid(
+        pdf=pdf, Q=Q, xgrid=xgrid, basis=basis, flavours=flavours, derivative=1
+    )
+    # Compute the kinetic energy
+    kinen_rawdata = np.sqrt(1 + xpg.grid_values.data**2)
+    kinen_gv = pdf.stats_class(kinen_rawdata)
+    return xpg.copy_grid(kinen_gv)
+
+
 xplotting_grids = collect(xplotting_grid, ('pdfs',))
-
-
+kinetic_xplotting_grids = collect(kinetic_xplotting_grid, ('pdfs',))
 
 
 Lumi2dGrid = namedtuple('Lumi2dGrid', ['y','m','grid_values'])

--- a/validphys2/src/validphys/pdfplots.py
+++ b/validphys2/src/validphys/pdfplots.py
@@ -91,14 +91,12 @@ class PDFPlotter(metaclass=abc.ABCMeta):
         if self.normalize_to is not None:
             return f"Ratio to {self.normalize_pdf.label}"
 
-        # If it is a derivative, add the operator to the plot
-        derivative_str = ""
-        dg = self.firstgrid.derivative_degree
-        if dg > 0:
-            dgs = f"{dg}" if dg > 0 else ""
-            derivative_str = fr"\frac{{d^{dgs}}}{{d^{dgs}logx}}"
-        
-        return f"${derivative_str} x{parton_name}(x)$"
+        base_str = f"x{parton_name}(x)"
+        # Ask the xplotting grid if it has something to add:
+        final_str = self.firstgrid.process_label(base_str)
+
+        # Wrap it in latex
+        return f"${final_str}$"
 
     def get_title(self, parton_name):
         return f"${parton_name}$ at {self.Q} GeV"

--- a/validphys2/src/validphys/pdfplots.py
+++ b/validphys2/src/validphys/pdfplots.py
@@ -532,6 +532,37 @@ def plot_pdfs(
         legend_stat_labels=legend_stat_labels,
     )
 
+@figuregen
+@check_pdf_normalize_to
+@check_pdfs_noband
+@check_scale("xscale", allow_none=True)
+def plot_pdfs_kinetic_energy(
+    pdfs,
+    kinetic_xplotting_grids,
+    xscale: (str, type(None)) = None,
+    normalize_to: (int, str, type(None)) = None,
+    ymin=None,
+    ymax=None,
+    pdfs_noband: (list, type(None)) = None,
+    show_mc_errors: bool = True,
+    legend_stat_labels: bool = True,
+):
+    """Band plotting of the "kinetic energy" of the PDF as a function of x for a given value of Q.
+    The input of this function is similar to those of ``plot_pdfs``.
+    """
+    yield from BandPDFPlotter(
+        pdfs,
+        kinetic_xplotting_grids,
+        xscale,
+        normalize_to,
+        ymin,
+        ymax,
+        pdfs_noband=pdfs_noband,
+        show_mc_errors=show_mc_errors,
+        legend_stat_labels=legend_stat_labels,
+    )
+
+
 class FlavoursPlotter(AllFlavoursPlotter, BandPDFPlotter):
     def get_title(self, parton_name):
         return f'{self.pdfs[0]} Q={self.Q : .1f} GeV'

--- a/validphys2/src/validphys/pdfplots.py
+++ b/validphys2/src/validphys/pdfplots.py
@@ -221,6 +221,30 @@ def plot_pdfreplicas(pdfs, xplotting_grids, xscale:(str,type(None))=None,
                                  xscale=xscale, normalize_to=normalize_to, ymin=ymin, ymax=ymax)
 
 
+@figuregen
+@check_pdf_normalize_to
+@check_scale('xscale', allow_none=True)
+@_warn_any_pdf_not_montecarlo
+def plot_pdfreplicas_kinetic_energy(
+    pdfs,
+    kinetic_xplotting_grids,
+    xscale: (str, type(None)) = None,
+    normalize_to: (int, str, type(None)) = None,
+    ymin=None,
+    ymax=None,
+):
+    """Plot the kinetic energy of the replicas of the specified PDFs.
+    Otherise it works the same as ``plot_pdfs_kinetic_energy``.
+    """
+    yield from ReplicaPDFPlotter(
+        pdfs=pdfs,
+        xplotting_grids=kinetic_xplotting_grids,
+        xscale=xscale,
+        normalize_to=normalize_to,
+        ymin=ymin,
+        ymax=ymax,
+    )
+
 class UncertaintyPDFPlotter(PDFPlotter):
 
     def get_ylabel(self, parton_name):


### PR DESCRIPTION
This PR adds the kinetic energy of the PDF as two new actions:

```
plot_pdfs_kinetic_energy
plot_pdfreplicas_kinetic_energy
```

Example of a resulting report: https://vp.nnpdf.science/IixzVlnyQX2wi9ACRPeniQ==/

I'm using #1605 to get the derivative and then these create the kinetic energy PDF.

To get the correct label I've added a `process_label` method to the `XPlottingGrid` which the PDFPlotter will call before generating the `ylabel`. This is quite generic so it might be helpful for future things.

The addition of `KineticXPlottingGrid` just to get a label might be too much though but I am not sure how to do it more cleanly.