### PR TITLE
Mix bands and replicas

### DIFF
--- a/validphys2/examples/mixbandreplicas.yaml
+++ b/validphys2/examples/mixbandreplicas.yaml
@@ -8,7 +8,7 @@ pdfs:
 - {id: NNPDF40_nnlo_as_01180, label: NNLO}
 - {id: NNPDF40_nlo_as_01180, label: NLO}
 
-pdfs_plot_replicas: [2,]
+mixband_as_replicas: [2,]
 basis: flavour
 xscale: log
 npoints: 20

--- a/validphys2/examples/mixbandreplicas.yaml
+++ b/validphys2/examples/mixbandreplicas.yaml
@@ -1,0 +1,23 @@
+meta:
+  title: Example for mixing bands and replicas
+  author: The Creator
+  keywords: [replicas, bands, mix]
+
+Q: 1.7
+pdfs:
+- {id: NNPDF40_nnlo_as_01180, label: NNLO}
+- {id: NNPDF40_nlo_as_01180, label: NLO}
+
+pdfs_plot_replicas: [2,]
+basis: flavour
+xscale: log
+npoints: 20
+template_text: |
+  Plots
+  --------------
+
+  {@plot_pdfs_mixed@}
+  {@plot_pdfs_mixed_kinetic_energy@}
+actions_:
+- report(main=True)
+

--- a/validphys2/src/validphys/checks.py
+++ b/validphys2/src/validphys/checks.py
@@ -231,43 +231,43 @@ def check_pdfs_noband(pdfs, pdfs_noband):
 
 
 @make_argcheck
-def check_pdfs_plot_replicas(pdfs, pdfs_plot_replicas):
-    """Same as check_pdfs_noband, but for the pdfs_plot_replicas key.
-    Allows pdfs_plot_replicas to be specified as a list of PDF IDs or a list of
+def check_mixband_as_replicas(pdfs, mixband_as_replicas):
+    """Same as check_pdfs_noband, but for the mixband_as_replicas key.
+    Allows mixband_as_replicas to be specified as a list of PDF IDs or a list of
     PDF indexes (starting from one)."""
 
-    msg = ("pdfs_plot_replicas should be a list of PDF IDs (strings) or a list of "
+    msg = ("mixband_as_replicas should be a list of PDF IDs (strings) or a list of "
            "PDF indexes (integers, starting from one)")
-    msg_range = ("At least one of the choices in pdfs_plot_replicas indexes is out of range. "
+    msg_range = ("At least one of the choices in mixband_as_replicas indexes is out of range. "
                  "Note that pdf_noband indexing starts at 1, not 0.")
 
-    if pdfs_plot_replicas is None:
-        return {'pdfs_plot_replicas': []}
+    if mixband_as_replicas is None:
+        return {'mixband_as_replicas': []}
 
     names = [pdf.name for pdf in pdfs]
     # A list to which PDF IDs can be added, when the PDF is specified by either
     # its PDF ID (i.e. a string) or an index (i.e. an int)
-    pdfs_plot_replicas_combined = []
+    mixband_as_replicas_combined = []
 
-    for pdf_noband in pdfs_plot_replicas:
+    for pdf_noband in mixband_as_replicas:
         if isinstance(pdf_noband, int):
             if not pdf_noband <= len(names) or pdf_noband < 0:
                 raise CheckError(msg_range)
             # Convert PDF index to list index (i.e. starting from zero)
             pdf_noband -= 1
-            pdfs_plot_replicas_combined.append(pdfs[pdf_noband])
+            mixband_as_replicas_combined.append(pdfs[pdf_noband])
 
         elif isinstance(pdf_noband, str):
             try:
                 pdf_index = names.index(pdf_noband)
-                pdfs_plot_replicas_combined.append(pdfs[pdf_index])
+                mixband_as_replicas_combined.append(pdfs[pdf_index])
             except ValueError:
                 raise CheckError(msg, pdf_noband, alternatives=names)
 
         else:
             raise CheckError(msg)
 
-    return {'pdfs_plot_replicas': pdfs_plot_replicas_combined}
+    return {'mixband_as_replicas': mixband_as_replicas_combined}
 
 def _check_list_different(l, name):
     strs = [str(item) for item in l]

--- a/validphys2/src/validphys/checks.py
+++ b/validphys2/src/validphys/checks.py
@@ -238,11 +238,11 @@ def check_pdfs_plot_replicas(pdfs, pdfs_plot_replicas):
 
     msg = ("pdfs_plot_replicas should be a list of PDF IDs (strings) or a list of "
            "PDF indexes (integers, starting from one)")
-    msg_range = ("At least one of your pdf_noband indexes is out of range. "
+    msg_range = ("At least one of the choices in pdfs_plot_replicas indexes is out of range. "
                  "Note that pdf_noband indexing starts at 1, not 0.")
 
     if pdfs_plot_replicas is None:
-        return
+        return {'pdfs_plot_replicas': []}
 
     names = [pdf.name for pdf in pdfs]
     # A list to which PDF IDs can be added, when the PDF is specified by either

--- a/validphys2/src/validphys/checks.py
+++ b/validphys2/src/validphys/checks.py
@@ -230,6 +230,45 @@ def check_pdfs_noband(pdfs, pdfs_noband):
     return {'pdfs_noband': pdfs_noband_combined}
 
 
+@make_argcheck
+def check_pdfs_plot_replicas(pdfs, pdfs_plot_replicas):
+    """Same as check_pdfs_noband, but for the pdfs_plot_replicas key.
+    Allows pdfs_plot_replicas to be specified as a list of PDF IDs or a list of
+    PDF indexes (starting from one)."""
+
+    msg = ("pdfs_plot_replicas should be a list of PDF IDs (strings) or a list of "
+           "PDF indexes (integers, starting from one)")
+    msg_range = ("At least one of your pdf_noband indexes is out of range. "
+                 "Note that pdf_noband indexing starts at 1, not 0.")
+
+    if pdfs_plot_replicas is None:
+        return
+
+    names = [pdf.name for pdf in pdfs]
+    # A list to which PDF IDs can be added, when the PDF is specified by either
+    # its PDF ID (i.e. a string) or an index (i.e. an int)
+    pdfs_plot_replicas_combined = []
+
+    for pdf_noband in pdfs_plot_replicas:
+        if isinstance(pdf_noband, int):
+            if not pdf_noband <= len(names) or pdf_noband < 0:
+                raise CheckError(msg_range)
+            # Convert PDF index to list index (i.e. starting from zero)
+            pdf_noband -= 1
+            pdfs_plot_replicas_combined.append(pdfs[pdf_noband])
+
+        elif isinstance(pdf_noband, str):
+            try:
+                pdf_index = names.index(pdf_noband)
+                pdfs_plot_replicas_combined.append(pdfs[pdf_index])
+            except ValueError:
+                raise CheckError(msg, pdf_noband, alternatives=names)
+
+        else:
+            raise CheckError(msg)
+
+    return {'pdfs_plot_replicas': pdfs_plot_replicas_combined}
+
 def _check_list_different(l, name):
     strs = [str(item) for item in l]
     if not len(set(strs))==len(l):

--- a/validphys2/src/validphys/pdfplots.py
+++ b/validphys2/src/validphys/pdfplots.py
@@ -198,9 +198,9 @@ class ReplicaPDFPlotter(PDFPlotter):
         gv = stats.data
         ax.plot(grid.xgrid, gv.T, alpha=0.2, linewidth=0.5,
                 color=color, zorder=1)
-        cv_line,  = ax.plot(grid.xgrid[0:1], stats.central_value()[0:1], color=color,
-                linewidth=2)
-        handle = cv_line
+        cv_line = ax.plot(grid.xgrid[0:1], stats.central_value()[0:1], 
+                color=color, linewidth=2)
+        handle = cv_line[0]
         labels.append(pdf.label)
         handles.append(handle)
         return gv

--- a/validphys2/src/validphys/pdfplots.py
+++ b/validphys2/src/validphys/pdfplots.py
@@ -189,7 +189,6 @@ def _warn_any_pdf_not_montecarlo(pdfs):
 
 class ReplicaPDFPlotter(PDFPlotter):
     def draw(self, pdf, grid, flstate):
-        ax = flstate.ax
         labels = flstate.labels
         handles = flstate.handles
         ax = flstate.ax

--- a/validphys2/src/validphys/pdfplots.py
+++ b/validphys2/src/validphys/pdfplots.py
@@ -1052,6 +1052,9 @@ class MixMatchPDFPlotter(BandPDFPlotter, ReplicaPDFPlotter):
     Practical use: plot together the PDF central values with the NNPDF bands
     """
     def draw(self, pdf, grid, flstate):
+        # small values corresponding to charm result in a +1 placed on top of
+        # the y-axis if axes.formatter.useoffset is not False
+        plt.rcParams['axes.formatter.useoffset'] = False 
         if pdf.label.startswith("HOP"):
             # Go then to the draw method of ReplicaPDFPlotter
             return super(BandPDFPlotter, self).draw(pdf, grid, flstate)

--- a/validphys2/src/validphys/pdfplots.py
+++ b/validphys2/src/validphys/pdfplots.py
@@ -43,7 +43,7 @@ class PDFPlotter(metaclass=abc.ABCMeta):
     explicitly as arguments.
     """
 
-    def __init__(self, pdfs, xplotting_grids, xscale, normalize_to, ymin, ymax, pdfs_plot_replicas):
+    def __init__(self, pdfs, xplotting_grids, xscale, normalize_to, ymin, ymax):
         self.pdfs = pdfs
         self._xplotting_grids = xplotting_grids
         self._xscale = xscale
@@ -51,7 +51,6 @@ class PDFPlotter(metaclass=abc.ABCMeta):
         self.xplotting_grids = self.normalize()
         self.ymin = ymin
         self.ymax = ymax
-        self.pdfs_plot_replicas = pdfs_plot_replicas
 
     def setup_flavour(self, flstate):
         flstate.handles=[]
@@ -1133,6 +1132,10 @@ class MixMatchPDFPlotter(ReplicaPDFPlotter, BandPDFPlotter):
     depending on the type of PDF.
     Practical use: plot together the PDF central values with the NNPDF bands
     """
+    def __init__(self, *args, pdfs_plot_replicas, **kwargs):
+        self.pdfs_plot_replicas = pdfs_plot_replicas
+        super().__init__(*args, **kwargs)
+    
     def draw(self, pdf, grid, flstate):
         if pdf in self.pdfs_plot_replicas:
             # Go then to the draw method of ReplicaPDFPlotter

--- a/validphys2/src/validphys/pdfplots.py
+++ b/validphys2/src/validphys/pdfplots.py
@@ -196,7 +196,7 @@ class ReplicaPDFPlotter(PDFPlotter):
         gv = stats.data
         ax.plot(grid.xgrid, gv.T, alpha=0.2, linewidth=0.5,
                 color=color, zorder=1)
-        ax.plot(grid.xgrid, stats.central_value(), color=color,
+        ax.plot(grid.xgrid[0:1], stats.central_value()[0:1], color=color,
                 linewidth=2,
                 label=pdf.label)
         return gv
@@ -543,7 +543,7 @@ def plot_pdfs(
     legend_stat_labels (bool): Show detailed information on what kind of confidence
     interval is being plotted in the legend labels.
     """
-    yield from BandPDFPlotter(
+    yield from MixMatchPDFPlotter(
         pdfs,
         xplotting_grids,
         xscale,
@@ -1044,3 +1044,15 @@ def plot_lumi2d_uncertainty(pdf, lumi_channel, lumigrid2d, sqrts:numbers.Real):
     ax.grid(False)
 
     return fig
+
+
+class MixMatchPDFPlotter(BandPDFPlotter, ReplicaPDFPlotter):
+    """Special wrapper class to plot, in the same figure, PDF bands and PDF replicas
+    depending on the type of PDF.
+    Practical use: plot together the PDF central values with the NNPDF bands
+    """
+    def draw(self, pdf, grid, flstate):
+        if pdf.label.startswith("HOP"):
+            # Go then to the draw method of ReplicaPDFPlotter
+            return super(BandPDFPlotter, self).draw(pdf, grid, flstate)
+        return super().draw(pdf, grid, flstate)

--- a/validphys2/src/validphys/pdfplots.py
+++ b/validphys2/src/validphys/pdfplots.py
@@ -25,7 +25,7 @@ from validphys.core import MCStats
 from validphys.gridvalues import LUMI_CHANNELS
 from validphys.utils import scale_from_grid
 from validphys.checks import check_pdf_normalize_to, check_scale, check_have_two_pdfs
-from validphys.checks import check_pdfs_noband, check_pdfs_plot_replicas
+from validphys.checks import check_pdfs_noband, check_mixband_as_replicas
 
 log = logging.getLogger(__name__)
 
@@ -529,7 +529,7 @@ def plot_pdfs(
 
 @figuregen
 @check_pdf_normalize_to
-@check_pdfs_plot_replicas
+@check_mixband_as_replicas
 @check_pdfs_noband
 @check_scale("xscale", allow_none=True)
 def plot_pdfs_mixed(
@@ -542,22 +542,22 @@ def plot_pdfs_mixed(
     pdfs_noband: (list, type(None)) = None,
     show_mc_errors: bool = True,
     legend_stat_labels: bool = True,
-    pdfs_plot_replicas: (list, type(None)) = None,
+    mixband_as_replicas: (list, type(None)) = None,
 ):
     """This function is similar to plot_pdfs, except instead of only plotting
     the central value and the uncertainty of the PDFs, those PDFs indicated by
-    pdfs_plot_replicas will be plotted as replicas without the central value.
+    mixband_as_replicas will be plotted as replicas without the central value.
 
-    Inputs are the same as plot_pdfs, with the exeption of pdfs_plot_replicas,
+    Inputs are the same as plot_pdfs, with the exeption of mixband_as_replicas,
     which only exists here.
 
-    pdfs_plot_replicas: A list of PDFs to plot as replicas, i.e. the
+    mixband_as_replicas: A list of PDFs to plot as replicas, i.e. the
     central values and replicas of these PDFs will be plotted. The list can be
     formed of strings, corresponding to PDF IDs, integers (starting from one),
     corresponding to the index of the PDF in the list of PDFs, or a mixture
     of both.
     """
-    yield from MixMatchPDFPlotter(
+    yield from MixBandPDFPlotter(
         pdfs,
         xplotting_grids,
         xscale,
@@ -567,7 +567,7 @@ def plot_pdfs_mixed(
         pdfs_noband=pdfs_noband,
         show_mc_errors=show_mc_errors,
         legend_stat_labels=legend_stat_labels,
-        pdfs_plot_replicas=pdfs_plot_replicas,
+        mixband_as_replicas=mixband_as_replicas,
     )
 
 
@@ -630,7 +630,7 @@ def plot_pdfreplicas_kinetic_energy(
 @figuregen
 @check_pdf_normalize_to
 @check_pdfs_noband
-@check_pdfs_plot_replicas
+@check_mixband_as_replicas
 @check_scale("xscale", allow_none=True)
 def plot_pdfs_mixed_kinetic_energy(
     pdfs,
@@ -642,7 +642,7 @@ def plot_pdfs_mixed_kinetic_energy(
     pdfs_noband: (list, type(None)) = None,
     show_mc_errors: bool = True,
     legend_stat_labels: bool = True,
-    pdfs_plot_replicas: (list, type(None)) = None,
+    mixband_as_replicas: (list, type(None)) = None,
 ):
     """Mixed band and replica plotting of the "kinetic energy" of the PDF as a
     function of x for a given value of Q.
@@ -657,7 +657,7 @@ def plot_pdfs_mixed_kinetic_energy(
         pdfs_noband=pdfs_noband,
         show_mc_errors=show_mc_errors,
         legend_stat_labels=legend_stat_labels,
-        pdfs_plot_replicas=pdfs_plot_replicas,
+        mixband_as_replicas=mixband_as_replicas,
     )
 
 
@@ -1120,17 +1120,17 @@ def plot_lumi2d_uncertainty(pdf, lumi_channel, lumigrid2d, sqrts:numbers.Real):
     return fig
 
 
-class MixMatchPDFPlotter(BandPDFPlotter):
+class MixBandPDFPlotter(BandPDFPlotter):
     """Special wrapper class to plot, in the same figure, PDF bands and PDF replicas
     depending on the type of PDF.
     Practical use: plot together the PDF central values with the NNPDF bands
     """
-    def __init__(self, *args, pdfs_plot_replicas, **kwargs):
-        self.pdfs_plot_replicas = pdfs_plot_replicas
+    def __init__(self, *args, mixband_as_replicas, **kwargs):
+        self.mixband_as_replicas = mixband_as_replicas
         super().__init__(*args, **kwargs)
 
     def draw(self, pdf, grid, flstate):
-        if pdf in self.pdfs_plot_replicas:
+        if pdf in self.mixband_as_replicas:
             labels = flstate.labels
             handles = flstate.handles
             ax = flstate.ax


### PR DESCRIPTION
Uses #1605 and #1606

Since the hopscotch replicas are single PDFs but we want to compare them to the "true" NNPDF we need to somehow be able to see in a single plot the hopscotch PDFs and the NNPDF bands. This is what I've come up with:



You might notice there is no label for the replicas, cannot see how to make them cross-talk (the bands and the replicas) but I don't think we will want to have this in the core code anyway? Or do we?

I've also removed the "central replica" since it makes no sense for the hopscotchy ones https://vp.nnpdf.science/avVrWwjGTsOtYFh1n5j66A==/