### PR TITLE
Prevent offset in plot axis values

### DIFF
--- a/validphys2/src/validphys/mplstyles/biglabels.mplstyle
+++ b/validphys2/src/validphys/mplstyles/biglabels.mplstyle
@@ -6,6 +6,7 @@ axes.formatter.limits   : -5,5
 axes.formatter.use_mathtext : True
 axes.spines.top         : False
 axes.spines.right       : False
+axes.formatter.useoffset: False
 
 errorbar.capsize        : 2
 

--- a/validphys2/src/validphys/mplstyles/small.mplstyle
+++ b/validphys2/src/validphys/mplstyles/small.mplstyle
@@ -6,6 +6,7 @@ axes.formatter.limits   : -5,5
 axes.formatter.use_mathtext : True
 axes.spines.top         : False
 axes.spines.right       : False
+axes.formatter.useoffset: False
 
 errorbar.capsize        : 2
 


### PR DESCRIPTION
Set axes.formatter.useoffset to False in the .mplstyle files as per https://github.com/NNPDF/nnpdf/pull/1607#discussion_r985610198