### PR TITLE
Fix overfitmetric in comparefits

### DIFF
--- a/validphys2/src/validphys/checks.py
+++ b/validphys2/src/validphys/checks.py
@@ -154,11 +154,10 @@ def check_have_two_pdfs(pdfs):
 
 
 @make_argcheck
-def check_at_least_two_replicas(pdfs):
-    for pdf in pdfs:
-        # The get_members function also includes the central value replica, 
-        # therefore we need it to be larger than 3
-        check(pdf.get_members() >= 3,'Expecting at least two replicas.')
+def check_at_least_two_replicas(pdf):
+    # The get_members function also includes the central value replica,
+    # therefore we need it to be larger than 3
+    check(pdf.get_members() >= 3,'Expecting at least two replicas.')
 
 
 #The indexing to one instead of zero is so that we can be consistent with

--- a/validphys2/src/validphys/comparefittemplates/comparecard.yaml
+++ b/validphys2/src/validphys/comparefittemplates/comparecard.yaml
@@ -129,6 +129,13 @@ dataspecs:
     speclabel:
       from_: reference
 
+t0_info:
+  - use_t0: True
+    datacuts:
+      from_: fit
+    t0pdfset:
+      from_: datacuts
+
 Normalize:
   normalize_to: 2
 
@@ -141,36 +148,6 @@ DataGroups:
 
 ProcessGroup:
     metadata_group: nnpdf31_process
-
-overfitmetric:
-  - use_t0: True
-    fit:
-      from_: reference
-    datacuts:
-      from_: fit
-    t0pdfset:
-      from_: datacuts
-    theory:
-        from_: fit
-    theoryid:
-        from_: theory
-    pdfs:
-      - from_: fit
-
-  - use_t0: True
-    fit:
-      from_: current
-    datacuts:
-      from_: fit
-    t0pdfset:
-      from_: datacuts
-    theory:
-        from_: fit
-    theoryid:
-        from_: theory
-    pdfs:
-      - from_: fit
-
 
 actions_:
   - report(main=true)

--- a/validphys2/src/validphys/comparefittemplates/comparecard.yaml
+++ b/validphys2/src/validphys/comparefittemplates/comparecard.yaml
@@ -154,6 +154,8 @@ overfitmetric:
         from_: fit
     theoryid:
         from_: theory
+    pdfs:
+      - from_: fit
 
   - use_t0: True
     fit:
@@ -166,6 +168,8 @@ overfitmetric:
         from_: fit
     theoryid:
         from_: theory
+    pdfs:
+      - from_: fit
 
 
 actions_:

--- a/validphys2/src/validphys/comparefittemplates/report.md
+++ b/validphys2/src/validphys/comparefittemplates/report.md
@@ -71,9 +71,9 @@ Training lengths
 
 Overfit measure
 ----------------
-{@with overfitmetric@}
-{@plot_overfitting_histogram@}
-{@fit_overfitting_summary@}
+{@with dataspecs::t0_info@}
+{@t0_info plot_overfitting_histogram@}
+{@t0_info fit_overfitting_summary@}
 {@endwith@}
 
 

--- a/validphys2/src/validphys/overfit_metric.py
+++ b/validphys2/src/validphys/overfit_metric.py
@@ -181,19 +181,21 @@ def plot_overfitting_histogram(fit, array_expected_overfitting):
 
     f, ax = plt.subplots(1, 1)
 
-    ax.hist(array_expected_overfitting, bins=50, density=True)
-    ax.axvline(x=mean, color="black")
-    ax.axvline(x=0, color="black", linestyle="--")
-    xrange = [
-        array_expected_overfitting.min(),
-        array_expected_overfitting.max(),
-    ]
-    xgrid = np.linspace(xrange[0], xrange[1], num=100)
-    ax.plot(xgrid, stats.norm.pdf(xgrid, mean, std))
-    ax.set_xlabel(r"$\mathcal{R}_O$")
-    ax.set_ylabel("density")
-    ax.set_title(f"{fit.label}")
-    plt.tight_layout()
+    # if array_expected_overfitting is nan it should not produce a histogram
+    if (array_expected_overfitting == array_expected_overfitting).all():
+        ax.hist(array_expected_overfitting, bins=50, density=True)
+        ax.axvline(x=mean, color="black")
+        ax.axvline(x=0, color="black", linestyle="--")
+        xrange = [
+            array_expected_overfitting.min(),
+            array_expected_overfitting.max(),
+        ]
+        xgrid = np.linspace(xrange[0], xrange[1], num=100)
+        ax.plot(xgrid, stats.norm.pdf(xgrid, mean, std))
+        ax.set_xlabel(r"$\mathcal{R}_O$")
+        ax.set_ylabel("density")
+        ax.set_title(f"{fit.label}")
+        plt.tight_layout()
     return f
 
 

--- a/validphys2/src/validphys/overfit_metric.py
+++ b/validphys2/src/validphys/overfit_metric.py
@@ -20,14 +20,7 @@ from validphys.checks import check_at_least_two_replicas
 
 log = logging.getLogger(__name__)
 
-preds = collect(
-    "predictions",
-    (
-        "pdfs",
-        "dataset_inputs",
-    ),
-)
-
+preds = collect("predictions",("dataset_inputs",))
 
 def _create_new_val_pseudodata(pdf_data_index, fit_data_indices_list):
     """Loads all validation pseudodata replicas used during the fiting of the

--- a/validphys2/src/validphys/overfit_metric.py
+++ b/validphys2/src/validphys/overfit_metric.py
@@ -105,6 +105,7 @@ def calculate_chi2s_per_replica(
 
 
 def array_expected_overfitting(
+    fit_code_version,
     calculate_chi2s_per_replica,
     replica_data,
     number_of_resamples=1000,
@@ -137,22 +138,30 @@ def array_expected_overfitting(
         (number_of_resamples*Npdfs,) sized array containing the mean delta chi2
         values per resampled list.
     """
-    fitted_val_erf = np.array([info.validation for info in replica_data])
+    fit_name = fit_code_version.columns[0]
+    nnpdf_version = fit_code_version[fit_name]['nnpdf']
+    if nnpdf_version>='4.0.5':
 
-    number_pdfs = calculate_chi2s_per_replica.shape[0]
-    list_expected_overfitting = []
-    for _ in range(number_pdfs * number_of_resamples):
-        mask = np.random.randint(
-            0, number_pdfs, size=int(resampling_fraction * number_pdfs)
-        )
-        res_tmp = calculate_chi2s_per_replica[mask][:, mask]
+        fitted_val_erf = np.array([info.validation for info in replica_data])
 
-        fitted_val_erf_tmp = fitted_val_erf[mask]
-        expected_val_chi2 = res_tmp.mean(axis=0)
-        delta_chi2 = fitted_val_erf_tmp - expected_val_chi2
-        expected_delta_chi2 = delta_chi2.mean()
+        number_pdfs = calculate_chi2s_per_replica.shape[0]
+        list_expected_overfitting = []
+        for _ in range(number_pdfs * number_of_resamples):
+            mask = np.random.randint(
+                0, number_pdfs, size=int(resampling_fraction * number_pdfs)
+            )
+            res_tmp = calculate_chi2s_per_replica[mask][:, mask]
 
-        list_expected_overfitting.append(expected_delta_chi2)
+            fitted_val_erf_tmp = fitted_val_erf[mask]
+            expected_val_chi2 = res_tmp.mean(axis=0)
+            delta_chi2 = fitted_val_erf_tmp - expected_val_chi2
+            expected_delta_chi2 = delta_chi2.mean()
+
+            list_expected_overfitting.append(expected_delta_chi2)
+    else:
+        log.warning(f"""Since {fit_name} pseudodata generation has changed,
+            hence the overfit metric cannot be determined.""")
+        list_expected_overfitting = np.array([0])
     return np.array(list_expected_overfitting)
 
 

--- a/validphys2/src/validphys/overfit_metric.py
+++ b/validphys2/src/validphys/overfit_metric.py
@@ -109,7 +109,7 @@ def calculate_chi2s_per_replica(
     else:
         log.warning(f"""Since {fit_name} pseudodata generation has changed,
             hence the overfit metric cannot be determined.""")
-        ret = np.array([0])
+        ret = np.array(np.nan)
 
     return ret
 
@@ -147,10 +147,10 @@ def array_expected_overfitting(
         (number_of_resamples*Npdfs,) sized array containing the mean delta chi2
         values per resampled list.
     """
-    # calculate_chi2s_per_replica is set to zero if the pseudodata generation 
+    # calculate_chi2s_per_replica is set to NaN if the pseudodata generation 
     # has changed sinc the fit has been performed. As a result the overfitting
     # metric can no longer be determined.
-    if (calculate_chi2s_per_replica == 0).all():
+    if (calculate_chi2s_per_replica != calculate_chi2s_per_replica).all():
         list_expected_overfitting = calculate_chi2s_per_replica
     else:
         fitted_val_erf = np.array([info.validation for info in replica_data])

--- a/validphys2/src/validphys/overfit_metric.py
+++ b/validphys2/src/validphys/overfit_metric.py
@@ -147,7 +147,12 @@ def array_expected_overfitting(
         (number_of_resamples*Npdfs,) sized array containing the mean delta chi2
         values per resampled list.
     """
-    if calculate_chi2s_per_replica != 0:
+    # calculate_chi2s_per_replica is set to zero if the pseudodata generation 
+    # has changed sinc the fit has been performed. As a result the overfitting
+    # metric can no longer be determined.
+    if (calculate_chi2s_per_replica == 0).all():
+        list_expected_overfitting = calculate_chi2s_per_replica
+    else:
         fitted_val_erf = np.array([info.validation for info in replica_data])
 
         number_pdfs = calculate_chi2s_per_replica.shape[0]
@@ -164,8 +169,6 @@ def array_expected_overfitting(
             expected_delta_chi2 = delta_chi2.mean()
 
             list_expected_overfitting.append(expected_delta_chi2)
-    else:
-        list_expected_overfitting = calculate_chi2s_per_replica
     return np.array(list_expected_overfitting)
 
 

--- a/validphys2/src/validphys/tests/test_overfit_metric.py
+++ b/validphys2/src/validphys/tests/test_overfit_metric.py
@@ -15,7 +15,7 @@ config = {
     "theoryid": {"from_": "theory"},
     "datacuts": {"from_": "fit"},
     "t0pdfset": {"from_": "datacuts"},
-    "pdfs": [{"from_": "fit"}],
+    "pdf": {"from_": "fit"},
     "dataset_inputs": {"from_": "fit"},
 }
 


### PR DESCRIPTION
I think due to this collect here
https://github.com/NNPDF/nnpdf/blob/ec6cbaf972240de035b60e5321a4c406e36f78da/validphys2/src/validphys/overfit_metric.py#L23

The overfit metric in the comparefits report gets all predictions from both pdf, i..e, in this function
 https://github.com/NNPDF/nnpdf/blob/ec6cbaf972240de035b60e5321a4c406e36f78da/validphys2/src/validphys/overfit_metric.py#L51

preds is not just a prediction per dataset per replica but the union of what should be preds for both PDFs.

In other words, `preds` is a list of size datasets*2 where the first half are the predictions for one PDF and the second one for the other. The `current` comes first so if the `current` fit has more replicas than the `reference` it will work, but the result for he `reference` will probably be wrong.

This is very obvious if one tries to do a comparefits in which both PDF have a different number of replicas (and crucially, the `current` one has less than the `reference`) because it will fail. 

Note: a better fix would be to modify the offending functions, but I wanted to have something working, so my fix has been overwrite the `pdfs` of the `comparefits` report.