### PR TITLE
New make replica

### DIFF
--- a/validphys2/src/validphys/config.py
+++ b/validphys2/src/validphys/config.py
@@ -773,6 +773,17 @@ class CoreConfig(configparser.Config):
                 else:
                     return covmats.dataset_inputs_exp_covmat
 
+    @configparser.explicit_node
+    def produce_dataset_inputs_sampling_covmat_eigs(
+        self
+    ):
+        """
+        Produces the diagonalization of the sampling covmat to be used in new
+        approach to make_replica.
+        """
+        from validphys import covmats_utils
+        return covmats_utils.diagonalize_sampling_covmat
+
     def produce_loaded_theory_covmat(
         self,
         output_path,

--- a/validphys2/src/validphys/covmats_utils.py
+++ b/validphys2/src/validphys/covmats_utils.py
@@ -8,6 +8,7 @@ actions/providers.
 """
 import numpy as np
 import pandas as pd
+import scipy.linalg as la
 
 def systematics_matrix(stat_errors: np.array, sys_errors: pd.DataFrame):
     """Basic function to create a systematics matrix , :math:`A`, such that:
@@ -85,3 +86,8 @@ def construct_covmat(stat_errors: np.array, sys_errors: pd.DataFrame):
 
     corr_sys_mat = sys_errors.loc[:, ~is_uncorr].to_numpy()
     return np.diag(diagonal) + corr_sys_mat @ corr_sys_mat.T
+
+def diagonalize_sampling_covmat(
+    dataset_inputs_sampling_covmat
+):
+    return la.eig(dataset_inputs_sampling_covmat)


### PR DESCRIPTION
The main version of `make_replica` in `pseudodata.py` takes a sampling covariance matrix in input and uses its square root to generate shifts for pseudodata. This is done through `sqrt_covmat` in `covmats.py` by calling a Cholesky decomposition method from `scipy.linalg` module.
The new version of `make_replica` will take as input only the eigenvalues and eigenvectors and will calculate the square root of the covariance matrix without using the `scipy` module. This is done under the assumption that another scipy module, `scipy.linalg.eig`, returns a orthogonal (or unitary) base change. Let $C$ be the covmat: it follows that $C=UDU^T$, when $D$ is diagonal and $U$ is the eigenvector matrix. Since $D$ is diagonal and $C$ is positive definite, we can write $C=UD^{1/2}D^{1/2}U^T=UD^{1/2}(UD^{1/2})^T$ and therefore $UD^{1/2}$ is a Cholesky decomposition, i.e. a square root of $C$.

I have tested the two methodologies with a level 2 closure test [here](https://vp.nnpdf.science/Bx1JXmgeR6yGwkpICmOIaQ==/) (the fits are also uploaded on the server). Is there another way of testing the right behavior of the new approach? I also would like to know if this would give problems elsewhere.