### PR TITLE
Use theory 400 for the fit bot

### DIFF
--- a/n3fit/runcards/examples/developing.yml
+++ b/n3fit/runcards/examples/developing.yml
@@ -60,7 +60,7 @@ datacuts:
 
 ############################################################
 theory:
-  theoryid: 200        # database id
+  theoryid: 400        # database id
 
 sampling:
   use_t0: false


### PR DESCRIPTION
Since pineappl will soon become the default and main provider for fktable, the fit bot should be testing with theory 400.

We might need to create a theory specific for this since theory 400 has a very large number of points and I don't have a feeling of how much memory it will take.

It might also be a good idea to retain a "fitbot-legacy" in order to check that a fit with theory 200 also works.