### PR TITLE
Simplify MetaModel input handling

### DIFF
--- a/n3fit/src/n3fit/hyper_optimization/penalties.py
+++ b/n3fit/src/n3fit/hyper_optimization/penalties.py
@@ -45,7 +45,7 @@ def saturation(pdf_models=None, n=100, min_x=1e-6, max_x=1e-4, flavors=None, **_
     >>> from n3fit.model_gen import pdfNN_layer_generator
     >>> fake_fl = [{'fl' : i, 'largex' : [0,1], 'smallx': [1,2]} for i in ['u', 'ubar', 'd', 'dbar', 'c', 'cbar', 's', 'sbar']]
     >>> pdf_model = pdfNN_layer_generator(nodes=[8], activations=['linear'], seed=0, flav_info=fake_fl)
-    >>> isinstance(saturation([pdf_model], None), float)
+    >>> isinstance(saturation(pdf_model, 5), float)
     True
 
     """
@@ -55,7 +55,7 @@ def saturation(pdf_models=None, n=100, min_x=1e-6, max_x=1e-4, flavors=None, **_
     xin = np.expand_dims(x, axis=[0, -1])
     extra_loss = 0.0
     for pdf_model in pdf_models:
-        y = pdf_model.predict([xin])
+        y = pdf_model.predict({"pdf_input": xin})
         xpdf = y[0, :, flavors]
         slope = np.diff(xpdf) / np.diff(np.log10(x))
         pen = abs(np.mean(slope, axis=1)) + np.std(slope, axis=1)

--- a/n3fit/src/n3fit/model_gen.py
+++ b/n3fit/src/n3fit/model_gen.py
@@ -552,10 +552,10 @@ def pdfNN_layer_generator(
         # create a x --> (x, logx) layer to preppend to everything
         process_input = Lambda(lambda x: op.concatenate([x, op.op_log(x)], axis=-1))
 
-    model_input = [placeholder_input]
+    model_input = {"pdf_input": placeholder_input}
     if subtract_one:
         layer_x_eq_1 = op.numpy_to_input(np.array(input_x_eq_1).reshape(1, 1))
-        model_input.append(layer_x_eq_1)
+        model_input["layer_x_eq_1"] = layer_x_eq_1
 
     # Evolution layer
     layer_evln = FkRotation(input_shape=(last_layer_nodes,), output_dim=out)
@@ -566,7 +566,7 @@ def pdfNN_layer_generator(
     # Normalization and sum rules
     if impose_sumrule:
         sumrule_layer, integrator_input = msr_impose(mode=impose_sumrule, scaler=scaler)
-        model_input.append(integrator_input)
+        model_input["integrator_input"] = integrator_input
     else:
         sumrule_layer = lambda x: x
 

--- a/n3fit/src/n3fit/model_trainer.py
+++ b/n3fit/src/n3fit/model_trainer.py
@@ -363,7 +363,7 @@ class ModelTrainer:
         for pdf_model in pdf_models:
             # The input to the full model also works as the input to the PDF model
             # We apply the Model as Layers and save for later the model (full_pdf)
-            full_model_input_dict, full_pdf = pdf_model.apply_as_layer([input_layer])
+            full_model_input_dict, full_pdf = pdf_model.apply_as_layer({"pdf_input": input_layer})
 
             all_replicas_pdf.append(full_pdf)
             # Note that all models share the same symbolic input so we take as input the last

--- a/n3fit/src/n3fit/tests/test_modelgen.py
+++ b/n3fit/src/n3fit/tests/test_modelgen.py
@@ -25,7 +25,7 @@ def test_generate_dense_network():
     curr_layer = input_layer
     for layer in layers:
         curr_layer = layer(curr_layer)
-    modelito = MetaModel(input_layer, curr_layer)
+    modelito = MetaModel({"input": input_layer}, curr_layer)
     # The number of layers should be input layer + len(OUT_SIZES)
     assert len(modelito.layers) == len(OUT_SIZES) + 1
     # Check that the number of parameters is as expected
@@ -55,7 +55,7 @@ def test_generate_dense_per_flavour_network():
     curr_layer = input_layer
     for layer in layers:
         curr_layer = layer(curr_layer)
-    modelito = MetaModel(input_layer, curr_layer)
+    modelito = MetaModel({"input": input_layer}, curr_layer)
     # The number of layers should be input + BASIS_SIZE*len(OUT_SIZES) + concatenate
     assert len(modelito.layers) == BASIS_SIZE * len(OUT_SIZES) + 2
     # The shape for this network of denses for flavours will depend on the basis_size

--- a/n3fit/src/n3fit/vpinterface.py
+++ b/n3fit/src/n3fit/vpinterface.py
@@ -105,12 +105,12 @@ class N3LHAPDFSet(LHAPDFSet):
 
         if replica is None or replica == 0:
             # We need generate output values for all replicas
-            result = np.concatenate([m.predict([mod_xgrid]) for m in self._lhapdf_set], axis=0)
+            result = np.concatenate([m.predict({"pdf_input": mod_xgrid}) for m in self._lhapdf_set], axis=0)
             if replica == 0:
                 # We want _only_ the central value
                 result = np.mean(result, axis=0, keepdims=True)
         else:
-            result = self._lhapdf_set[replica - 1].predict([mod_xgrid])
+            result = self._lhapdf_set[replica - 1].predict({"pdf_input": mod_xgrid})
 
         if flavours != "n3fit":
             # Ensure that the result has its flavour in the basis-defined order


### PR DESCRIPTION
Mandate that all input is passed as dictionaries. This has the advantage of doing away with a lot of code, having an obvious way to derive the name for each input (the dictionary key) and allowing for better error messages.

Closes #1624