### PR TITLE
Remove additional t0 flags

### DIFF
--- a/doc/sphinx/source/tutorials/thcov_tutorial.rst
+++ b/doc/sphinx/source/tutorials/thcov_tutorial.rst
@@ -164,11 +164,6 @@ It can be found `here <https://github.com/NNPDF/nnpdf/tree/master/validphys2/exa
 	  use_thcovmat_in_fitting: true
 	  use_thcovmat_in_sampling: true
 
-	sampling_t0:
-	  use_t0: false
-
-	fitting_t0:
-	  use_t0: true
 
 	############################################################
 	fitting:

--- a/n3fit/runcards/examples/Basic_feature_scaling.yml
+++ b/n3fit/runcards/examples/Basic_feature_scaling.yml
@@ -33,8 +33,8 @@ datacuts:
 theory:
   theoryid: 200       # database id
 sampling:
-  use_t0: false
   separate_multiplicative: true
+
 ############################################################
 trvlseed: 1
 nnseed: 2

--- a/n3fit/runcards/examples/Basic_hyperopt.yml
+++ b/n3fit/runcards/examples/Basic_hyperopt.yml
@@ -49,9 +49,7 @@ theory:
   theoryid: 200        # database id
 
 sampling:
-  use_t0: false
   separate_multiplicative: true
-
 hyperscan_config:
   stopping:
       min_epochs: 1e3

--- a/n3fit/runcards/examples/Basic_runcard.yml
+++ b/n3fit/runcards/examples/Basic_runcard.yml
@@ -34,9 +34,7 @@ theory:
   theoryid: 200       # database id
 
 sampling:
-  use_t0: false
   separate_multiplicative: true
-
 parameters: # This defines the parameter dictionary that is passed to the Model Trainer
   nodes_per_layer: [15, 10, 8]
   activation_per_layer: ['sigmoid', 'sigmoid', 'linear']

--- a/n3fit/runcards/examples/Basic_runcard_parallel.yml
+++ b/n3fit/runcards/examples/Basic_runcard_parallel.yml
@@ -35,7 +35,6 @@ theory:
   theoryid: 162        # database id
 
 sampling:
-  use_t0: false
   separate_multiplicative: true
 ############################################################
 trvlseed: 1

--- a/n3fit/runcards/examples/DIS_diagonal_l2reg_example.yml
+++ b/n3fit/runcards/examples/DIS_diagonal_l2reg_example.yml
@@ -57,9 +57,7 @@ theory:
   theoryid: 162        # database id
 
 sampling:
-  use_t0: false
   separate_multiplicative: true
-
 ############################################################
 trvlseed: 1
 nnseed: 2

--- a/n3fit/runcards/examples/Fit_with_theory_covmat.yml
+++ b/n3fit/runcards/examples/Fit_with_theory_covmat.yml
@@ -75,9 +75,6 @@ theorycovmatconfig:
   use_thcovmat_in_fitting: true
   use_thcovmat_in_sampling: true
 
-sampling:
-  use_t0: false
-  separate_multiplicative: false
 
 ############################################################
 trvlseed: 376191634

--- a/n3fit/runcards/examples/developing.yml
+++ b/n3fit/runcards/examples/developing.yml
@@ -63,9 +63,7 @@ theory:
   theoryid: 200        # database id
 
 sampling:
-  use_t0: false
   separate_multiplicative: true
-
 ############################################################
 trvlseed: 1
 nnseed: 2

--- a/n3fit/src/n3fit/scripts/n3fit_exec.py
+++ b/n3fit/src/n3fit/scripts/n3fit_exec.py
@@ -158,10 +158,8 @@ class N3FitConfig(Config):
             N3FIT_FIXED_CONFIG['use_scalevar_uncertainties'] = thconfig.get('use_scalevar_uncertainties', True) 
         #Sampling flags
         if (sam_t0:=file_content.get('sampling')) is not None:
-            N3FIT_FIXED_CONFIG['use_t0_sampling'] = sam_t0.get('use_t0', False) 
             N3FIT_FIXED_CONFIG['separate_multiplicative'] = sam_t0.get('separate_multiplicative', True) 
         #Fitting flag
-        N3FIT_FIXED_CONFIG['use_t0_fitting'] = file_content.get('fitting').get('use_t0', True)
         file_content.update(N3FIT_FIXED_CONFIG)
         return cls(file_content, *args, **kwargs)
 

--- a/validphys2/src/validphys/config.py
+++ b/validphys2/src/validphys/config.py
@@ -713,7 +713,6 @@ class CoreConfig(configparser.Config):
         self,
         theory_covmat_flag=False,
         use_thcovmat_in_fitting=False,
-        use_t0_fitting=True,
     ):
         """
         Produces the correct covmat to be used in fitting_data_dict according
@@ -723,16 +722,9 @@ class CoreConfig(configparser.Config):
         """
         from validphys import covmats
 
-        if use_t0_fitting:
-            if theory_covmat_flag and use_thcovmat_in_fitting:
-                return covmats.dataset_inputs_t0_total_covmat
-            else:
-                return covmats.dataset_inputs_t0_exp_covmat
-        else:
-            if theory_covmat_flag and use_thcovmat_in_fitting:
-                return covmats.dataset_inputs_total_covmat
-            else:
-                return covmats.dataset_inputs_exp_covmat
+        if theory_covmat_flag and use_thcovmat_in_fitting:
+            return covmats.dataset_inputs_t0_total_covmat
+        return covmats.dataset_inputs_t0_exp_covmat
 
     @configparser.explicit_node
     def produce_dataset_inputs_sampling_covmat(
@@ -740,7 +732,6 @@ class CoreConfig(configparser.Config):
         sep_mult,
         theory_covmat_flag=False,
         use_thcovmat_in_sampling=False,
-        use_t0_sampling=False,
     ):
         """
         Produces the correct covmat to be used in make_replica according
@@ -750,28 +741,16 @@ class CoreConfig(configparser.Config):
         """
         from validphys import covmats
 
-        if use_t0_sampling:
-            if theory_covmat_flag and use_thcovmat_in_sampling:
-                if sep_mult:
-                    return covmats.dataset_inputs_t0_total_covmat_separate
-                else:
-                    return covmats.dataset_inputs_t0_total_covmat
+        if theory_covmat_flag and use_thcovmat_in_sampling:
+            if sep_mult:
+                return covmats.dataset_inputs_total_covmat_separate
             else:
-                if sep_mult:
-                    return covmats.dataset_inputs_t0_exp_covmat_separate
-                else:
-                    return covmats.dataset_inputs_t0_exp_covmat
+                return covmats.dataset_inputs_total_covmat
         else:
-            if theory_covmat_flag and use_thcovmat_in_sampling:
-                if sep_mult:
-                    return covmats.dataset_inputs_total_covmat_separate
-                else:
-                    return covmats.dataset_inputs_total_covmat
+            if sep_mult:
+                return covmats.dataset_inputs_exp_covmat_separate
             else:
-                if sep_mult:
-                    return covmats.dataset_inputs_exp_covmat_separate
-                else:
-                    return covmats.dataset_inputs_exp_covmat
+                return covmats.dataset_inputs_exp_covmat
 
     def produce_loaded_theory_covmat(
         self,
@@ -1051,12 +1030,12 @@ class CoreConfig(configparser.Config):
 
     # TODO: Find a good name for this
     def produce_t0set(
-        self, t0pdfset=None, use_t0_sampling=False, use_t0_fitting=True,
+        self, t0pdfset=None, use_t0=False,
     ):
         """Return the t0set if use_t0 is True and None otherwise. Raises an
         error if t0 is requested but no t0set is given.
         """
-        if use_t0_sampling or use_t0_fitting:
+        if use_t0:
             if not t0pdfset:
                 raise ConfigError("Setting use_t0 requires specifying a valid t0pdfset")
             return t0pdfset


### PR DESCRIPTION
The work on covariance matrices added new flags to control to t0 setting, namely `use_t0_sampling` and `use_t0_fitting`. These were undocumented, and caused bugs in validphys since t0pdfset could be set by either of them.

Remove both flags and mandate that the fitting covmat always uses t0 while the sampling covmat never uses it.

This removes some footguns and its backwards compatible.

It has the minor disadvantage that the fitting covmat implicitly requires use_t0=True, which is redundant, but it only really matters in n3fit and we set the flag there anyway.