### PR TITLE
Propagate target info from the runcard

### DIFF
--- a/validphys2/src/validphys/config.py
+++ b/validphys2/src/validphys/config.py
@@ -405,7 +405,7 @@ class CoreConfig(configparser.Config):
     def parse_dataset_input(self, dataset: Mapping):
         """The mapping that corresponds to the dataset specifications in the
         fit files"""
-        known_keys = {"dataset", "sys", "cfac", "frac", "weight", "custom_group"}
+        known_keys = {"dataset", "sys", "target_info", "cfac", "frac", "weight", "custom_group"}
         try:
             name = dataset["dataset"]
             if not isinstance(name, str):
@@ -424,6 +424,7 @@ class CoreConfig(configparser.Config):
         sysnum = dataset.get("sys")
         cfac = dataset.get("cfac", tuple())
         frac = dataset.get("frac", 1)
+        target_info = dataset.get("target_info", {})
         if not isinstance(frac, numbers.Real):
             raise ConfigError(f"'frac' must be a number, not '{frac}'")
         if frac < 0 or frac > 1:
@@ -444,6 +445,7 @@ class CoreConfig(configparser.Config):
         return DataSetInput(
             name=name,
             sys=sysnum,
+            target_info=target_info,
             cfac=cfac,
             frac=frac,
             weight=weight,
@@ -621,6 +623,7 @@ class CoreConfig(configparser.Config):
         sysnum = dataset_input.sys
         cfac = dataset_input.cfac
         frac = dataset_input.frac
+        target_info = dataset_input.target_info
         weight = dataset_input.weight
 
         try:
@@ -628,6 +631,7 @@ class CoreConfig(configparser.Config):
                 name=name,
                 sysnum=sysnum,
                 theoryid=theoryid,
+                target_info=target_info,
                 cfac=cfac,
                 cuts=cuts,
                 frac=frac,

--- a/validphys2/src/validphys/core.py
+++ b/validphys2/src/validphys/core.py
@@ -324,14 +324,15 @@ class CommonDataSpec(TupleComp):
 class DataSetInput(TupleComp):
     """Represents whatever the user enters in the YAML to specify a
     dataset."""
-    def __init__(self, *, name, sys, cfac, frac, weight, custom_group):
+    def __init__(self, *, name, sys, target_info, cfac, frac, weight, custom_group):
         self.name=name
         self.sys=sys
+        self.target_info = target_info
         self.cfac = cfac
         self.frac = frac
         self.weight = weight
         self.custom_group = custom_group
-        super().__init__(name, sys, cfac, frac, weight, custom_group)
+        super().__init__(name, sys, target_info, cfac, frac, weight, custom_group)
 
     def __str__(self):
         return self.name
@@ -447,7 +448,7 @@ def cut_mask(cuts):
 class DataSetSpec(TupleComp):
 
     def __init__(self, *, name, commondata, fkspecs, thspec, cuts,
-                 frac=1, op=None, weight=1):
+                 target_info=None, frac=1, op=None, weight=1):
         self.name = name
         self.commondata = commondata
 
@@ -459,6 +460,7 @@ class DataSetSpec(TupleComp):
 
         self.cuts = cuts
         self.frac = frac
+        self.target_info = target_info
 
         #Do this way (instead of setting op='NULL' in the signature)
         #so we don't have to know the default everywhere
@@ -468,7 +470,7 @@ class DataSetSpec(TupleComp):
         self.weight = weight
 
         super().__init__(name, commondata, fkspecs, thspec, cuts,
-                         frac, op, weight)
+                         target_info, frac, op, weight)
 
     @functools.lru_cache()
     def load(self):
@@ -519,6 +521,7 @@ class DataSetSpec(TupleComp):
             fkspecs=self.fkspecs,
             thspec=self.thspec,
             cuts=self.cuts,
+            target_info=self.target_info,
             frac=self.frac,
             op=self.op,
             weight=1,

--- a/validphys2/src/validphys/loader.py
+++ b/validphys2/src/validphys/loader.py
@@ -520,6 +520,7 @@ class Loader(LoaderBase):
                       rules=None,
                       sysnum=None,
                       theoryid,
+                      target_info=None,
                       cfac=(),
                       frac=1,
                       cuts=CutsPolicy.INTERNAL,
@@ -567,7 +568,7 @@ class Loader(LoaderBase):
 
         return DataSetSpec(name=name, commondata=commondata,
                            fkspecs=fkspec, thspec=theoryid, cuts=cuts,
-                           frac=frac, op=op, weight=weight)
+                           target_info=target_info, frac=frac, op=op, weight=weight)
 
     def check_experiment(self, name: str, datasets: List[DataSetSpec]) -> DataGroupSpec:
         """Loader method for instantiating DataGroupSpec objects. The NNPDF::Experiment

--- a/validphys2/src/validphys/n3fit_data_utils.py
+++ b/validphys2/src/validphys/n3fit_data_utils.py
@@ -10,6 +10,7 @@ loading their fktables (and applying any necessary cuts).
 from itertools import zip_longest
 import dataclasses
 import numpy as np
+from typing import Union
 
 
 @dataclasses.dataclass
@@ -43,8 +44,9 @@ class FittableDataSet:
 
     # Things that can have default values:
     operation: str = "NULL"
-    frac: float = 1.0
-    training_mask: np.ndarray = None  # boolean array
+    target_info: Union[None, dict]=None
+    frac: float=1.0
+    training_mask: Union[None, np.ndarray] = None  # boolean array
 
     def __post_init__(self):
         self._tr_mask = None
@@ -102,6 +104,8 @@ def validphys_group_extractor(datasets, tr_masks):
     for dspec, mask in zip_longest(datasets, tr_masks):
         # Load all fktables with the appropiate cuts
         fktables = [fk.load_with_cuts(dspec.cuts) for fk in dspec.fkspecs]
+        # Evaluate the stringified target specs of the target info
+        info_target = eval(dspec.target_info) if dspec.target_info is not None else None
         # And now put them in a FittableDataSet object which
-        loaded_obs.append(FittableDataSet(dspec.name, fktables, dspec.op, dspec.frac, mask))
+        loaded_obs.append(FittableDataSet(dspec.name, fktables, dspec.op, info_target, dspec.frac, mask))
     return loaded_obs


### PR DESCRIPTION
The following propagates the information on the target(s) from the run card into the data specs. The information are passed as a stringified dictionary into the `target_info` key:
```yaml
- { dataset: NMCPD, frac: 0.5, target_info: '{"A": [1, 2], "Z": [1, 2]}'}
```
These changes will be reverted in the future when the target info are added as metadata in the pineappl grids/FK tables in which they will be part of `validphys.coredata.FKTableData`.

@scarlehoff After some thoughts, for the time being, I have left it the way I did it before, ie adding the info as an attribute of `validphys.n3fit_data_utils.FittableDataSet` instead of `validphys.coredata.FKTableData`. Adding it into the later will require more changes in various places inc. `fkparser` and `pineparser`. Does this make sense?