### PR TITLE
Adding filter rule to remove one linearly dependent bin from the CMS 2D top distribution

### DIFF
--- a/validphys2/src/validphys/cuts/filters.yaml
+++ b/validphys2/src/validphys/cuts/filters.yaml
@@ -1,3 +1,9 @@
+- dataset: CMS_TTBAR_2D_DIFF_MTT_TRAP_NORM
+  reason: |
+   We remove one bin from the normalised distribution because it is 
+   linearly dependent on the others
+  rule: "idat != 8"
+
 - dataset: ATLAS_TTB_DIFF_8TEV_LJ_TPTNORM
   reason: |
    We remove the last bin of the normalised distribution because it is 


### PR DESCRIPTION
As the title says. 