### PR TITLE
add a photon placeholder to n3fit

### DIFF
--- a/n3fit/src/n3fit/layers/msr_normalization.py
+++ b/n3fit/src/n3fit/layers/msr_normalization.py
@@ -16,7 +16,8 @@ class MSR_Normalization(MetaLayer):
     _msr_enabled = False
     _vsr_enabled = False
 
-    def __init__(self, output_dim=14, mode="ALL", **kwargs):
+    def __init__(self, output_dim=14, mode="ALL", photon_contribution=0.0, **kwargs):
+        self._photon = photon_contribution
         if mode == True or mode.upper() == "ALL":
             self._msr_enabled = True
             self._vsr_enabled = True
@@ -53,7 +54,7 @@ class MSR_Normalization(MetaLayer):
         norm_constants = []
 
         if self._msr_enabled:
-            n_ag = [(1.0 - y[GLUON_IDX[0][0]-1]) / y[GLUON_IDX[0][0]]] * len(GLUON_IDX)
+            n_ag = [(1.0 - y[GLUON_IDX[0][0]-1] + self._photon) / y[GLUON_IDX[0][0]]] * len(GLUON_IDX)
             norm_constants += n_ag
 
         if self._vsr_enabled:

--- a/n3fit/src/n3fit/model_trainer.py
+++ b/n3fit/src/n3fit/model_trainer.py
@@ -640,7 +640,7 @@ class ModelTrainer:
         regularizer,
         regularizer_args,
         seed,
-        pdf_ph,
+        photon_computer,
     ):
         """
         Defines the internal variable layer_pdf
@@ -667,6 +667,8 @@ class ModelTrainer:
                 dictionary of arguments for the regularizer
             seed: int
                 seed for the NN
+            photon_computer: function
+                function to compute the photon PDF
         see model_gen.pdfNN_layer_generator for more information
 
         Returns
@@ -692,7 +694,7 @@ class ModelTrainer:
             impose_sumrule=self.impose_sumrule,
             scaler=self._scaler,
             parallel_models=self._parallel_models,
-            pdf_ph=pdf_ph,
+            photon_computer=photon_computer,
         )
         return pdf_models
 
@@ -865,9 +867,15 @@ class ModelTrainer:
         xinput = self._xgrid_generation()
         
         # compute photon:
-        photon=Photon(theoryid=self.theoryid, fiatlux_runcard=self.fiatlux_runcard)
-        photon_array = photon.photon_fitting_scale(xinput.input_l.tensor_content[0,:,0])
-        ph_pdf = op.batchit(op.numpy_to_tensor(photon_array[:, np.newaxis]))
+#         photon=Photon(theoryid=self.theoryid, fiatlux_runcard=self.fiatlux_runcard)
+#         photon_array = photon.photon_fitting_scale(xinput.input_l.tensor_content[0,:,0])
+#         ph_pdf = op.batchit(op.numpy_to_tensor(photon_array[:, np.newaxis]))
+
+        def photon_computer(x):
+            """Receives a grid with shape (1, n_x, 1)
+            and returns the photon PDF (1, n_x, 1)
+            """
+            return np.zeros_like(x)
 
         ### Training loop
         for k, partition in enumerate(self.kpartitions):
@@ -887,8 +895,18 @@ class ModelTrainer:
                 params.get("regularizer", None),  # regularizer optional
                 params.get("regularizer_args", None),
                 seeds,
-                ph_pdf,
+                photon_computer,
             )
+
+            # Register the fitting grid with the photon layer
+            try:
+                for m in pdf_models:
+                    pl = m.get_layer("add_photon")
+                    pl.register_photon(xinput.input_l.tensor_content)
+            except ValueError:
+                # There's no photon I guess
+                pass
+
 
             # Model generation joins all the different observable layers
             # together with pdf model generated above

--- a/n3fit/src/n3fit/msr.py
+++ b/n3fit/src/n3fit/msr.py
@@ -36,7 +36,7 @@ def gen_integration_input(nx):
     return xgrid, weights_array
 
 
-def msr_impose(nx=int(2e3), mode='All', scaler=None):
+def msr_impose(nx=int(2e3), mode='All', scaler=None, photon=None):
     """
         This function receives:
         Generates a function that applies a normalization layer to the fit.
@@ -70,8 +70,13 @@ def msr_impose(nx=int(2e3), mode='All', scaler=None):
     # 3. Now create the integration layer (the layer that will simply integrate, given some weight
     integrator = xIntegrator(weights_array, input_shape=(nx,))
 
+    # 3.1 If a photon is given, compute the photon component of the MSR
+    photon_c = 0.0
+    if photon is not None:
+        photon_c = np.sum(photon(np.linspace(0,1,100)))/100
+
     # 4. Now create the normalization by selecting the right integrations
-    normalizer = MSR_Normalization(mode=mode)
+    normalizer = MSR_Normalization(mode=mode, photon_contribution=photon_c)
 
     # 5. Make the xgrid array into a backend input layer so it can be given to the normalization
     xgrid_input = op.numpy_to_input(xgrid, name="integration_grid")


### PR DESCRIPTION
@niclaurenti please have a look at the changes in this PR, this is all that is needed to have the photon in n3fit

This is just a placeholder, the `photon_computer` that I'm using to compute the photon is just a `np.zeros`, this should be your call to fiatlux.

Inside the `add_photon` layer you might also want to implement some caching mechanism to avoid recomputing the photon more often than you actually need.