### PR TITLE
fix default elements for ccbar_asymm basis

### DIFF
--- a/validphys2/src/validphys/pdfbases.py
+++ b/validphys2/src/validphys/pdfbases.py
@@ -4,6 +4,7 @@ pdfbases.py
 This holds the concrete labels data relative to the PDF bases,
 as declaratively as possible.
 """
+import copy
 import inspect
 import functools
 import abc
@@ -508,7 +509,7 @@ evolution = LinearBasis.from_mapping({
 
 EVOL = evolution
 
-CCBAR_ASYMM = evolution
+CCBAR_ASYMM = copy.deepcopy(evolution)
 CCBAR_ASYMM.default_elements = (r'\Sigma', 'V', 'T3', 'V3', 'T8', 'V8', 'T15', 'gluon', 'V15')
 
 PDF4LHC20 = LinearBasis.from_mapping({

--- a/validphys2/src/validphys/pdfbases.py
+++ b/validphys2/src/validphys/pdfbases.py
@@ -509,6 +509,7 @@ evolution = LinearBasis.from_mapping({
 EVOL = evolution
 
 CCBAR_ASYMM = evolution
+CCBAR_ASYMM.default_elements = (r'\Sigma', 'V', 'T3', 'V3', 'T8', 'V8', 'T15', 'gluon', 'V15')
 
 PDF4LHC20 = LinearBasis.from_mapping({
         r'\Sigma': {


### PR DESCRIPTION
```V15``` was missing from the ```defualts_elemets``` of the ```CCBAR_ASYMM``` and this was breaking ```vp-nextfitruncard```