### PR TITLE
Change numpy to python for `int`, `float` and `bool`.

### DIFF
--- a/n3fit/src/n3fit/checks.py
+++ b/n3fit/src/n3fit/checks.py
@@ -21,7 +21,7 @@ def _is_floatable(num):
     if isinstance(num, numbers.Number):
         return True
     try:
-        np.float(num)
+        float(num)
         return True
     except (ValueError, TypeError):
         return False

--- a/n3fit/src/n3fit/stopping.py
+++ b/n3fit/src/n3fit/stopping.py
@@ -451,8 +451,8 @@ class Stopping:
         # Initialize internal variables for the stopping
         self.n_replicas = len(pdf_models)
         self.threshold_chi2 = threshold_chi2
-        self.stopping_degree = np.zeros(self.n_replicas, dtype=np.int)
-        self.count = np.zeros(self.n_replicas, dtype=np.int)
+        self.stopping_degree = np.zeros(self.n_replicas, dtype=int)
+        self.count = np.zeros(self.n_replicas, dtype=int)
 
         self.dont_stop = dont_stop
         self.stop_now = False

--- a/validphys2/src/validphys/dataplots.py
+++ b/validphys2/src/validphys/dataplots.py
@@ -299,7 +299,7 @@ def _plot_fancy_impl(results, commondata, cutlist,
             x = info.get_xcol(line_data)
 
             try:
-                x = np.asanyarray(x, np.float)
+                x = np.asanyarray(x, float)
             except ValueError:
                 xticklabels = x
                 npoints = len(x)

--- a/validphys2/src/validphys/lhio.py
+++ b/validphys2/src/validphys/lhio.py
@@ -33,7 +33,7 @@ def read_xqf_from_file(f):
         return None
     xvals = np.fromstring(xtext, sep = " ")
     qvals = np.fromstring(qtext, sep = " ")
-    fvals = np.fromstring(ftext, sep = " ", dtype=np.int)
+    fvals = np.fromstring(ftext, sep = " ", dtype=int)
     vals = np.fromstring(b''.join(lines), sep= " ")
     return pd.Series(vals, index = pd.MultiIndex.from_product((xvals, qvals, fvals)))
 

--- a/validphys2/src/validphys/n3fit_data.py
+++ b/validphys2/src/validphys/n3fit_data.py
@@ -98,7 +98,7 @@ def tr_masks(data, replica_trvlseed):
             # If that number is 0, then get 1 point with probability frac
             trmax = int(rng.random() < frac)
         mask = np.concatenate(
-            [np.ones(trmax, dtype=np.bool), np.zeros(ndata - trmax, dtype=np.bool)]
+            [np.ones(trmax, dtype=bool), np.zeros(ndata - trmax, dtype=bool)]
         )
         rng.shuffle(mask)
         trmask_partial.append(mask)
@@ -164,10 +164,10 @@ def kfold_masks(kpartitions, data):
                 ndata = len(cuts.load()) if cuts else dataset.commondata.ndata
                 # If the dataset is in the fold, its mask is full of 0s
                 if str(dataset) in data_fold:
-                    mask.append(np.zeros(ndata, dtype=np.bool))
+                    mask.append(np.zeros(ndata, dtype=bool))
                 # otherwise of ones
                 else:
-                    mask.append(np.ones(ndata, dtype=np.bool))
+                    mask.append(np.ones(ndata, dtype=bool))
             list_folds.append(np.concatenate(mask))
     return list_folds
 
@@ -519,7 +519,7 @@ def _fitting_lagrange_dict(lambdadataset):
     ndata = positivity_datasets[0].ndata
     return {
         "datasets": positivity_datasets,
-        "trmask": np.ones(ndata, dtype=np.bool),
+        "trmask": np.ones(ndata, dtype=bool),
         "name": lambdadataset.name,
         "expdata": np.zeros((1, ndata)),
         "ndata": ndata,


### PR DESCRIPTION
Following deprecation notices for `np.int`, `np.float` and `np.bool` which will be removed in 1.24. They were already aliases for the underlying python types.