### PR TITLE
fixed bug following from introduction of parse_fakepdf in config.py

### DIFF
--- a/validphys2/src/validphys/config.py
+++ b/validphys2/src/validphys/config.py
@@ -321,8 +321,8 @@ class CoreConfig(configparser.Config):
         pdf
         """
         with self.set_context(ns=self._curr_ns.new_child({"fit": fit})):
-            _, datacuts = self.parse_from_("fit", "closuretest", write=False)
-        underlyinglaw = self.parse_pdf(datacuts["fakepdf"].name)
+            _, datacuts = self.parse_from_("fit", "closuretest", write=False)       
+        underlyinglaw = datacuts["fakepdf"]
         return {"pdf": underlyinglaw}
 
     @element_of("hyperscans")

--- a/validphys2/src/validphys/config.py
+++ b/validphys2/src/validphys/config.py
@@ -321,7 +321,7 @@ class CoreConfig(configparser.Config):
         pdf
         """
         with self.set_context(ns=self._curr_ns.new_child({"fit": fit})):
-            _, datacuts = self.parse_from_("fit", "closuretest", write=False)       
+            _, datacuts = self.parse_from_("fit", "closuretest", write=False)
         underlyinglaw = datacuts["fakepdf"]
         return {"pdf": underlyinglaw}
 

--- a/validphys2/src/validphys/config.py
+++ b/validphys2/src/validphys/config.py
@@ -322,7 +322,7 @@ class CoreConfig(configparser.Config):
         """
         with self.set_context(ns=self._curr_ns.new_child({"fit": fit})):
             _, datacuts = self.parse_from_("fit", "closuretest", write=False)
-        underlyinglaw = self.parse_pdf(datacuts["fakepdf"])
+        underlyinglaw = self.parse_pdf(datacuts["fakepdf"].name)
         return {"pdf": underlyinglaw}
 
     @element_of("hyperscans")

--- a/validphys2/src/validphys/config.py
+++ b/validphys2/src/validphys/config.py
@@ -381,7 +381,7 @@ class CoreConfig(configparser.Config):
                 "Did not find unique underlying law from fits, "
                 f"instead found: {laws}"
             )
-        return laws.pop()
+        return self.parse_pdf(laws.pop())
 
     def produce_basisfromfit(self, fit):
         """Set the basis from fit config. In the fit config file the basis

--- a/validphys2/src/validphys/config.py
+++ b/validphys2/src/validphys/config.py
@@ -381,7 +381,7 @@ class CoreConfig(configparser.Config):
                 "Did not find unique underlying law from fits, "
                 f"instead found: {laws}"
             )
-        return self.parse_pdf(laws.pop())
+        return laws.pop()
 
     def produce_basisfromfit(self, fit):
         """Set the basis from fit config. In the fit config file the basis


### PR DESCRIPTION
Because of the introduction of the parse_fakepdf method in config.py, the val corresponding to the "fakepdf" key of the datacuts dict in produce_fitunderlyinglaw function is not type str anymore but core.PDF. This leads to an error when running vp-comparefits:

[ERROR]: Bad configuration encountered:
Bad input type for parameter 'pdf': Value 'NNPDF40_nnlo_as_01180' is not of type str, but of type 'PDF'.