### PR TITLE
Fix extra labels slicing when cuts are given

### DIFF
--- a/validphys2/src/validphys/plotoptions/core.py
+++ b/validphys2/src/validphys/plotoptions/core.py
@@ -175,6 +175,11 @@ class PlotInfo:
 
         kinlabels = commondata.plot_kinlabels
         kinlabels = plot_params['kinematics_override'].new_labels(*kinlabels)
+        if "extra_labels" in plot_params and cuts is not None:
+            cut_extra_labels ={
+                k: [v[i] for i in cuts] for k, v in plot_params["extra_labels"].items()
+            }
+            plot_params["extra_labels"] = cut_extra_labels
 
         return cls(kinlabels=kinlabels, **plot_params)
 

--- a/validphys2/src/validphys/plotoptions/core.py
+++ b/validphys2/src/validphys/plotoptions/core.py
@@ -57,10 +57,11 @@ def get_info(data, *, normalize=False, cuts=None, use_plotfiles=True):
     if cuts is None:
         if isinstance(data, DataSetSpec):
             cuts = data.cuts.load() if data.cuts else None
-    elif isinstance(cuts, (Cuts, InternalCutsWrapper)):
+    elif hasattr(cuts, 'load'):
         cuts = cuts.load()
-    elif not cuts:
-        cuts = None
+
+    if cuts is not None and not len(cuts):
+        raise NotImplementedError("No point passes the cuts. Cannot retieve info")
 
     if isinstance(data, DataSetSpec):
         data = data.commondata

--- a/validphys2/src/validphys/tests/test_loader.py
+++ b/validphys2/src/validphys/tests/test_loader.py
@@ -17,18 +17,22 @@ l = FallbackLoader()
 #The sorted is to appease hypothesis
 dss = sorted(l.available_datasets - {"PDFEVOLTEST"})
 
+class MockCuts():
+    def __init__(self, arr):
+        self.arr = arr
+    def load(self):
+        return self.arr
+
 
 @composite
-def commodata_and_cuts(draw):
+def commondata_and_cuts(draw):
     cd = l.check_commondata(draw(sampled_from(dss)))
     ndata = cd.metadata.ndata
-    #TODO: Maybe upgrade to this
-    #https://github.com/HypothesisWorks/hypothesis/issues/1115
-    mask = sorted(draw(sets(sampled_from(range(ndata)))))
+    mask = sorted(draw(sets(sampled_from(range(ndata)), min_size=1)))
     return cd, mask
 
 
-@given(arg=commodata_and_cuts())
+@given(arg=commondata_and_cuts())
 @settings(deadline=None)
 def test_rebuild_commondata_without_cuts(tmp_path_factory, arg):
     # We need to create a new directory for each call of the test
@@ -59,6 +63,13 @@ def test_rebuild_commondata_without_cuts(tmp_path_factory, arg):
         nocuts = np.ones(cd.ndata, dtype=bool)
         nocuts[cuts] = False
         assert (lncd.get_cv()[nocuts] == 0).all()
+
+@given(inp=commondata_and_cuts())
+def test_kitable_with_cuts(inp):
+    cd, cuts = inp
+    info = get_info(cd, cuts=cuts)
+    tb = kitable(cd, info, cuts=MockCuts(cuts))
+    assert len(tb) == len(cuts)
 
 def test_load_fit():
     assert l.check_fit(FIT)

--- a/validphys2/src/validphys/tests/test_loader.py
+++ b/validphys2/src/validphys/tests/test_loader.py
@@ -28,7 +28,9 @@ class MockCuts():
 def commondata_and_cuts(draw):
     cd = l.check_commondata(draw(sampled_from(dss)))
     ndata = cd.metadata.ndata
-    mask = sorted(draw(sets(sampled_from(range(ndata)), min_size=1)))
+    # Get a cut mask with at least one selected datapoint
+    masks = sets(sampled_from(range(ndata)), min_size=1)
+    mask = sorted(draw(masks))
     return cd, mask
 
 


### PR DESCRIPTION
plot_smpdf can break with some mismatch error like

```python-traceback
  File "/home/zah/nngit/nnpdf/validphys2/src/validphys/dataplots.py", line 869, in plot_smpdf
    table = kitable(dataset, info)
  File "/home/zah/nngit/nnpdf/validphys2/src/validphys/plotoptions/core.py", line 328, in kitable
    table[label] = value
  File "/home/zah/anaconda3/envs/nnpdfdev/lib/python3.9/site-packages/pandas/core/frame.py", line 3978, in __setitem__
    self._set_item(key, value)
  File "/home/zah/anaconda3/envs/nnpdfdev/lib/python3.9/site-packages/pandas/core/frame.py", line 4172, in _set_item
    value = self._sanitize_column(value)
  File "/home/zah/anaconda3/envs/nnpdfdev/lib/python3.9/site-packages/pandas/core/frame.py", line 4912, in _sanitize_column
    com.require_length_match(value, self.index)
  File "/home/zah/anaconda3/envs/nnpdfdev/lib/python3.9/site-packages/pandas/core/common.py", line 561, in require_length_match
    raise ValueError(
ValueError: Length of values (34) does not match length of index (30)

----
```

This is caused by cuts not being used anywhere when calling PlotInfo.from_commondata, specifically not to being used to filter the extra_labels.

I am a bit unsure why this was noticed before, but part of the answer is that plot_fancy use the plotting information without cuts and applies them later itself.

Fix that by filtering the extra labels.