### PR TITLE
Tensorflow in macos

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -24,8 +24,7 @@ requirements:
         - python
         - numpy
     run:
-        # Only install tensorflow on linux. Select eigen build
-        - tensorflow >=2 *eigen* # [linux]
+        - tensorflow >=2 *eigen*
         - psutil # to ensure n3fit affinity is with the right processors
         - hyperopt
         - seaborn


### PR DESCRIPTION
I don't remember why we had this constraint here, but it bit me yesterday... so let us remove it. The fit works well in mac when you install things manually so this limitation is artificial.

I'll see whether I can get my hands onto a few different types of mac so I can test it in more than one computer before merging.