### PR TITLE
Use ndata instead of len

### DIFF
--- a/validphys2/src/validphys/fitdata.py
+++ b/validphys2/src/validphys/fitdata.py
@@ -323,7 +323,7 @@ def print_different_cuts(fits, test_for_same_cuts):
         res.write("The following datasets are both included but have different kinematical cuts:\n\n")
         for (first, second) in test_for_same_cuts:
             info = get_info(first.commondata)
-            total_points = len(first.commondata.load())
+            total_points = first.commondata.ndata
             res.write(" - %s:\n" % info.dataset_label)
             first_len = len(first.cuts.load()) if first.cuts else total_points
             second_len = len(second.cuts.load()) if second.cuts else total_points

--- a/validphys2/src/validphys/tests/conftest.py
+++ b/validphys2/src/validphys/tests/conftest.py
@@ -51,6 +51,7 @@ HESSIAN_PDF = "NNPDF40_nnlo_as_01180_hessian"
 THEORYID = 162
 FIT = "NNPDF40_nnlo_lowprecision"
 FIT_3REPLICAS = "Basic_runcard_3replicas_lowprec_221130"
+FIT_3REPLICAS_DCUTS = "Basic_runcard_3replicas_diffcuts_230221"
 FIT_ITERATED = "NNPDF40_nnlo_low_precision_iterated"
 PSEUDODATA_FIT = "pseudodata_test_fit_n3fit_221130"
 

--- a/validphys2/src/validphys/tests/test_fitdata.py
+++ b/validphys2/src/validphys/tests/test_fitdata.py
@@ -1,5 +1,18 @@
 from validphys.api import API
-from validphys.fitdata import print_systype_overlap
+from validphys.fitdata import print_systype_overlap, print_different_cuts
+from validphys.tests.conftest import FIT_3REPLICAS, FIT_3REPLICAS_DCUTS
+
+def test_print_different_cuts():
+    fit_1 = API.fit(fit=FIT_3REPLICAS)
+    fit_2 = API.fit(fit=FIT_3REPLICAS_DCUTS)
+    fits = [fit_1, fit_2]
+    testi = API.test_for_same_cuts(fits=[FIT_3REPLICAS, FIT_3REPLICAS_DCUTS], use_cuts="fromfit")
+    res = print_different_cuts(fits, testi)
+    assert "121 out of 260" in res
+    assert "59 out of 260" in res
+    assert "33 out of 211" in res
+    assert "0 out of 211" in res
+
 
 def test_print_systype_overlap():
     """Test that print_systype_overlap does expected thing

--- a/validphys2/src/validphys/tests/test_fitdata.py
+++ b/validphys2/src/validphys/tests/test_fitdata.py
@@ -2,7 +2,15 @@ from validphys.api import API
 from validphys.fitdata import print_systype_overlap, print_different_cuts
 from validphys.tests.conftest import FIT_3REPLICAS, FIT_3REPLICAS_DCUTS
 
+
 def test_print_different_cuts():
+    """Checks the print_different_cuts functions
+    using two fits with a different choice of q2min and w2min in the runcard
+    One of the datasets (SLACP) gets 0 points in in the most restrictive case
+    The different cuts are:
+    q2min: 3.49 - 13.49
+    w2min: 12.5 - 22.5
+    """
     fit_1 = API.fit(fit=FIT_3REPLICAS)
     fit_2 = API.fit(fit=FIT_3REPLICAS_DCUTS)
     fits = [fit_1, fit_2]


### PR DESCRIPTION
Fixes #1674 

I'll think of a better way of testing https://github.com/NNPDF/nnpdf/issues/1674#issuecomment-1438335958 this afternoon I don't like checking the string itself but of course needed to check the `str` so ¯\_(ツ)_/¯ 

But if you want to have the fix merged asap, @Zaharid, feel free to merge this.