### PR TITLE
Keep name of target dataset (avoid reutilizing fktables)

### DIFF
--- a/validphys2/src/validphys/core.py
+++ b/validphys2/src/validphys/core.py
@@ -525,10 +525,9 @@ class FKTableSpec(TupleComp):
         self.fkpath = fkpath
         self.metadata = metadata
 
-        # If this is a yaml file that loads an applgrid-converted pineappl,
-        # keep also the name of the target
-        # this is needed since we can now easily reutilize grids
-        if not self.legacy and self.metadata.get("appl"):
+        # For new theories, add also the target_dataset so that we don't reuse fktables
+        # Ideally this won't be necessary in the future and we will be able to reutilize fktables.
+        if not self.legacy:
             super().__init__(fkpath, cfactors, self.metadata.get("target_dataset"))
         else:
             super().__init__(fkpath, cfactors)


### PR DESCRIPTION
Reutilizing fktables is not well tested enough to work in all cases (and @RoyStegeman has already found bugs when he eliminated cfactors and different fktables started "being the same") so for now let's remove that possibility.

We can revisit it with the new commondata (when the reutilization of fktables by different datasets will also be more obvious)