### PR TITLE
Update recommended pylintrc

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -51,83 +51,20 @@ confidence=
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
 disable=
-    print-statement,
-	parameter-unpacking,
-	unpacking-in-except,
-	old-raise-syntax,
-	backtick,
-	long-suffix,
-	old-ne-operator,
-	old-octal-literal,
-	import-star-module-level,
 	raw-checker-failed,
 	bad-inline-option,
 	locally-disabled,
-	locally-enabled,
 	file-ignored,
 	suppressed-message,
 	useless-suppression,
 	deprecated-pragma,
-	apply-builtin,
-	basestring-builtin,
-	buffer-builtin,
-	cmp-builtin,
-	coerce-builtin,
-	execfile-builtin,
-	file-builtin,
-	long-builtin,
-	raw_input-builtin,
-	reduce-builtin,
-	standarderror-builtin,
-	unicode-builtin,
-	xrange-builtin,
-	coerce-method,
-	delslice-method,
-	getslice-method,
-	setslice-method,
-	no-absolute-import,
-	old-division,
-	dict-iter-method,
-	dict-view-method,
-	next-method-called,
-	metaclass-assignment,
-	indexing-exception,
-	raising-string,
-	reload-builtin,
-	oct-method,
-	hex-method,
-	nonzero-method,
-	cmp-method,
-	input-builtin,
-	round-builtin,
-	intern-builtin,
-	unichr-builtin,
-	map-builtin-not-iterating,
-	zip-builtin-not-iterating,
-	range-builtin-not-iterating,
-	filter-builtin-not-iterating,
-	using-cmp-argument,
-	eq-without-hash,
-	div-method,
-	idiv-method,
-	rdiv-method,
-	exception-message-attribute,
-	invalid-str-codec,
-	sys-max-int,
-	bad-python3-import,
-	deprecated-string-function,
-	deprecated-str-translate-call,
 	invalid-name,
 	too-few-public-methods,
 	too-many-arguments,
-	bad-continuation,
 	redefined-outer-name,
 	missing-docstring,
-	bad-whitespace,
-	no-self-use,
 	no-else-return,
 	global-statement,
-	too-many-public-method,
 	too-many-ancestors
 
 # Enable the message, report, category or checker with the given id(s). You can
@@ -191,35 +128,21 @@ min-similarity-lines=4
 
 [BASIC]
 
-# Naming hint for argument names
-argument-name-hint=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
 
 # Regular expression matching correct argument names
 argument-rgx=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
 
-# Naming hint for attribute names
-attr-name-hint=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
 
 # Regular expression matching correct attribute names
 attr-rgx=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
 
-# Bad variable names which should always be refused, separated by a comma
-bad-names=foo,bar,baz,toto,tutu,tata
-
-# Naming hint for class attribute names
-class-attribute-name-hint=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
-
 # Regular expression matching correct class attribute names
 class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
 
-# Naming hint for class names
-class-name-hint=[A-Z_][a-zA-Z0-9]+$
 
 # Regular expression matching correct class names
 class-rgx=[A-Z_][a-zA-Z0-9]+$
 
-# Naming hint for constant names
-const-name-hint=(([A-Z_][A-Z0-9_]*)|(__.*__))$
 
 # Regular expression matching correct constant names
 const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
@@ -228,8 +151,6 @@ const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
 # ones are exempt.
 docstring-min-length=-1
 
-# Naming hint for function names
-function-name-hint=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
 
 # Regular expression matching correct function names
 function-rgx=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
@@ -240,20 +161,14 @@ good-names=i,j,k,ex,Run,_
 # Include a hint for the correct naming format with invalid-name
 include-naming-hint=no
 
-# Naming hint for inline iteration names
-inlinevar-name-hint=[A-Za-z_][A-Za-z0-9_]*$
 
 # Regular expression matching correct inline iteration names
 inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
 
-# Naming hint for method names
-method-name-hint=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
 
 # Regular expression matching correct method names
 method-rgx=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
 
-# Naming hint for module names
-module-name-hint=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
 
 # Regular expression matching correct module names
 module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
@@ -270,8 +185,6 @@ no-docstring-rgx=^_
 # to this list to register other decorators that produce valid properties.
 property-classes=abc.abstractproperty
 
-# Naming hint for variable names
-variable-name-hint=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
 
 # Regular expression matching correct variable names
 variable-rgx=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
@@ -327,11 +240,6 @@ max-line-length=100
 # Maximum number of lines in a module
 max-module-lines=1000
 
-# List of optional constructs for which whitespace checking is disabled. `dict-
-# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
-# `trailing-comma` allows a space between comma and closing bracket: (a, ).
-# `empty-line` allows space-only lines.
-no-space-check=trailing-comma,dict-separator
 
 # Allow the body of a class to be on the same line as the declaration if body
 # contains single statement.
@@ -498,6 +406,3 @@ known-third-party=enchant
 
 [EXCEPTIONS]
 
-# Exceptions that will emit a warning when being caught. Defaults to
-# "Exception"
-overgeneral-exceptions=Exception


### PR DESCRIPTION
Pylint has deprecated a ton of options and broken some vim plugins in the process. This removes the deprecated configurations it complains about.