### PR TITLE
Expand possible dataset configurations in the training report

### DIFF
--- a/validphys2/src/validphys/comparefittemplates/comparecard.yaml
+++ b/validphys2/src/validphys/comparefittemplates/comparecard.yaml
@@ -25,6 +25,9 @@
 #   theoryid:
 #     from_: theory
 #   speclabel: "Reference Fit"
+#
+# data_theory_dataset:
+#   dataset_join: the dataset_join setting
 
 pdfs:
   - from_: current

--- a/validphys2/src/validphys/comparefittemplates/report.md
+++ b/validphys2/src/validphys/comparefittemplates/report.md
@@ -78,6 +78,7 @@ Training-validation
 -------------------
 {@fits plot_training_validation@}
 
+{@with data_theory_dataset@}
 {@with DataGroups@}
 $\chi^2$ by {@processed_metadata_group@}
 ----------------------------------------
@@ -98,6 +99,7 @@ $\phi$ by {@processed_metadata_group@}
 --------------------------------------
 {@plot_fits_groups_data_phi@}
 {@endwith@}
+{@endwith@} <!-- ends data_theory_dataset -->
 
 Dataset plots
 -------------

--- a/validphys2/src/validphys/scripts/vp_comparefits.py
+++ b/validphys2/src/validphys/scripts/vp_comparefits.py
@@ -62,6 +62,12 @@ class CompareFitApp(App):
             default=REFERENCE_FIT_LABEL_DEFAULT,
             help="The label for the fit that is being compared to.")
         parser.add_argument(
+            '--dataset_join',
+            nargs='?',
+            default="intersection",
+            choices=['intersection', 'union', 'current', 'reference'],
+            help="Which datasets to use for the computation of chi2 for the data-theory comparison.")
+        parser.add_argument(
             '-i',
             '--interactive',
             help="Ask interactively for the missing data",
@@ -79,7 +85,7 @@ class CompareFitApp(App):
         argnames = (
             'current_fit', 'reference_fit', 'title', 'author', 'keywords')
         optionalnames = (
-            'current_fit_label', 'reference_fit_label')
+            'current_fit_label', 'reference_fit_label', 'dataset_join')
         boolnames = (
             'thcovmat_if_present',)
         badargs = [argname for argname in argnames if not args[argname]]
@@ -171,6 +177,13 @@ class CompareFitApp(App):
                    "to calculate the statistical estimators? ")
         return confirm(message, default=True)
 
+    def interactive_dataset_join(self):
+        """Interactively fill in the `dataset_join` runcard flag. Which is "intersection" by default
+        """
+        message = ("For the data theory comparsion, do you wish to use the datasets of: \n"
+                   "current, reference, intersection, or union")
+        return confirm(message, default="intersection")
+
     def get_commandline_arguments(self, cmdline=None):
         args = super().get_commandline_arguments(cmdline)
         # This is needed because the environment wants to know how to resolve
@@ -217,6 +230,7 @@ class CompareFitApp(App):
             'speclabel': args['reference_fit_label']
         }
         autosettings['use_thcovmat_if_present'] = args['thcovmat_if_present']
+        autosettings['data_theory_dataset'] = {'dataset_join': args['dataset_join'], "use_cuts": "internal"}
         return autosettings
 
 


### PR DESCRIPTION
This resolves #1707 

I'm not really happy about the way it's implemented now. The problem is that the chi2 info in the reports is generated by collecting over the fitcontexts so there's not an easy way to insert a set of preferred datasets in the vp workflow. 

I guess it's probably somehow possible to edit the reportengine graph itself? But this seems like it would be a pain. Maybe @Zaharid has an idea? 