### PR TITLE
add use_scalevar_uncertainties to loading custom comvat docs

### DIFF
--- a/doc/sphinx/source/tutorials/general_th_covmat.rst
+++ b/doc/sphinx/source/tutorials/general_th_covmat.rst
@@ -46,10 +46,11 @@ Instructions
 
     ############################################################################
     theorycovmatconfig:
+      use_scalevar_uncertainties: False
       use_user_uncertainties: True
       user_covmat_path: "IeGM9CY8RxGcb5r6bIEYlQ==/shrek_covmat.csv"
       use_thcovmat_in_sampling: True
-      use_thcovmat_in_fitting: True		
+      use_thcovmat_in_fitting: True
     ############################################################################
 
 The flags ``use_thcovmat_in_fitting`` and ``use_thcovmat_in_sampling`` specify
@@ -61,10 +62,16 @@ generation). The default is ``True`` for both.
       Changing either of these to ``False`` will affect the fit outcome and should
       be avoided unless you know what you are doing.
       
-4. Make sure that datasets are grouped under one big experiment called "BIGEXP", 
+
+4. The flag ``use_scalevar_uncertainties``  corresponds to whether or not a 
+   theory covmat is to be constructed from a pointprescription with instructions 
+   inside ``theorycovmatconfig``. Usually in cases where a custom covmat is 
+   being loades, this will be set to ``False``.
+
+5. Make sure that datasets are grouped under one big experiment called "BIGEXP", 
    just like in :ref:`vptheorycov-index`.
    
-5. For an example runcard, see `here <https://github.com/NNPDF/nnpdf/tree/master/validphys2/examples/fit_with_user_covmat.yaml.>`_
+6. For an example runcard, see `here <https://github.com/NNPDF/nnpdf/tree/master/validphys2/examples/fit_with_user_covmat.yaml.>`_
 
 
 Including both scale variation uncertainties and user uncertainties


### PR DESCRIPTION
Different from what we originally said, there are different ways of combining custom covmats and covmats that are generated from pointprescirption instructions in the runcards and it's not either one or the other. The implementation of scalevariations is in general a bit messy so we may want to improve that, but it's not a priority right now so hopefully we can fix that at some point :crossed_fingers:. 

Having said that - this bit of the docs was still outdated. 