### PR TITLE
futureproofing: make dropna keyword based

### DIFF
--- a/validphys2/src/validphys/theorycovariance/construction.py
+++ b/validphys2/src/validphys/theorycovariance/construction.py
@@ -466,7 +466,7 @@ def fromfile_covmat(covmatpath, procs_data, procs_index):
     cut_df = filecovmat.reindex(newindex).T
     cut_df = cut_df.reindex(newindex).T
     # Elements where cuts are applied will become NaN - remove these rows and columns
-    cut_df = cut_df.dropna(0).dropna(1)
+    cut_df = cut_df.dropna(axis=0).dropna(axis=1)
     # -------------------- #
     # 2: Expand dimensions #
     # -------------------- #


### PR DESCRIPTION
Got a warning:
> FutureWarning: In a future version of pandas all arguments of DataFrame.dropna will be keyword-only.