### PR TITLE
reintroduce AlphaS_* attributes in the PDF class and add a test of alpha_s_bundle_pdf

### DIFF
--- a/nnpdfcpp/src/nnfit/src/evolgrid.cc
+++ b/nnpdfcpp/src/nnfit/src/evolgrid.cc
@@ -197,7 +197,7 @@ void EvolveGrid::WriteInfoFile(string const& infofile, int nrep) const
     for (int iq = 0; iq < (int) q2subgrids[s].size(); iq++)
       infodata << sqrt(q2subgrids[s][iq]) << ((s == (int) q2subgrids.size()-1 && iq == (int) q2subgrids[s].size()-1) ? "]\n" : ", ");
 
-  infodata << "AlphaS_Vals: [";
+  infodata << "AlphaS_vals: [";
   for (int s = 0; s < (int) q2subgrids.size(); s++)
     for (int iq = 0; iq < (int) q2subgrids[s].size(); iq++)
       infodata << APFEL::AlphaQCD(sqrt(q2subgrids[s][iq])) << ((s == (int) q2subgrids.size()-1 && iq == (int) q2subgrids[s].size()-1) ? "]\n" : ", ");

--- a/nnpdfcpp/src/nnfit/src/evolgrid.cc
+++ b/nnpdfcpp/src/nnfit/src/evolgrid.cc
@@ -197,7 +197,7 @@ void EvolveGrid::WriteInfoFile(string const& infofile, int nrep) const
     for (int iq = 0; iq < (int) q2subgrids[s].size(); iq++)
       infodata << sqrt(q2subgrids[s][iq]) << ((s == (int) q2subgrids.size()-1 && iq == (int) q2subgrids[s].size()-1) ? "]\n" : ", ");
 
-  infodata << "AlphaS_vals: [";
+  infodata << "AlphaS_Vals: [";
   for (int s = 0; s < (int) q2subgrids.size(); s++)
     for (int iq = 0; iq < (int) q2subgrids[s].size(); iq++)
       infodata << APFEL::AlphaQCD(sqrt(q2subgrids[s][iq])) << ((s == (int) q2subgrids.size()-1 && iq == (int) q2subgrids[s].size()-1) ? "]\n" : ", ");

--- a/validphys2/src/validphys/core.py
+++ b/validphys2/src/validphys/core.py
@@ -145,6 +145,19 @@ class PDF(TupleComp):
         return self.info["ErrorType"]
 
     @property
+    def alphas_mz(self):
+        """Alpha_s(M_Z) type as defined in the LHAPDF .info file"""
+        return self.info["AlphaS_MZ"]
+
+    @property
+    def alphas_vals(self):
+        """Alpha_s(M_Z) type as defined in the LHAPDF .info file"""
+        try:
+            return self.info["AlphaS_vals"]
+        except KeyError:
+            return self.info["AlphaS_Vals"]
+
+    @property
     def error_conf_level(self):
         """Error confidence level as defined in the LHAPDF .info file
         if no number is given in the LHAPDF .info file defaults to 68%

--- a/validphys2/src/validphys/core.py
+++ b/validphys2/src/validphys/core.py
@@ -152,6 +152,8 @@ class PDF(TupleComp):
     @property
     def alphas_vals(self):
         """Alpha_s(M_Z) type as defined in the LHAPDF .info file"""
+        # For a long time the nnpdf code wrote the incorrect "AlphaS_Vals"
+        # key to the LHAPDF .info files, therefore we check for both options.
         try:
             return self.info["AlphaS_vals"]
         except KeyError:

--- a/validphys2/src/validphys/core.py
+++ b/validphys2/src/validphys/core.py
@@ -146,18 +146,14 @@ class PDF(TupleComp):
 
     @property
     def alphas_mz(self):
-        """Alpha_s(M_Z) type as defined in the LHAPDF .info file"""
+        """Alpha_s(M_Z) as defined in the LHAPDF .info file"""
         return self.info["AlphaS_MZ"]
 
     @property
     def alphas_vals(self):
-        """Alpha_s(M_Z) type as defined in the LHAPDF .info file"""
-        # For a long time the nnpdf code wrote the incorrect "AlphaS_Vals"
-        # key to the LHAPDF .info files, therefore we check for both options.
-        try:
-            return self.info["AlphaS_vals"]
-        except KeyError:
-            return self.info["AlphaS_Vals"]
+        """List of alpha_s(Q) at various Q for interpolation based alphas.
+        Values as defined in the LHAPDF .info file"""
+        self.info["AlphaS_Vals"]
 
     @property
     def error_conf_level(self):

--- a/validphys2/src/validphys/paramfits/config.py
+++ b/validphys2/src/validphys/paramfits/config.py
@@ -44,7 +44,7 @@ class ParamfitsConfig(Config):
     def produce_fits_as(self, fits_pdf_config):
         """NOTE: EXPERIMENTAL. Return the as value of the fits, reading
         it from the installed pdf"""
-        return [pdf.AlphaS_MZ for pdf in fits_pdf_config]
+        return [pdf.alphas_mz for pdf in fits_pdf_config]
 
     #TODO: Try to remove the loop from here.
     def produce_fits_as_from_fitdeclarations(self, fitdeclarations):

--- a/validphys2/src/validphys/replica_selector.py
+++ b/validphys2/src/validphys/replica_selector.py
@@ -25,12 +25,12 @@ def _fixup_new_replica(alphas_pdf: PDF, new_replica_file):
     to the header file.
     """
     AlphaS_MZ = alphas_pdf.AlphaS_MZ
-    AlphaS_Vals = alphas_pdf.AlphaS_Vals
+    AlphaS_vals = alphas_pdf.AlphaS_vals
     with open(new_replica_file, 'rb') as in_stream:
         data = in_stream.read()
     with open(new_replica_file, 'wb') as out_stream:
-        # Add the AlphaS_MZ and AlphaS_Vals keys
-        out_stream.write(f"AlphaS_MZ: {AlphaS_MZ}\nAlphaS_Vals: {AlphaS_Vals}\n".encode())
+        # Add the AlphaS_MZ and AlphaS_vals keys
+        out_stream.write(f"AlphaS_MZ: {AlphaS_MZ}\nAlphaS_vals: {AlphaS_vals}\n".encode())
         out_stream.write(data)
 
 @make_argcheck

--- a/validphys2/src/validphys/replica_selector.py
+++ b/validphys2/src/validphys/replica_selector.py
@@ -25,12 +25,12 @@ def _fixup_new_replica(alphas_pdf: PDF, new_replica_file):
     to the header file.
     """
     alphas_mz = alphas_pdf.alphas_mz
-    alphaS_vals = alphas_pdf.alphas_vals
+    alphas_vals = alphas_pdf.alphas_vals
     with open(new_replica_file, 'rb') as in_stream:
         data = in_stream.read()
     with open(new_replica_file, 'wb') as out_stream:
-        # Add the AlphaS_MZ and AlphaS_vals keys
-        out_stream.write(f"AlphaS_MZ: {alphas_mz}\nAlphaS_vals: {alphaS_vals}\n".encode())
+        # Add the AlphaS_MZ and AlphaS_Vals keys
+        out_stream.write(f"AlphaS_MZ: {alphas_mz}\nAlphaS_Vals: {alphas_vals}\n".encode())
         out_stream.write(data)
 
 @make_argcheck

--- a/validphys2/src/validphys/replica_selector.py
+++ b/validphys2/src/validphys/replica_selector.py
@@ -24,13 +24,13 @@ def _fixup_new_replica(alphas_pdf: PDF, new_replica_file):
     PDF and handles the writing of the alphas values
     to the header file.
     """
-    AlphaS_MZ = alphas_pdf.AlphaS_MZ
-    AlphaS_vals = alphas_pdf.AlphaS_vals
+    alphas_mz = alphas_pdf.alphas_mz
+    alphaS_vals = alphas_pdf.alphas_vals
     with open(new_replica_file, 'rb') as in_stream:
         data = in_stream.read()
     with open(new_replica_file, 'wb') as out_stream:
         # Add the AlphaS_MZ and AlphaS_vals keys
-        out_stream.write(f"AlphaS_MZ: {AlphaS_MZ}\nAlphaS_vals: {AlphaS_vals}\n".encode())
+        out_stream.write(f"AlphaS_MZ: {alphas_mz}\nAlphaS_vals: {alphaS_vals}\n".encode())
         out_stream.write(data)
 
 @make_argcheck
@@ -72,7 +72,7 @@ def alpha_s_bundle_pdf(pdf, pdfs, output_path, target_name: (str, type(None)) = 
     alphas_paths = [i.infopath.parent for i in pdfs]
     alphas_replica0s = [path / f'{p}_0000.dat' for path, p in zip(alphas_paths, pdfs)]
     new_nrep = nrep + len(alphas_replica0s)
-    alphas_values = [str(p.AlphaS_MZ) for p in pdfs]
+    alphas_values = [str(p.alphas_mz) for p in pdfs]
 
     if target_path.exists():
         log.warning(f"{target_path} already exists. Deleting contents.")
@@ -99,7 +99,7 @@ def alpha_s_bundle_pdf(pdf, pdfs, output_path, target_name: (str, type(None)) = 
             yaml_obj = yaml.YAML()
             info_yaml = yaml_obj.load(stream)
         info_yaml['NumMembers'] = new_nrep
-        info_yaml['error_type'] += '+as'
+        info_yaml['ErrorType'] += '+as'
         extra_desc = '; '.join(
             f"mem={i} => alphas(MZ)={val}"
             for val, i in zip(alphas_values, range(nrep, new_nrep))

--- a/validphys2/src/validphys/tests/conftest.py
+++ b/validphys2/src/validphys/tests/conftest.py
@@ -3,11 +3,13 @@ conftest.py
 
 Pytest fixtures.
 """
+import contextlib
 import pathlib
 import sys
 
-import pytest
 from hypothesis import settings
+import lhapdf
+import pytest
 
 # Adding this here to change the time of deadline from default (200ms) to 1500ms
 settings.register_profile("extratime", deadline=1500)
@@ -192,3 +194,13 @@ def hessian_single_data_internal_cuts_config(single_data_internal_cuts_config):
     new_config = dict(single_data_internal_cuts_config)
     new_config["pdf"] = HESSIAN_PDF
     return new_config
+
+@contextlib.contextmanager
+def temp_lhapdf_path(folder):
+    """Modify the data path for LHAPDF sets"""
+    oldpaths = lhapdf.paths()
+    lhapdf.setPaths([str(folder)])
+    try:
+        yield
+    finally:
+        lhapdf.setPaths(oldpaths)

--- a/validphys2/src/validphys/tests/test_alpha_s_bundle_pdf.py
+++ b/validphys2/src/validphys/tests/test_alpha_s_bundle_pdf.py
@@ -1,0 +1,25 @@
+import lhapdf
+
+from validphys.api import API
+from validphys.tests.conftest import PDF, temp_lhapdf_path
+
+
+def test_alpha_s_bundle_pdf(tmp_path):
+    API.alpha_s_bundle_pdf(pdf=PDF, pdfs=[PDF, PDF], output_path=tmp_path)
+
+    # Save a reference to the original pdf
+    orig_pdf = API.pdf(pdf=PDF)
+
+    pdf_alpha_s_bundle_name = PDF + '_pdfas'
+
+    # Now try to read the PDF we just wrote to some non_std location
+    with temp_lhapdf_path(tmp_path):
+        pdf = lhapdf.mkPDFs(pdf_alpha_s_bundle_name)
+
+        orig_pdf_members = orig_pdf.get_members()
+        assert len(pdf) == orig_pdf_members + 2
+        assert pdf[-1].type == pdf[-2].type == "central"
+
+        # orig_pdf_members also includes replica0, therefore only +1
+        assert pdf[-1].memberID == orig_pdf_members + 1
+        assert pdf[-2].memberID == orig_pdf_members

--- a/validphys2/src/validphys/tests/test_covmats.py
+++ b/validphys2/src/validphys/tests/test_covmats.py
@@ -3,8 +3,6 @@ test_covmats.py
 
 Tests related to the computation of the covariance matrix and its derivatives
 """
-import random
-
 import pytest
 
 import numpy as np
@@ -13,7 +11,6 @@ import numpy as np
 from validphys.api import API
 from validphys.commondataparser import load_commondata
 from validphys.covmats import sqrt_covmat, dataset_t0_predictions
-from validphys.loader import Loader
 from validphys.tests.conftest import THEORYID, PDF, HESSIAN_PDF, DATA
 
 

--- a/validphys2/src/validphys/tests/test_mc2hessian.py
+++ b/validphys2/src/validphys/tests/test_mc2hessian.py
@@ -1,23 +1,10 @@
 """
     Test for the mc2hessian module
 """
-import contextlib
-import lhapdf
 from validphys.api import API
+from validphys.tests.conftest import temp_lhapdf_path
 
 NEIG = 5
-
-
-@contextlib.contextmanager
-def temp_lhapdf_path(folder):
-    """Modify the data path for LHAPDF sets"""
-    oldpaths = lhapdf.paths()
-    lhapdf.setPaths([str(folder)])
-    try:
-        yield
-    finally:
-        lhapdf.setPaths(oldpaths)
-
 
 def test_mc2hessian(data_config, tmp):
     """Tests that the generated hessian PDF is indeed marked as such


### PR DESCRIPTION
~~It's actually `Alphas_vals` instead of `Alphas_Vals`, see [here](https://lhapdf.hepforge.org/config.html). An LHAPDF dev (Max Knobbe) pointed out that it is case sensitive.~~

Surprising no-one ever complained about it though

------------------
**UPDATE:**

Okay, not so surprising since the [typo was on the lhapdf website](https://gitlab.com/hepcedar/lhapdf/-/merge_requests/68) where it says Alphas_vals, but the code does require Alphas_Vals. I already pointed this out to them so I guess they'll update it. 

This PR is still needed for reintroducing the `AlphaS_*` attributes in the `PDF` class and adding the test of `alpha_s_bundle_pdf`.