### PR TITLE
Use pdf error in bias and variance definition

### DIFF
--- a/validphys2/src/validphys/closuretest/multiclosure.py
+++ b/validphys2/src/validphys/closuretest/multiclosure.py
@@ -162,6 +162,8 @@ def fits_dataset_bias_variance(
         variances = []
         pdf_cov = np.asarray([np.cov(reps[j], rowvar=True) for j in range(n_fits)])
         # There are n_fits pdf_covariances
+        # flag to see whether to eliminate dataset
+        flag = True
         for i in range(n_fits):
             n_data = len(law_th)
             #evals, eigens = la.eigh(pdf_cov[i])
@@ -195,15 +197,18 @@ def fits_dataset_bias_variance(
                     bias = calc_chi2(sqrt_cov, bias_diffs)
                     var = np.mean(calc_chi2(sqrt_cov, var_diffs))
                     if (abs(var-law_th.central_value.shape[0])) > law_th.central_value.shape[0]*5./100:
-                        var = 0
-                        bias = 0
+                        flag = False
+                        break
 
 
                 except:
-                    var = 0
-                    bias = 0
+                    flag = False
+                    break
             biases.append(bias)
             variances.append(var)
+        if flag == False:
+            biases = np.full(n_fits,0.000001)
+            variances = np.full(n_fits,0.000001)
         print("this is biases mean"+ str(np.mean(biases)))
         print("this is vars mean"+ str(np.mean(variances)))
         return np.asarray(biases), np.asarray(variances), n_data

--- a/validphys2/src/validphys/closuretest/multiclosure.py
+++ b/validphys2/src/validphys/closuretest/multiclosure.py
@@ -10,7 +10,6 @@ in this module are used to produce results which are plotted in
 import numpy as np
 import scipy.linalg as la
 import scipy.special as special
-import copy
 
 from reportengine import collect
 
@@ -224,6 +223,8 @@ def fits_dataset_bias_variance(
             variances = np.full(n_fits,0.000001)
         print("this is biases mean"+ str(np.mean(biases)))
         print("this is vars mean"+ str(np.mean(variances)))
+        print("these are biases: " + str(biases))
+        print("these are variances: " + str(variances))
         return np.asarray(biases), np.asarray(variances), n_data
     
     if pdf_and_exp_err and only_pdf_err == False:

--- a/validphys2/src/validphys/closuretest/multiclosure.py
+++ b/validphys2/src/validphys/closuretest/multiclosure.py
@@ -204,7 +204,7 @@ def fits_dataset_bias_variance(
                     bias = calc_chi2(sqrt_cov, bias_diffs)
                     var = (np.mean(calc_chi2(sqrt_cov, var_diffs)))
                 if only_diag==False and regularize_corr == False and cut_obs == True:
-                    d = np.sqrt(np.diag(pdf_cov[i]))[:, np.newaxis]
+                    """d = np.sqrt(np.diag(pdf_cov[i]))[:, np.newaxis]
                     corr = pdf_cov[i]/d/d.T-np.diag(np.ones(pdf_cov[i].shape[0]))
                     #Here the matrix is reduced deleting observables which are too correlated
                     if i == 0:
@@ -214,6 +214,22 @@ def fits_dataset_bias_variance(
                     indices = list(set(np.where(np.tril(mask))[0]))
                     corr_cov = np.delete(pdf_cov[i],indices,0)
                     corr_cov = np.delete(corr_cov,indices,1)
+                    n_data = corr_cov.shape[0]
+                    corr_reps = np.delete(reps[i], indices,0)
+                    corr_theo = np.delete(law_th.central_value,indices)
+                    bias_diffs = np.mean(corr_reps, axis = 1) - corr_theo
+                    var_diffs = np.mean(corr_reps, axis = 1)[:,np.newaxis] - corr_reps
+                    sqrt_cov = sqrt_covmat(corr_cov)
+                    bias = calc_chi2(sqrt_cov, bias_diffs)
+                    var = (np.mean(calc_chi2(sqrt_cov, var_diffs)))"""
+                    # Different approach
+                    if i == 0:
+                        d = np.sqrt(np.diag(pdf_cov[i]))[:, np.newaxis]
+                        corr = pdf_cov[i]/d/d.T-np.diag(np.ones(pdf_cov[i].shape[0]))
+                        # diagonalize corr and get indices of observables which are too correlated
+                        evals, evecs = la.eigh(corr)
+                        indices = np.where(np.diag(evecs.T@corr@evecs) < 10**(-10))[0]
+                    corr_cov = np.delete(np.delete(pdf_cov[i],indices,1),indices,0)
                     n_data = corr_cov.shape[0]
                     corr_reps = np.delete(reps[i], indices,0)
                     corr_theo = np.delete(law_th.central_value,indices)

--- a/validphys2/src/validphys/closuretest/multiclosure.py
+++ b/validphys2/src/validphys/closuretest/multiclosure.py
@@ -147,9 +147,9 @@ def fits_dataset_bias_variance(
     if only_pdf_err and pdf_and_exp_err == False:
     #TODO: For now I am using the mean of the pdf covs over fits. It is simply easier to implement
     # and there shouldnt be a lot of differences between the covmats.
-        pdf_cov = np.mean(np.asarray([np.cov(reps[j], rowvar=True) for j in range(np.shape(reps)[0])]), axis = 0)
-        sqrt_pdf_cov = la.cholesky(pdf_cov, lower = True)
-
+        pdf_cov = np.asarray([np.cov(reps[j], rowvar=True) for j in range(np.shape(reps)[0])])
+        sqrt_pdf_cov = np.asarray([la.cholesky(pdf_cov[i], lower = True) for i in range(np.shape(pdf_cov)[0])])
+        sqrt_pdf_cov = np.mean(sqrt_pdf_cov, axis = 0)
     if pdf_and_exp_err and only_pdf_err == False:
         pdf_cov = np.mean(np.asarray([np.cov(reps[j], rowvar=True) for j in range(np.shape(reps)[0])]), axis = 0)
         sqrt_pdf_exp_cov = la.cholesky(pdf_cov + exp_cov, lower = True)

--- a/validphys2/src/validphys/closuretest/multiclosure.py
+++ b/validphys2/src/validphys/closuretest/multiclosure.py
@@ -165,7 +165,7 @@ def fits_dataset_bias_variance(
         for i in range(n_fits):
             n_data = len(law_th)
             #evals, eigens = la.eigh(pdf_cov[i])
-            if(np.shape(pdf_cov[i]) == ()):
+            """if(np.shape(pdf_cov[i]) == ()):
                 bias_diffs = np.asarray(np.mean(reps[i], axis = 1) - law_th.central_value)
                 var_diffs = np.asarray(np.mean(reps[i], axis = 1)[:,np.newaxis] - reps[i])
                 bias = bias_diffs[0]*bias_diffs[0]/(pdf_cov[i])
@@ -178,8 +178,8 @@ def fits_dataset_bias_variance(
                 bias = bias_diffs*bias_diffs*diag_inv
                 var = np.mean(var_diffs.T*var_diffs.T*diag_inv, axis = 0)
                 bias = np.sum(bias)
-                var = np.sum(var)
-            """if(np.shape(pdf_cov[i]) == ()):
+                var = np.sum(var)"""
+            if(np.shape(pdf_cov[i]) == ()):
                 bias_diffs = np.asarray(np.mean(reps[i], axis = 1) - law_th.central_value)
                 var_diffs = np.asarray(np.mean(reps[i], axis = 1)[:,np.newaxis] - reps[i])
                 bias = bias_diffs[0]*bias_diffs[0]/(pdf_cov[i])
@@ -194,31 +194,14 @@ def fits_dataset_bias_variance(
                     sqrt_cov = sqrt_covmat(pdf_cov[i])
                     bias = calc_chi2(sqrt_cov, bias_diffs)
                     var = np.mean(calc_chi2(sqrt_cov, var_diffs))
+                    if (abs(var-law_th.central_value.shape[0])) > law_th.central_value.shape[0]*5./100:
+                        var = 0
+                        bias = 0
+
 
                 except:
-                    evals, eigens = la.eigh(pdf_cov[i])  
-                    ##compute as quadratic form biases
-                    bias = (eigens.T@bias_diffs)*(eigens.T@bias_diffs)/evals
-                    rotated_var_diffs = eigens.T@var_diffs
-                if (abs(np.sum(bias) -  law_th.central_value.shape[0])> 5*np.sqrt(2*law_th.central_value.shape[0])):
-                    print("entro nell'if")
-                    evals, eigens = la.eigh(pdf_cov[i])
-                    bias = np.asarray((eigens.T@bias_diffs)*(eigens.T@bias_diffs)/evals)
-                    var = np.asarray(np.mean((rotated_var_diffs*rotated_var_diffs).T/evals, axis = 0))
-                    mask_b = bias > 30
-                    mask_b_1 = bias < 0
-                    mask_v = var > 30
-                    mask_v_1 = var < 0
-
-                    m1 = np.logical_or(mask_b,mask_b_1)
-                    m2 = np.logical_or(mask_v,mask_v_1)
-                    mask = np.logical_or(m1,m2)
-                    indices = np.where(mask)[0]
-                    n_data = n_data - np.size(indices)
-                    bias = np.delete(bias,indices)
-                    var = np.delete(var,indices)
-                    bias = np.sum(bias)
-                    var = np.sum(var)"""
+                    var = 0
+                    bias = 0
             biases.append(bias)
             variances.append(var)
         print("this is biases mean"+ str(np.mean(biases)))

--- a/validphys2/src/validphys/closuretest/multiclosure.py
+++ b/validphys2/src/validphys/closuretest/multiclosure.py
@@ -115,7 +115,8 @@ def fits_dataset_bias_variance(
     _internal_max_reps=None,
     _internal_min_reps=20,
     only_pdf_err = False,
-    pdf_and_exp_err = False
+    pdf_and_exp_err = False,
+    threshold = 0
 ):
     """For a single dataset, calculate the bias and variance for each fit
     and return tuple (bias, variance, n_data), where bias and variance are
@@ -156,7 +157,6 @@ def fits_dataset_bias_variance(
         biases = []
         variances = []
         pdf_cov = np.asarray([np.cov(reps[j], rowvar=True) for j in range(n_fits)])
-        dist_threshold = 0.2
         # There are n_fits pdf_covariances
         for i in range(n_fits):
 
@@ -164,7 +164,6 @@ def fits_dataset_bias_variance(
                 sqrt_cov = sqrt_covmat(pdf_cov[i])
             except:
                 evals, eigens = la.eigh(pdf_cov[i])  
-                threshold = 10**(-8)  
                 mask = evals < threshold
                 indices = np.where(mask)[0]
                 print("number of raw obs: " + str(np.shape(evals)))
@@ -300,13 +299,14 @@ def fits_data_bias_variance(
     _internal_max_reps=None,
     _internal_min_reps=20,
     only_pdf_err = False,
-    pdf_and_exp_err = False
+    pdf_and_exp_err = False,
+    threshold = 0
 
 ):
     """Like `fits_dataset_bias_variance` but for all data"""
     return fits_dataset_bias_variance(
         internal_multiclosure_data_loader, _internal_max_reps, _internal_min_reps,
-        only_pdf_err, pdf_and_exp_err
+        only_pdf_err, pdf_and_exp_err, threshold
     )
 
 
@@ -563,7 +563,8 @@ def bias_variance_resampling_dataset(
     boot_seed=DEFAULT_SEED,
     use_repeats=True,
     only_pdf_err = False,
-    pdf_and_exp_err = False
+    pdf_and_exp_err = False,
+    threshold = 0
 ):
     """For a single dataset, create bootstrap distributions of bias and variance
     varying the number of fits and replicas drawn for each resample. Return two
@@ -616,7 +617,8 @@ def bias_variance_resampling_dataset(
                 # explicitly pass n_rep to fits_dataset_bias_variance so it uses
                 # full subsample
                 bias, variance, _ = expected_dataset_bias_variance(
-                    fits_dataset_bias_variance(boot_internal_loader, n_rep_sample, only_pdf_err, pdf_and_exp_err)
+                    fits_dataset_bias_variance(boot_internal_loader, n_rep_sample, only_pdf_err, pdf_and_exp_err,
+                                               threshold)
                 )
                 bias_boot.append(bias)
                 variance_boot.append(variance)
@@ -796,7 +798,8 @@ def fits_bootstrap_data_bias_variance(
     bootstrap_samples=100,
     boot_seed=DEFAULT_SEED,
     only_pdf_err = False,
-    pdf_and_exp_err = False
+    pdf_and_exp_err = False,
+    threshold = 0
 ):
     """Perform bootstrap resample of `fits_data_bias_variance`, returns
     tuple of bias_samples, variance_samples where each element is a 1-D np.array
@@ -824,7 +827,7 @@ def fits_bootstrap_data_bias_variance(
         bias, variance, _ = expected_dataset_bias_variance(
             fits_dataset_bias_variance(
                 boot_internal_loader, _internal_max_reps, _internal_min_reps,
-                only_pdf_err, pdf_and_exp_err
+                only_pdf_err, pdf_and_exp_err, threshold
             )
         )
         bias_boot.append(bias)

--- a/validphys2/src/validphys/closuretest/multiclosure.py
+++ b/validphys2/src/validphys/closuretest/multiclosure.py
@@ -143,29 +143,22 @@ def fits_dataset_bias_variance(
     # Compute pdf covariance matrix for each fit. Dimensions here are (fit, data point, data point)
     # Across fits the pdf_cov should be all similair. Just to be consistent biases and variances should be
     # calculated using for each fit its sampled pdf_cov
-    import ipdb; ipdb.set_trace()
 
     if only_pdf_err and pdf_and_exp_err == False:
     #TODO: For now I am using the mean of the pdf covs over fits. It is simply easier to implement
     # and there shouldnt be a lot of differences between the covmats.
-        print("entro nel for di only_pdf_err")
         pdf_cov = np.mean(np.asarray([np.cov(reps[j], rowvar=True) for j in range(np.shape(reps)[0])]), axis = 0)
-        print("shape della covmat")
-        print(np.shape(pdf_cov))
         sqrt_pdf_cov = la.cholesky(pdf_cov, lower = True)
 
     if pdf_and_exp_err and only_pdf_err == False:
-        print("entro nel for di pdf_and_exp_err")
         pdf_cov = np.mean(np.asarray([np.cov(reps[j], rowvar=True) for j in range(np.shape(reps)[0])]), axis = 0)
-        print("shape della covmat")
-        print(np.shape(pdf_cov))
         sqrt_pdf_exp_cov = la.cholesky(pdf_cov + exp_cov, lower = True)
     # take mean across replicas - since we might have changed no. of reps
     centrals = reps.mean(axis=2)
     # place bins on first axis
     diffs = law_th.central_value[:, np.newaxis] - centrals.T
     if (only_pdf_err == False and pdf_and_exp_err == False):
-        print("comportamento standard")
+        # Standard behaviour
         biases = calc_chi2(sqrtcov, diffs)
         variances = []
         # this seems slow but breaks for datasets with single data point otherwise
@@ -175,7 +168,7 @@ def fits_dataset_bias_variance(
         return biases, np.asarray(variances), len(law_th)
     
     if (only_pdf_err and pdf_and_exp_err == False):
-        print("calcolo chi2 con only_pdf")
+        # Only pdf error
         biases = calc_chi2(sqrt_pdf_cov, diffs)
         variances = []
         # this seems slow but breaks for datasets with single data point otherwise
@@ -185,7 +178,7 @@ def fits_dataset_bias_variance(
         return biases, np.asarray(variances), len(law_th)
     
     if (only_pdf_err == False and pdf_and_exp_err):
-        print("calcolo chi2 con pdf and exp")
+        # pdf error + exp error
         biases = calc_chi2(sqrt_pdf_exp_cov, diffs)
         variances = []
         # this seems slow but breaks for datasets with single data point otherwise

--- a/validphys2/src/validphys/closuretest/multiclosure.py
+++ b/validphys2/src/validphys/closuretest/multiclosure.py
@@ -164,7 +164,7 @@ def fits_dataset_bias_variance(
         # There are n_fits pdf_covariances
         for i in range(n_fits):
             n_data = len(law_th)
-            evals, eigens = la.eigh(pdf_cov[i])
+            #evals, eigens = la.eigh(pdf_cov[i])
             if(np.shape(pdf_cov[i]) == ()):
                 bias_diffs = np.asarray(np.mean(reps[i], axis = 1) - law_th.central_value)
                 var_diffs = np.asarray(np.mean(reps[i], axis = 1)[:,np.newaxis] - reps[i])

--- a/validphys2/src/validphys/closuretest/multiclosure.py
+++ b/validphys2/src/validphys/closuretest/multiclosure.py
@@ -163,13 +163,16 @@ def fits_dataset_bias_variance(
         pdf_cov = np.asarray([np.cov(reps[j], rowvar=True) for j in range(n_fits)])
         # There are n_fits pdf_covariances
         for i in range(n_fits):
+            n_data = len(law_th)
+            print("questa pdf cov ecc: " + str(pdf_cov[i]))
             if(np.shape(pdf_cov[i]) == ()):
-                bias_diffs = np.mean(reps[i], axis = 1) - law_th.central_value
-                var_diffs = np.mean(reps[i], axis = 1)[:,np.newaxis] - reps[i]
+                bias_diffs = np.asarray(np.mean(reps[i], axis = 1) - law_th.central_value)
+                var_diffs = np.asarray(np.mean(reps[i], axis = 1)[:,np.newaxis] - reps[i])
+                print("queste le bias diffs: " + str(bias_diffs))
                 print("bias diffs shape: " + str(np.shape(bias_diffs)))
                 print("var diffs shape: " + str(np.shape(var_diffs)))
-                bias = bias_diffs*bias_diffs/(float(pdf_cov[i]))
-                var = np.mean(var_diffs*var_diffs, axis = 1)/(float(pdf_cov[i]))
+                bias = bias_diffs[0]*bias_diffs[0]/(pdf_cov[i])
+                var = np.mean(var_diffs[0]*var_diffs[0])/(pdf_cov[i])
             else:
                 bias_diffs = np.mean(reps[i], axis = 1) - law_th.central_value
                 var_diffs = np.mean(reps[i], axis = 1)[:,np.newaxis] - reps[i]
@@ -198,9 +201,9 @@ def fits_dataset_bias_variance(
                     print("this is variance:" + str(var))
                     print("this is bias: " + str (bias))
                     print("shape of the thing i wanna divide: " + str(np.shape(rotated_var_diffs)))
-                    mask_b = bias > 30
+                    mask_b = bias > 10
                     mask_b_1 = bias < 0
-                    mask_v = var > 30
+                    mask_v = var > 10
                     mask_v_1 = var < 0
 
                     m1 = np.logical_or(mask_b,mask_b_1)
@@ -213,10 +216,10 @@ def fits_dataset_bias_variance(
                     var = np.delete(var,indices)
                     bias = np.sum(bias)
                     var = np.sum(var)
-                biases.append(bias)
-                variances.append(var)
-                print("this is bias for fit: " + str(bias))
-                print("this is var for fit: " + str(var))
+            biases.append(bias)
+            variances.append(var)
+            print("this is bias for fit: " + str(bias))
+            print("this is var for fit: " + str(var))
             print("mean bias: " + str(np.mean(biases)))    
             print("mean var: " + str(np.mean(variances)))
             print("square root ratio: " + str(np.sqrt(np.mean(biases)/np.mean(variances))))  

--- a/validphys2/src/validphys/closuretest/multiclosure.py
+++ b/validphys2/src/validphys/closuretest/multiclosure.py
@@ -160,7 +160,6 @@ def fits_dataset_bias_variance(
         biases = []
         variances = []
         pdf_cov = np.asarray([np.cov(reps[j], rowvar=True) for j in range(n_fits)])
-        import ipdb; ipdb.set_trace()
         # There are n_fits pdf_covariances
         # flag to see whether to eliminate dataset
         for i in range(n_fits):

--- a/validphys2/src/validphys/closuretest/multiclosure.py
+++ b/validphys2/src/validphys/closuretest/multiclosure.py
@@ -91,7 +91,6 @@ def internal_multiclosure_dataset_loader(
     sqrt_covmat = la.cholesky(t0_covmat_from_systematics, lower=True)
     # TODO: support covmat reg and theory covariance matrix
     # possibly make this a named tuple
-    print(np.shape(t0_covmat_from_systematics))
     return (fits_dataset_predictions, fits_underlying_predictions, t0_covmat_from_systematics, sqrt_covmat)
 
 
@@ -142,19 +141,31 @@ def fits_dataset_bias_variance(
     # The dimentions here are (fit, data point, replica)
     reps = np.asarray([th.error_members[:, :_internal_max_reps] for th in closures_th])
     # Compute pdf covariance matrix for each fit. Dimensions here are (fit, data point, data point)
-    # Across fits the pdf_cov should be all similair. Just to be consistent biases and variances are
+    # Across fits the pdf_cov should be all similair. Just to be consistent biases and variances should be
     # calculated using for each fit its sampled pdf_cov
+    import ipdb; ipdb.set_trace()
+
     if only_pdf_err and pdf_and_exp_err == False:
-        pdf_cov = np.cov(reps, axes = (1,2))
-        sqrt_pdf_cov = np.asarray([la.cholesky(pdf_cov[j]) for j in range(np.shape(pdf_cov)[0])])
+    #TODO: For now I am using the mean of the pdf covs over fits. It is simply easier to implement
+    # and there shouldnt be a lot of differences between the covmats.
+        print("entro nel for di only_pdf_err")
+        pdf_cov = np.mean(np.asarray([np.cov(reps[j], rowvar=True) for j in range(np.shape(reps)[0])]), axis = 0)
+        print("shape della covmat")
+        print(np.shape(pdf_cov))
+        sqrt_pdf_cov = la.cholesky(pdf_cov, lower = True)
+
     if pdf_and_exp_err and only_pdf_err == False:
-        pdf_cov = np.cov(reps, axes = (1,2))
-        sqrt_pdf_exp_cov = np.asarray([la.cholesky(pdf_cov[j] + exp_cov) for j in range(np.shape(pdf_cov)[0])])
+        print("entro nel for di pdf_and_exp_err")
+        pdf_cov = np.mean(np.asarray([np.cov(reps[j], rowvar=True) for j in range(np.shape(reps)[0])]), axis = 0)
+        print("shape della covmat")
+        print(np.shape(pdf_cov))
+        sqrt_pdf_exp_cov = la.cholesky(pdf_cov + exp_cov, lower = True)
     # take mean across replicas - since we might have changed no. of reps
     centrals = reps.mean(axis=2)
     # place bins on first axis
     diffs = law_th.central_value[:, np.newaxis] - centrals.T
-    if (only_pdf_err==False and pdf_and_exp_err == False):
+    if (only_pdf_err == False and pdf_and_exp_err == False):
+        print("comportamento standard")
         biases = calc_chi2(sqrtcov, diffs)
         variances = []
         # this seems slow but breaks for datasets with single data point otherwise
@@ -164,21 +175,23 @@ def fits_dataset_bias_variance(
         return biases, np.asarray(variances), len(law_th)
     
     if (only_pdf_err and pdf_and_exp_err == False):
+        print("calcolo chi2 con only_pdf")
         biases = calc_chi2(sqrt_pdf_cov, diffs)
         variances = []
         # this seems slow but breaks for datasets with single data point otherwise
         for i in range(reps.shape[0]):
             diffs = reps[i, :, :] - reps[i, :, :].mean(axis=1, keepdims=True)
-            variances.append(np.mean(calc_chi2(sqrtcov, diffs)))
+            variances.append(np.mean(calc_chi2(sqrt_pdf_cov, diffs)))
         return biases, np.asarray(variances), len(law_th)
     
     if (only_pdf_err == False and pdf_and_exp_err):
+        print("calcolo chi2 con pdf and exp")
         biases = calc_chi2(sqrt_pdf_exp_cov, diffs)
         variances = []
         # this seems slow but breaks for datasets with single data point otherwise
         for i in range(reps.shape[0]):
             diffs = reps[i, :, :] - reps[i, :, :].mean(axis=1, keepdims=True)
-            variances.append(np.mean(calc_chi2(sqrtcov, diffs)))
+            variances.append(np.mean(calc_chi2(sqrt_pdf_exp_cov, diffs)))
         return biases, np.asarray(variances), len(law_th)
 
 

--- a/validphys2/src/validphys/closuretest/multiclosure.py
+++ b/validphys2/src/validphys/closuretest/multiclosure.py
@@ -145,12 +145,12 @@ def fits_dataset_bias_variance(
     # calculated using for each fit its sampled pdf_cov
 
     #if only_pdf_err and pdf_and_exp_err == False:
-    #TODO: There is a problem in the inversion of the matrix. Probably comes from too few replicas 
+    #TODO: There is a problem in the inversion of the pdf matrix. Probably comes from too few replicas 
     # being sampled since when testing on out of sample data one is trying to compute a covariance matrix of
     # a high dimensional random variable (n > 800) with a sample of ~100 elements (the replicas per fit)
-        #pdf_cov = np.asarray([np.cov(reps[j], rowvar=True) for j in range(np.shape(reps)[0])])
-        #sqrt_pdf_cov = np.asarray([la.cholesky(pdf_cov[i], lower = True) for i in range(np.shape(pdf_cov)[0])])
-        #sqrt_pdf_cov = np.mean(sqrt_pdf_cov, axis = 0)
+        # pdf_cov = np.asarray([np.cov(reps[j], rowvar=True) for j in range(np.shape(reps)[0])])
+        # sqrt_pdf_cov = np.asarray([la.cholesky(pdf_cov[i], lower = True) for i in range(np.shape(pdf_cov)[0])])
+        # sqrt_pdf_cov = np.mean(sqrt_pdf_cov, axis = 0)
     if pdf_and_exp_err and only_pdf_err == False:
         pdf_cov = np.mean(np.asarray([np.cov(reps[j], rowvar=True) for j in range(np.shape(reps)[0])]), axis = 0)
         sqrt_pdf_exp_cov = la.cholesky(pdf_cov + exp_cov, lower = True)
@@ -179,6 +179,9 @@ def fits_dataset_bias_variance(
         return biases, np.asarray(variances), len(law_th)
     
     if (only_pdf_err and pdf_and_exp_err == False):
+        # temporary measure: assume the pdf_covmat is diagonalized by the same change of baasis
+        # as the experimental one (assume the correlations induced by pdfs in data space are the same as the
+        # experiments)
         print(type(only_pdf_dataset_bias_variance(internal_multiclosure_dataset_loader)))
         return (*only_pdf_dataset_bias_variance(internal_multiclosure_dataset_loader), len(law_th))
     

--- a/validphys2/src/validphys/closuretest/multiclosure_output.py
+++ b/validphys2/src/validphys/closuretest/multiclosure_output.py
@@ -9,6 +9,7 @@ data.
 import numpy as np
 import pandas as pd
 import scipy.special as special
+import matplotlib.pyplot as plt
 import scipy.stats
 import yaml
 
@@ -219,7 +220,7 @@ def datasets_bias_variance_ratio(datasets_expected_bias_variance, each_dataset):
 @table
 def datasets_bias_variance(datasets_expected_bias_variance, each_dataset):
     """For each dataset calculate the expected bias and expected variance
-    across fitsband tabulate the results. Bias and Variance are normalized by number of data points
+    across fits and tabulate the results. Bias and Variance are normalized by number of data points
 
     Notes
     -----
@@ -240,6 +241,7 @@ def datasets_bias_variance(datasets_expected_bias_variance, each_dataset):
     return df
 
 
+# This does not work for now
 @figure
 def plot_bias_variance_ndata(datasets_expected_bias_variance, each_dataset):
     """

--- a/validphys2/src/validphys/closuretest/multiclosure_output.py
+++ b/validphys2/src/validphys/closuretest/multiclosure_output.py
@@ -32,7 +32,57 @@ log = logging.getLogger(__name__)
 
 l = Loader()
 
+def CDF(x, bins = 1000):
+    """
+    Given an array of observations "x" build the cumulative distribution function 
+    """
+    count, bins_count = np.histogram(x, bins=bins)
+    pdf = count / sum(count)
+    cdf = np.cumsum(pdf)
+    return bins_count, pdf, cdf
 
+
+@figure
+def plot_CDF_dataset_KS(alternative_fits_dataset_bias_variance, bins = 1000):
+    biases, variances, n_dat = alternative_fits_dataset_bias_variance
+    import itertools
+    fig, ax = plotutils.subplots()
+    bin_bias_count, pdf_bias, cdf_bias = CDF(biases, bins)
+    bin_var_count, pdf_variance, cdf_variance = CDF(variances, bins)
+    ## probably one cdf ends before the other. Fill the plot to match the domains
+    # take maximum and minimum of 2 domains
+    left = min(min(bin_bias_count[1:]),min(bin_var_count[1:]))
+    right = max(max(bin_var_count[1:]),max(bin_bias_count[1:]))
+
+    #import ipdb; ipdb.set_trace()
+    ax.plot(np.insert(np.insert(bin_bias_count[1:],0,left),bins+1,right), 
+    np.insert(np.insert(cdf_bias,0,0),bins+1,1), label = "cdf of bias")
+    ##Plot the CDF of a normal chi square
+    chi2 = scipy.stats.chi2.cdf(bin_bias_count[1:],n_dat)
+    ax.plot(np.insert(np.insert(bin_var_count[1:],0,left),bins+1,right), 
+    np.insert(np.insert(cdf_variance,0,0),bins+1,1), label = "cdf of variance")
+    ##Find maximum of difference
+    maximum = np.max(abs(np.insert(np.insert(cdf_variance,0,0),bins+1,1)-np.insert(np.insert(cdf_bias,0,0),bins+1,1)))
+    print("maximum diff is: " + str(maximum))
+    ax.legend()
+    return fig
+
+@figure
+def plot_CDF_data_KS(alternative_fits_data_bias_variance, bins = 1000):
+    return plot_CDF_dataset_KS(alternative_fits_data_bias_variance, bins)
+
+@figure
+def plot_hist_bias_variance_dataset(alternative_fits_dataset_bias_variance, bins):
+    fig, ax = plotutils.subplots()
+    biases, variances, n_dat = alternative_fits_dataset_bias_variance
+    ax.hist(biases, bins = 100, label = "bias", alpha = 0.3, density = True)
+    ax.hist(variances, bins = 100, label = "variance", alpha = 0.3, density = True)
+    ax.legend()
+    return fig
+
+@figure
+def plot_hist_bias_variance_data(alternative_fits_data_bias_variance, bins = 1000):
+    return plot_hist_bias_variance_dataset(alternative_fits_data_bias_variance, bins)
 
 
 

--- a/validphys2/src/validphys/covmats.py
+++ b/validphys2/src/validphys/covmats.py
@@ -581,6 +581,25 @@ def sqrt_covmat(covariance_matrix):
     return sqrt_matrix
 
 
+def regularize_sqrt_cov(covmat):
+    """Function that computes the sqrt covmat regularizing the starting covmat in case it is not positive
+    definite. Introducing the pdf covmat in the calculation of bias and variance what happens is that too
+    few replicas can lead to instabilities in the inversion since the sampled covmat is not pos def
+
+    """
+    eigenvalues, eigenvectors = la.eigh(covmat)
+    for i in range(np.size(eigenvalues)):
+        if eigenvalues[i] < 10**(-16):
+            eigenvalues[i] = 10**(-16)
+    s = 0
+    for i in range(np.size(eigenvalues)):
+        temp = (eigenvalues[i]*(eigenvectors.T[i][:,np.newaxis]@eigenvectors.T[i][:,np.newaxis].T))
+        s += temp
+    reg_covmat = s
+
+    return sqrt_covmat(reg_covmat)
+    
+
 def groups_covmat_no_table(
        groups_data, groups_index, groups_covmat_collection):
     """Export the covariance matrix for the groups. It exports the full


### PR DESCRIPTION
We would like to introduce the possibility of computing bias and variance in the context of a multi closure test with the following settings:

- standard behavior (only experimental covariance matrix)
- pdf error 
- pdf error + experimental error

@andreab1997 @comane 