### PR TITLE
Fixes to prepare the code for pandas 2.0

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -41,7 +41,7 @@ requirements:
         - matplotlib >=3.3.0
         - blessings >=1.7
         - scipy >=0.19.1
-        - pandas
+        - pandas <2 # In principle the code runs with pandas 2 but the results (plots, tables, formats) are untested
         - requests
         - prompt_toolkit
         - validobj

--- a/validphys2/src/validphys/tableloader.py
+++ b/validphys2/src/validphys/tableloader.py
@@ -94,7 +94,7 @@ def set_actual_column_level0(df, new_levels):
     This is a separate function mostly because it breaks
     in every patch update of pandas."""
     cols = df.columns
-    cols.set_levels(new_levels, inplace=True, level=0)
+    df.columns = cols.set_levels(new_levels, level=0)
 
 
 # TODO: Find a better place for this function
@@ -130,7 +130,7 @@ def combine_pseudoreplica_tables(
     # The idea is: Set to inf the nans of the valid curves, so that we select
     # the minimum (which is not infinite).  Leave the bad nans as nans, so we
     # write nan always for those.
-    total_chis = total_chis.groupby(axis=1, level=1).apply(fixup_min_points)
+    total_chis = total_chis.groupby(axis=1, level=1, group_keys=False).apply(fixup_min_points)
 
     # Note, asarray is needed because it ignores NANs otherwise.
     argmin = lambda x: pd.Series(np.argmin(np.asarray(x), axis=1), index=x.index)


### PR DESCRIPTION
Fixes #1722, at least such that the test pass in my computer. 

Note, right now we are "blocked" in pandas < 2.0 due to `eko`. But we might as well fix these small things as we find them. In this case they removed a keyword and change some defaults https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.groupby.html

Since pandas 2.0 changed a bunch of defaults we will have to look very careful at many reports when we decide to make the change... so for now I'm happy that we are blocked at 1.X.

