### PR TITLE
Fix `Q2grid` in `evolven3fit_new`

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -51,7 +51,7 @@ requirements:
         - sphinxcontrib-bibtex
         - curio >=1.0
         - pineappl >=0.5.8
-        - eko >=0.13.2,<0.14
+        - eko >=0.13.4,<0.14
         - banana-hep >=0.6.8
         - fiatlux
 

--- a/n3fit/src/evolven3fit_new/evolve.py
+++ b/n3fit/src/evolven3fit_new/evolve.py
@@ -174,7 +174,7 @@ def evolve_exportgrid(exportgrid, eko, x_grid, qed):
     block = genpdf.generate_block(
         ev_pdf,
         xgrid=targetgrid,
-        evolgrid=eko.evolgrid,
+        evolgrid=[(float(q2), int(nf)) for q2, nf in np.sort(eko.evolgrid, axis=0)],
         pids=basis_rotation.flavor_basis_pids,
     )
     return block

--- a/n3fit/src/evolven3fit_new/evolve.py
+++ b/n3fit/src/evolven3fit_new/evolve.py
@@ -174,7 +174,7 @@ def evolve_exportgrid(exportgrid, eko, x_grid, qed):
     block = genpdf.generate_block(
         ev_pdf,
         xgrid=targetgrid,
-        evolgrid=[(float(q2), int(nf)) for q2, nf in np.sort(eko.evolgrid, axis=0)],
+        evolgrid=eko.evolgrid,
         pids=basis_rotation.flavor_basis_pids,
     )
     return block


### PR DESCRIPTION
Unfortunately `Q2` values from `eko.evolgrid` (`eko=0.13.2`) are not sorted anymore, so we need this temporary fix to produce correct `lhapdf` files, otherwise the interpolation is just crazy. 

We should consider to fix this in `ekobox` directly in the newer version ( @all_eko_autors ). 

cc @niclaurenti, @andreab1997 