### PR TITLE
Upgrade to eko0.13.5

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -51,7 +51,7 @@ requirements:
         - sphinxcontrib-bibtex
         - curio >=1.0
         - pineappl >=0.5.8
-        - eko >=0.13.4,<0.14
+        - eko >=0.13.5,<0.14
         - banana-hep >=0.6.8
         - fiatlux
 

--- a/n3fit/src/evolven3fit_new/eko_utils.py
+++ b/n3fit/src/evolven3fit_new/eko_utils.py
@@ -77,11 +77,6 @@ def construct_eko_cards(
     legacy_class = runcards.Legacy(theory, {})
     theory_card = legacy_class.new_theory
 
-    # if Qedref = Qref alphaem is running, otherwise it's fixed
-    if theory["QED"] > 0:
-        if np.isclose(theory["Qref"], theory["Qedref"]):
-            theory_card.couplings.em_running = True
-
     # construct operator card
     q2_grid = utils.generate_q2grid(
         theory["Q0"],


### PR DESCRIPTION
Very fast PR that upgrades `evolven3fit_new` to the new version of `eko` (i.e. 0.13.5), in which the check
```
if np.isclose(theory["Qref"], theory["Qedref"]):
            theory_card.couplings.em_running = True
```
is performed directly inside `eko`:

https://github.com/NNPDF/eko/blob/e019ad23495c5bd2ee61426c4705d265137f6596/src/eko/io/runcards.py#L176