### PR TITLE
Separate photon's elastic, inelastic and msbar components

### DIFF
--- a/n3fit/runcards/examples/Basic_runcard_qed.yml
+++ b/n3fit/runcards/examples/Basic_runcard_qed.yml
@@ -170,3 +170,4 @@ fiatlux:
   additional_errors: true # should be set to true only for the last iteration
   luxseed: 1234567890
   eps_base: 1e-2
+  component: total

--- a/n3fit/src/n3fit/layers/rotations.py
+++ b/n3fit/src/n3fit/layers/rotations.py
@@ -111,10 +111,10 @@ class AddPhoton(MetaLayer):
         self._pdf_ph = None
         super().__init__(**kwargs)
 
-    def register_photon(self, xgrid):
+    def register_photon(self, xgrid, total):
         """Compute the photon array and set the layer to be rebuilt"""
         if self._photons_generator:
-            self._pdf_ph = self._photons_generator(xgrid)
+            self._pdf_ph = self._photons_generator(xgrid, total)
             self.built = False
 
     def call(self, pdfs, ph_replica):

--- a/n3fit/src/n3fit/model_trainer.py
+++ b/n3fit/src/n3fit/model_trainer.py
@@ -916,7 +916,7 @@ class ModelTrainer:
             if photons:
                 for m in pdf_models:
                     pl = m.get_layer("add_photon")
-                    pl.register_photon(xinput.input.tensor_content)
+                    pl.register_photon(xinput.input.tensor_content, True)
 
             # Model generation joins all the different observable layers
             # together with pdf model generated above

--- a/n3fit/src/n3fit/tests/test_layers.py
+++ b/n3fit/src/n3fit/tests/test_layers.py
@@ -276,5 +276,5 @@ def test_compute_photon():
     photon = FakePhoton()
     addphoton = layers.AddPhoton(photons=photon)
     xgrid = np.geomspace(1e-4, 1., 10)
-    addphoton.register_photon(xgrid)
+    addphoton.register_photon(xgrid, True)
     np.testing.assert_allclose(addphoton._pdf_ph, [np.exp(-xgrid)])

--- a/n3fit/src/n3fit/vpinterface.py
+++ b/n3fit/src/n3fit/vpinterface.py
@@ -87,7 +87,7 @@ class N3LHAPDFSet(LHAPDFSet):
             # if pl is an empy list there's no photon
             if not pl:
                 continue
-            pl[0].register_photon(xgrid)
+            pl[0].register_photon(xgrid, False)
             # Recompile the model if necessary
             if not pl[0].built:
                 m.compile()

--- a/validphys2/src/validphys/photon/compute.py
+++ b/validphys2/src/validphys/photon/compute.py
@@ -75,7 +75,7 @@ class Photon:
         self.additional_errors = lux_params["additional_errors"]
         self.luxseed = lux_params["luxseed"]
 
-        if not lux_params["component"]:
+        if "component" not in lux_params:
             self.component = "total"
         else:
             self.component = lux_params["component"]
@@ -160,7 +160,6 @@ class Photon:
             photon_qin["inelastic"][i] = pht.inelastic_pf
             photon_qin["msbar"][i] = pht.msbar_pf
         # photon_qin += self.generate_errors(replica)
-        # fiatlux computes x * gamma(x)
         # TODO : the different x points could be even computed in parallel
 
         # Load eko and reshape it
@@ -175,6 +174,7 @@ class Photon:
                 pdfs_init = np.zeros((len(eko.bases.inputpids), len(XGRID)))
                 for j, pid in enumerate(eko.bases.inputpids):
                     if pid == 22:
+                        # fiatlux computes x * gamma(x)
                         pdfs_init[j] = value / XGRID
                         ph_id = j
                     else:
@@ -198,8 +198,10 @@ class Photon:
 
         Parameters
         ----------
-        xgrid : nd.array
+        xgrid: nd.array
             array of x values with shape (1,xgrid,1)
+        total: bool
+            True for the total component, False for the others
 
         Returns
         -------

--- a/validphys2/src/validphys/photon/compute.py
+++ b/validphys2/src/validphys/photon/compute.py
@@ -94,7 +94,7 @@ class Photon:
         mb_thr = theory["kbThr"] * theory["mb"]
         mt_thr = theory["ktThr"] * theory["mt"] if theory["MaxNfPdf"] == 6 else 1e100
 
-        self.interpolator = {"total":[], "elastic":[], "inelastic":[], "msbar":[]}
+        self.interpolator = {"total": [], "elastic": [], "inelastic": [], "msbar": []}
         self.integral = []
 
         for replica in replicas:
@@ -147,7 +147,12 @@ class Photon:
         """
         # Compute photon PDF
         log.info(f"Computing photon")
-        photon_qin = {"total": np.zeros_like(XGRID), "elastic": np.zeros_like(XGRID), "inelastic": np.zeros_like(XGRID), "msbar": np.zeros_like(XGRID)}
+        photon_qin = {
+            "total": np.zeros_like(XGRID),
+            "elastic": np.zeros_like(XGRID),
+            "inelastic": np.zeros_like(XGRID),
+            "msbar": np.zeros_like(XGRID),
+        }
         for i, x in enumerate(XGRID):
             pht = self.lux[replica].EvaluatePhoton(x, self.q_in**2)
             photon_qin["total"][i] = pht.total
@@ -157,7 +162,7 @@ class Photon:
         # photon_qin += self.generate_errors(replica)
         # fiatlux computes x * gamma(x)
         # TODO : the different x points could be even computed in parallel
-        
+
         # Load eko and reshape it
         photon_Q0 = {}
         with EKO.read(self.path_to_eko_photon) as eko:


### PR DESCRIPTION
This PR aim is the following: we want to provide PDF sets in which, instead of the total photon, there is only its elastic or inelastic component.
However, in the sum rules and in the FKtables contraction we still want to have the total component. So, the elastic/inelastic part must be called only at the very last moment, when we register the photon in the lhapdf grid.

At the moment I still don't know how we should treat the additional errors, since they are supposed to be the errors of the total pdf and not of a component of it.