### PR TITLE
Change also luxset with vp-nextfitruncard

### DIFF
--- a/validphys2/src/validphys/eff_exponents.py
+++ b/validphys2/src/validphys/eff_exponents.py
@@ -599,5 +599,8 @@ def iterated_runcard_yaml(fit, update_runcard_description_yaml):
         closuretest_data = filtermap["closuretest"]
         if "filterseed" in closuretest_data:
             closuretest_data["filterseed"] = random.randrange(0, maxint)
+    
+    if "fiatlux" in filtermap:
+        filtermap['fiatlux']['luxset'] = fit.name
 
     return yaml.dump(filtermap, Dumper=yaml.RoundTripDumper)


### PR DESCRIPTION
This PR's aim is to change the also `luxset` (if present) with `vp-nextfitruncard`, and set it to the input fit.

In this case there's no need to change also the `luxseed` since it is used only by the last iteration of the fit, i.e. when `additional_errors` is set to `True` (operation that has to be done manually since one in principle could do as many iterations as he wishes)