### PR TITLE
remove mention that vp-setupfit doesn't always have to be the first step

### DIFF
--- a/doc/sphinx/source/tutorials/run-fit.md
+++ b/doc/sphinx/source/tutorials/run-fit.md
@@ -122,15 +122,6 @@ following the points presented above you can proceed with a fit.
     downloaded automatically. Alternatively they can be obtained with the
     ``vp-get`` tool.
 
-    ```eval_rst
-    .. note::
-       This step is not strictly necessary when producing a standard fit with
-       ``n3fit`` but it is required by :ref:`validphys <vp-index>`
-       and it should therefore always be done. Note that :ref:`vp-upload <upload-fit>`
-       will fail unless this step has been followed. If necessary, this step can
-       be done after the fit has been run.
-    ```
-
 2. The ``n3fit`` program takes a ``runcard.yml`` as input and a replica number, e.g.
 ```n3fit runcard.yml replica``` where ``replica`` goes from 1-n where n is the
 maximum number of desired replicas. Note that if you desire, for example, a 100


### PR DESCRIPTION
Since the note did not clarify what is meant by "a standard fit" this has caused some confusion recently: https://github.com/NNPDF/nnpdf/issues/1769. 

We can clarify what a standard fit is (or rather, what isn't), but I imagine exceptions won't be updated if they are added so we may as well instruct people to just always run `vp-setupfit` before running `n3fit`. I would be hard-pressed to think of a scenario, as the last sentence of the note suggests, in which it is necessary to run `vp-setupfit` after `n3fit`. 

This of course shouldn't stop people who know what they're doing from running it in a different order, but there's no need to mention that explicitly in the docs. 