### PR TITLE
Refactor rotations

### DIFF
--- a/n3fit/src/n3fit/backends/keras_backend/operations.py
+++ b/n3fit/src/n3fit/backends/keras_backend/operations.py
@@ -354,6 +354,20 @@ def op_subtract(inputs, **kwargs):
     """
     return keras_subtract(inputs, **kwargs)
 
+def moveaxis(tensor, source, destination):
+    """
+    Moves the axis of the tensor from source to destination
+    """
+    indices = list(range(tensor.shape.rank))
+    if source < 0:
+        source += tensor.shape.rank
+    if destination < 0:
+        destination += tensor.shape.rank
+
+    indices[source], indices[destination] = indices[destination], indices[source]
+
+    return tf.transpose(tensor, indices)
+
 
 @tf.function
 def backend_function(fun_name, *args, **kwargs):

--- a/n3fit/src/n3fit/layers/rotations.py
+++ b/n3fit/src/n3fit/layers/rotations.py
@@ -18,14 +18,13 @@ class Rotation(MetaLayer):
     ----------
         rotation_matrix: np.array
             rotation matrix
-        axes: int or list
-            if given a number, contracts as many indices as given
-            if given a list (of tuples) contracts indices according to op.tensor_product
+        rotation_axis: int
+            rotation_axis of input to be rotated
     """
 
-    def __init__(self, rotation_matrix, axes=1, **kwargs):
+    def __init__(self, rotation_matrix, rotation_axis=2, **kwargs):
         self.rotation_matrix = op.numpy_to_tensor(rotation_matrix)
-        self.axes = axes
+        self.rotation_axis = rotation_axis
         super().__init__(**kwargs)
 
     def is_identity(self):
@@ -37,7 +36,9 @@ class Rotation(MetaLayer):
             return np.allclose(self.rotation_matrix, iden)
 
     def call(self, x_raw):
-        return op.tensor_product(x_raw, self.rotation_matrix, self.axes)
+        rotated = op.tensor_product(x_raw, self.rotation_matrix, [self.rotation_axis, 0])
+        # this puts the rotated axis back in the original place
+        return op.moveaxis(rotated, -1, self.rotation_axis)
 
 
 class FlavourToEvolution(Rotation):
@@ -45,7 +46,6 @@ class FlavourToEvolution(Rotation):
     Rotates from the flavour basis to
     the evolution basis.
     """
-
     def __init__(
         self,
         flav_info,
@@ -53,7 +53,7 @@ class FlavourToEvolution(Rotation):
         **kwargs,
     ):
         rotation_matrix = pdfbases.fitbasis_to_NN31IC(flav_info, fitbasis)
-        super().__init__(rotation_matrix, axes=1, **kwargs)
+        super().__init__(rotation_matrix, **kwargs)
 
 
 class FkRotation(Rotation):
@@ -67,7 +67,7 @@ class FkRotation(Rotation):
     def __init__(self, output_dim=14, name="evolution", **kwargs):
         self.output_dim = output_dim
         rotation_matrix = self._create_rotation_matrix()
-        super().__init__(rotation_matrix, axes=1, name=name, **kwargs)
+        super().__init__(rotation_matrix, name=name, **kwargs)
 
     def _create_rotation_matrix(self):
         """Create the rotation matrix"""

--- a/n3fit/src/n3fit/tests/test_rotations.py
+++ b/n3fit/src/n3fit/tests/test_rotations.py
@@ -1,0 +1,51 @@
+import numpy as np
+
+from n3fit.backends import operations as op
+from n3fit.layers import FkRotation, FlavourToEvolution
+
+
+def test_fk():
+    rotation = FkRotation()
+    gridpoints = 2
+    np.random.seed(0)
+    pdf = op.numpy_to_tensor(np.random.rand(1, gridpoints, 9))
+    pdf_rotated = rotation(pdf)
+    pdf_rotated_known = op.numpy_to_tensor(
+        [
+            [
+                [
+                    0.0,
+                    0.5488135,
+                    0.71518934,
+                    0.60276335,
+                    0.5448832,
+                    0.4236548,
+                    0.96366274,
+                    0.60276335,
+                    0.60276335,
+                    0.6458941,
+                    0.4375872,
+                    -3.0182784,
+                    0.5488135,
+                    0.5488135,
+                ],
+                [
+                    0.0,
+                    0.3834415,
+                    0.79172504,
+                    0.5288949,
+                    0.56804454,
+                    0.92559665,
+                    0.83261985,
+                    0.5288949,
+                    0.5288949,
+                    0.07103606,
+                    0.0871293,
+                    0.30256793,
+                    0.3834415,
+                    0.3834415,
+                ],
+            ]
+        ]
+    )
+    np.testing.assert_allclose(pdf_rotated.numpy(), pdf_rotated_known.numpy(), rtol=1e-5)


### PR DESCRIPTION
This is a small refactor of the rotation layer, now requiring a `rotation_axis` argument that will be used to take a tensor product with that axis from the input and the 0th axis of the rotation matrix. (the resulting axis is by default put at the end, so this is transposed back afterward).
It's more intuitive than the previous `axes` which specified the amount of axes to contract (starting from the end of the input and the start of the rotation matrix). 
More importantly, it now requires no change when axes are added to the pdf.

I've added a regression test to make sure results are still the same.