### PR TITLE
Mamba ci

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         python-version: ["3.9", "3.10"]
-        resolver: ["conda", "mamba"]
+        resolver: [conda, mamba]
         include:
           - os: ubuntu-latest
             CONDA_OS: linux-64
@@ -30,7 +30,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Configure mamba as the resolver
-      if: startsWith(matrix.resolver, "mamba")
+      if: startsWith(matrix.resolver, 'mamba')
       run: |
         conda install -n base conda-libmamba-solver
         conda config --set solver libmamba

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         python-version: ["3.9", "3.10"]
+        resolver: ["conda", "mamba"]
         include:
           - os: ubuntu-latest
             CONDA_OS: linux-64
@@ -28,6 +29,10 @@ jobs:
     - uses: conda-incubator/setup-miniconda@v2
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Configure mamba as the resolver
+      if: startsWith(matrix.resolver, "mamba")
+      conda install -n base conda-libmamba-solver
+      conda config --set solver libmamba
     - name: Install macOS SDK
       if: startsWith(matrix.os, 'macOS')
       shell: bash -l {0}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,8 +31,9 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Configure mamba as the resolver
       if: startsWith(matrix.resolver, "mamba")
-      conda install -n base conda-libmamba-solver
-      conda config --set solver libmamba
+      run: |
+        conda install -n base conda-libmamba-solver
+        conda config --set solver libmamba
     - name: Install macOS SDK
       if: startsWith(matrix.os, 'macOS')
       shell: bash -l {0}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         python-version: ["3.9", "3.10"]
-        resolver: [conda, mamba]
         include:
           - os: ubuntu-latest
             CONDA_OS: linux-64
@@ -29,11 +28,6 @@ jobs:
     - uses: conda-incubator/setup-miniconda@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Configure mamba as the resolver
-      if: startsWith(matrix.resolver, 'mamba')
-      run: |
-        conda install -n base conda-libmamba-solver
-        conda config --set solver libmamba
     - name: Install macOS SDK
       if: startsWith(matrix.os, 'macOS')
       shell: bash -l {0}
@@ -45,6 +39,8 @@ jobs:
       shell: bash -l {0}
       run: |
         echo "$NETRC_FILE" | base64 --decode > ~/.netrc
+        conda install -n base conda-libmamba-solver
+        conda config --set solver libmamba
         conda config --append channels conda-forge
         conda config --prepend channels https://packages.nnpdf.science/public
         conda config --set show_channel_urls true


### PR DESCRIPTION
Because of the issues we have been having with the CI the last month or so, I had a look at using the mamba resolver within conda. In this branch I added this option to the matrix, so the original 4 tests are still there, along with 4 new copies that only differ in that they use the mamba resolver.

It reduces the conda setup step from ~15 minutes (or I've even seen 3 hours on a job from a few weeks ago.. ) to ~1 minute.
And it seems to fix the issue, all of them pass whereas with conda the python 3.9 ubuntu test still fails.

So I would propose to make that the only option