### PR TITLE
Add `--lite` option to vp-comparefits for quick comparisons

### DIFF
--- a/validphys2/src/validphys/comparefittemplates/__init__.py
+++ b/validphys2/src/validphys/comparefittemplates/__init__.py
@@ -1,3 +1,4 @@
 import pathlib
 
 template_path = pathlib.Path(__file__).with_name('comparecard.yaml')
+template_lite_path = pathlib.Path(__file__).with_name('comparecard_lite.yaml')

--- a/validphys2/src/validphys/comparefittemplates/comparecard_lite.yaml
+++ b/validphys2/src/validphys/comparefittemplates/comparecard_lite.yaml
@@ -60,27 +60,13 @@ PDFscalespecs:
   - xscale: linear
     Xscaletitle: Linear
 
-Energies:
-  - sqrts: 13000
-    Energytitle: "13 TeV"
-
 Distspecs:
   - ymin: 0
     ymax: 20
 
-pos_use_kin: True
-
-dataset_report:
-  meta: Null
-  template: data.md
-
 pdf_report:
   meta: Null
   template: pdf.md
-
-exponents_report:
-  meta: Null
-  template: exponents.md
 
 template: report_lite.md
 
@@ -88,9 +74,6 @@ positivity:
   from_: fit
 
 description:
-  from_: fit
-
-dataset_inputs:
   from_: fit
 
 dataspecs:
@@ -111,26 +94,9 @@ dataspecs:
       from_: reference
     speclabel:
       from_: reference
-      
-t0_info:
-  - use_t0: True
-    datacuts:
-      from_: fit
-    t0pdfset:
-      from_: datacuts     
  
 Normalize:
   normalize_to: 2
-
-Datanorm:
-  normalize_to: data
-
-DataGroups:
-  - metadata_group: nnpdf31_process
-  - metadata_group: experiment
-
-ProcessGroup:
-    metadata_group: nnpdf31_process
 
 actions_:
   - report(main=true)

--- a/validphys2/src/validphys/comparefittemplates/comparecard_lite.yaml
+++ b/validphys2/src/validphys/comparefittemplates/comparecard_lite.yaml
@@ -1,0 +1,136 @@
+# This is the driver template for vp-comparefits when using the --lite flag
+# It is the same as the comparecard_lite template but it is missing a number
+# of comparisongs
+#
+# meta:
+#   title: The title of the Report
+#   keywords: [report_template]
+#   author: NNPDF Collaboration
+#
+# current:
+#   fit: {id: id_of_the_base_fit}
+#   pdf: {id: id_of_the_base_fit, label: "Current Fit"}
+#   theory:
+#     from_: fit
+#   theoryid:
+#     from_: theory
+#   speclabel: "Current Fit"
+#
+# reference:
+#   fit: {id: id_of_the_reference_fit}
+#   pdf: {id: id_of_the_reference_fit, label: "Reference Fit" }
+#   theory:
+#     from_: fit
+#   theoryid:
+#     from_: theory
+#   speclabel: "Reference Fit"
+
+pdfs:
+  - from_: current
+  - from_: reference
+
+fits:
+  - from_: current
+  - from_: reference
+
+use_cuts: "fromfit"
+use_weights_in_covmat: False
+
+Q: 1.651
+
+Scales:
+  - Q: 1.651
+    Scaletitle: "Q = 1.65 GeV"
+
+PDFnormalize:
+  - Normtitle: Absolute
+
+  - normalize_to: 2
+    Normtitle: Ratio
+
+Basespecs:
+  - basis: CCBAR_ASYMM_FLAVOUR
+    Basistitle: Flavour basis
+  - basis: CCBAR_ASYMM
+    Basistitle: Evolution basis
+
+PDFscalespecs:
+  - xscale: log
+    Xscaletitle: Log
+  - xscale: linear
+    Xscaletitle: Linear
+
+Energies:
+  - sqrts: 13000
+    Energytitle: "13 TeV"
+
+Distspecs:
+  - ymin: 0
+    ymax: 20
+
+pos_use_kin: True
+
+dataset_report:
+  meta: Null
+  template: data.md
+
+pdf_report:
+  meta: Null
+  template: pdf.md
+
+exponents_report:
+  meta: Null
+  template: exponents.md
+
+template: report_lite.md
+
+positivity:
+  from_: fit
+
+description:
+  from_: fit
+
+dataset_inputs:
+  from_: fit
+
+dataspecs:
+  - theoryid:
+      from_: current
+    pdf:
+      from_: current
+    fit:
+      from_: current
+    speclabel:
+      from_: current
+
+  - theoryid:
+      from_: reference
+    pdf:
+      from_: reference
+    fit:
+      from_: reference
+    speclabel:
+      from_: reference
+      
+t0_info:
+  - use_t0: True
+    datacuts:
+      from_: fit
+    t0pdfset:
+      from_: datacuts     
+ 
+Normalize:
+  normalize_to: 2
+
+Datanorm:
+  normalize_to: data
+
+DataGroups:
+  - metadata_group: nnpdf31_process
+  - metadata_group: experiment
+
+ProcessGroup:
+    metadata_group: nnpdf31_process
+
+actions_:
+  - report(main=true)

--- a/validphys2/src/validphys/comparefittemplates/report_lite.md
+++ b/validphys2/src/validphys/comparefittemplates/report_lite.md
@@ -1,0 +1,78 @@
+%NNPDF light report comparing {@ current fit_id @} and {@ reference fit_id @}
+
+Summary
+-------
+
+We are comparing:
+
+  - {@ current fit @} (`{@ current fit_id @}`): {@ current description @}
+  - {@ reference fit @} (`{@ reference fit_id @}`): {@ reference description @}
+
+{@ summarise_fits @}
+
+Theory covariance summary
+-------------------------
+{@summarise_theory_covmat_fits@}
+
+Dataset properties
+------------------
+{@current fit_datasets_properties_table@}
+
+Distances
+---------
+{@with Scales@}
+### {@Scaletitle@}
+{@with Normalize::Basespecs::PDFscalespecs::Distspecs@}
+#### {@Basistitle@}, {@Xscaletitle@}
+{@plot_pdfdistances@}
+{@plot_pdfvardistances@}
+{@endwith@}
+{@endwith@}
+
+PDF arc-lengths
+---------------
+{@Basespecs plot_arc_lengths@}
+
+Sum rules
+---------
+{@with pdfs@}
+### {@pdf@}
+
+#### Known sum rules
+
+{@sum_rules_table@}
+
+#### Unknown sum rules
+
+{@unknown_sum_rules_table@}
+
+{@endwith@}
+
+PDF plots
+---------
+{@with Scales@}
+[Plots at {@Scaletitle@}]({@pdf_report report@})
+{@endwith@}
+
+Training lengths
+----------------
+{@fits plot_training_length@}
+
+Training-validation
+-------------------
+{@fits plot_training_validation@}
+
+Positivity
+----------
+{@with matched_positivity_from_dataspecs@}
+{@plot_dataspecs_positivity@}
+{@endwith@}
+
+Dataset differences and cuts
+----------------------------
+{@print_dataset_differences@}
+{@print_different_cuts@}
+
+Code versions
+-------------
+{@fits_version_table@}

--- a/validphys2/src/validphys/scripts/vp_comparefits.py
+++ b/validphys2/src/validphys/scripts/vp_comparefits.py
@@ -71,6 +71,11 @@ class CompareFitApp(App):
             '--closure',
             help="Use the closure comparison template.",
             action='store_true')
+        parser.add_argument(
+            '-l',
+            '--lite',
+            help="Smaller version of the usual comparefit fit",
+            action='store_true')
 
         parser.set_defaults()
 
@@ -176,12 +181,14 @@ class CompareFitApp(App):
         # This is needed because the environment wants to know how to resolve
         # the relative paths to find the templates. Best to have the template
         # look as much as possible as a runcard passed from the command line
-        if not args['closure']:
-            args['config_yml'] = comparefittemplates.template_path
-        else:
-            #This doesn't print anything
-            log.info(f"using closure test template.")
+        if args['closure']:
+            log.info("using closure test template.")
             args['config_yml'] = compareclosuretemplates.template_path
+        elif args['lite']:
+            log.info("using compare-lite template.")
+            args['config_yml'] = comparefittemplates.template_lite_path
+        else:
+            args['config_yml'] = comparefittemplates.template_path
         return args
 
     def complete_mapping(self):


### PR DESCRIPTION
The default remains the normal comparefit but this adds an option to have a quick comparison without the heavy stuff (i.e., without anything that involves doing the fktable convolution with all replicas).

This is quite useful when iterating overfit when you just want to see whether the cuts are the same, how the PDF/distances look etc.

Closes #1553