### PR TITLE
Update PLOTTING_ATLAS_Z_TOT_13TEV.yaml

### DIFF
--- a/nnpdfcpp/data/commondata/PLOTTING_ATLAS_Z_TOT_13TEV.yaml
+++ b/nnpdfcpp/data/commondata/PLOTTING_ATLAS_Z_TOT_13TEV.yaml
@@ -13,5 +13,5 @@ extra_labels:
 
 experiment: "ATLAS"
 
-nnpdf31_process: DY CC
+nnpdf31_process: DY NC
 


### PR DESCRIPTION
This fixes a wrong label for the `ATLAS_Z_TOT_13TEV` data set, which was misclassified as DY_CC, while it must be DY_NC.