### PR TITLE
add skip_magic_trailing_comma to black config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [tool.black]
 line-length = 100
 skip-string-normalization = 1
+skip_magic_trailing_comma = true
 
 [tool.isort]
 atomic = true


### PR DESCRIPTION
If a function input has a trailing comma black will not put the inputs on a single line, even if the line-length would be less than the specified length. I believe this is done to minimize diff, but I think it's undesirable: https://github.com/NNPDF/nnpdf/pull/1824#discussion_r1375994068