### PR TITLE
Generic hessian PDF covmat

### DIFF
--- a/validphys2/examples/chi2_tables_montecarlo_hessian.yaml
+++ b/validphys2/examples/chi2_tables_montecarlo_hessian.yaml
@@ -1,0 +1,67 @@
+meta:
+  title: chi2 with Monte Carlo and Hessian sets
+  author: Mark N. Costantini
+  keywords: [example]
+
+dataset_inputs: 
+- {dataset: SLACP_dwsh, frac: 0.75}
+# - {dataset: HERACOMBNCEM, frac: 0.75}
+# - {dataset: HERACOMBNCEP460, frac: 0.75}
+# - {dataset: DYE605_dw_ite, frac: 0.75, cfac: [QCD]}
+# - {dataset: ATLAS_SINGLETOP_TCH_DIFF_7TEV_T_RAP_NORM, frac: 0.75, cfac: [QCD]}
+# - {dataset: CMSWEASY840PB, frac: 0.75, cfac: [QCD]}
+# - {dataset: CMSWMASY47FB, frac: 0.75, cfac: [QCD]}
+# - {dataset: CMSWMU8TEV, frac: 0.75, cfac: [QCD]}
+# - {dataset: CMSZDIFF12, frac: 0.75, cfac: [QCD, NRM], sys: 10}
+# - {dataset: CMS_2JET_7TEV, frac: 0.75, cfac: [QCD]}
+# - {dataset: CMS_1JET_8TEV, frac: 0.75, cfac: [QCD]}
+# - {dataset: CMSTTBARTOT7TEV, frac: 0.75, cfac: [QCD]}
+# - {dataset: CMSTTBARTOT8TEV, frac: 0.75, cfac: [QCD]}
+# - {dataset: CMSTTBARTOT13TEV, frac: 0.75, cfac: [QCD]}
+# - {dataset: CMSTTBARTOT5TEV, frac: 0.75, cfac: [QCD]}
+# - {dataset: CMS_TTBAR_2D_DIFF_MTT_TRAP_NORM, frac: 0.75, cfac: [QCD]}
+# - {dataset: CMS_SINGLETOP_TCH_R_8TEV, frac: 0.75, cfac: [QCD]}
+# - {dataset: LHCBZEE2FB_40, frac: 0.75, cfac: [QCD]}
+# - {dataset: LHCBWZMU8TEV, frac: 0.75, cfac: [NRM, QCD]}
+- {dataset: LHCB_Z_13TEV_DIMUON, frac: 0.75, cfac: [QCD]}
+
+
+
+# used to add the PDF covariance matrix to the experimental one
+use_pdferr: True
+
+theoryid: 200
+
+use_cuts: internal
+
+pdfs:
+  - NNPDF40_nnlo_as_01180_hessian
+  - NNPDF40_nnlo_as_01180
+  # - NNPDF31_nnlo_as_0118_hessian
+
+  # - MMHT2014nnlo68cl
+  # - MSHT20nnlo_as118
+  # - CT18NNLO
+  # - ABMP16_5_nnlo
+
+
+template_text: |
+  
+  Chi2 Report
+  -----------
+  
+  {@plot_datasets_pdfs_chi2@}
+
+  {@ with pdfs @}
+  
+  ### {@ pdf @}
+
+  ### Chi2 of Central PDF Replica Theory Prediction
+  
+
+  {@groups_chi2_table@}
+
+  {@ endwith @}
+
+actions_:
+  - report(main=True)

--- a/validphys2/examples/chi2_tables_montecarlo_hessian.yaml
+++ b/validphys2/examples/chi2_tables_montecarlo_hessian.yaml
@@ -1,29 +1,13 @@
 meta:
-  title: chi2 with Monte Carlo and Hessian sets
+  title: Chi2 with Monte Carlo and Hessian sets
   author: Mark N. Costantini
   keywords: [example]
 
 dataset_inputs: 
 - {dataset: SLACP_dwsh, frac: 0.75}
-# - {dataset: HERACOMBNCEM, frac: 0.75}
-# - {dataset: HERACOMBNCEP460, frac: 0.75}
-# - {dataset: DYE605_dw_ite, frac: 0.75, cfac: [QCD]}
-# - {dataset: ATLAS_SINGLETOP_TCH_DIFF_7TEV_T_RAP_NORM, frac: 0.75, cfac: [QCD]}
-# - {dataset: CMSWEASY840PB, frac: 0.75, cfac: [QCD]}
-# - {dataset: CMSWMASY47FB, frac: 0.75, cfac: [QCD]}
-# - {dataset: CMSWMU8TEV, frac: 0.75, cfac: [QCD]}
-# - {dataset: CMSZDIFF12, frac: 0.75, cfac: [QCD, NRM], sys: 10}
-# - {dataset: CMS_2JET_7TEV, frac: 0.75, cfac: [QCD]}
-# - {dataset: CMS_1JET_8TEV, frac: 0.75, cfac: [QCD]}
-# - {dataset: CMSTTBARTOT7TEV, frac: 0.75, cfac: [QCD]}
-# - {dataset: CMSTTBARTOT8TEV, frac: 0.75, cfac: [QCD]}
-# - {dataset: CMSTTBARTOT13TEV, frac: 0.75, cfac: [QCD]}
-# - {dataset: CMSTTBARTOT5TEV, frac: 0.75, cfac: [QCD]}
-# - {dataset: CMS_TTBAR_2D_DIFF_MTT_TRAP_NORM, frac: 0.75, cfac: [QCD]}
-# - {dataset: CMS_SINGLETOP_TCH_R_8TEV, frac: 0.75, cfac: [QCD]}
-# - {dataset: LHCBZEE2FB_40, frac: 0.75, cfac: [QCD]}
-# - {dataset: LHCBWZMU8TEV, frac: 0.75, cfac: [NRM, QCD]}
-- {dataset: LHCB_Z_13TEV_DIMUON, frac: 0.75, cfac: [QCD]}
+- {dataset: HERACOMBNCEM, frac: 0.75}
+- {dataset: HERACOMBNCEP460, frac: 0.75}
+- {dataset: DYE605_dw_ite, frac: 0.75, cfac: [QCD]}
 
 
 
@@ -37,31 +21,17 @@ use_cuts: internal
 pdfs:
   - NNPDF40_nnlo_as_01180_hessian
   - NNPDF40_nnlo_as_01180
-  # - NNPDF31_nnlo_as_0118_hessian
-
-  # - MMHT2014nnlo68cl
-  # - MSHT20nnlo_as118
-  # - CT18NNLO
-  # - ABMP16_5_nnlo
+  - MMHT2014nnlo68cl
+  - MSHT20nnlo_as118
+  - CT18NNLO
+  - ABMP16_5_nnlo
 
 
 template_text: |
   
   Chi2 Report
-  -----------
-  
+  -----------  
   {@plot_datasets_pdfs_chi2@}
-
-  {@ with pdfs @}
-  
-  ### {@ pdf @}
-
-  ### Chi2 of Central PDF Replica Theory Prediction
-  
-
-  {@groups_chi2_table@}
-
-  {@ endwith @}
 
 actions_:
   - report(main=True)

--- a/validphys2/src/validphys/checks.py
+++ b/validphys2/src/validphys/checks.py
@@ -44,10 +44,10 @@ def check_pdf_is_montecarlo(ns, **kwargs):
 
 
 @make_argcheck
-def check_pdf_is_montecarlo_or_symmhessian(pdf, **kwargs):
+def check_pdf_is_montecarlo_or_hessian(pdf, **kwargs):
     etype = pdf.error_type
     check(
-        etype in {'replicas', 'symmhessian'},
+        etype in {'replicas', 'symmhessian', 'hessian'},
         f"Error type of PDF {pdf} must be either 'replicas' or 'symmhessian' and not {etype}",
     )
 

--- a/validphys2/src/validphys/covmats.py
+++ b/validphys2/src/validphys/covmats.py
@@ -685,6 +685,8 @@ def pdferr_plus_covmat(dataset, pdf, covmat_t0_considered):
       the replica theory predictions
     - If the PDF error_type is 'symmhessian', a covariance matrix is estimated using
       formulas from (mc2hessian) https://arxiv.org/pdf/1505.06736.pdf
+    - If the PDF error_type is 'hessian' a covariance matrix is estimated using
+      the hessian formula from core.HessianStats
 
 
     Parameters
@@ -737,7 +739,6 @@ def pdferr_plus_covmat(dataset, pdf, covmat_t0_considered):
         pdf_cov = X @ X.T
 
     elif pdf.error_type == 'hessian':
-        
         rescale_fac = pdf._rescale_factor()
         hessian_eigenvectors = th.error_members
         

--- a/validphys2/src/validphys/covmats.py
+++ b/validphys2/src/validphys/covmats.py
@@ -15,7 +15,7 @@ from validphys.checks import (
     check_data_cuts_match_theorycovmat,
     check_dataset_cuts_match_theorycovmat,
     check_norm_threshold,
-    check_pdf_is_montecarlo_or_symmhessian,
+    check_pdf_is_montecarlo_or_hessian,
     check_speclabels_different,
 )
 from validphys.commondata import loaded_commondata_with_cuts
@@ -677,7 +677,7 @@ def groups_corrmat(groups_covmat):
     return mat
 
 
-@check_pdf_is_montecarlo_or_symmhessian
+@check_pdf_is_montecarlo_or_hessian
 def pdferr_plus_covmat(dataset, pdf, covmat_t0_considered):
     """For a given `dataset`, returns the sum of the covariance matrix given by
     `covmat_t0_considered` and the PDF error:
@@ -732,6 +732,17 @@ def pdferr_plus_covmat(dataset, pdf, covmat_t0_considered):
         # need to subtract the central set which is not the same as the average of the
         # Hessian eigenvectors.
         X = hessian_eigenvectors - central_predictions.reshape((central_predictions.shape[0], 1))
+        # need to rescale the Hessian eigenvectors in case the eigenvector confidence interval is not 68%
+        X = X / rescale_fac
+        pdf_cov = X @ X.T
+
+    elif pdf.error_type == 'hessian':
+        
+        rescale_fac = pdf._rescale_factor()
+        hessian_eigenvectors = th.error_members
+        
+        # see core.HessianStats
+        X = hessian_eigenvectors[:,0::2] - hessian_eigenvectors[:,1::2]
         # need to rescale the Hessian eigenvectors in case the eigenvector confidence interval is not 68%
         X = X / rescale_fac
         pdf_cov = X @ X.T

--- a/validphys2/src/validphys/covmats.py
+++ b/validphys2/src/validphys/covmats.py
@@ -686,7 +686,7 @@ def pdferr_plus_covmat(dataset, pdf, covmat_t0_considered):
     - If the PDF error_type is 'symmhessian', a covariance matrix is estimated using
       formulas from (mc2hessian) https://arxiv.org/pdf/1505.06736.pdf
     - If the PDF error_type is 'hessian' a covariance matrix is estimated using
-      the hessian formula from core.HessianStats
+      the hessian formula from Eq. 5 of https://arxiv.org/pdf/1401.0013.pdf
 
 
     Parameters
@@ -743,7 +743,7 @@ def pdferr_plus_covmat(dataset, pdf, covmat_t0_considered):
         hessian_eigenvectors = th.error_members
         
         # see core.HessianStats
-        X = hessian_eigenvectors[:,0::2] - hessian_eigenvectors[:,1::2]
+        X = (hessian_eigenvectors[:,0::2] - hessian_eigenvectors[:,1::2])*0.5
         # need to rescale the Hessian eigenvectors in case the eigenvector confidence interval is not 68%
         X = X / rescale_fac
         pdf_cov = X @ X.T

--- a/validphys2/src/validphys/dataplots.py
+++ b/validphys2/src/validphys/dataplots.py
@@ -621,6 +621,35 @@ def plot_datasets_chi2(groups_data, groups_chi2):
     return fig
 
 
+each_dataset_chi2_pdfs = collect("each_dataset_chi2", ("pdfs",))
+
+@figure
+def plot_datasets_pdfs_chi2(data, each_dataset_chi2_pdfs, pdfs):
+    """
+    Plot the chi² of all datasets with bars, and for different
+    pdfs.
+    """
+    
+    chi2_pdfs = list(each_dataset_chi2_pdfs)
+    
+    pdf_dict = {dataset.name: 
+                [chi2_pdfs[i][j] for i in range(len(chi2_pdfs))] 
+                for j, dataset in enumerate(data)
+            }
+
+    vals = []
+    collabels = []
+
+    for ds, val in pdf_dict.items():
+        vals.append([chi2.central_result / chi2.ndata for chi2 in val])
+        collabels.append(ds)
+
+    fig, ax = plotutils.barplot(vals, collabels, datalabels=[f'$\chi^2$, {str(pdf)}' for pdf in pdfs])
+    ax.set_title(r"$\chi^2$ distribution for datasets")
+    ax.legend()
+    return fig
+
+
 @figure
 def plot_datasets_chi2_spider(groups_data, groups_chi2):
     """Plot the chi² of all datasets with bars."""

--- a/validphys2/src/validphys/dataplots.py
+++ b/validphys2/src/validphys/dataplots.py
@@ -643,8 +643,8 @@ def plot_datasets_pdfs_chi2(data, each_dataset_chi2_pdfs, pdfs):
     for ds, val in pdf_dict.items():
         vals.append([chi2.central_result / chi2.ndata for chi2 in val])
         collabels.append(ds)
-
-    fig, ax = plotutils.barplot(vals, collabels, datalabels=[f'$\chi^2$, {str(pdf)}' for pdf in pdfs])
+    
+    fig, ax = plotutils.barplot(np.array(vals).T, collabels, datalabels=[f'$\chi^2$, {str(pdf)}' for pdf in pdfs])
     ax.set_title(r"$\chi^2$ distribution for datasets")
     ax.legend()
     return fig


### PR DESCRIPTION
This PR adds to `covmats.pdferr_plus_covmat` the option for an asymmetric hessian set.
The way in which the PDF covmat is computed follows `core.HessianStats`.

TODO:

- Are there some references on how to compute the hessian pdf covmat?
- understand why the ABMP1_6_5_nnlo set (symmhessian) has such a large chi2  (see report below)

https://vp.nnpdf.science/9rRTyXihSsqCDE3h4qmZ5A==