### PR TITLE
update pineappl dependency to 0.6.2

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -50,7 +50,7 @@ requirements:
         - sphinx_rtd_theme >0.5
         - sphinxcontrib-bibtex
         - curio >=1.0
-        - pineappl >=0.5.8
+        - pineappl >=0.6.2
         - eko >=0.13.5,<0.14
         - banana-hep >=0.6.8
         - fiatlux


### PR DESCRIPTION
There were some bugfixes in pineappl since 0.5.8. Not sure if they affect anything we do in this repo but we may as well update it. 