### PR TITLE
Raise an exception when use_pdferr is used together with plot_fancy

### DIFF
--- a/validphys2/examples/future_test_example.yaml
+++ b/validphys2/examples/future_test_example.yaml
@@ -5,6 +5,9 @@ meta:
   my_description: "The PDF errors are included in all cases"
 
 use_pdferr: True
+disable_pdferr:
+  use_pdferr: False
+
 my_description:
   from_: meta
 
@@ -162,11 +165,15 @@ dataset_report:
    Data-theory comparison for {@dataset@}
    --------------------------------------
 
-   # Absolute
-   {@plot_fancy_dataspecs@}
- 
-   # Normalized
-   {@datanorm plot_fancy_dataspecs@}
+    {@with disable_pdferr@}
+
+      # Absolute
+      {@plot_fancy_dataspecs@}
+
+      # Normalized
+      {@datanorm plot_fancy_dataspecs@}
+
+    {@endwith@}
 
 coverage_report:
   meta: Null

--- a/validphys2/src/validphys/checks.py
+++ b/validphys2/src/validphys/checks.py
@@ -54,7 +54,10 @@ def check_pdf_is_montecarlo_or_hessian(pdf, **kwargs):
 
 @make_argcheck
 def check_not_using_pdferr(use_pdferr=False, **kwargs):
-    check(not use_pdferr, "The flag 'use_pdferr' must be `False` to use this function. This is to avoid including the PDF error in the uncertainty bars of the experimental datapoints.")
+    check(
+        not use_pdferr,
+        "The flag 'use_pdferr' must be `False` to use this function. This is to avoid including the PDF error in the uncertainty bars of the experimental datapoints.",
+    )
 
 
 @make_check

--- a/validphys2/src/validphys/checks.py
+++ b/validphys2/src/validphys/checks.py
@@ -52,6 +52,11 @@ def check_pdf_is_montecarlo_or_hessian(pdf, **kwargs):
     )
 
 
+@make_argcheck
+def check_not_using_pdferr(use_pdferr, **kwargs):
+    check(not use_pdferr, "The flag 'use_pdferr' must be off to use this function")
+
+
 @make_check
 def check_know_errors(ns, **kwargs):
     pdf = ns['pdf']

--- a/validphys2/src/validphys/checks.py
+++ b/validphys2/src/validphys/checks.py
@@ -53,7 +53,7 @@ def check_pdf_is_montecarlo_or_hessian(pdf, **kwargs):
 
 
 @make_argcheck
-def check_not_using_pdferr(use_pdferr, **kwargs):
+def check_not_using_pdferr(use_pdferr=False, **kwargs):
     check(not use_pdferr, "The flag 'use_pdferr' must be `False` to use this function. This is to avoid including the PDF error in the uncertainty bars of the experimental datapoints.")
 
 

--- a/validphys2/src/validphys/checks.py
+++ b/validphys2/src/validphys/checks.py
@@ -54,7 +54,7 @@ def check_pdf_is_montecarlo_or_hessian(pdf, **kwargs):
 
 @make_argcheck
 def check_not_using_pdferr(use_pdferr, **kwargs):
-    check(not use_pdferr, "The flag 'use_pdferr' must be off to use this function")
+    check(not use_pdferr, "The flag 'use_pdferr' must be `False` to use this function. This is to avoid including the PDF error in the uncertainty bars of the experimental datapoints.")
 
 
 @make_check

--- a/validphys2/src/validphys/dataplots.py
+++ b/validphys2/src/validphys/dataplots.py
@@ -397,7 +397,13 @@ def _plot_fancy_impl(
 @check_not_using_pdferr
 @check_normalize_to
 @figuregen
-def plot_fancy(one_or_more_results, commondata, cuts, normalize_to: (int, str, type(None)) = None):
+def plot_fancy(
+    one_or_more_results,
+    commondata,
+    cuts,
+    normalize_to: (int, str, type(None)) = None,
+    use_pdferr: bool = False,  # pylint: disable=unused-argument # for checks
+):
     """
     Read the PLOTTING configuration for the dataset and generate the
     corrspondig data theory plot.
@@ -451,6 +457,7 @@ def _check_dataspec_normalize_to(normalize_to, dataspecs):
     )
 
 
+@check_not_using_pdferr
 @_check_same_dataset_name
 @_check_dataspec_normalize_to
 @figuregen
@@ -460,6 +467,7 @@ def plot_fancy_dataspecs(
     dataspecs_cuts,
     dataspecs_speclabel,
     normalize_to: (str, int, type(None)) = None,
+    use_pdferr: bool = False,  # pylint: disable=unused-argument # for checks
 ):
     """
     General interface for data-theory comparison plots.


### PR DESCRIPTION
Addresses #1843 

I'm just adding a check to `plot_fancy`. I've taken the liberty to also run `black` since apparently it was missing from `dataplots.py`?

The only change that is not from black is in line 397   (sorry @RoyStegeman, I must've somehow missed `dataplots.py` when I passed black to every file...)