### PR TITLE
Avoiding duplicated computations by having a single observable model

### DIFF
--- a/n3fit/src/n3fit/backends/__init__.py
+++ b/n3fit/src/n3fit/backends/__init__.py
@@ -5,6 +5,7 @@ from n3fit.backends.keras_backend.MetaModel import (
     NN_PREFIX,
     PREPROCESSING_LAYER_ALL_REPLICAS,
     MetaModel,
+    extract_replica_weights,
 )
 from n3fit.backends.keras_backend.base_layers import (
     Concatenate,

--- a/n3fit/src/n3fit/backends/__init__.py
+++ b/n3fit/src/n3fit/backends/__init__.py
@@ -18,5 +18,6 @@ from n3fit.backends.keras_backend.internal_state import (
     set_eager,
     set_initial_state,
 )
+from n3fit.backends.keras_backend.metrics import LossMetric
 
 print("Using Keras backend")

--- a/n3fit/src/n3fit/backends/keras_backend/callbacks.py
+++ b/n3fit/src/n3fit/backends/keras_backend/callbacks.py
@@ -10,9 +10,10 @@
 
 import logging
 from time import time
+
 import numpy as np
 import tensorflow as tf
-from tensorflow.keras.callbacks import TensorBoard, Callback
+from tensorflow.keras.callbacks import Callback, TensorBoard
 
 log = logging.getLogger(__name__)
 
@@ -30,7 +31,7 @@ class TimerCallback(Callback):
         self.last_time = 0
 
     def on_epoch_end(self, epoch, logs=None):
-        """ At the end of every epoch it checks the time """
+        """At the end of every epoch it checks the time"""
         new_time = time()
         if epoch == 0:
             # The first epoch is only useful for starting
@@ -45,13 +46,13 @@ class TimerCallback(Callback):
         self.last_time = new_time
 
     def on_train_end(self, logs=None):
-        """ Print the results """
+        """Print the results"""
         total_time = time() - self.starting_time
         n_times = len(self.all_times)
         # Skip the first 100 epochs to avoid fluctuations due to compilations of part of the code
         # by epoch 100 all parts of the code have usually been called so it's a good compromise
-        mean = np.mean(self.all_times[min(110, n_times-1):])
-        std = np.std(self.all_times[min(110, n_times-1):])
+        mean = np.mean(self.all_times[min(110, n_times - 1) :])
+        std = np.std(self.all_times[min(110, n_times - 1) :])
         log.info(f"> > Average time per epoch: {mean:.5} +- {std:.5} s")
         log.info(f"> > > Total time: {total_time/60:.5} min")
 
@@ -77,7 +78,7 @@ class StoppingCallback(Callback):
         self.stopping_object = stopping_object
 
     def on_epoch_end(self, epoch, logs=None):
-        """ Function to be called at the end of every epoch """
+        """Function to be called at the end of every epoch"""
         print_stats = ((epoch + 1) % self.log_freq) == 0
         # Note that the input logs correspond to the fit before the weights are updated
         self.stopping_object.monitor_chi2(logs, epoch, print_stats=print_stats)
@@ -103,11 +104,13 @@ class LagrangeCallback(Callback):
             List of the names of the datasets to be trained
         multipliers: list(float)
             List of multipliers to be applied
+        losses: dict
+            Dictionary of losses
         update_freq: int
             each how many epochs the positivity lambda is updated
     """
 
-    def __init__(self, datasets, multipliers, update_freq=100):
+    def __init__(self, datasets, multipliers, losses, update_freq=100):
         super().__init__()
         if len(multipliers) != len(datasets):
             raise ValueError("The number of datasets and multipliers do not match")
@@ -115,11 +118,12 @@ class LagrangeCallback(Callback):
         self.datasets = datasets
         self.multipliers = multipliers
         self.updateable_weights = []
+        self.losses = losses
 
     def on_train_begin(self, logs=None):
-        """ Save an instance of all relevant layers """
+        """Save an instance of all relevant layers"""
         for layer_name in self.datasets:
-            layer = self.model.get_layer(layer_name)
+            layer = self.losses[layer_name]
             self.updateable_weights.append(layer.weights)
 
     @tf.function
@@ -133,7 +137,7 @@ class LagrangeCallback(Callback):
                 w.assign(w * multiplier)
 
     def on_epoch_end(self, epoch, logs=None):
-        """ Function to be called at the end of every epoch """
+        """Function to be called at the end of every epoch"""
         if (epoch + 1) % self.update_freq == 0:
             self._update_weights()
 

--- a/n3fit/src/n3fit/backends/keras_backend/metrics.py
+++ b/n3fit/src/n3fit/backends/keras_backend/metrics.py
@@ -1,0 +1,41 @@
+import tensorflow as tf
+from tensorflow.keras.metrics import Metric
+
+import n3fit.backends.keras_backend.operations as op
+
+
+class LossMetric(Metric):
+    """
+    Implementation of the (validation) loss as a metric.
+    Keeps track of per replica loss internally, aggregates just for logging.
+
+    Parameters
+    ----------
+        loss_layer : tf.keras.layers.Layer
+            The loss layer to use for the metric.
+        agg : str
+            Aggregation method to use for the replicas. Can be 'sum' or 'mean'.
+    """
+
+    def __init__(self, loss_layer, agg='sum', name='val_loss', **kwargs):
+        super().__init__(name=name, **kwargs)
+        self.loss_layer = loss_layer
+        if agg == 'sum':
+            self.agg = op.sum
+        elif agg == 'mean':
+            self.agg = op.mean
+        else:
+            raise ValueError(f'agg must be sum or mean, got {agg}')
+        num_replicas = loss_layer.output.shape[0]
+        self.per_replica_losses = self.add_weight(
+            name="per_replica_losses", shape=(num_replicas,), initializer="zeros"
+        )
+
+    def update_state(self, y_true, y_pred, sample_weight=None):
+        self.per_replica_losses.assign(self.loss_layer(y_pred))
+
+    def result(self):
+        return self.agg(self.per_replica_losses)
+
+    def reset_state(self):
+        self.per_replica_losses.assign(tf.zeros_like(self.per_replica_losses))

--- a/n3fit/src/n3fit/hyper_optimization/rewards.py
+++ b/n3fit/src/n3fit/hyper_optimization/rewards.py
@@ -145,15 +145,16 @@ def fit_future_tests(n3pdfs=None, experimental_models=None, **_kwargs):
             # Update the mask of the last_model so that its synced with this layer
             last_model.get_layer(layer.name).update_mask(layer.mask)
 
-        # Compute the loss with pdf errors
-        pdf_chi2 = exp_model.compute_losses()["loss"][0]
-
-        # And the loss of the best (most complete) fit
-        best_chi2 = last_model.compute_losses()["loss"][0]
-
-        # Now make this into a measure of the total loss
-        # for instance, any deviation from the "best" value is bad
-        total_loss += np.abs(best_chi2 - pdf_chi2)
+    # TODO Aron: replace compute_losses here, is this even ever called?
+    #        # Compute the loss with pdf errors
+    #        pdf_chi2 = exp_model.compute_losses()["loss"][0]
+    #
+    #        # And the loss of the best (most complete) fit
+    #        best_chi2 = last_model.compute_losses()["loss"][0]
+    #
+    #        # Now make this into a measure of the total loss
+    #        # for instance, any deviation from the "best" value is bad
+    #        total_loss += np.abs(best_chi2 - pdf_chi2)
 
     if compatibility_mode:
         set_eager(False)

--- a/n3fit/src/n3fit/io/writer.py
+++ b/n3fit/src/n3fit/io/writer.py
@@ -308,11 +308,12 @@ class WriterWrapper:
             json.dump(json_dict, fs, indent=2, cls=SuperEncoder)
 
         log.info(
-            "Best fit for replica #%d, chi2=%.3f (tr=%.3f, vl=%.3f)",
+            "Best fit for replica #%d, chi2=%.3f (tr=%.3f, vl=%.3f), at epoch %d.",
             self.replica_numbers[i],
             self.true_chi2[i],
             self.tr_chi2[i],
             self.vl_chi2[i],
+            self.stopping_object.e_best_chi2[i],
         )
 
     def _export_pdf_grid(self, i, out_path):
@@ -513,7 +514,6 @@ def evln2lha(evln, nf=6):
         - 3 * evln[7]
         - 2 * evln[8]
     ) / 120
-
 
     # if a heavy quark is not active at Q0 (the scale at which the output of the fit is stored),
     # keep the PDF values at 0.0 to prevent small negative values due to numerical instabilities

--- a/n3fit/src/n3fit/stopping.py
+++ b/n3fit/src/n3fit/stopping.py
@@ -31,7 +31,7 @@ import logging
 
 import numpy as np
 
-from n3fit.backends import LossMetric
+from n3fit.backends import LossMetric, extract_replica_weights
 
 log = logging.getLogger(__name__)
 
@@ -377,7 +377,9 @@ class Stopping:
             # By definition, if we have a ``best_epoch`` then positivity passed
             self.positivity_statuses[i_replica] = POS_OK
 
-            self._best_weights[i_replica] = self.previous_weights[i_replica]
+            self._best_weights[i_replica] = extract_replica_weights(
+                self.previous_weights, i_replica
+            )
             self._best_val_chi2s[i_replica] = self._history.get_state(epoch).vl_loss[i_replica]
 
             self._stopping_degrees[i_replica] = 0


### PR DESCRIPTION
# Goal

The goal of this PR is to speed up the code by a factor 2 by a refactoring that avoids redoing the same computations.
Currently there are separate training and validation models.
At every training step the validation model is run from scratch on x inputs, while the only difference with the training model is in the final masking just before computing the loss.

This will hopefully also improve readability. From an ML point of view the current naming is very confusing. Instead of having a training model and a validation model, we can have a single observable model, and on top of that a training and validation loss. (Just talking about names here, they may still be MetaModels)

The same holds of course for the experimental model, except that there is no significant performance cost there. But for consistency and readability let's try to treat that on the same footing.

This PR branches off of trvl-mask-layers because that PR changes the masking. That one should be merged before this one.

# Current implementation

## Models creation
The models are constructed in [`ModelTrainer._model_generation`](https://github.com/NNPDF/nnpdf/blob/d49196b7327df0c343f080844790723078a2f0da/n3fit/src/n3fit/model_trainer.py#L374).
Specifically in the function [`_pdf_injection`](https://github.com/NNPDF/nnpdf/blob/d49196b7327df0c343f080844790723078a2f0da/n3fit/src/n3fit/model_trainer.py#L43), which is given the pdfs, a list of observables and a corresponding list of masks.
For the different "models", both the values of the mask but also the list of observables change, as not all models use all observables, in particular the positivity and integrability ones.
This function just calls the observables on the pdfs with the mask as argument.
And each observable's call method, defined [here](https://github.com/NNPDF/nnpdf/blob/d49196b7327df0c343f080844790723078a2f0da/n3fit/src/n3fit/model_gen.py#L102), does two steps: 1. compute the observable, 2. apply the mask and compute the loss.

## Models usage

Once they are created, the training model is, obviously, used for training [here](https://github.com/NNPDF/nnpdf/blob/d49196b7327df0c343f080844790723078a2f0da/n3fit/src/n3fit/model_trainer.py#L942). 
The validation model used to initialize the [`Stopping`](https://github.com/NNPDF/nnpdf/blob/d49196b7327df0c343f080844790723078a2f0da/n3fit/src/n3fit/model_trainer.py#L928) object. The only thing that happens there is that its [`compute_losses`](https://github.com/NNPDF/nnpdf/blob/d49196b7327df0c343f080844790723078a2f0da/n3fit/src/n3fit/backends/keras_backend/MetaModel.py#L180) method is called. Similarly for the experimental model, where it is called directly in the `ModelTrainer` ([here](https://github.com/NNPDF/nnpdf/blob/d49196b7327df0c343f080844790723078a2f0da/n3fit/src/n3fit/model_trainer.py#L950)).

# Changes proposed

1. Decouple the masking and loss computation from the `ObservableWrapper` class. Just remove those parts from `ObservableWrapper`, and create perhaps an `ObservableLoss` layer that does this.
2. Apply this pure observable class to the pdfs, for all observables, to create an `observables_model`.
3. Create 3 loss models, that take as input all observables, do both a masking and a selection and a computation of losses.
4. For the training one, put it on top of the `observables_model`, to create a model identical to the current training model.
5. Add the output of the observables_model to the output list of this training model, so these can be reused.
6. The validation and experimental models can be discarded, instead we have the validation and experimental losses that are applied to the output of the observables_model. So e.g. we can replace `self.experimental["model"].compute_losses()` with `experimental_loss(observables)`.

