### PR TITLE
Set `reportengine version ==0.30.28`

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -37,7 +37,7 @@ requirements:
         - apfel
         - pkg-config
         - python # requirements for validphys
-        - reportengine >=0.30.25 # see https://github.com/NNPDF/reportengine
+        - reportengine >=0.30.25,<=0.30.28 # see https://github.com/NNPDF/reportengine
         - matplotlib >=3.3.0,<3.8  # see https://github.com/NNPDF/nnpdf/pull/1809
         - blessings >=1.7
         - scipy >=0.19.1

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -37,7 +37,7 @@ requirements:
         - apfel
         - pkg-config
         - python # requirements for validphys
-        - reportengine >=0.30.25,<=0.30.28 # see https://github.com/NNPDF/reportengine
+        - reportengine ==0.30.28  # see https://github.com/NNPDF/reportengine
         - matplotlib >=3.3.0,<3.8  # see https://github.com/NNPDF/nnpdf/pull/1809
         - blessings >=1.7
         - scipy >=0.19.1


### PR DESCRIPTION
This is the version used in the environment in #1852. Newer versions would change quite a few things and are currently untested together with this repository. Since there are effectively no maintainers for `reportengine` I think we should stop updates until someone can commit the time to actually making sure that everything works ok.