### PR TITLE
Set deadline=None for test_kitable_with_cuts

### DIFF
--- a/validphys2/src/validphys/tests/test_loader.py
+++ b/validphys2/src/validphys/tests/test_loader.py
@@ -67,6 +67,7 @@ def test_rebuild_commondata_without_cuts(tmp_path_factory, arg):
         assert (lncd.get_cv()[nocuts] == 0).all()
 
 @given(inp=commondata_and_cuts())
+@settings(deadline=None)
 def test_kitable_with_cuts(inp):
     cd, cuts = inp
     info = get_info(cd, cuts=cuts)


### PR DESCRIPTION
This test is lately producing inconsistent timings in Macos which can lead to false positives in the tests.

Clearly the variability of the size and complexity of the dataset is too much, since I would argue that variability is expected, better to remove the check on the time...