### PR TITLE
Allow photon PDF to reports

### DIFF
--- a/validphys2/src/validphys/pdfbases.py
+++ b/validphys2/src/validphys/pdfbases.py
@@ -525,7 +525,7 @@ evolution = LinearBasis.from_mapping({
 EVOL = evolution
 
 LUX = copy.deepcopy(evolution)
-LUX.default_elements = (r'\Sigma', 'V', 'T3', 'V3', 'T8', 'V8', 'T15', 'gluon', 'photon')
+LUX.default_elements = (r'\Sigma', 'V', 'T3', 'V3', 'T8', 'V8', 'T15', 'V15', 'gluon', 'photon')
 
 CCBAR_ASYMM = copy.deepcopy(evolution)
 CCBAR_ASYMM.default_elements = (r'\Sigma', 'V', 'T3', 'V3', 'T8', 'V8', 'T15', 'gluon', 'V15')
@@ -616,6 +616,22 @@ FLAVOUR = LinearBasis.from_mapping(
 
 CCBAR_ASYMM_FLAVOUR = copy.deepcopy(FLAVOUR)
 CCBAR_ASYMM_FLAVOUR.default_elements=('u', 'ubar', 'd', 'dbar', 's', 'sbar', 'c', 'cbar', 'g')
+
+LUX_FLAVOUR = LinearBasis.from_mapping(
+    {
+        'u': {'u': 1},
+        'ubar': {'ubar': 1},
+        'd': {'d': 1},
+        'dbar': {'dbar': 1},
+        's': {'s': 1},
+        'sbar': {'sbar': 1},
+        'c': {'c': 1},
+        'cbar': {'cbar': 1},
+        'g': {'g': 1},
+        'photon': {'photon':1},
+    },
+    default_elements=('u', 'ubar', 'd', 'dbar', 's', 'sbar', 'c', 'cbar', 'g', 'photon')
+)
 
 pdg = LinearBasis.from_mapping({
 'g/10': {'g':0.1},

--- a/validphys2/src/validphys/pdfbases.py
+++ b/validphys2/src/validphys/pdfbases.py
@@ -611,27 +611,15 @@ FLAVOUR = LinearBasis.from_mapping(
         'c': {'c': 1},
         'cbar': {'cbar': 1},
         'g': {'g': 1},
+        'photon': {'photon':1},
     },
     default_elements=('u', 'ubar', 'd', 'dbar', 's', 'sbar', 'c', 'g', ))
 
 CCBAR_ASYMM_FLAVOUR = copy.deepcopy(FLAVOUR)
 CCBAR_ASYMM_FLAVOUR.default_elements=('u', 'ubar', 'd', 'dbar', 's', 'sbar', 'c', 'cbar', 'g')
 
-LUX_FLAVOUR = LinearBasis.from_mapping(
-    {
-        'u': {'u': 1},
-        'ubar': {'ubar': 1},
-        'd': {'d': 1},
-        'dbar': {'dbar': 1},
-        's': {'s': 1},
-        'sbar': {'sbar': 1},
-        'c': {'c': 1},
-        'cbar': {'cbar': 1},
-        'g': {'g': 1},
-        'photon': {'photon':1},
-    },
-    default_elements=('u', 'ubar', 'd', 'dbar', 's', 'sbar', 'c', 'cbar', 'g', 'photon')
-)
+LUX_FLAVOUR = copy.deepcopy(FLAVOUR)
+LUX_FLAVOUR.default_elements=('u', 'ubar', 'd', 'dbar', 's', 'sbar', 'c', 'cbar', 'g', 'photon')
 
 pdg = LinearBasis.from_mapping({
 'g/10': {'g':0.1},

--- a/validphys2/src/validphys/scripts/vp_comparefits.py
+++ b/validphys2/src/validphys/scripts/vp_comparefits.py
@@ -79,7 +79,7 @@ class CompareFitApp(App):
         parser.add_argument(
             '-p',
             '--photon',
-            help="Add photon PDF to the report",
+            help="Use LUX basis (which include the photon) for the report",
             action='store_true')
 
         parser.set_defaults()

--- a/validphys2/src/validphys/scripts/vp_comparefits.py
+++ b/validphys2/src/validphys/scripts/vp_comparefits.py
@@ -76,6 +76,11 @@ class CompareFitApp(App):
             '--lite',
             help="Smaller version of the usual comparefit fit",
             action='store_true')
+        parser.add_argument(
+            '-p',
+            '--photon',
+            help="Add photon PDF to the report",
+            action='store_true')
 
         parser.set_defaults()
 
@@ -224,6 +229,11 @@ class CompareFitApp(App):
             'speclabel': args['reference_fit_label']
         }
         autosettings['use_thcovmat_if_present'] = args['thcovmat_if_present']
+        if args['photon']:
+            autosettings['Basespecs'] = [
+                {'basis': 'LUX_FLAVOUR', 'Basistitle': 'Flavour basis'},
+                {'basis': 'LUX', 'Basistitle': 'Evolution basis'}
+            ]
         return autosettings
 
 


### PR DESCRIPTION
Allow photon PDF in reports through the argument `--photon` in `vp-comparefits`