### PR TITLE
Add two extra colors

### DIFF
--- a/validphys2/src/validphys/mplstyles/biglabels.mplstyle
+++ b/validphys2/src/validphys/mplstyles/biglabels.mplstyle
@@ -1,6 +1,6 @@
 axes.grid               : True
 axes.titlesize          : large
-axes.prop_cycle        : cycler('color', ['66c2a5', 'fc8d62', '8da0cb', 'e78ac3', 'a6d854', 'ffd92f', 'e5c494', 'b3b3b3', '0072b2','000000'])
+axes.prop_cycle        : cycler('color', ['66c2a5', 'fc8d62', '8da0cb', 'e78ac3', 'a6d854', 'ffd92f', 'e5c494', 'b3b3b3', 'c37892','789895'])
 axes.labelsize          : medium
 axes.formatter.limits   : -5,5
 axes.formatter.use_mathtext : True

--- a/validphys2/src/validphys/mplstyles/biglabels.mplstyle
+++ b/validphys2/src/validphys/mplstyles/biglabels.mplstyle
@@ -1,6 +1,6 @@
 axes.grid               : True
 axes.titlesize          : large
-axes.prop_cycle        : cycler('color', ['66c2a5', 'fc8d62', '8da0cb', 'e78ac3', 'a6d854', 'ffd92f', 'e5c494', 'b3b3b3'])
+axes.prop_cycle        : cycler('color', ['66c2a5', 'fc8d62', '8da0cb', 'e78ac3', 'a6d854', 'ffd92f', 'e5c494', 'b3b3b3', '0072b2','000000'])
 axes.labelsize          : medium
 axes.formatter.limits   : -5,5
 axes.formatter.use_mathtext : True

--- a/validphys2/src/validphys/mplstyles/small.mplstyle
+++ b/validphys2/src/validphys/mplstyles/small.mplstyle
@@ -1,6 +1,6 @@
 axes.grid               : True
 axes.titlesize          : medium 
-axes.prop_cycle        : cycler('color', ['66c2a5', 'fc8d62', '8da0cb', 'e78ac3', 'a6d854', 'ffd92f', 'e5c494', 'b3b3b3'])
+axes.prop_cycle        : cycler('color', ['66c2a5', 'fc8d62', '8da0cb', 'e78ac3', 'a6d854', 'ffd92f', 'e5c494', 'b3b3b3', '0072b2','000000'])
 axes.labelsize          : small
 axes.formatter.limits   : -5,5
 axes.formatter.use_mathtext : True

--- a/validphys2/src/validphys/mplstyles/small.mplstyle
+++ b/validphys2/src/validphys/mplstyles/small.mplstyle
@@ -1,6 +1,6 @@
 axes.grid               : True
-axes.titlesize          : medium 
-axes.prop_cycle        : cycler('color', ['66c2a5', 'fc8d62', '8da0cb', 'e78ac3', 'a6d854', 'ffd92f', 'e5c494', 'b3b3b3', '0072b2','000000'])
+axes.titlesize          : medium
+axes.prop_cycle        : cycler('color', ['66c2a5', 'fc8d62', '8da0cb', 'e78ac3', 'a6d854', 'ffd92f', 'e5c494', 'b3b3b3', 'c37892','789895'])
 axes.labelsize          : small
 axes.formatter.limits   : -5,5
 axes.formatter.use_mathtext : True


### PR DESCRIPTION
Right now we are using this list of 8 https://scottplot.net/cookbook/4.1/colors/#dark-pastel
But of course, we added cbar and photon so now we need 10

See e.g.:

https://vp.nnpdf.science/7DxRLas3S_a3zqixFEzADg==/figures/Scales0_Normalize_Basespecs0_PDFscalespecs0_Distspecs0_plot_pdfdistances.pdf

So I've added two extra colors at the end. If you don't like them suggestions are welcome. One example here:

![image](https://github.com/NNPDF/nnpdf/assets/20564015/6ff3e8b9-37fb-4319-a8d9-8d027f7f55a2)
