### PR TITLE
Move replica axis to front everywhere

### DIFF
--- a/n3fit/src/n3fit/backends/keras_backend/MetaModel.py
+++ b/n3fit/src/n3fit/backends/keras_backend/MetaModel.py
@@ -396,8 +396,7 @@ class MetaModel(Model):
         if self.single_replica_generator is None:
             raise ValueError("Trying to generate single replica models with no generator set.")
         replicas = []
-        num_replicas = self.output.shape[-1]
-        for i_replica in range(num_replicas):
+        for i_replica in range(self.num_replicas):
             replica = self.single_replica_generator()
             replica.set_replica_weights(self.get_replica_weights(i_replica))
 
@@ -410,14 +409,17 @@ class MetaModel(Model):
 
         return replicas
 
+    @property
+    def num_replicas(self):
+        return self.output.shape[1]
+
     def load_identical_replicas(self, model_file):
         """
         From a single replica model, load the same weights into all replicas.
         """
         weights = self._format_weights_from_file(model_file)
 
-        num_replicas = self.output.shape[-1]
-        for i_replica in range(num_replicas):
+        for i_replica in range(self.num_replicas):
             self.set_replica_weights(weights, i_replica)
 
     def _format_weights_from_file(self, model_file):

--- a/n3fit/src/n3fit/backends/keras_backend/operations.py
+++ b/n3fit/src/n3fit/backends/keras_backend/operations.py
@@ -261,7 +261,7 @@ def pdf_masked_convolution(raw_pdf, basis_mask):
     Parameters
     ----------
         pdf: tf.tensor
-            rank 4 (batchsize, xgrid, flavours, replicas)
+            rank 4 (batchsize, replicas, xgrid, flavours)
         basis_mask: tf.tensor
             rank  2 tensor (flavours, flavours)
             mask to apply to the pdf convolution
@@ -269,18 +269,18 @@ def pdf_masked_convolution(raw_pdf, basis_mask):
     Return
     ------
         pdf_x_pdf: tf.tensor
-            rank3 (len(mask_true), xgrid, xgrid, replicas)
+            rank3 (replicas, len(mask_true), xgrid, xgrid)
     """
-    if raw_pdf.shape[-1] == 1:  # only one replica!
-        pdf = tf.squeeze(raw_pdf, axis=(0, -1))
+    if raw_pdf.shape[1] == 1:  # only one replica!
+        pdf = tf.squeeze(raw_pdf, axis=(0, 1))
         luminosity = tensor_product(pdf, pdf, axes=0)
         lumi_tmp = K.permute_dimensions(luminosity, (3, 1, 2, 0))
-        pdf_x_pdf = batchit(boolean_mask(lumi_tmp, basis_mask), -1)
+        pdf_x_pdf = batchit(boolean_mask(lumi_tmp, basis_mask), 0)
     else:
         pdf = tf.squeeze(raw_pdf, axis=0)  # remove the batchsize
-        luminosity = tf.einsum('air,bjr->jibar', pdf, pdf)
+        luminosity = tf.einsum('rai,rbj->rjiba', pdf, pdf)
         # (xgrid, flavour, xgrid, flavour)
-        pdf_x_pdf = boolean_mask(luminosity, basis_mask)
+        pdf_x_pdf = boolean_mask(luminosity, basis_mask, axis=1)
     return pdf_x_pdf
 
 

--- a/n3fit/src/n3fit/hyper_optimization/penalties.py
+++ b/n3fit/src/n3fit/hyper_optimization/penalties.py
@@ -53,17 +53,18 @@ def saturation(pdf_model=None, n=100, min_x=1e-6, max_x=1e-4, flavors=None, **_k
     if flavors is None:
         flavors = [1, 2]
     x = np.logspace(np.log10(min_x), np.log10(max_x), n)
-    x = np.expand_dims(x, axis=[0, -1])
     extra_loss = 0.0
 
-    y = pdf_model.predict({"pdf_input": x})
-    xpdf = y[0, :, flavors]
+    x_input = np.expand_dims(x, axis=[0, -1])
+    y = pdf_model.predict({"pdf_input": x_input})
+    xpdf = y[0, :, :, flavors]  # this is now of shape (flavors, replicas, xgrid)
 
-    delta_logx = np.diff(np.log10(x), axis=1)
-    delta_xpdf = np.diff(xpdf, axis=1)
+    x = np.expand_dims(x, axis=[0, 1])
+    delta_logx = np.diff(np.log10(x), axis=2)
+    delta_xpdf = np.diff(xpdf, axis=2)
     slope = delta_xpdf / delta_logx
 
-    pen = abs(np.mean(slope, axis=1)) + np.std(slope, axis=1)
+    pen = abs(np.mean(slope, axis=2)) + np.std(slope, axis=2)
 
     # sum over flavors
     # Add a small offset to avoid ZeroDivisionError

--- a/n3fit/src/n3fit/layers/DY.py
+++ b/n3fit/src/n3fit/layers/DY.py
@@ -1,6 +1,8 @@
 import numpy as np
-from .observable import Observable
+
 from n3fit.backends import operations as op
+
+from .observable import Observable
 
 
 class DY(Observable):
@@ -30,7 +32,7 @@ class DY(Observable):
         Parameters
         ----------
             pdf_in: tensor
-                rank 4 tensor (batchsize, xgrid, flavours, replicas)
+                rank 4 tensor (batchsize, replicas, xgrid, flavours)
 
         Returns
         -------
@@ -43,20 +45,20 @@ class DY(Observable):
         results = []
         if self.many_masks:
             if self.splitting:
-                splitted_pdf = op.split(pdf_raw, self.splitting, axis=1)
+                splitted_pdf = op.split(pdf_raw, self.splitting, axis=2)
                 for mask, pdf, fk in zip(self.all_masks, splitted_pdf, self.fktables):
                     pdf_x_pdf = op.pdf_masked_convolution(pdf, mask)
-                    res = op.tensor_product(fk, pdf_x_pdf, axes=3)
+                    res = op.tensor_product(fk, pdf_x_pdf, axes=[(1, 2, 3), (1, 2, 3)])
                     results.append(res)
             else:
                 for mask, fk in zip(self.all_masks, self.fktables):
                     pdf_x_pdf = op.pdf_masked_convolution(pdf_raw, mask)
-                    res = op.tensor_product(fk, pdf_x_pdf, axes=3)
+                    res = op.tensor_product(fk, pdf_x_pdf, axes=[(1, 2, 3), (1, 2, 3)])
                     results.append(res)
         else:
             pdf_x_pdf = op.pdf_masked_convolution(pdf_raw, self.all_masks[0])
             for fk in self.fktables:
-                res = op.tensor_product(fk, pdf_x_pdf, axes=3)
+                res = op.tensor_product(fk, pdf_x_pdf, axes=[(1, 2, 3), (1, 2, 3)])
                 results.append(res)
 
         # the masked convolution removes the batch dimension

--- a/n3fit/src/n3fit/layers/rotations.py
+++ b/n3fit/src/n3fit/layers/rotations.py
@@ -22,7 +22,7 @@ class Rotation(MetaLayer):
             rotation_axis of input to be rotated
     """
 
-    def __init__(self, rotation_matrix, rotation_axis=2, **kwargs):
+    def __init__(self, rotation_matrix, rotation_axis=3, **kwargs):
         self.rotation_matrix = op.numpy_to_tensor(rotation_matrix)
         self.rotation_axis = rotation_axis
         super().__init__(**kwargs)
@@ -47,12 +47,7 @@ class FlavourToEvolution(Rotation):
     the evolution basis.
     """
 
-    def __init__(
-        self,
-        flav_info,
-        fitbasis,
-        **kwargs,
-    ):
+    def __init__(self, flav_info, fitbasis, **kwargs):
         rotation_matrix = pdfbases.fitbasis_to_NN31IC(flav_info, fitbasis)
         super().__init__(rotation_matrix, **kwargs)
 
@@ -111,7 +106,7 @@ class AddPhoton(MetaLayer):
         super().__init__(**kwargs)
 
     def register_photon(self, xgrid):
-        """Compute the photon array of shape (1, xgrid, 1, replicas) and set the layer to be rebuilt"""
+        """Compute the photon array of shape (1, replicas, xgrid, 1) and set the layer to be rebuilt"""
         if self._photons_generator:
             self._pdf_ph = self._photons_generator(xgrid)
             self.built = False
@@ -119,7 +114,7 @@ class AddPhoton(MetaLayer):
     def call(self, pdfs):
         if self._pdf_ph is None:
             return pdfs
-        return op.concatenate([self._pdf_ph, pdfs[:, :, 1:]], axis=2)
+        return op.concatenate([self._pdf_ph, pdfs[:, :, :, 1:]], axis=3)
 
 
 class ObsRotation(MetaLayer):

--- a/n3fit/src/n3fit/layers/x_operations.py
+++ b/n3fit/src/n3fit/layers/x_operations.py
@@ -65,11 +65,11 @@ class xIntegrator(MetaLayer):
     ----------
         grid_weights: np.array
             weights of the grid
-        x_axis: int (default=1)
+        x_axis: int (default=2)
             axis of the input tensor that corresponds to the x-grid
     """
 
-    def __init__(self, grid_weights, x_axis=1, **kwargs):
+    def __init__(self, grid_weights, x_axis=2, **kwargs):
         self.x_axis = x_axis
         self.grid_weights = op.flatten(op.numpy_to_tensor(grid_weights))
         super().__init__(**kwargs)

--- a/n3fit/src/n3fit/model_trainer.py
+++ b/n3fit/src/n3fit/model_trainer.py
@@ -356,7 +356,7 @@ class ModelTrainer:
         # The PDF model will be called with a concatenation of all inputs
         # now the output needs to be splitted so that each experiment takes its corresponding input
         sp_ar = [[i.shape[1] for i in inputs_unique]]
-        sp_kw = {"axis": 1}
+        sp_kw = {"axis": 2}
         sp_layer = op.as_layer(op.split, op_args=sp_ar, op_kwargs=sp_kw, name="pdf_split")
 
         return InputInfo(input_layer, sp_layer, inputs_idx)

--- a/n3fit/src/n3fit/stopping.py
+++ b/n3fit/src/n3fit/stopping.py
@@ -349,7 +349,7 @@ class Stopping:
         self._positivity = Positivity(threshold_positivity, pos_sets)
 
         # Initialize internal variables for the stopping
-        self._n_replicas = pdf_model.output_shape[-1]
+        self._n_replicas = pdf_model.num_replicas
         self._threshold_chi2 = threshold_chi2
         self._stopping_degrees = np.zeros(self._n_replicas, dtype=int)
         self._counts = np.zeros(self._n_replicas, dtype=int)

--- a/n3fit/src/n3fit/tests/test_layers.py
+++ b/n3fit/src/n3fit/tests/test_layers.py
@@ -3,11 +3,12 @@
     This module checks that the layers do what they would do with numpy
 """
 import dataclasses
+
 import numpy as np
-from validphys.pdfbases import fitbasis_to_NN31IC
+
 from n3fit.backends import operations as op
 import n3fit.layers as layers
-
+from validphys.pdfbases import fitbasis_to_NN31IC
 
 FLAVS = 3
 XSIZE = 4
@@ -145,7 +146,7 @@ def test_DIS():
         fks = [i.fktable for i in fktables]
         obs_layer = layers.DIS(fktables, fks, ope, nfl=FLAVS)
         pdf = np.random.rand(XSIZE, FLAVS)
-        kp = op.numpy_to_tensor(np.expand_dims(pdf, 0))
+        kp = op.numpy_to_tensor([[pdf]])  # add batch and replica dimension
         # generate the n3fit results
         result_tensor = obs_layer(kp)
         result = op.evaluate(result_tensor)
@@ -169,8 +170,7 @@ def test_DY():
         fks = [i.fktable for i in fktables]
         obs_layer = layers.DY(fktables, fks, ope, nfl=FLAVS)
         pdf = np.random.rand(XSIZE, FLAVS)
-        # Add batch dimension (0) and replica dimension (-1)
-        kp = op.numpy_to_tensor(np.expand_dims(pdf, [0, -1]))
+        kp = op.numpy_to_tensor([[pdf]])  # add batch and replica dimension
         # generate the n3fit results
         result_tensor = obs_layer(kp)
         result = op.evaluate(result_tensor)
@@ -201,15 +201,15 @@ def test_rotation_flavour():
         {"fl": "g"},
     ]
     # Apply the rotation using numpy tensordot
-    x = np.ones(8)  # Vector in the flavour basis v_i
-    x = np.expand_dims(x, axis=[0, 1])  # Give to the input the shape (1,1,8)
+    pdf = np.ones(8)  # Vector in the flavour basis v_i
+    pdf = np.expand_dims(pdf, axis=[0, 1, 2])  # Add batch, replica, x dimensions
     mat = fitbasis_to_NN31IC(flav_info, "FLAVOUR")  # Rotation matrix R_ij, i=flavour, j=evolution
-    res_np = np.tensordot(x, mat, (2, 0))  # Vector in the evolution basis u_j=R_ij*vi
+    res_np = np.tensordot(pdf, mat, (3, 0))  # Vector in the evolution basis u_j=R_ij*vi
 
     # Apply the rotation through the rotation layer
-    x = op.numpy_to_tensor(x)
+    pdf = op.numpy_to_tensor(pdf)
     rotmat = layers.FlavourToEvolution(flav_info, "FLAVOUR")
-    res_layer = rotmat(x)
+    res_layer = rotmat(pdf)
     assert np.alltrue(res_np == res_layer)
 
 
@@ -226,15 +226,15 @@ def test_rotation_evol():
         {"fl": "g"},
     ]
     # Apply the rotation using numpy tensordot
-    x = np.ones(8)  # Vector in the flavour basis v_i
-    x = np.expand_dims(x, axis=[0, 1])  # Give to the input the shape (1,1,8)
+    pdf = np.ones(8)  # Vector in the flavour basis v_i
+    pdf = np.expand_dims(pdf, axis=[0, 1, 2])  # Add batch, replica, x dimensions
     mat = fitbasis_to_NN31IC(flav_info, "EVOL")  # Rotation matrix R_ij, i=flavour, j=evolution
-    res_np = np.tensordot(x, mat, (2, 0))  # Vector in the evolution basis u_j=R_ij*vi
+    res_np = np.tensordot(pdf, mat, (3, 0))  # Vector in the evolution basis u_j=R_ij*vi
 
     # Apply the rotation through the rotation layer
-    x = op.numpy_to_tensor(x)
+    pdf = op.numpy_to_tensor(pdf)
     rotmat = layers.FlavourToEvolution(flav_info, "EVOL")
-    res_layer = rotmat(x)
+    res_layer = rotmat(pdf)
     assert np.alltrue(res_np == res_layer)
 
 
@@ -260,6 +260,7 @@ def test_mask():
     ret = masker(fi)
     np.testing.assert_allclose(ret, masked_fi * rn_val, rtol=1e-5)
 
+
 def test_addphoton_init():
     """Test AddPhoton class."""
     addphoton = layers.AddPhoton(photons=None)
@@ -268,13 +269,15 @@ def test_addphoton_init():
     np.testing.assert_equal(addphoton._photons_generator, 1234)
     np.testing.assert_equal(addphoton._pdf_ph, None)
 
-class FakePhoton():
+
+class FakePhoton:
     def __call__(self, xgrid):
         return [np.exp(-xgrid)]
+
 
 def test_compute_photon():
     photon = FakePhoton()
     addphoton = layers.AddPhoton(photons=photon)
-    xgrid = np.geomspace(1e-4, 1., 10)
+    xgrid = np.geomspace(1e-4, 1.0, 10)
     addphoton.register_photon(xgrid)
     np.testing.assert_allclose(addphoton._pdf_ph, [np.exp(-xgrid)])

--- a/n3fit/src/n3fit/tests/test_msr.py
+++ b/n3fit/src/n3fit/tests/test_msr.py
@@ -6,9 +6,9 @@ from n3fit.layers import MSR_Normalization
 
 def apply_layer_to_fixed_input(layer):
     np.random.seed(422)
-    pdf_integrated = op.numpy_to_tensor(np.random.normal(size=(1, 14,1)))
+    pdf_integrated = op.numpy_to_tensor(np.random.normal(size=(1, 1, 14)))
 
-    photon_integral = op.numpy_to_tensor([np.random.normal(size=(1,1))])
+    photon_integral = op.numpy_to_tensor([np.random.normal(size=(1, 1))])
 
     return layer(pdf_integrated, photon_integral)
 
@@ -17,25 +17,26 @@ def test_all():
     layer = MSR_Normalization(mode='ALL')
     output = apply_layer_to_fixed_input(layer)
     known_output = op.numpy_to_tensor(
-        np.expand_dims(
+        [
             [
-                1.0,
-                1.0,
-                6.7740397,
-                -3.8735497,
-                15.276561,
-                5.9522753,
-                8.247783,
-                -3.8735497,
-                -3.8735497,
-                1.0,
-                1.0,
-                1.0,
-                1.0,
-                1.0,
-            ],
-            -1,
-        )
+                [
+                    1.0,
+                    1.0,
+                    6.7740397,
+                    -3.8735497,
+                    15.276561,
+                    5.9522753,
+                    8.247783,
+                    -3.8735497,
+                    -3.8735497,
+                    1.0,
+                    1.0,
+                    1.0,
+                    1.0,
+                    1.0,
+                ]
+            ]
+        ]
     )
     np.testing.assert_allclose(output, known_output, rtol=1e-5)
 
@@ -44,25 +45,7 @@ def test_msr():
     layer = MSR_Normalization(mode='MSR')
     output = apply_layer_to_fixed_input(layer)
     known_output = op.numpy_to_tensor(
-        np.expand_dims(
-            [
-                1.0,
-                1.0,
-                6.7740397,
-                1.0,
-                1.0,
-                1.0,
-                1.0,
-                1.0,
-                1.0,
-                1.0,
-                1.0,
-                1.0,
-                1.0,
-                1.0,
-            ],
-            -1,
-        )
+        [[[1.0, 1.0, 6.7740397, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]]]
     )
     np.testing.assert_allclose(output, known_output, rtol=1e-5)
 
@@ -71,24 +54,25 @@ def test_vsr():
     layer = MSR_Normalization(mode='VSR')
     output = apply_layer_to_fixed_input(layer)
     known_output = op.numpy_to_tensor(
-        np.expand_dims(
+        [
             [
-                1.0,
-                1.0,
-                1.0,
-                -3.8735497,
-                15.276561,
-                5.9522753,
-                8.247783,
-                -3.8735497,
-                -3.8735497,
-                1.0,
-                1.0,
-                1.0,
-                1.0,
-                1.0,
-            ],
-            -1,
-        )
+                [
+                    1.0,
+                    1.0,
+                    1.0,
+                    -3.8735497,
+                    15.276561,
+                    5.9522753,
+                    8.247783,
+                    -3.8735497,
+                    -3.8735497,
+                    1.0,
+                    1.0,
+                    1.0,
+                    1.0,
+                    1.0,
+                ]
+            ]
+        ]
     )
     np.testing.assert_allclose(output, known_output, rtol=1e-5)

--- a/n3fit/src/n3fit/tests/test_multireplica.py
+++ b/n3fit/src/n3fit/tests/test_multireplica.py
@@ -6,7 +6,7 @@ from n3fit.model_gen import generate_pdf_model
 def test_replica_split():
     """Check that multi replica pdf and concatenated single output pdfs agree"""
     num_replicas = 3
-    replica_axis = -1
+    replica_axis = 1
     fake_fl = [
         {"fl": i, "largex": [0, 1], "smallx": [1, 2]}
         for i in ["u", "ubar", "d", "dbar", "c", "g", "s", "sbar"]

--- a/n3fit/src/n3fit/tests/test_rotations.py
+++ b/n3fit/src/n3fit/tests/test_rotations.py
@@ -8,8 +8,10 @@ def test_fk():
     rotation = FkRotation()
     gridpoints = 2
     np.random.seed(0)
-    pdf = op.numpy_to_tensor(np.random.rand(1, gridpoints, 9))
+    pdf = op.numpy_to_tensor(np.random.rand(1, 1, gridpoints, 9))
     pdf_rotated = rotation(pdf)
+    # extract single replica
+    pdf_rotated = pdf_rotated[:, 0]
     pdf_rotated_known = op.numpy_to_tensor(
         [
             [

--- a/n3fit/src/n3fit/tests/test_xops.py
+++ b/n3fit/src/n3fit/tests/test_xops.py
@@ -38,10 +38,10 @@ def test_xdivide_indices():
 def test_xintegrator():
     np.random.seed(42)
     weights = np.random.rand(5, 1)
-    pdf = op.numpy_to_tensor(np.random.rand(1, 5, 8))
+    pdf = op.numpy_to_tensor(np.random.rand(1, 1, 5, 8))
     xint = xIntegrator(weights)
     xint_out = xint(pdf)
     xint_out_reference = np.array(
-        [[0.405455, 0.878931, 0.937715, 0.906214, 1.984154, 1.147975, 1.642387, 1.549858]]
+        [[[0.405455, 0.878931, 0.937715, 0.906214, 1.984154, 1.147975, 1.642387, 1.549858]]]
     )
     np.testing.assert_allclose(xint_out.numpy(), xint_out_reference, rtol=1e-05)

--- a/validphys2/src/validphys/photon/compute.py
+++ b/validphys2/src/validphys/photon/compute.py
@@ -187,14 +187,14 @@ class Photon:
         Returns
         -------
         photon values : nd.array
-            array of photon values with shape (1,xgrid,1,replicas)
+            array of photon values with shape (1, replicas, xgrid, 1)
         """
         return np.stack(
             [
                 self.interpolator[id](xgrid[0, :, 0])[np.newaxis, :, np.newaxis]
                 for id in range(len(self.replicas))
             ],
-            axis=-1,
+            axis=1,
         )
 
     @property

--- a/validphys2/src/validphys/tests/photon/test_compute.py
+++ b/validphys2/src/validphys/tests/photon/test_compute.py
@@ -203,18 +203,8 @@ def test_betas():
     """test betas for different nf"""
     test_theory = API.theoryid(theoryid=THEORY_QED)
     alpha = Alpha(test_theory.get_description(), 1e8)
-    vec_beta0 = [
-        -0.5305164769729844,
-        -0.6719875374991137,
-        -0.7073553026306458,
-        -0.8488263631567751,
-    ]
-    vec_b1 = [
-        0.17507043740108488,
-        0.1605510390839295,
-        0.1538497783221655,
-        0.1458920311675707,
-    ]
+    vec_beta0 = [-0.5305164769729844, -0.6719875374991137, -0.7073553026306458, -0.8488263631567751]
+    vec_b1 = [0.17507043740108488, 0.1605510390839295, 0.1538497783221655, 0.1458920311675707]
     for nf in range(3, 6 + 1):
         np.testing.assert_allclose(alpha.betas_qed[nf][0], vec_beta0[nf - 3], rtol=1e-7)
         np.testing.assert_allclose(alpha.betas_qed[nf][1], vec_b1[nf - 3], rtol=1e-7)
@@ -288,6 +278,6 @@ def test_photon():
         photon_Q0 = pdfs_final[ph_id]
         photon_fiatlux = XGRID * photon_Q0
 
-        photon_validphys = photon(XGRID[np.newaxis, :, np.newaxis])[0, :, 0, 0]
+        photon_validphys = photon(XGRID[np.newaxis, :, np.newaxis])[0, 0, :, 0]
 
         np.testing.assert_allclose(photon_fiatlux, photon_validphys, rtol=1e-7)


### PR DESCRIPTION
This just puts the replica axis first wherever it wasn't yet.

It gives identical results, to the last digit, on:
- [x] Basic runcard
- [x] feature scaling runcard
- [x] flavour basis
- [x] qed

In the MSR normalization layer, I do transpose them back to their old shape just because having the flavor axis first there makes for cleaner code. I think the performance hit there is negligible, but this can always be optimized later on.