### PR TITLE
Set to 0 not active flavours

### DIFF
--- a/n3fit/src/n3fit/performfit.py
+++ b/n3fit/src/n3fit/performfit.py
@@ -273,7 +273,7 @@ def performfit(
             pdf_instances,
             stopping_object,
             all_chi2s,
-            q0**2,
+            theoryid,
             final_time,
         )
         writer_wrapper.write_data(replica_path, output_path.name, save)


### PR DESCRIPTION
In the previous evolution (I think apfel?) was setting to 0 the flavours that were not active.

Instead, with eko, a non-evolved flavour just remains unchanged, which means that values of `-1e-7` in the bottom column are repeated for every value of Q until the threshold is reached.

Not a big issue in general, but if people have code that just breaks when it sees a negative value this would create unnecessary problems and we want our grids to be as problem free as possible.