### PR TITLE
Nn layers refactor

### DIFF
--- a/n3fit/src/n3fit/checks.py
+++ b/n3fit/src/n3fit/checks.py
@@ -114,6 +114,13 @@ def check_dropout(parameters):
     if dropout is not None and not 0.0 <= dropout <= 1.0:
         raise CheckError(f"Dropout must be between 0 and 1, got: {dropout}")
 
+    layer_type = parameters.get("layer_type")
+    if dropout is not None and dropout > 0.0 and layer_type == "dense_per_flavour":
+        raise CheckError(
+            "Dropout is not compatible with the dense_per_flavour layer type, "
+            "please use instead the dense layer type"
+        )
+
 
 def check_tensorboard(tensorboard):
     """Check that the tensorbard callback can be enabled correctly"""

--- a/n3fit/src/n3fit/checks.py
+++ b/n3fit/src/n3fit/checks.py
@@ -108,6 +108,16 @@ def check_initializer(initializer):
         raise CheckError(f"Initializer {initializer} not accepted by {MetaLayer}")
 
 
+def check_layer_type_implemented(parameters):
+    """Checks whether the layer_type is implemented"""
+    layer_type = parameters.get("layer_type")
+    implemented_types = ["dense", "dense_per_flavour"]
+    if layer_type not in implemented_types:
+        raise CheckError(
+            f"Layer type {layer_type} not implemented, must be one of {implemented_types}"
+        )
+
+
 def check_dropout(parameters):
     """Checks the dropout setup (positive and smaller than 1.0)"""
     dropout = parameters.get("dropout")
@@ -175,6 +185,7 @@ def wrapper_check_NN(basis, tensorboard, save, load, parameters):
     check_consistent_layers(parameters)
     check_basis_with_layers(basis, parameters)
     check_stopping(parameters)
+    check_layer_type_implemented(parameters)
     check_dropout(parameters)
     check_lagrange_multipliers(parameters, "integrability")
     check_lagrange_multipliers(parameters, "positivity")

--- a/n3fit/src/n3fit/checks.py
+++ b/n3fit/src/n3fit/checks.py
@@ -118,7 +118,7 @@ def check_dropout(parameters):
     if dropout is not None and dropout > 0.0 and layer_type == "dense_per_flavour":
         raise CheckError(
             "Dropout is not compatible with the dense_per_flavour layer type, "
-            "please use instead the dense layer type"
+            "please use instead `parameters::layer_type: dense`"
         )
 
 

--- a/n3fit/src/n3fit/model_gen.py
+++ b/n3fit/src/n3fit/model_gen.py
@@ -795,19 +795,16 @@ def generate_nn(
     }
     if layer_type == "dense_per_flavour":
         constant_args['basis_size'] = last_layer_nodes
+        layers_generator = generate_dense_per_flavour_network
     if layer_type == "dense":
         constant_args['dropout_rate'] = dropout
         reg = regularizer_selector(regularizer, **regularizer_args)
         constant_args['regularizer'] = reg
+        layers_generator = generate_dense_network
 
     models = []
     for i_replica, replica_seed in enumerate(replica_seeds):
-        if layer_type == "dense":
-            list_of_pdf_layers = generate_dense_network(**constant_args, seed=replica_seed)
-        elif layer_type == "dense_per_flavour":
-            list_of_pdf_layers = generate_dense_per_flavour_network(
-                **constant_args, seed=replica_seed
-            )
+        list_of_pdf_layers = layers_generator(**constant_args, seed=replica_seed)
 
         # apply layers to create model
         pdf = x

--- a/n3fit/src/n3fit/model_gen.py
+++ b/n3fit/src/n3fit/model_gen.py
@@ -722,6 +722,7 @@ def generate_nn(
         nn_replicas: List[MetaModel]
             List of MetaModel objects, one for each replica.
     """
+    nodes_local = nodes.copy()  # make a local copy so we can modify it
     x = Input(shape=(None, nodes_in), batch_size=1, name='xgrids_processed')
 
     custom_args = {}
@@ -731,7 +732,7 @@ def generate_nn(
         # TODO the mismatch is due to the fact that basis_size
         # is set to the number of nodes of the last layer when it should
         # come from the runcard
-        nodes[-1] = 1
+        nodes_local[-1] = 1
         basis_size = last_layer_nodes
 
         def initializer_generator(initializer_name, seed):
@@ -751,7 +752,7 @@ def generate_nn(
     # First create all the layers...
     # list_of_pdf_layers[d][r] is the layer at depth d for replica r
     list_of_pdf_layers = []
-    for i_layer, (nodes_out, activation) in enumerate(zip(nodes, activations)):
+    for i_layer, (nodes_out, activation) in enumerate(zip(nodes_local, activations)):
         inits = [
             initializer_generator(initializer_name, replica_seed + i_layer)
             for replica_seed in replica_seeds

--- a/n3fit/src/n3fit/model_gen.py
+++ b/n3fit/src/n3fit/model_gen.py
@@ -725,7 +725,7 @@ def generate_nn(
     if dropout > 0 and layer_type == "dense_per_flavour":
         raise ValueError("Dropout is not supported for dense_per_flavour layers")
 
-    nodes_local = nodes.copy()  # make a local copy so we can modify it
+    nodes_list = list(nodes)  # so we can modify it
     x = Input(shape=(None, nodes_in), batch_size=1, name='xgrids_processed')
 
     custom_args = {}
@@ -735,7 +735,7 @@ def generate_nn(
         # TODO the mismatch is due to the fact that basis_size
         # is set to the number of nodes of the last layer when it should
         # come from the runcard
-        nodes_local[-1] = 1
+        nodes_list[-1] = 1
         basis_size = last_layer_nodes
         custom_args['basis_size'] = basis_size
 
@@ -758,7 +758,7 @@ def generate_nn(
     # First create all the layers...
     # list_of_pdf_layers[d][r] is the layer at depth d for replica r
     list_of_pdf_layers = []
-    for i_layer, (nodes_out, activation) in enumerate(zip(nodes_local, activations)):
+    for i_layer, (nodes_out, activation) in enumerate(zip(nodes_list, activations)):
         inits = [
             initializer_generator(initializer_name, replica_seed, i_layer)
             for replica_seed in replica_seeds

--- a/n3fit/src/n3fit/model_gen.py
+++ b/n3fit/src/n3fit/model_gen.py
@@ -737,6 +737,7 @@ def generate_nn(
         # come from the runcard
         nodes_local[-1] = 1
         basis_size = last_layer_nodes
+        custom_args['basis_size'] = basis_size
 
         def initializer_generator(initializer_name, seed, i_layer):
             seed += i_layer * basis_size

--- a/n3fit/src/n3fit/model_gen.py
+++ b/n3fit/src/n3fit/model_gen.py
@@ -735,7 +735,8 @@ def generate_nn(
         nodes_local[-1] = 1
         basis_size = last_layer_nodes
 
-        def initializer_generator(initializer_name, seed):
+        def initializer_generator(initializer_name, seed, i_layer):
+            seed += i_layer * basis_size
             initializers = [
                 MetaLayer.select_initializer(initializer_name, seed=seed + b)
                 for b in range(basis_size)
@@ -746,7 +747,8 @@ def generate_nn(
         reg = regularizer_selector(regularizer, **regularizer_args)
         custom_args['regularizer'] = reg
 
-        def initializer_generator(initializer_name, seed):
+        def initializer_generator(initializer_name, seed, i_layer):
+            seed += i_layer
             return MetaLayer.select_initializer(initializer_name, seed=seed)
 
     # First create all the layers...
@@ -754,7 +756,7 @@ def generate_nn(
     list_of_pdf_layers = []
     for i_layer, (nodes_out, activation) in enumerate(zip(nodes_local, activations)):
         inits = [
-            initializer_generator(initializer_name, replica_seed + i_layer)
+            initializer_generator(initializer_name, replica_seed, i_layer)
             for replica_seed in replica_seeds
         ]
         layers = [

--- a/n3fit/src/n3fit/model_gen.py
+++ b/n3fit/src/n3fit/model_gen.py
@@ -316,12 +316,9 @@ def generate_dense_network(
     for the next to last layer (i.e., the last layer of the dense network before getting to
     the output layer for the basis choice)
     """
-    list_of_pdf_layers = []
-    for i, (nodes_out, activation) in enumerate(zip(nodes, activations)):
-        # select the initializer and move the seed
-        init = MetaLayer.select_initializer(initializer_name, seed=seed + i)
 
-        # set the arguments that will define the layer
+    def layer_generator(nodes_in, nodes_out, activation, seed):
+        init = MetaLayer.select_initializer(initializer_name, seed=seed)
         arguments = {
             "kernel_initializer": init,
             "units": int(nodes_out),
@@ -329,9 +326,11 @@ def generate_dense_network(
             "input_shape": (nodes_in,),
             "kernel_regularizer": regularizer,
         }
+        return base_layer_selector("dense", **arguments)
 
-        layer = base_layer_selector("dense", **arguments)
-
+    list_of_pdf_layers = []
+    for i, (nodes_out, activation) in enumerate(zip(nodes, activations)):
+        layer = layer_generator(nodes_in, nodes_out, activation, seed + i)
         list_of_pdf_layers.append(layer)
         nodes_in = int(nodes_out)
 

--- a/n3fit/src/n3fit/model_gen.py
+++ b/n3fit/src/n3fit/model_gen.py
@@ -722,6 +722,9 @@ def generate_nn(
         nn_replicas: List[MetaModel]
             List of MetaModel objects, one for each replica.
     """
+    if dropout > 0 and layer_type == "dense_per_flavour":
+        raise ValueError("Dropout is not supported for dense_per_flavour layers")
+
     nodes_local = nodes.copy()  # make a local copy so we can modify it
     x = Input(shape=(None, nodes_in), batch_size=1, name='xgrids_processed')
 

--- a/n3fit/src/n3fit/model_gen.py
+++ b/n3fit/src/n3fit/model_gen.py
@@ -692,7 +692,35 @@ def generate_nn(
 ) -> MetaModel:
     """
     Create the part of the model that contains all of the actual neural network
-    layers.
+    layers, for each replica.
+
+    Parameters
+    ----------
+        layer_type: str
+            Type of layer to use. Can be "dense" or "dense_per_flavour".
+        nodes_in: int
+            Number of nodes in the input layer.
+        nodes: List[int]
+            Number of nodes in each hidden layer.
+        activations: List[str]
+            Activation function to use in each hidden layer.
+        initializer_name: str
+            Name of the initializer to use.
+        replica_seeds: List[int]
+            List of seeds to use for each replica.
+        dropout: float
+            Dropout rate to use (if 0, no dropout is used).
+        regularizer: str
+            Name of the regularizer to use.
+        regularizer_args: dict
+            Arguments to pass to the regularizer.
+        last_layer_nodes: int
+            Number of nodes in the last layer.
+
+    Returns
+    -------
+        nn_replicas: List[MetaModel]
+            List of MetaModel objects, one for each replica.
     """
     x = Input(shape=(None, nodes_in), batch_size=1, name='xgrids_processed')
 

--- a/n3fit/src/n3fit/model_gen.py
+++ b/n3fit/src/n3fit/model_gen.py
@@ -771,14 +771,10 @@ def generate_nn(
 
         # In case of per flavour network, concatenate at the last layer
         if layer_type == "dense_per_flavour":
-            last_layer = list_of_pdf_layers[-1]
             concat = base_layer_selector("concatenate")
-
-            def concatenated_last_layer(inputs):
-                result = last_layer(inputs)
-                return concat(result)
-
-            list_of_pdf_layers[-1] = concatenated_last_layer
+            list_of_pdf_layers[-1] = [
+                lambda x: concat(layer(x)) for layer in list_of_pdf_layers[-1]
+            ]
 
         # apply layers to create model
         pdf = x

--- a/n3fit/src/n3fit/model_gen.py
+++ b/n3fit/src/n3fit/model_gen.py
@@ -311,21 +311,23 @@ def generate_dense_network(
     """
     Generates a dense network
     """
+    layer_type = "dense"
+    custom_args = {"kernel_regularizer": regularizer}
 
-    def layer_generator(nodes_in, nodes_out, activation, seed):
-        init = MetaLayer.select_initializer(initializer_name, seed=seed)
-        arguments = {
-            "kernel_initializer": init,
-            "units": int(nodes_out),
-            "activation": activation,
-            "input_shape": (nodes_in,),
-            "kernel_regularizer": regularizer,
-        }
-        return base_layer_selector("dense", **arguments)
+    def initializer_generator(initializer_name, seed):
+        return MetaLayer.select_initializer(initializer_name, seed=seed)
 
     list_of_pdf_layers = []
     for i, (nodes_out, activation) in enumerate(zip(nodes, activations)):
-        layer = layer_generator(nodes_in, nodes_out, activation, seed + i)
+        init = initializer_generator(initializer_name, seed + i)
+        layer = base_layer_selector(
+            layer_type,
+            kernel_initializer=init,
+            units=nodes_out,
+            activation=activation,
+            input_shape=(nodes_in,),
+            **custom_args,
+        )
         list_of_pdf_layers.append(layer)
         nodes_in = int(nodes_out)
 
@@ -339,23 +341,26 @@ def generate_dense_per_flavour_network(
     For each flavour generates a dense network of the chosen size
 
     """
+    layer_type = "dense_per_flavour"
+    custom_args = {"basis_size": basis_size}
 
-    def layer_generator(nodes_in, nodes_out, activation, seed):
+    def initializer_generator(initializer_name, seed):
         initializers = [
             MetaLayer.select_initializer(initializer_name, seed=seed + b) for b in range(basis_size)
         ]
-        arguments = {
-            "kernel_initializer": initializers,
-            "units": nodes_out,
-            "activation": activation,
-            "input_shape": (nodes_in,),
-            "basis_size": basis_size,
-        }
-        return base_layer_selector("dense_per_flavour", **arguments)
+        return initializers
 
     list_of_pdf_layers = []
     for i, (nodes_out, activation) in enumerate(zip(nodes, activations)):
-        layer = layer_generator(nodes_in, nodes_out, activation, seed + i)
+        init = initializer_generator(initializer_name, seed + i)
+        layer = base_layer_selector(
+            layer_type,
+            kernel_initializer=init,
+            units=nodes_out,
+            activation=activation,
+            input_shape=(nodes_in,),
+            **custom_args,
+        )
         list_of_pdf_layers.append(layer)
         nodes_in = int(nodes_out)
 

--- a/n3fit/src/n3fit/model_gen.py
+++ b/n3fit/src/n3fit/model_gen.py
@@ -736,7 +736,7 @@ def generate_nn(
         basis_size = last_layer_nodes
         custom_args['basis_size'] = basis_size
 
-        def initializer_generator(initializer_name, seed, i_layer):
+        def initializer_generator(seed, i_layer):
             seed += i_layer * basis_size
             initializers = [
                 MetaLayer.select_initializer(initializer_name, seed=seed + b)
@@ -748,7 +748,7 @@ def generate_nn(
         reg = regularizer_selector(regularizer, **regularizer_args)
         custom_args['regularizer'] = reg
 
-        def initializer_generator(initializer_name, seed, i_layer):
+        def initializer_generator(seed, i_layer):
             seed += i_layer
             return MetaLayer.select_initializer(initializer_name, seed=seed)
 
@@ -756,10 +756,7 @@ def generate_nn(
     # list_of_pdf_layers[d][r] is the layer at depth d for replica r
     list_of_pdf_layers = []
     for i_layer, (nodes_out, activation) in enumerate(zip(nodes_list, activations)):
-        inits = [
-            initializer_generator(initializer_name, replica_seed, i_layer)
-            for replica_seed in replica_seeds
-        ]
+        inits = [initializer_generator(replica_seed, i_layer) for replica_seed in replica_seeds]
         layers = [
             base_layer_selector(
                 layer_type,

--- a/n3fit/src/n3fit/model_gen.py
+++ b/n3fit/src/n3fit/model_gen.py
@@ -732,7 +732,7 @@ def generate_nn(
         # is set to the number of nodes of the last layer when it should
         # come from the runcard
         nodes[-1] = 1
-        custom_args['basis_size'] = last_layer_nodes
+        basis_size = last_layer_nodes
 
         def initializer_generator(initializer_name, seed):
             initializers = [

--- a/n3fit/src/n3fit/model_gen.py
+++ b/n3fit/src/n3fit/model_gen.py
@@ -784,6 +784,7 @@ def generate_nn(
     # Apply all layers to the input to create the models
     pdfs = [layer(x_input) for layer in list_of_pdf_layers[0]]
     for layers in list_of_pdf_layers[1:]:
+        # Since some layers (dropout) are shared, we have to treat them separately
         if type(layers) is list:
             pdfs = [layer(x) for layer, x in zip(layers, pdfs)]
         else:

--- a/n3fit/src/n3fit/model_gen.py
+++ b/n3fit/src/n3fit/model_gen.py
@@ -772,8 +772,8 @@ def generate_nn(
 
     # add dropout as second to last layer
     if dropout > 0:
-        dropout_layer = MetaLayer.base_layer_selector("dropout", rate=dropout)
-        list_of_pdf_layers.insert(dropout_layer, -2)
+        dropout_layer = base_layer_selector("dropout", rate=dropout)
+        list_of_pdf_layers.insert(-2, dropout_layer)
 
     # In case of per flavour network, concatenate at the last layer
     if layer_type == "dense_per_flavour":

--- a/n3fit/src/n3fit/model_gen.py
+++ b/n3fit/src/n3fit/model_gen.py
@@ -349,12 +349,6 @@ def generate_dense_per_flavour_network(
     For each flavour generates a dense network of the chosen size
 
     """
-    # set the arguments that will define the layer
-    # but careful, the last layer must be nodes = 1
-    # TODO the mismatch is due to the fact that basis_size
-    # is set to the number of nodes of the last layer when it should
-    # come from the runcard
-    nodes[-1] = 1
 
     def layer_generator(nodes_in, nodes_out, activation, seed):
         initializers = [
@@ -784,6 +778,14 @@ def generate_nn(
     layers.
     """
     x = Input(shape=(None, input_dimensions), batch_size=1, name='xgrids_processed')
+
+    if layer_type == "dense_per_flavour":
+        # set the arguments that will define the layer
+        # but careful, the last layer must be nodes = 1
+        # TODO the mismatch is due to the fact that basis_size
+        # is set to the number of nodes of the last layer when it should
+        # come from the runcard
+        nodes[-1] = 1
 
     common_args = {
         'nodes_in': input_dimensions,

--- a/n3fit/src/n3fit/model_gen.py
+++ b/n3fit/src/n3fit/model_gen.py
@@ -722,9 +722,6 @@ def generate_nn(
         nn_replicas: List[MetaModel]
             List of MetaModel objects, one for each replica.
     """
-    if dropout > 0 and layer_type == "dense_per_flavour":
-        raise ValueError("Dropout is not supported for dense_per_flavour layers")
-
     nodes_list = list(nodes)  # so we can modify it
     x = Input(shape=(None, nodes_in), batch_size=1, name='xgrids_processed')
 

--- a/n3fit/src/n3fit/model_gen.py
+++ b/n3fit/src/n3fit/model_gen.py
@@ -317,16 +317,7 @@ def generate_dense_network(
     the output layer for the basis choice)
     """
     list_of_pdf_layers = []
-    number_of_layers = len(nodes)
-    if dropout_rate > 0:
-        dropout_layer = number_of_layers - 2
-    else:
-        dropout_layer = -1
     for i, (nodes_out, activation) in enumerate(zip(nodes, activations)):
-        # if we have dropout set up, add it to the list
-        if dropout_rate > 0 and i == dropout_layer:
-            list_of_pdf_layers.append(base_layer_selector("dropout", rate=dropout_rate))
-
         # select the initializer and move the seed
         init = MetaLayer.select_initializer(initializer_name, seed=seed + i)
 
@@ -343,6 +334,12 @@ def generate_dense_network(
 
         list_of_pdf_layers.append(layer)
         nodes_in = int(nodes_out)
+
+    # add dropout as second to last layer
+    if dropout_rate > 0:
+        dropout_layer = MetaLayer.base_layer_selector("dropout", rate=dropout_rate)
+        list_of_pdf_layers.insert(dropout_layer, -2)
+
     return list_of_pdf_layers
 
 

--- a/n3fit/src/n3fit/model_gen.py
+++ b/n3fit/src/n3fit/model_gen.py
@@ -781,7 +781,7 @@ def generate_nn(
         concat = base_layer_selector("concatenate")
         list_of_pdf_layers[-1] = [lambda x: concat(layer(x)) for layer in list_of_pdf_layers[-1]]
 
-    # ... then apply them to the input to create the models
+    # Apply all layers to the input to create the models
     pdfs = [layer(x_input) for layer in list_of_pdf_layers[0]]
     for layers in list_of_pdf_layers[1:]:
         if type(layers) is list:

--- a/n3fit/src/n3fit/model_gen.py
+++ b/n3fit/src/n3fit/model_gen.py
@@ -756,17 +756,16 @@ def generate_nn(
     # list_of_pdf_layers[d][r] is the layer at depth d for replica r
     list_of_pdf_layers = []
     for i_layer, (nodes_out, activation) in enumerate(zip(nodes_list, activations)):
-        inits = [initializer_generator(replica_seed, i_layer) for replica_seed in replica_seeds]
         layers = [
             base_layer_selector(
                 layer_type,
-                kernel_initializer=init,
+                kernel_initializer=initializer_generator(replica_seed, i_layer),
                 units=nodes_out,
                 activation=activation,
                 input_shape=(nodes_in,),
                 **custom_args,
             )
-            for init in inits
+            for replica_seed in replica_seeds
         ]
         list_of_pdf_layers.append(layers)
         nodes_in = int(nodes_out)

--- a/n3fit/src/n3fit/model_gen.py
+++ b/n3fit/src/n3fit/model_gen.py
@@ -359,16 +359,6 @@ def generate_dense_per_flavour_network(
         list_of_pdf_layers.append(layer)
         nodes_in = int(nodes_out)
 
-    # For the last layer, apply concatenate
-    last_layer = list_of_pdf_layers[-1]
-    concat = base_layer_selector("concatenate")
-
-    def concatenated_last_layer(inputs):
-        result = last_layer(inputs)
-        return concat(result)
-
-    list_of_pdf_layers[-1] = concatenated_last_layer
-
     return list_of_pdf_layers
 
 
@@ -799,6 +789,17 @@ def generate_nn(
         if dropout > 0:
             dropout_layer = MetaLayer.base_layer_selector("dropout", rate=dropout)
             list_of_pdf_layers.insert(dropout_layer, -2)
+
+        # In case of per flavour network, concatenate at the last layer
+        if layer_type == "dense_per_flavour":
+            last_layer = list_of_pdf_layers[-1]
+            concat = base_layer_selector("concatenate")
+
+            def concatenated_last_layer(inputs):
+                result = last_layer(inputs)
+                return concat(result)
+
+            list_of_pdf_layers[-1] = concatenated_last_layer
 
         # apply layers to create model
         pdf = x

--- a/n3fit/src/n3fit/tests/test_modelgen.py
+++ b/n3fit/src/n3fit/tests/test_modelgen.py
@@ -5,62 +5,48 @@
     It checks that both the number of layers and the shape
     of the weights of the layers are what is expected
 """
-import numpy as np
-import n3fit.model_gen
-from n3fit.backends import MetaModel
-from n3fit.backends import operations as op
+from n3fit.model_gen import generate_nn
 
 INSIZE = 16
-OUT_SIZES = (4, 3)
+OUT_SIZES = [4, 3]
 BASIS_SIZE = 3
+
+COMMON_ARGS = {
+    "nodes_in": INSIZE,
+    "nodes": OUT_SIZES,
+    "activations": ["sigmoid", "tanh"],
+    "initializer_name": "glorot_uniform",
+    "replica_seeds": [0],
+    "dropout": 0.0,
+    "regularizer": None,
+    "regularizer_args": {},
+    "last_layer_nodes": BASIS_SIZE,
+}
 
 
 def test_generate_dense_network():
-    nodes_in = INSIZE
-    nodes_out = OUT_SIZES
-    activations = ["sigmoid", "tanh"]
-    layers = n3fit.model_gen.generate_dense_network(nodes_in, nodes_out, activations)
-    arr = np.random.rand(1, INSIZE)
-    input_layer = op.numpy_to_input(arr)
-    curr_layer = input_layer
-    for layer in layers:
-        curr_layer = layer(curr_layer)
-    modelito = MetaModel({"input": input_layer}, curr_layer)
+    nn = generate_nn("dense", **COMMON_ARGS)[0]
+
     # The number of layers should be input layer + len(OUT_SIZES)
-    assert len(modelito.layers) == len(OUT_SIZES) + 1
+    assert len(nn.layers) == len(OUT_SIZES) + 1
     # Check that the number of parameters is as expected
     # We expect 4 weights where the two first ones are
     # (INSIZE, OUT_SIZE[0]) (OUT_SIZE[0],)
     # and the second one
     # (OUT_SIZE[0], OUT_SIZE[1]) (OUT_SIZE[1],)
-    expected_sizes = [
-        (INSIZE, OUT_SIZES[0]),
-        (OUT_SIZES[0],),
-        OUT_SIZES,
-        (OUT_SIZES[1],),
-    ]
-    for weight, esize in zip(modelito.weights, expected_sizes):
+    expected_sizes = [(INSIZE, OUT_SIZES[0]), (OUT_SIZES[0],), OUT_SIZES, (OUT_SIZES[1],)]
+    for weight, esize in zip(nn.weights, expected_sizes):
         assert weight.shape == esize
 
 
 def test_generate_dense_per_flavour_network():
-    nodes_in = INSIZE
-    nodes_out = OUT_SIZES
-    activations = ["sigmoid", "tanh"]
-    layers = n3fit.model_gen.generate_dense_per_flavour_network(
-        nodes_in, nodes_out, activations, basis_size=BASIS_SIZE
-    )
-    arr = np.random.rand(1, INSIZE)
-    input_layer = op.numpy_to_input(arr)
-    curr_layer = input_layer
-    for layer in layers:
-        curr_layer = layer(curr_layer)
-    modelito = MetaModel({"input": input_layer}, curr_layer)
+    nn = generate_nn("dense_per_flavour", **COMMON_ARGS)[0]
+
     # The number of layers should be input + BASIS_SIZE*len(OUT_SIZES) + concatenate
-    assert len(modelito.layers) == BASIS_SIZE * len(OUT_SIZES) + 2
+    assert len(nn.layers) == BASIS_SIZE * len(OUT_SIZES) + 2
     # The shape for this network of denses for flavours will depend on the basis_size
     expected_sizes = []
     expected_sizes += BASIS_SIZE * [(INSIZE, OUT_SIZES[0]), (OUT_SIZES[0],)]
     expected_sizes += BASIS_SIZE * [(OUT_SIZES[0], 1), (1,)]
-    for weight, esize in zip(modelito.weights, expected_sizes):
+    for weight, esize in zip(nn.weights, expected_sizes):
         assert weight.shape == esize

--- a/n3fit/src/n3fit/tests/test_modelgen.py
+++ b/n3fit/src/n3fit/tests/test_modelgen.py
@@ -8,7 +8,7 @@
 from n3fit.model_gen import generate_nn
 
 INSIZE = 16
-OUT_SIZES = [4, 3]
+OUT_SIZES = (4, 3)
 BASIS_SIZE = 3
 
 COMMON_ARGS = {


### PR DESCRIPTION
This PR does two things that both should leave everything identical:

### 1. Pull together the 3 functions that were responsible for generating the neural network layers:
   - `generate_dense_network`
   - `generate_dense_per_flavor_network`
   - `generate_nn`

Only the last one remains, the first two had a lot of overlap.
I have also pulled in the loop over replicas out of `pdf_NN_layer_generator` into `generate_nn`

This is everything up to and including[this commit](https://github.com/NNPDF/nnpdf/pull/1888/commits/cfc3b8d6f315811a5d37abf4e7403fc70157a6bb).
This PR may be easier to follow commit by commit.

### 2. Reverse the order of the loops over replicas and layers

This is the actual point, currently we do: for all replicas, for all layers, create the layer.
To accomodate the upcoming multi-replica layers, where one layer contains all replicas, the order needed to change.

## Status

I think there are 3 relevant choices to test for:
- dropout or not
- dense layers or dense_per_flavour layers
- 1 or multiple replicas

The dense_per_flavour layers aren't compatible with multiple replicas or with dropout (they could be, but in the first case it doesn't pass a check, and the second case just wasn't implemented), but the dropout and replicas choices should be independent, so we have:

default layer:
| replicas \ dropout | yes | no |
| --- | --- | --- |
| 1 | X | X |
| multiple | X | X |

- [x] dense_per_flavour, 1 replica, no dropout

For each of these I have taken a simple runcard, ran it for 100 epochs, and compared the last 3 digits of the chi2 between this branch and master (well, replica_axis_first, which is ready to be merged). (Xs mean they pass this test)

## TODO:
- [x] Fix dense_per_flavour case, getting a size mismatch after training, at single replica models
- [x] Either test and fix or explicitly exclude the combination of dense_per_flavour and dropout (as it was, but no longer is)
- [x] Update tests which still use the old `generate_dense_network` and `generate_dense_per_flavour_network`
- [x] Check if a third step is possible without changing numerics: directly concatenating each layer over replicas. Actually no this isn't possible until the `MultiDense` layer itself is implemented.