### PR TITLE
Enable conda package for 3.11

### DIFF
--- a/.github/workflows/fitbot.yml
+++ b/.github/workflows/fitbot.yml
@@ -10,7 +10,7 @@ on:
 env:
   N3FIT_MAXNREP: 20 # total number of replicas to fit
   POSTFIT_NREP: 16 # requested replicas for postfit
-  REFERENCE_SET: NNBOT-092dc91e5-2023-12-06 # reference set for vp
+  REFERENCE_SET: NNBOT-a5240b65e-2023-12-12 # reference set for vp
   CONDA_PY: 310
 
 jobs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11"]
         include:
           - os: ubuntu-latest
             CONDA_OS: linux-64

--- a/conda-recipe/conda_build_config.yaml
+++ b/conda-recipe/conda_build_config.yaml
@@ -1,7 +1,7 @@
 #For some reason the resolver decides to use an old version of numpy
 #without this
 numpy:
-    - 1.21
+    - 1.24
 
 pin_run_as_build:
     lhapdf: x.x.x

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -18,13 +18,14 @@ requirements:
         - lhapdf      # with python wrapper
         - sqlite
         - gsl         # Gsl doesn't link openblas on old debian 7
-        - libarchive ==3.4.2 # See https://github.com/NNPDF/nnpdf/pull/1130
+        - libarchive
         - yaml-cpp >=0.6.3
         - apfel >=3   # see https://github.com/scarrazza/apfel
         - python
         - numpy
     run:
-        - tensorflow >=2 *eigen*
+        - tensorflow >=2.10
+        - tensorflow >=2.10 *eigen* # [py < 311]
         - psutil # to ensure n3fit affinity is with the right processors
         - hyperopt
         - seaborn
@@ -52,7 +53,6 @@ requirements:
         - curio >=1.0
         - pineappl >=0.6.2
         - eko >=0.14.0
-        - banana-hep >=0.6.8
         - fiatlux
 
 test:


### PR DESCRIPTION
In https://github.com/NNPDF/nnpdf/pull/1871 I've been able to test with 3.11 (although I had to change some test thresholds).

This PR tries to prepare the package for python 3.11. If this works well (even lowering the threshold) I think it would be a good idea to merge before the final tag so that we have 3.9 to 3.11 with 4.0.7

Note that for 4.0.8 if everything goes according to plan the conda package for nnpdf will not depend on any version of python since nnpdf will be python-only.


Edit:
Turns out the problem with conda was a pinned libarchive many moons ago (which we pinned because of a problem with conda!)

During the testing I've also removed *eigen* since the tensorflow package in anaconda has not been updated in a while. I've tested in my computer (with linux and python 3.9) and there is no memory leak anymore it seems?

However, I think I'm going to have a slightly different conda-recipe for 3.9/3.10 and 3.11 to avoid changing things too much for the next tag.


