### PR TITLE
also upload conda package if push corresponds to a tag creation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,7 +60,7 @@ jobs:
         export CONDA_BUILD_SYSROOT=$CONDA_PREFIX/MacOSX10.9.sdk
         conda build -q conda-recipe
     - name: Upload conda package to NNPDF server
-      if: github.ref == 'refs/heads/master'
+      if: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')}}
       shell: bash -l {0}
       run: |
         KEY=$( mktemp )


### PR DESCRIPTION
I can't really test this, but I hope it works.. 

The problem is that the env files pushed to the repo contain nnpdf versions that are not uploaded to the server. Or rather, a version with the same state exists even on the server but the version number corresponds to the last version of the previous tag rather than the 0th version of the current tag since after tagging they are not re-uploaded until another commit is made to master.