### PR TITLE
Fix dataset/prediction ordering problem in theory covmat creation

### DIFF
--- a/validphys2/src/validphys/app.py
+++ b/validphys2/src/validphys/app.py
@@ -39,7 +39,7 @@ providers = [
     "validphys.paramfits.plots",
     "validphys.theorycovariance.construction",
     "validphys.theorycovariance.output",
-    # "validphys.theorycovariance.tests",
+    "validphys.theorycovariance.tests",
     "validphys.replica_selector",
     "validphys.closuretest",
     "validphys.mc_gen",

--- a/validphys2/src/validphys/app.py
+++ b/validphys2/src/validphys/app.py
@@ -39,7 +39,7 @@ providers = [
     "validphys.paramfits.plots",
     "validphys.theorycovariance.construction",
     "validphys.theorycovariance.output",
-    "validphys.theorycovariance.tests",
+    # "validphys.theorycovariance.tests",
     "validphys.replica_selector",
     "validphys.closuretest",
     "validphys.mc_gen",

--- a/validphys2/src/validphys/results.py
+++ b/validphys2/src/validphys/results.py
@@ -75,6 +75,7 @@ class DataResult(StatsResult):
         stats = Stats(self._central_value)
         self._covmat = covmat
         self._sqrtcovmat = sqrtcovmat
+        self._name = dataset.name
         super().__init__(stats)
 
     @property
@@ -98,15 +99,19 @@ class DataResult(StatsResult):
         """Lower part of the Cholesky decomposition"""
         return self._sqrtcovmat
 
+    @property
+    def name(self):
+        return self._name
 
 class ThPredictionsResult(StatsResult):
     """Class holding theory prediction, inherits from StatsResult
     When created with `from_convolution`, it keeps tracks of the PDF for which it was computed
     """
 
-    def __init__(self, dataobj, stats_class, label=None, pdf=None, theoryid=None):
+    def __init__(self, dataobj, stats_class, datasetnames=None, label=None, pdf=None, theoryid=None):
         self.stats_class = stats_class
         self.label = label
+        self._datasetnames = datasetnames
         statsobj = stats_class(dataobj.T)
         self._pdf = pdf
         self._theoryid = theoryid
@@ -149,8 +154,12 @@ class ThPredictionsResult(StatsResult):
 
         label = cls.make_label(pdf, dataset)
         thid = dataset.thspec.id
+        datasetnames = [i.name for i in datasets]
+        return cls(th_predictions, pdf.stats_class, datasetnames, label, pdf=pdf, theoryid=thid)
 
-        return cls(th_predictions, pdf.stats_class, label, pdf=pdf, theoryid=thid)
+    @property
+    def datasetnames(self):
+        return self._datasetnames
 
 
 class ThUncertaintiesResult(StatsResult):

--- a/validphys2/src/validphys/results.py
+++ b/validphys2/src/validphys/results.py
@@ -75,7 +75,7 @@ class DataResult(StatsResult):
         stats = Stats(self._central_value)
         self._covmat = covmat
         self._sqrtcovmat = sqrtcovmat
-        self._name = dataset.name
+        self._dataset = dataset
         super().__init__(stats)
 
     @property
@@ -101,7 +101,7 @@ class DataResult(StatsResult):
 
     @property
     def name(self):
-        return self._name
+        return self._dataset.name
 
 class ThPredictionsResult(StatsResult):
     """Class holding theory prediction, inherits from StatsResult

--- a/validphys2/src/validphys/theorycovariance/construction.py
+++ b/validphys2/src/validphys/theorycovariance/construction.py
@@ -184,21 +184,19 @@ ProcessInfo = namedtuple("ProcessInfo", ("preds", "namelist", "sizes"))
 
 
 def combine_by_type(each_dataset_results_central_bytheory):
-    """Groups the datasets according to processes returns an instance of the ProcessInfo class
+    """Groups the datasets bu process and returns an instance of the ProcessInfo class
 
     Parameters
     ----------
-    each_dataset_results_central_bytheory: list(list((DataResult,ThPredictionsResult)))
+    each_dataset_results_central_bytheory: list[list[(DataResult,ThPredictionsResult)]]
+        Tuples of DataResult and ThPredictionsResult (where only the second is used for the
+        construction of the theory covariance matrix), wrapped in a list such that there is a tuple
+        per theoryid, wrapped in another list per dataset.
 
     Returns
     -------
-    ProcesInfo
+    :ProcesInfo :py:class:`validphys.theorycovariance.construction.ProcessInfo`
         Class with info needed to construct the theory covmat.
-
-    Raises
-    ------
-    ValueError
-        If the order is of the inputs are not the same
     """
     dataset_size = defaultdict(list)
     theories_by_process = defaultdict(list)
@@ -215,6 +213,9 @@ def combine_by_type(each_dataset_results_central_bytheory):
     process_info = ProcessInfo(
         preds=theories_by_process, namelist=ordered_names, sizes=dataset_size
     )
+    import ipdb
+
+    ipdb.set_trace()
     return process_info
 
 
@@ -484,7 +485,14 @@ def covs_pt_prescrip(combine_by_type, theoryids, point_prescription, fivetheorie
             central2, *others2 = process_info.preds[name2]
             deltas2 = list((other - central2 for other in others2))
             s = compute_covs_pt_prescrip(
-                point_prescription, len(theoryids), name1, deltas1, name2, deltas2, fivetheories, seventheories
+                point_prescription,
+                len(theoryids),
+                name1,
+                deltas1,
+                name2,
+                deltas2,
+                fivetheories,
+                seventheories,
             )
             start_locs = (start_proc[name1], start_proc[name2])
             covmats[start_locs] = s

--- a/validphys2/src/validphys/theorycovariance/construction.py
+++ b/validphys2/src/validphys/theorycovariance/construction.py
@@ -745,7 +745,8 @@ def theory_normcovmat_custom(theory_covmat_custom, procs_data_values):
     """Calculates the theory covariance matrix for scale variations normalised
     to data, with variations according to the relevant prescription."""
     df = theory_covmat_custom
-    mat = df / np.outer(procs_data_values, procs_data_values)
+    vals = procs_data_values.reindex(df.index)
+    mat = df / np.outer(vals, vals)
     return mat
 
 

--- a/validphys2/src/validphys/theorycovariance/construction.py
+++ b/validphys2/src/validphys/theorycovariance/construction.py
@@ -483,8 +483,6 @@ def covs_pt_prescrip(combine_by_type, theoryids, point_prescription, fivetheorie
         start_proc[name] = running_index
         running_index += size
 
-    l = len(theoryids)
-    process_info = combine_by_type
     covmats = defaultdict(list)
     for name1 in process_info.preds:
         for name2 in process_info.preds:
@@ -493,7 +491,7 @@ def covs_pt_prescrip(combine_by_type, theoryids, point_prescription, fivetheorie
             central2, *others2 = process_info.preds[name2]
             deltas2 = list((other - central2 for other in others2))
             s = compute_covs_pt_prescrip(
-                point_prescription, l, name1, deltas1, name2, deltas2, fivetheories, seventheories
+                point_prescription, len(theoryids), name1, deltas1, name2, deltas2, fivetheories, seventheories
             )
             start_locs = (start_proc[name1], start_proc[name2])
             covmats[start_locs] = s

--- a/validphys2/src/validphys/theorycovariance/construction.py
+++ b/validphys2/src/validphys/theorycovariance/construction.py
@@ -183,15 +183,12 @@ def total_covmat_procs(procs_results_theory, fivetheories):
 ProcessInfo = namedtuple("ProcessInfo", ("preds", "namelist", "sizes"))
 
 
-def combine_by_type(each_dataset_results_central_bytheory, data_input):
+def combine_by_type(each_dataset_results_central_bytheory):
     """Groups the datasets according to processes returns an instance of the ProcessInfo class
 
     Parameters
     ----------
     each_dataset_results_central_bytheory: list(list((DataResult,ThPredictionsResult)))
-
-    data_input: list(DataSetInput)
-        List with DatasetInput as order in the runcard
 
     Returns
     -------
@@ -206,12 +203,8 @@ def combine_by_type(each_dataset_results_central_bytheory, data_input):
     dataset_size = defaultdict(list)
     theories_by_process = defaultdict(list)
     ordered_names = defaultdict(list)
-    for dataset, datain in zip(each_dataset_results_central_bytheory, data_input):
-        name = datain.name
-        # A difference in ordering of each_dataset_results_central_bytheory and
-        # data_input has caused problems before, so let's explicitly check
-        if name != dataset[0][0].name:
-            raise ValueError
+    for dataset in each_dataset_results_central_bytheory:
+        name = dataset[0][0].name
         theory_centrals = [x[1].central_value for x in dataset]
         dataset_size[name] = len(theory_centrals[0])
         proc_type = process_lookup(name)
@@ -521,7 +514,7 @@ def theory_covmat_custom(covs_pt_prescrip, procs_index, combine_by_type):
                     data_id = ind[2]
                     indexlist.append((procname, expname, data_id))
     # Is this always the exact same as procs index? This depends on how procs_index orders datasets
-    # within a process. 
+    # within a process.
     covmat_index = pd.MultiIndex.from_tuples(indexlist, names=procs_index.names)
 
     # Initialise arrays of zeros and set precision to same as FK tables

--- a/validphys2/src/validphys/theorycovariance/construction.py
+++ b/validphys2/src/validphys/theorycovariance/construction.py
@@ -505,14 +505,14 @@ def theory_covmat_custom(covs_pt_prescrip, procs_index, combine_by_type):
     # construct covmat_index based on the order of experiments as they are in combine_by_type
     indexlist = []
     for procname in process_info.preds:
-        for expname in process_info.namelist[procname]:
+        for datasetname in process_info.namelist[procname]:
             for ind in procs_index:
                 # we need procs_index for the datapoint ids of the datapoints that survived the cuts
                 # or do we just assume they're the same as for the exp covmat? Perhaps this
                 # additional layer is a bit pointless.
-                if ind[0] == procname and ind[1] == expname:
+                if ind[0] == procname and ind[1] == datasetname:
                     data_id = ind[2]
-                    indexlist.append((procname, expname, data_id))
+                    indexlist.append((procname, datasetname, data_id))
     # Is this always the exact same as procs index? This depends on how procs_index orders datasets
     # within a process.
     covmat_index = pd.MultiIndex.from_tuples(indexlist, names=procs_index.names)

--- a/validphys2/src/validphys/theorycovariance/construction.py
+++ b/validphys2/src/validphys/theorycovariance/construction.py
@@ -213,9 +213,6 @@ def combine_by_type(each_dataset_results_central_bytheory):
     process_info = ProcessInfo(
         preds=theories_by_process, namelist=ordered_names, sizes=dataset_size
     )
-    import ipdb
-
-    ipdb.set_trace()
     return process_info
 
 

--- a/validphys2/src/validphys/theorycovariance/tests.py
+++ b/validphys2/src/validphys/theorycovariance/tests.py
@@ -21,15 +21,10 @@ from validphys import plotutils
 from validphys.checks import check_two_dataspecs
 from validphys.theorycovariance.construction import (
     combine_by_type,
-    covmap,
-    covs_pt_prescrip,
-    process_starting_points,
     theory_corrmat_singleprocess,
-    theory_covmat_custom,
 )
 from validphys.theorycovariance.output import _get_key, matrix_plot_labels
 from validphys.theorycovariance.theorycovarianceutils import (
-    check_correct_theory_combination_dataspecs,
     check_correct_theory_combination_theoryconfig,
     process_lookup,
 )
@@ -147,36 +142,6 @@ def combine_by_type_dataspecs(all_matched_results, matched_dataspecs_dataset_nam
 dataspecs_theoryids = collect("theoryid", ["theoryconfig", "original", "dataspecs"])
 
 
-def process_starting_points_dataspecs(combine_by_type_dataspecs):
-    """Like process_starting_points but for matched dataspecs."""
-    return process_starting_points(combine_by_type_dataspecs)
-
-
-@check_correct_theory_combination_dataspecs
-def covs_pt_prescrip_dataspecs(
-    combine_by_type_dataspecs,
-    process_starting_points_dataspecs,
-    dataspecs_theoryids,
-    point_prescription,
-    fivetheories,
-    seventheories,
-):
-    """Like covs_pt_prescrip but for matched dataspecs."""
-    return covs_pt_prescrip(
-        combine_by_type_dataspecs,
-        process_starting_points_dataspecs,
-        dataspecs_theoryids,
-        point_prescription,
-        fivetheories,
-        seventheories,
-    )
-
-
-def covmap_dataspecs(combine_by_type_dataspecs, matched_dataspecs_dataset_name):
-    """Like covmap but for matched dataspecs."""
-    return covmap(combine_by_type_dataspecs, matched_dataspecs_dataset_name)
-
-
 matched_dataspecs_process = collect("process", ["dataspecs"])
 matched_dataspecs_dataset_name = collect("dataset_name", ["dataspecs"])
 matched_cuts_datasets = collect("dataset", ["dataspecs"])
@@ -202,16 +167,6 @@ def matched_experiments_index(matched_dataspecs_dataset_name, all_matched_data_l
     point_indexes = np.concatenate([np.arange(l) for l in lens])
     index = pd.MultiIndex.from_arrays([dsnames, point_indexes], names=["Dataset name", "Point"])
     return index
-
-
-@table
-def theory_covmat_custom_dataspecs(
-    covs_pt_prescrip_dataspecs, covmap_dataspecs, matched_experiments_index
-):
-    """Like theory_covmat_custom but for matched dataspecs."""
-    return theory_covmat_custom(
-        covs_pt_prescrip_dataspecs, covmap_dataspecs, matched_experiments_index
-    )
 
 
 thx_corrmat = collect(


### PR DESCRIPTION
we should probably use `reindex` in most (all?) places where multiple dataframes with the same labels in the index are being loaded. 