### PR TITLE
Restore needed thcovmat functions

### DIFF
--- a/doc/sphinx/source/vp/theorycov/examples.rst
+++ b/doc/sphinx/source/vp/theorycov/examples.rst
@@ -154,38 +154,6 @@ a comprehensive set of plots and tables describing the covariance matrices.
       {@plot_diag_cov_comparison@}
    {@endwith@}
 
-   Experimental $\chi^2$
-   ---------------------
-   {@with default_theory@}
-      {@total_experiments_chi2@}
-
-   Total (exp. + th.) $\chi^2$
-   ---------------------------
-      {@chi2_impact_custom@}
-
-   Experimental $\chi^2$ by dataset
-   --------------------------------
-      {@experiments_chi2_table@}
-
-   Total (exp. + th.) $\chi^2$ by dataset
-   --------------------------------------
-      {@experiments_chi2_table_theory@}
-
-   $\chi^2$ including only diagonal theory elements
-   ------------------------------------------------
-      {@chi2_diag_only@}
-
-   Impact of theory covariance matrix on $\chi^2$s 
-   -----------------------------------------------
-      {@plot_datasets_chi2_theory@}
-   {@endwith@}
-
-   Scale variations as a function of the kinematics
-   ------------------------------------------------
-   {@with matched_datasets_from_dataspecs@}
-      [Plots for {@dataset_name@}]({@dataset_report report@})
-   {@endwith@}
-
 
 Validation report
 ----------------- 

--- a/validphys2/examples/theory_covariance/template_matrix_plots.md
+++ b/validphys2/examples/theory_covariance/template_matrix_plots.md
@@ -18,35 +18,3 @@ Diagonal elements of covariance matrices
 {@with default_theory@}
    {@plot_diag_cov_comparison@}
 {@endwith@}
-
-Experimental $\chi^2$
----------------------
-{@with default_theory@}
-   {@total_chi2_per_point_data@}
-
-Total (exp. + th.) $\chi^2$
----------------------------
-   {@chi2_impact_custom@}
-
-Experimental $\chi^2$ by dataset
---------------------------------
-   {@procs_chi2_table@}
-
-Total (exp. + th.) $\chi^2$ by dataset
---------------------------------------
-   {@procs_chi2_table_theory@}
-
-$\chi^2$ including only diagonal theory elements
-------------------------------------------------
-   {@chi2_diag_only@}
-
-Impact of theory covariance matrix on $\chi^2$s
------------------------------------------------
-   {@plot_datasets_chi2_theory@}
-{@endwith@}
-
-Scale variations as a function of the kinematics
-------------------------------------------------
-{@with matched_datasets_from_dataspecs@}
-   [Plots for {@dataset_name@}]({@dataset_report report@})
-{@endwith@}

--- a/validphys2/src/validphys/config.py
+++ b/validphys2/src/validphys/config.py
@@ -909,20 +909,16 @@ class CoreConfig(configparser.Config):
         """Produces path to the theory.db file"""
         return self.loader.theorydb_file
 
-    def produce_combined_shift_and_theory_dataspecs(self, theoryconfig, shiftconfig):
-        total_dataspecs = theoryconfig["dataspecs"] + shiftconfig["dataspecs"]
-        matched_datasets = self.produce_matched_datasets_from_dataspecs(total_dataspecs)
+    def produce_combined_shift_and_theory_dataspecs(self, dataspecs):
+        matched_datasets = self.produce_matched_datasets_from_dataspecs(dataspecs)
         for ns in matched_datasets:
             ns["dataspecs"] = self.produce_dataspecs_with_matched_cuts(ns["dataspecs"])
-        new_theoryconfig = []
-        new_shiftconfig = []
-        len_th = len(theoryconfig["dataspecs"])
+        new_dataspecs = []
+        len_th = len(dataspecs)
         for s in matched_datasets:
-            new_theoryconfig.append(ChainMap({"dataspecs": s["dataspecs"][:len_th]}, s))
-            new_shiftconfig.append(ChainMap({"dataspecs": s["dataspecs"][len_th:]}, s))
+            new_dataspecs.append(ChainMap({"dataspecs": s["dataspecs"][len_th:]}, s))
         return {
-            "shiftconfig": {"dataspecs": new_shiftconfig, "original": shiftconfig},
-            "theoryconfig": {"dataspecs": new_theoryconfig, "original": theoryconfig},
+            "dataspecs": {"dataspecs": new_dataspecs, "original": dataspecs },
         }
 
     # TODO: Worth it to do some black magic to not pass params explicitly?

--- a/validphys2/src/validphys/theorycovariance/construction.py
+++ b/validphys2/src/validphys/theorycovariance/construction.py
@@ -171,6 +171,37 @@ def combine_by_type(each_dataset_results_central_bytheory):
     )
     return process_info
 
+def process_starting_points(combine_by_type):
+    """Returns a dictionary of indices in the covariance matrix corresponding
+    to the starting point of each process."""
+    process_info = combine_by_type
+    running_index = 0
+    start_proc = defaultdict(list)
+    for name in process_info.theory:
+        size = len(process_info.theory[name][0])
+        start_proc[name] = running_index
+        running_index += size
+    return start_proc
+
+
+def covmap(combine_by_type, dataset_names):
+    """Creates a map between the covmat indices from matrices ordered by
+    process to matrices ordered by experiment as listed in the runcard"""
+    mapping = defaultdict(list)
+    start_exp = defaultdict(list)
+    process_info = combine_by_type
+    running_index = 0
+    for dataset in dataset_names:
+        size = process_info.sizes[dataset]
+        start_exp[dataset] = running_index
+        running_index += size
+    start = 0
+    names_by_proc_list = [item for sublist in process_info.namelist.values() for item in sublist]
+    for dataset in names_by_proc_list:
+        for i in range(process_info.sizes[dataset]):
+            mapping[start + i] = start_exp[dataset] + i
+        start += process_info.sizes[dataset]
+    return mapping
 
 def covmat_3fpt(name1, name2, deltas1, deltas2):
     """Returns theory covariance sub-matrix for 3pt factorisation

--- a/validphys2/src/validphys/theorycovariance/construction.py
+++ b/validphys2/src/validphys/theorycovariance/construction.py
@@ -31,37 +31,6 @@ from validphys.theorycovariance.theorycovarianceutils import (
 
 log = logging.getLogger(__name__)
 
-theoryids_procs_central_values = collect(procs_central_values, ("theoryids",))
-
-theoryids_procs_central_values_no_table = collect(procs_central_values_no_table, ("theoryids",))
-
-collected_theoryids = collect("theoryids", ["theoryconfig"])
-
-
-def make_scale_var_covmat(predictions):
-    raise Exception(
-        "If you are seeing this error, please open an issue. This function should not be used"
-    )
-
-
-@check_correct_theory_combination
-def theory_covmat_singleprocess_no_table(
-    theoryids_procs_central_values_no_table, procs_index, theoryids, fivetheories
-):
-    """Calculates the theory covariance matrix for scale variations.
-    The matrix is a dataframe indexed by procs_index."""
-    s = make_scale_var_covmat(theoryids_procs_central_values_no_table)
-    df = pd.DataFrame(s, index=procs_index, columns=procs_index)
-    return df
-
-
-@table
-@check_correct_theory_combination
-def theory_covmat_singleprocess(theory_covmat_singleprocess_no_table, fivetheories):
-    """Duplicate of theory_covmat_singleprocess_no_table but with a table decorator."""
-    return theory_covmat_singleprocess_no_table
-
-
 results_central_bytheoryids = collect(results_central, ("theoryids",))
 each_dataset_results_central_bytheory = collect("results_central_bytheoryids", ("data",))
 
@@ -98,44 +67,6 @@ def theory_covmat_dataset(
     return thcovmat
 
 
-@table
-def theory_block_diag_covmat(theory_covmat_datasets, procs_index):
-    """Takes the theory covariance matrices for individual datasets and
-    returns a data frame with a block diagonal theory covariance matrix
-    by dataset"""
-    s = la.block_diag(*theory_covmat_datasets)
-    df = pd.DataFrame(s, index=procs_index, columns=procs_index)
-    return df
-
-
-@table
-def theory_diagonal_covmat(theory_covmat_singleprocess_no_table, procs_index):
-    """Returns theory covmat with only diagonal values"""
-    s = theory_covmat_singleprocess_no_table.values
-    # Initialise array of zeros and set precision to same as FK tables
-    s_diag = np.zeros((len(s), len(s)), dtype=np.float32)
-    np.fill_diagonal(s_diag, np.diag(s))
-    df = pd.DataFrame(s_diag, index=procs_index, columns=procs_index)
-    return df
-
-
-procs_results_theory = collect("procs_results", ("theoryids",))
-
-
-@check_correct_theory_combination
-def total_covmat_procs(procs_results_theory, fivetheories):
-    """Same as total_covmat_datasets but per experiment rather than
-    per dataset. Needed for calculation of chi2 per experiment."""
-    proc_result_covmats = []
-    for proc_result in zip(*procs_results_theory):
-        theory_centrals = [x[1].central_value for x in proc_result]
-        s = make_scale_var_covmat(theory_centrals)
-        sigma = proc_result[0][0].covmat
-        cov = s + sigma
-        proc_result_covmats.append(cov)
-    return proc_result_covmats
-
-
 ProcessInfo = namedtuple("ProcessInfo", ("preds", "namelist", "sizes"))
 
 
@@ -170,38 +101,6 @@ def combine_by_type(each_dataset_results_central_bytheory):
         preds=theories_by_process, namelist=ordered_names, sizes=dataset_size
     )
     return process_info
-
-def process_starting_points(combine_by_type):
-    """Returns a dictionary of indices in the covariance matrix corresponding
-    to the starting point of each process."""
-    process_info = combine_by_type
-    running_index = 0
-    start_proc = defaultdict(list)
-    for name in process_info.theory:
-        size = len(process_info.theory[name][0])
-        start_proc[name] = running_index
-        running_index += size
-    return start_proc
-
-
-def covmap(combine_by_type, dataset_names):
-    """Creates a map between the covmat indices from matrices ordered by
-    process to matrices ordered by experiment as listed in the runcard"""
-    mapping = defaultdict(list)
-    start_exp = defaultdict(list)
-    process_info = combine_by_type
-    running_index = 0
-    for dataset in dataset_names:
-        size = process_info.sizes[dataset]
-        start_exp[dataset] = running_index
-        running_index += size
-    start = 0
-    names_by_proc_list = [item for sublist in process_info.namelist.values() for item in sublist]
-    for dataset in names_by_proc_list:
-        for i in range(process_info.sizes[dataset]):
-            mapping[start + i] = start_exp[dataset] + i
-        start += process_info.sizes[dataset]
-    return mapping
 
 def covmat_3fpt(name1, name2, deltas1, deltas2):
     """Returns theory covariance sub-matrix for 3pt factorisation
@@ -662,24 +561,6 @@ def procs_index_matched(groups_index, procs_index):
 
     return pd.MultiIndex.from_tuples(tups, names=("process", "dataset", "id"))
 
-
-@check_correct_theory_combination
-def total_covmat_diagtheory_procs(procs_results_theory, fivetheories):
-    """Same as total_covmat_datasets but per proc rather than
-    per dataset. Needed for calculation of chi2 per proc."""
-    exp_result_covmats = []
-    for exp_result in zip(*procs_results_theory):
-        theory_centrals = [x[1].central_value for x in exp_result]
-        s = make_scale_var_covmat(theory_centrals)
-        # Initialise array of zeros and set precision to same as FK tables
-        s_diag = np.zeros((len(s), len(s)), dtype=np.float32)
-        np.fill_diagonal(s_diag, np.diag(s))
-        sigma = exp_result[0][0].covmat
-        cov = s_diag + sigma
-        exp_result_covmats.append(cov)
-    return exp_result_covmats
-
-
 @table
 def theory_corrmat_singleprocess(theory_covmat_singleprocess):
     """Calculates the theory correlation matrix for scale variations."""
@@ -691,36 +572,10 @@ def theory_corrmat_singleprocess(theory_covmat_singleprocess):
 
 
 @table
-def theory_blockcorrmat(theory_block_diag_covmat):
-    """Calculates the theory correlation matrix for scale variations
-    with block diagonal entries by dataset only"""
-    mat = theory_corrmat_singleprocess(theory_block_diag_covmat)
-    return mat
-
-
-@table
 def theory_corrmat_custom(theory_covmat_custom):
     """Calculates the theory correlation matrix for scale variations
     with variations by process type"""
     mat = theory_corrmat_singleprocess(theory_covmat_custom)
-    return mat
-
-
-@table
-def theory_normcovmat_singleprocess(theory_covmat_singleprocess, procs_data_values):
-    """Calculates the theory covariance matrix for scale variations normalised
-    to data."""
-    df = theory_covmat_singleprocess
-    mat = df / np.outer(procs_data_values, procs_data_values)
-    return mat
-
-
-@table
-def theory_normblockcovmat(theory_block_diag_covmat, procs_data_values):
-    """Calculates the theory covariance matrix for scale variations
-    normalised to data, block diagonal by dataset."""
-    df = theory_block_diag_covmat
-    mat = df / np.outer(procs_data_values, procs_data_values)
     return mat
 
 
@@ -735,65 +590,6 @@ def theory_normcovmat_custom(theory_covmat_custom, procs_data_values):
 
 
 @table
-def experimentplustheory_covmat_singleprocess(
-    procs_covmat_no_table, theory_covmat_singleprocess_no_table
-):
-    """Calculates the experiment + theory covariance matrix for
-    scale variations."""
-    df = procs_covmat_no_table + theory_covmat_singleprocess_no_table
-    return df
-
-
-@table
-def experimentplusblocktheory_covmat(procs_covmat, theory_block_diag_covmat):
-    """Calculates the experiment + theory covariance
-    matrix for scale variations."""
-    df = procs_covmat + theory_block_diag_covmat
-    return df
-
-
-@table
-def experimentplustheory_covmat_custom(procs_covmat, theory_covmat_custom):
-    """Calculates the experiment + theory covariance matrix for
-    scale variations correlated according to the relevant prescription."""
-    df = procs_covmat + theory_covmat_custom
-    return df
-
-
-@table
-def experimentplustheory_normcovmat_singleprocess(
-    procs_covmat, theory_covmat_singleprocess, procs_data
-):
-    """Calculates the experiment + theory covariance matrix for scale
-    variations normalised to data."""
-    df = procs_covmat + theory_covmat_singleprocess
-    procs_data_array = np.array(procs_data)
-    mat = df / np.outer(procs_data_array, procs_data_array)
-    return mat
-
-
-@table
-def experimentplusblocktheory_normcovmat(
-    procs_covmat, theory_block_diag_covmat, procs_data_values, experimentplustheory_normcovmat
-):
-    """Calculates the experiment + theory covariance matrix for scale
-    variations normalised to data, block diagonal by data set."""
-    mat = experimentplustheory_normcovmat(procs_covmat, theory_block_diag_covmat, procs_data_values)
-    return mat
-
-
-@table
-def experimentplustheory_normcovmat_custom(
-    procs_covmat, theory_covmat_custom, procs_data_values, experimentplustheory_normcovmat
-):
-    """Calculates the experiment + theory covariance matrix for scale
-    variations normalised to data, correlations by process type."""
-    mat = experimentplustheory_normcovmat(procs_covmat, theory_covmat_custom, procs_data_values)
-
-    return mat
-
-
-@table
 def experimentplustheory_corrmat_singleprocess(procs_covmat, theory_covmat_singleprocess):
     """Calculates the correlation matrix for the experimental
     plus theory covariance matrices."""
@@ -801,14 +597,6 @@ def experimentplustheory_corrmat_singleprocess(procs_covmat, theory_covmat_singl
     total_cov = (procs_covmat + theory_covmat_singleprocess).values
     diag_minus_half = (np.diagonal(total_cov)) ** (-0.5)
     corrmat = diag_minus_half[:, np.newaxis] * total_df * diag_minus_half
-    return corrmat
-
-
-@table
-def experimentplusblocktheory_corrmat(procs_covmat, theory_block_diag_covmat):
-    """Calculates the correlation matrix for the experimental
-    plus theory covariance matrices, block diagonal by dataset."""
-    corrmat = experimentplustheory_corrmat_singleprocess(procs_covmat, theory_block_diag_covmat)
     return corrmat
 
 
@@ -841,12 +629,6 @@ def data_theory_diff(procs_results):
     th_central = np.concatenate(th_central_list)
     central_diff = dat_central - th_central
     return central_diff
-
-
-def chi2_block_impact(theory_block_diag_covmat, procs_covmat, procs_results):
-    """Returns total chi2 including theory cov mat"""
-    chi2 = chi2_impact(theory_block_diag_covmat, procs_covmat, procs_results)
-    return chi2
 
 
 def chi2_impact_custom(theory_covmat_custom, procs_covmat, procs_results):
@@ -900,11 +682,6 @@ def abs_chi2_data_theory_proc(procs_results, total_covmat_procs):
             Chi2Data(th_result.stats_class(chi2s[:, np.newaxis]), central_result, len(data_result))
         )
     return chi2data_array
-
-
-def abs_chi2_data_diagtheory_proc(procs_results, total_covmat_diagtheory_procs):
-    """For a diagonal theory covmat"""
-    return abs_chi2_data_theory_proc(procs_results, total_covmat_diagtheory_procs)
 
 
 def abs_chi2_data_diagtheory_dataset(each_dataset_results, total_covmat_diagtheory_datasets):

--- a/validphys2/src/validphys/theorycovariance/construction.py
+++ b/validphys2/src/validphys/theorycovariance/construction.py
@@ -589,33 +589,4 @@ def experimentplustheory_corrmat_custom(procs_covmat, theory_covmat_custom):
     corrmat = diag_minus_half[:, np.newaxis] * total_df * diag_minus_half
     return corrmat
 
-def data_theory_diff(procs_results):
-    """Returns (D-T) for central theory, for use in chi2 calculations"""
-    dataresults, theoryresults = zip(*procs_results)
-    dat_central_list = [x.central_value for x in dataresults]
-    th_central_list = [x.central_value for x in theoryresults]
-    dat_central = np.concatenate(dat_central_list)
-    th_central = np.concatenate(th_central_list)
-    central_diff = dat_central - th_central
-    return central_diff
-
 each_dataset_results = collect(results, ("group_dataset_inputs_by_process", "data"))
-
-
-def abs_chi2_data_theory_dataset(each_dataset_results, total_covmat_datasets):
-    """Returns an array of tuples (member_chi², central_chi², numpoints)
-    corresponding to each data set, where theory errors are included"""
-    chi2data_array = []
-    for datresults, covmat in zip(each_dataset_results, total_covmat_datasets):
-        data_result, th_result = datresults
-        chi2s = all_chi2_theory(datresults, covmat)
-        central_result = central_chi2_theory(datresults, covmat)
-        chi2data_array.append(
-            Chi2Data(th_result.stats_class(chi2s[:, np.newaxis]), central_result, len(data_result))
-        )
-    return chi2data_array
-
-
-def abs_chi2_data_diagtheory_dataset(each_dataset_results, total_covmat_diagtheory_datasets):
-    """For a diagonal theory covmat"""
-    return abs_chi2_data_theory_dataset(each_dataset_results, total_covmat_diagtheory_datasets)

--- a/validphys2/src/validphys/theorycovariance/construction.py
+++ b/validphys2/src/validphys/theorycovariance/construction.py
@@ -584,8 +584,7 @@ def experimentplustheory_corrmat_custom(procs_covmat, theory_covmat_custom):
     """Calculates the correlation matrix for the experimental
     plus theory covariance matrices, correlations by prescription."""
     total_df = procs_covmat + theory_covmat_custom
-    total_cov = (procs_covmat + theory_covmat_custom).values
-    diag_minus_half = (np.diagonal(total_cov)) ** (-0.5)
+    diag_minus_half = (np.diagonal(total_df.values)) ** (-0.5)
     corrmat = diag_minus_half[:, np.newaxis] * total_df * diag_minus_half
     return corrmat
 

--- a/validphys2/src/validphys/theorycovariance/output.py
+++ b/validphys2/src/validphys/theorycovariance/output.py
@@ -38,17 +38,6 @@ def procs_chi2_table_theory(
     )
 
 
-@table
-def procs_chi2_table_diagtheory(
-    procs_data, pdf, abs_chi2_data_diagtheory_proc, abs_chi2_data_theory_dataset_by_process
-):
-    """Same as groups_chi2_table but including diagonal theory covariance matrix.
-    Note: we use groups_chi2_table here but provide data grouped by process."""
-    return groups_chi2_table(
-        procs_data, pdf, abs_chi2_data_diagtheory_proc, abs_chi2_data_theory_dataset_by_process
-    )
-
-
 def matrix_plot_labels(df):
     """Returns the tick locations and labels, and the starting
     point values for each category,  based on a dataframe
@@ -224,15 +213,6 @@ def plot_expcorrmat_heatmap(procs_corrmat):
 
 
 @figure
-def plot_normthblockcovmat_heatmap(theory_normblockcovmat):
-    """Matrix plot for block diagonal theory covariance matrix"""
-    fig = plot_covmat_heatmap(
-        theory_normblockcovmat, "Block diagonal theory covariance matrix by dataset"
-    )
-    return fig
-
-
-@figure
 def plot_normthcovmat_heatmap_custom(theory_normcovmat_custom, theoryids, fivetheories):
     """Matrix plot for block diagonal theory covariance matrix by process type"""
     l = len(theoryids)
@@ -240,15 +220,6 @@ def plot_normthcovmat_heatmap_custom(theory_normcovmat_custom, theoryids, fiveth
         if fivetheories == "bar":
             l = r"$\bar{5}$"
     fig = plot_covmat_heatmap(theory_normcovmat_custom, f"Theory Covariance matrix ({l} pt)")
-    return fig
-
-
-@figure
-def plot_thblockcorrmat_heatmap(theory_blockcorrmat):
-    """Matrix plot of the theory correlation matrix"""
-    fig = plot_corrmat_heatmap(
-        theory_blockcorrmat, "Theory correlation matrix block diagonal by dataset"
-    )
     return fig
 
 
@@ -264,41 +235,6 @@ def plot_thcorrmat_heatmap_custom(theory_corrmat_custom, theoryids, fivetheories
 
 
 @figure
-def plot_normexpplusblockthcovmat_heatmap(experimentplusblocktheory_normcovmat):
-    """Matrix plot of the exp + theory covariance matrix normalised to data"""
-    fig = plot_covmat_heatmap(
-        experimentplusblocktheory_normcovmat,
-        "Experiment + theory (block diagonal by dataset) covariance matrix",
-    )
-    return fig
-
-
-@figure
-def plot_normexpplusthcovmat_heatmap_custom(
-    experimentplustheory_normcovmat_custom, theoryids, fivetheories
-):
-    """Matrix plot of the exp + theory covariance matrix normalised to data"""
-    l = len(theoryids)
-    if l == 5:
-        if fivetheories == "bar":
-            l = r"$\bar{5}$"
-    fig = plot_covmat_heatmap(
-        experimentplustheory_normcovmat_custom, f"Experimental + Theory Covariance Matrix ({l} pt)"
-    )
-    return fig
-
-
-@figure
-def plot_expplusblockthcorrmat_heatmap(experimentplusblocktheory_corrmat):
-    """Matrix plot of the exp + theory correlation matrix"""
-    fig = plot_corrmat_heatmap(
-        experimentplusblocktheory_corrmat,
-        "Experiment + theory (block diagonal by dataset) correlation matrix",
-    )
-    return fig
-
-
-@figure
 def plot_expplusthcorrmat_heatmap_custom(
     experimentplustheory_corrmat_custom, theoryids, fivetheories
 ):
@@ -309,30 +245,6 @@ def plot_expplusthcorrmat_heatmap_custom(
             l = r"$\bar{5}$"
     fig = plot_corrmat_heatmap(
         experimentplustheory_corrmat_custom, f"Experimental + Theory Correlation Matrix ({l} pt)"
-    )
-    return fig
-
-
-@figure
-def plot_blockcovdiff_heatmap(theory_block_diag_covmat, procs_covmat):
-    """Matrix plot (thcov + expcov)/expcov"""
-    df = (theory_block_diag_covmat.as_matrix() + procs_covmat.values) / np.mean(procs_covmat.values)
-    fig = plot_covmat_heatmap(
-        df, "(Theory + experiment)/mean(experiment)" + "for block diagonal theory covmat by dataset"
-    )
-    return fig
-
-
-@figure
-def plot_covdiff_heatmap_custom(theory_covmat_custom, procs_covmat, theoryids, fivetheories):
-    """Matrix plot (thcov + expcov)/expcov"""
-    l = len(theoryids)
-    if l == 5:
-        if fivetheories == "bar":
-            l = r"$\bar{5}$"
-    df = (theory_covmat_custom + procs_covmat) / np.mean(procs_covmat.values)
-    fig = plot_covmat_heatmap(
-        df, f"(Theory + experiment)/mean(experiment) covariance matrices for {l} points"
     )
     return fig
 
@@ -381,43 +293,6 @@ def plot_diag_cov_comparison(
         + "normalised to absolute value of data",
         fontsize=20,
     )
-    ax.legend(fontsize=20)
-    ax.margins(x=0)
-    return fig
-
-
-@figure
-def plot_diag_cov_impact(
-    theory_covmat_custom, procs_covmat, procs_data_values, theoryids, fivetheories
-):
-    """Plot ((expcov)^-1_ii)^-0.5 versus ((expcov + thcov)^-1_ii)^-0.5"""
-    l = len(theoryids)
-    if l == 5:
-        if fivetheories == "bar":
-            l = r"$\bar{5}$"
-    matrix_theory = theory_covmat_custom.values
-    matrix_experiment = procs_covmat.values
-    inv_exp = (np.diag(la.inv(matrix_experiment))) ** (-0.5) / procs_data_values
-    inv_tot = (np.diag(la.inv(matrix_theory + matrix_experiment))) ** (-0.5) / procs_data_values
-    plot_index = theory_covmat_custom.index
-    df_inv_exp = pd.DataFrame(inv_exp, index=plot_index)
-    df_inv_exp.sort_index(axis=0, inplace=True)
-    oldindex = df_inv_exp.index.tolist()
-    newindex = sorted(oldindex, key=_get_key)
-    df_inv_exp = df_inv_exp.reindex(newindex)
-    df_inv_tot = pd.DataFrame(inv_tot, index=plot_index)
-    df_inv_tot.sort_index(axis=0, inplace=True)
-    df_inv_tot = df_inv_tot.reindex(newindex)
-    fig, ax = plotutils.subplots()
-    ax.plot(df_inv_exp.values, ".", label="Experiment", color="orange")
-    ax.plot(df_inv_tot.values, ".", label="Experiment + Theory", color="mediumseagreen")
-    ticklocs, ticklabels, startlocs = matrix_plot_labels(df_inv_exp)
-    ax.set_xticks(ticklocs)
-    ax.set_xticklabels(ticklabels, rotation="vertical", fontsize=20)
-    ax.vlines(startlocs, 0, len(matrix_theory), linestyles="dashed")
-    ax.set_ylabel(r"$\frac{1}{D_i}\frac{1}{\sqrt{[cov^{-1}_]{ii}}}$", fontsize=30)
-    ax.yaxis.set_tick_params(labelsize=20)
-    ax.set_title(f"Diagonal impact of adding theory covariance matrix for {l} points", fontsize=20)
     ax.legend(fontsize=20)
     ax.margins(x=0)
     return fig

--- a/validphys2/src/validphys/theorycovariance/output.py
+++ b/validphys2/src/validphys/theorycovariance/output.py
@@ -66,10 +66,9 @@ def plot_covmat_heatmap(covmat, title):
     matrixplot = ax.matshow(
         100 * matrix,
         cmap=cm.Spectral_r,
-        norm = mcolors.Normalize(vmin=-100 * matrix.max(), vmax=100 * matrix.max())
-        #norm=mcolors.SymLogNorm(
-        #    linthresh=0.00001, linscale=1, vmin=-100 * matrix.max(), vmax=100 * matrix.max()
-        #),
+        norm=mcolors.SymLogNorm(
+            linthresh=0.00001, linscale=0.1, vmin=-100 * matrix.max(), vmax=100 * matrix.max()
+        ),
     )
     cbar = fig.colorbar(matrixplot, fraction=0.046, pad=0.04)
     cbar.set_label(label="% of data", fontsize=20)

--- a/validphys2/src/validphys/theorycovariance/output.py
+++ b/validphys2/src/validphys/theorycovariance/output.py
@@ -27,17 +27,6 @@ abs_chi2_data_theory_dataset_by_process = collect(
 )
 
 
-@table
-def procs_chi2_table_theory(
-    procs_data, pdf, abs_chi2_data_theory_proc, abs_chi2_data_theory_dataset_by_process
-):
-    """Same as groups_chi2_table but including theory covariance matrix.
-    Note: we use groups_chi2_table here but provide data grouped by process."""
-    return groups_chi2_table(
-        procs_data, pdf, abs_chi2_data_theory_proc, abs_chi2_data_theory_dataset_by_process
-    )
-
-
 def matrix_plot_labels(df):
     """Returns the tick locations and labels, and the starting
     point values for each category,  based on a dataframe

--- a/validphys2/src/validphys/theorycovariance/output.py
+++ b/validphys2/src/validphys/theorycovariance/output.py
@@ -66,9 +66,10 @@ def plot_covmat_heatmap(covmat, title):
     matrixplot = ax.matshow(
         100 * matrix,
         cmap=cm.Spectral_r,
-        norm=mcolors.SymLogNorm(
-            linthresh=0.01, linscale=10, vmin=-100 * matrix.max(), vmax=100 * matrix.max()
-        ),
+        norm = mcolors.Normalize(vmin=-100 * matrix.max(), vmax=100 * matrix.max())
+        #norm=mcolors.SymLogNorm(
+        #    linthresh=0.00001, linscale=1, vmin=-100 * matrix.max(), vmax=100 * matrix.max()
+        #),
     )
     cbar = fig.colorbar(matrixplot, fraction=0.046, pad=0.04)
     cbar.set_label(label="% of data", fontsize=20)
@@ -270,7 +271,7 @@ def plot_diag_cov_comparison(
     # Shift startlocs elements 0.5 to left so lines are between indexes
     startlocs_lines = [x - 0.5 for x in startlocs]
     ax.vlines(startlocs_lines, 0, len(data), linestyles="dashed")
-    ax.set_ylabel(r"$\frac{\sqrt{cov_{ii}}}{|D_i|}$", fontsize=30)
+    ax.set_ylabel(r"$\frac{\sqrt{S_{ii}}}{|D_i|}$", fontsize=30)
     ax.yaxis.set_tick_params(labelsize=20)
     ax.set_ylim([0, 0.5])
     ax.set_title(

--- a/validphys2/src/validphys/theorycovariance/output.py
+++ b/validphys2/src/validphys/theorycovariance/output.py
@@ -22,10 +22,6 @@ from validphys.results import groups_chi2_table
 
 log = logging.getLogger(__name__)
 
-abs_chi2_data_theory_dataset_by_process = collect(
-    "abs_chi2_data_theory_dataset", ("group_dataset_inputs_by_process",)
-)
-
 
 def matrix_plot_labels(df):
     """Returns the tick locations and labels, and the starting
@@ -284,28 +280,4 @@ def plot_diag_cov_comparison(
     )
     ax.legend(fontsize=20)
     ax.margins(x=0)
-    return fig
-
-
-@figure
-def plot_datasets_chi2_theory(procs_data, each_dataset_chi2, abs_chi2_data_theory_dataset):
-    """Plot the chi² of all datasets, before and after adding theory errors, with bars."""
-    ds = iter(each_dataset_chi2)
-    dstheory = iter(abs_chi2_data_theory_dataset)
-    dschi2 = []
-    dschi2theory = []
-    xticks = []
-    for proc in procs_data:
-        for dataset, dsres in zip(proc, ds):
-            dschi2.append(dsres.central_result / dsres.ndata)
-            xticks.append(dataset.name)
-    for proc in procs_data:
-        for dataset, dsres in zip(proc, dstheory):
-            dschi2theory.append(dsres.central_result / dsres.ndata)
-    plotvalues = np.stack((dschi2theory, dschi2))
-    fig, ax = plotutils.barplot(
-        plotvalues, collabels=xticks, datalabels=["experiment + theory", "experiment"]
-    )
-    ax.set_title(r"$\chi^2$ distribution for datasets")
-    ax.legend(fontsize=14)
     return fig

--- a/validphys2/src/validphys/theorycovariance/output.py
+++ b/validphys2/src/validphys/theorycovariance/output.py
@@ -67,7 +67,7 @@ def plot_covmat_heatmap(covmat, title):
         100 * matrix,
         cmap=cm.Spectral_r,
         norm=mcolors.SymLogNorm(
-            linthresh=0.00001, linscale=0.1, vmin=-100 * matrix.max(), vmax=100 * matrix.max()
+            linthresh=0.00001, linscale=1, vmin=-100 * matrix.max(), vmax=100 * matrix.max()
         ),
     )
     cbar = fig.colorbar(matrixplot, fraction=0.046, pad=0.04)

--- a/validphys2/src/validphys/theorycovariance/tests.py
+++ b/validphys2/src/validphys/theorycovariance/tests.py
@@ -750,13 +750,13 @@ def ticklocs_thcovmat(theory_covmat_custom):
     return matrix_plot_labels(theory_covmat_custom)
 
 @figure
-def shift_diag_cov_comparison(sqrtdiags_thcovmat, fnorm_shifts, point_prescription, ticklocs_thcovmat):
+def shift_diag_cov_comparison(sqrtdiags_thcovmat, fnorm_shifts, point_prescription, ticklocs_thcovmat, dataspecs):
     fnorm_concat = [j for i in fnorm_shifts for j in i]
     sqrtdiags_concat = [j for i in sqrtdiags_thcovmat for j in i]
     fig, ax = plotutils.subplots(figsize=(20, 10))
     ax.plot(np.array(sqrtdiags_concat) * 100, ".-", label=f"MHOU ({point_prescription})", color="red")
     ax.plot(-np.array(sqrtdiags_concat) * 100, ".-", color="red")
-    ax.plot(-np.array(fnorm_concat) * 100, ".-", label="NNLO-NLO Shift", color="black")
+    ax.plot(-np.array(fnorm_concat) * 100, ".-", label=f"{dataspecs[1]['speclabel']}-{dataspecs[0]['speclabel']} Shift", color="black")
     ticklocs, ticklabels, startlocs = ticklocs_thcovmat
     ax.set_xticks(ticklocs)
     ax.set_xticklabels(ticklabels, rotation=45, fontsize=20)

--- a/validphys2/src/validphys/theorycovariance/tests.py
+++ b/validphys2/src/validphys/theorycovariance/tests.py
@@ -314,9 +314,7 @@ def evals_nonzero_basis(
     # constructing dictionary of datasets in each process type
     doubleindex = doubleindex_thcovmat(theory_covmat_custom)
     procdict = {}
-    for index in doubleindex:
-        name = index[1]
-        proc = index[0]
+    for proc, name in doubleindex:
         if proc not in list(procdict.keys()):
             procdict[proc] = [name]
         elif name not in procdict[proc]:
@@ -550,7 +548,7 @@ def deltamiss_plot(
     fnorm_vector = fnorm_shifts(concatenated_shx_vector, doubleindex_thcovmat)
     fnorm_concat = [j for i in fnorm_vector for j in i]
     # Minus sign changes it from NLO-NNLO shift to NNLO-NLO shift (convention)
-    f = -pd.DataFrame(fnorm_concat, index=tripleindex_thcovmat_complete)
+    f = -1.0 * pd.DataFrame(fnorm_concat, index=tripleindex_thcovmat_complete)
     tripleindex = f.index
     f.sort_index(axis=0, inplace=True)
     oldindex = f.index.tolist()

--- a/validphys2/src/validphys/theorycovariance/tests.py
+++ b/validphys2/src/validphys/theorycovariance/tests.py
@@ -384,7 +384,7 @@ def projected_condition_num(evals_nonzero_basis):
 def fnorm_shifts_ordered(concatenated_shx_vector, doubleindex_thcovmat):
     """Shifts vectors ordered as the theory covmat."""
     fnorm_vector = fnorm_shifts_byprocess(concatenated_shx_vector, doubleindex_thcovmat)
-    return np.array([j for i in fnorm_vector for j in i])
+    return np.array(sum(fnorm_vector, []))
 
 def theory_shift_test(fnorm_shifts_ordered, evals_nonzero_basis):
     """Compares the NNLO-NLO shift, f, with the eigenvectors and eigenvalues of the
@@ -638,15 +638,15 @@ def shift_diag_cov_comparison(
 ):
     """Plot of the comparison of a shift between two pertubative order and the diagonal entries of the theory covmat, both normalized to the first of the two perturbative orders."""
     # Concatenation of the arrays
-    fnorm_concat = [j for i in fnorm_shifts_byprocess for j in i]
-    sqrtdiags_concat = [j for i in sqrtdiags_thcovmat_byprocess for j in i]
+    fnorm_concat = sum(fnorm_shifts_byprocess, [])
+    sqrtdiags_concat = sum(sqrtdiags_thcovmat_byprocess, [])
     fig, ax = plotutils.subplots(figsize=(20, 10))
     ax.plot(
-        np.array(sqrtdiags_concat) * 100, ".-", label=f"MHOU ({point_prescription})", color="red"
+        np.array(sqrtdiags_concat), ".-", label=f"MHOU ({point_prescription})", color="red"
     )
-    ax.plot(-np.array(sqrtdiags_concat) * 100, ".-", color="red")
+    ax.plot(-np.array(sqrtdiags_concat), ".-", color="red")
     ax.plot(
-        -np.array(fnorm_concat) * 100,
+        -np.array(fnorm_concat),
         ".-",
         label=f"{dataspecs[1]['speclabel']}-{dataspecs[0]['speclabel']} Shift",
         color="black",
@@ -658,8 +658,8 @@ def shift_diag_cov_comparison(
     startlocs_lines = [x - 0.5 for x in startlocs]
     ax.vlines(startlocs_lines, -70, 70, linestyles="dashed")
     ax.margins(x=0, y=0)
-    ax.set_ylabel(r"% wrt central theory $T_i^{(0)}$", fontsize=20)
-    ax.set_ylim(-35, 35)
+    ax.set_ylabel(r"$\pm \sqrt{\hat{S_{ii}}}$, $\delta_{i}$", fontsize=20)
+    ax.set_ylim(-0.35, 0.35)
     ax.legend(fontsize=20)
     ax.yaxis.set_tick_params(labelsize=20)
     return fig

--- a/validphys2/src/validphys/theorycovariance/tests.py
+++ b/validphys2/src/validphys/theorycovariance/tests.py
@@ -817,7 +817,7 @@ def concatenated_shx_vector(shx_vector):
 def sqrtdiags_thcovmat(tripleindex_set, diagdf_theory_covmat, concatenated_shx_vector):
     sqrtdiags = []
     for index in tripleindex_set:
-        sqrtdiags.append(list(np.sqrt(diagdf_theory_covmat.loc[index[0]].loc[index[1]].values.transpose()[0]/concatenated_shx_vector.loc[index[0]].loc[index[1]].norm.values)))
+        sqrtdiags.append(list(np.sqrt(diagdf_theory_covmat.loc[index[0]].loc[index[1]].values.transpose()[0])/concatenated_shx_vector.loc[index[0]].loc[index[1]].norm.values))
     return sqrtdiags
 
 def fnorm_shifts(concatenated_shx_vector, tripleindex_set):

--- a/validphys2/src/validphys/theorycovariance/tests.py
+++ b/validphys2/src/validphys/theorycovariance/tests.py
@@ -22,6 +22,10 @@ from validphys.checks import check_two_dataspecs
 from validphys.theorycovariance.construction import (
     combine_by_type,
     theory_corrmat_singleprocess,
+    theory_covmat_custom,
+    covmap,
+    covs_pt_prescrip,
+    process_starting_points,
 )
 from validphys.theorycovariance.output import _get_key, matrix_plot_labels
 from validphys.theorycovariance.theorycovarianceutils import (
@@ -206,6 +210,43 @@ def theory_corrmat_custom_dataspecs(theory_covmat_custom_dataspecs):
     mat = theory_corrmat_singleprocess(theory_covmat_custom_dataspecs)
     return mat
 
+def process_starting_points_dataspecs(combine_by_type_dataspecs):
+    """Like process_starting_points but for matched dataspecs."""
+    return process_starting_points(combine_by_type_dataspecs)
+
+
+@check_correct_theory_combination_dataspecs
+def covs_pt_prescrip_dataspecs(
+    combine_by_type_dataspecs,
+    process_starting_points_dataspecs,
+    dataspecs_theoryids,
+    point_prescription,
+    fivetheories,
+    seventheories,
+):
+    """Like covs_pt_prescrip but for matched dataspecs."""
+    return covs_pt_prescrip(
+        combine_by_type_dataspecs,
+        process_starting_points_dataspecs,
+        dataspecs_theoryids,
+        point_prescription,
+        fivetheories,
+        seventheories,
+    )
+
+
+def covmap_dataspecs(combine_by_type_dataspecs, matched_dataspecs_dataset_name):
+    """Like covmap but for matched dataspecs."""
+    return covmap(combine_by_type_dataspecs, matched_dataspecs_dataset_name)
+
+@table
+def theory_covmat_custom_dataspecs(
+    covs_pt_prescrip_dataspecs, covmap_dataspecs, matched_experiments_index
+):
+    """Like theory_covmat_custom but for matched dataspecs."""
+    return theory_covmat_custom(
+        covs_pt_prescrip_dataspecs, covmap_dataspecs, matched_experiments_index
+    )
 
 def _shuffle_list(l, shift):
     """Function that moves list elements left by 'shift' entries"""

--- a/validphys2/src/validphys/theorycovariance/theorycovarianceutils.py
+++ b/validphys2/src/validphys/theorycovariance/theorycovarianceutils.py
@@ -121,18 +121,6 @@ def check_correct_theory_combination_internal(
 
 check_correct_theory_combination = make_argcheck(check_correct_theory_combination_internal)
 
-
-@make_argcheck
-def check_correct_theory_combination_theoryconfig(collected_theoryids, fivetheories):
-    check_correct_theory_combination_internal(collected_theoryids[0], fivetheories)
-
-
-@make_argcheck
-def check_correct_theory_combination_dataspecs(dataspecs_theoryids, fivetheories):
-    """Like check_correct_theory_combination but for matched dataspecs."""
-    return check_correct_theory_combination.__wrapped__(dataspecs_theoryids, fivetheories)
-
-
 @make_argcheck
 def check_fit_dataset_order_matches_grouped(
     group_dataset_inputs_by_metadata, data_input, processed_metadata_group


### PR DESCRIPTION
It seems that #1899 removed some functions that are needed for some of the reports we usually do (cc @giacomomagni). For example for `shift_diag_cov_comparison`. I am trying to restore and eventually fix this here. @RoyStegeman @scarlehoff 