### PR TITLE
modifications to remove the charm valence sum rule

### DIFF
--- a/n3fit/src/n3fit/layers/msr_normalization.py
+++ b/n3fit/src/n3fit/layers/msr_normalization.py
@@ -16,9 +16,9 @@ MSR_COMPONENTS = ['g']
 MSR_DENOMINATORS = {'g': 'g'}
 # The VSR normalization factor of component f is given by
 # VSR_CONSTANTS[f] / VSR_DENOMINATORS[f]
-VSR_COMPONENTS = ['v', 'v35', 'v24', 'v3', 'v8', 'v15']
-VSR_CONSTANTS = {'v': 3.0, 'v35': 3.0, 'v24': 3.0, 'v3': 1.0, 'v8': 3.0, 'v15': 3.0}
-VSR_DENOMINATORS = {'v': 'v', 'v35': 'v', 'v24': 'v', 'v3': 'v3', 'v8': 'v8', 'v15': 'v15'}
+VSR_COMPONENTS = ['v', 'v35', 'v24', 'v3', 'v8']
+VSR_CONSTANTS = {'v': 3.0, 'v35': 3.0, 'v24': 3.0, 'v3': 1.0, 'v8': 3.0}
+VSR_DENOMINATORS = {'v': 'v', 'v35': 'v', 'v24': 'v', 'v3': 'v3', 'v8': 'v8'}
 
 
 class MSR_Normalization(MetaLayer):

--- a/validphys2/src/validphys/sumrules.py
+++ b/validphys2/src/validphys/sumrules.py
@@ -90,7 +90,6 @@ KNOWN_SUM_RULES = {
     "uvalence": _make_pdf_integrand({"u": 1, "ubar": -1}),
     "dvalence": _make_pdf_integrand({"d": 1, "dbar": -1}),
     "svalence": _make_pdf_integrand({"s": 1, "sbar": -1}),
-    "cvalence": _make_pdf_integrand({"c": 1, "cbar": -1}),
 }
 
 UNKNOWN_SUM_RULES = {
@@ -102,6 +101,7 @@ UNKNOWN_SUM_RULES = {
     "sbar momentum fraction": _make_momentum_fraction_integrand({"sbar": 1}),
     "cp momentum fraction": _make_momentum_fraction_integrand({"c": 1, "cbar": 1}),
     "cm momentum fraction": _make_momentum_fraction_integrand({"c": 1, "cbar": -1}),
+    "cvalence": _make_pdf_integrand({"c": 1, "cbar": -1}),
     "g momentum fraction": _make_momentum_fraction_integrand({"g": 1}),
     "T3": _make_pdf_integrand({"u": 1, "ubar": 1, "d": -1, "dbar": -1}),
     "T8": _make_pdf_integrand({"u": 1, "ubar": 1, "d": 1, "dbar": 1, "s": -2, "sbar": -2}),
@@ -112,7 +112,6 @@ KNOWN_SUM_RULES_EXPECTED = {
     'uvalence': 2,
     'dvalence': 1,
     'svalence': 0,
-    'cvalence': 0,
 }
 
 
@@ -162,6 +161,7 @@ def unknown_sum_rules(pdf: PDF, Q: numbers.Real):
     - sbar momentum fraction
     - cp momentum fraction
     - cm momentum fraction
+    - cvalence
     - g momentum fraction
     - T3
     - T8


### PR DESCRIPTION
This branch contains modifications to remove the charm valence sum rule in ccbar asymm fits. Needed to reply to the the referee. A report comparing fits w/ and w/ the charm valence sum rule is [here](https://vp.nnpdf.science/3xe03GKkQ_uIvPXD7qOW_A==/).
This PR is not intended to be merged, but only to allow other people to check that what I did is sensible.