### PR TITLE
Update fit bot for 4.0.8

### DIFF
--- a/.github/workflows/fitbot.yml
+++ b/.github/workflows/fitbot.yml
@@ -77,7 +77,7 @@ jobs:
       run: |
         conda activate nnpdfenv
         cd $RUNFOLDER
-        for ((i=1; i<=$N3FIT_MAXNREP; i+=2)); do n3fit $RUNCARD.yml $i -r $((i+1)); done
+        for ((i=1; i<=$N3FIT_MAXNREP; i+=1)); do n3fit $RUNCARD.yml $i ; done
     # performing DGLAP
     - name: Running dglap
       shell: bash -l {0}

--- a/n3fit/src/n3fit/backends/keras_backend/MetaModel.py
+++ b/n3fit/src/n3fit/backends/keras_backend/MetaModel.py
@@ -341,9 +341,9 @@ class MetaModel(Model):
         """
         Get the weights of replica i_replica.
 
-        This assumes that the only weights are in layers called
-        ``NN_{i_replica}`` and ``preprocessing_factor_{i_replica}``
-
+        This assumes that the only weights are in the
+        layer types defined as the constants
+            NN_LAYER_ALL_REPLICAS & PREPROCESSING_LAYER_ALL_REPLICAS
 
         Parameters
         ----------
@@ -458,7 +458,8 @@ def get_layer_replica_weights(layer, i_replica: int):
             list of weights for the replica
     """
     if is_stacked_single_replicas(layer):
-        weights = layer.get_layer(f"{NN_PREFIX}_{i_replica}").weights
+        weights_ref = layer.get_layer(f"{NN_PREFIX}_{i_replica}").weights
+        weights = [tf.Variable(w, name=w.name) for w in weights_ref]
     else:
         weights = [tf.Variable(w[i_replica : i_replica + 1], name=w.name) for w in layer.weights]
 

--- a/validphys2/src/validphys/tests/photon/test_compute.py
+++ b/validphys2/src/validphys/tests/photon/test_compute.py
@@ -17,6 +17,8 @@ from ..conftest import PDF, THEORY_QED
 
 
 def generate_fiatlux_runcard():
+    # Ensures the PDF from conftest exists
+    _ = FallbackLoader().check_pdf(PDF)
     return {
         "luxset": PDFset(PDF),
         # check if "LUXqed17_plus_PDF4LHC15_nnlo_100" is installed


### PR DESCRIPTION
And use replica-by-replica fit.

Up to #1881 this was completely unchanged, see https://github.com/NNPDF/nnpdf/pull/1920#issuecomment-1913302769)

However, after #1881 it changed due to a bug in which weights were saved as reference. Upon fixing this bug the fitbot hopefully remains unchanged.