### PR TITLE
Update conda installation action

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v1
-    - uses: conda-incubator/setup-miniconda@v2
+    - uses: conda-incubator/setup-miniconda@v3
       with:
         python-version: ${{ matrix.python-version }}
     - name: Setup conda and install conda-build

--- a/.github/workflows/fitbot.yml
+++ b/.github/workflows/fitbot.yml
@@ -27,7 +27,7 @@ jobs:
       NETRC_FILE: ${{ secrets.NETRC_FILE }}
     steps:
     - uses: actions/checkout@v1
-    - uses: conda-incubator/setup-miniconda@v2
+    - uses: conda-incubator/setup-miniconda@v3
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install SSH key

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,7 +53,7 @@ jobs:
       shell: bash -l {0}
       run: |
         conda activate test
-        conda mambabuild -q conda-recipe
+        conda mambabuild --debug -q conda-recipe
     - name: Build recipe and run tests on macOS
       if: startsWith(matrix.os, 'macOS')
       shell: bash -l {0}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,7 +41,7 @@ jobs:
       shell: bash -l {0}
       run: |
         echo "$NETRC_FILE" | base64 --decode > ~/.netrc
-        conda install -n base conda-libmamba-solver
+        conda install -n base conda-libmamba-solver=23.12.0
         conda config --set solver libmamba
         conda config --append channels conda-forge
         conda config --prepend channels https://packages.nnpdf.science/public

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
       PYTHONHASHSEED: "0"
     steps:
     - uses: actions/checkout@v1
-    - uses: conda-incubator/setup-miniconda@v2
+    - uses: conda-incubator/setup-miniconda@v3
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install macOS SDK


### PR DESCRIPTION
I happened to look at the failing tests in #1929 on my phone, and there I saw a hint which I don't see on my laptop, which was to update the action that sets up conda, hope this fixes the tests that I think will fail now on master as well when rerun.