### PR TITLE
Use eko.runner.managed.solve instead of eko.runner.solve

### DIFF
--- a/n3fit/src/n3fit/scripts/evolven3fit_new.py
+++ b/n3fit/src/n3fit/scripts/evolven3fit_new.py
@@ -9,7 +9,7 @@ import sys
 from evolven3fit_new import cli, eko_utils, evolve
 import numpy as np
 
-from eko import runner
+from eko.runner.managed import solve
 from n3fit.io.writer import XGRID
 
 _logger = logging.getLogger(__name__)
@@ -173,7 +173,7 @@ def main():
                 op_card_info,
                 theory_card_info,
             )
-        runner.solve(tcard, opcard, args.dump)
+        solve(tcard, opcard, args.dump)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Now that `pineko` is using `eko.runner.managed.solve` instead of `eko.runner.solve` to save memory, I think it will be nice to use it also in evolven3fit_new by default. Moreover, I've been using it since forever to compute the evolution ekos of the QED theories.