### PR TITLE
Test only 3.9 and 3.11 ; build only in 3.11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.9", "3.11"]
+        python-version: ["3.9", "3.11"] # only test for the outer values for the range we support to prevent the cluster from refusing connections due to too many requests
       fail-fast: false
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,5 @@
 # A single CI script with github workflow to test NNPDF, and upload the conda package and documentation
-name: Tests
+name: Test conda package
 
 on: [push]
 
@@ -7,18 +7,12 @@ concurrency:
   group: ${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
-
 jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest] # , macos-latest]
-        python-version: ["3.11"] # ["3.9", "3.10", "3.11"]
-        include:
-          - os: ubuntu-latest
-            CONDA_OS: linux-64
-          - os: macos-latest
-            CONDA_OS: osx-64
+        os: [ubuntu-latest, macos-latest]
+        python-version: ["3.9", "3.11"]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     env:
@@ -50,39 +44,31 @@ jobs:
         conda config --append channels conda-forge
         conda config --prepend channels https://packages.nnpdf.science/public
         conda config --set show_channel_urls true
-    - name: Install boa in Linux
-      if: startsWith(matrix.os, 'ubuntu')
-      shell: bash -l {0}
-      run: |
-        conda install boa --yes
     - name: Build recipe and run tests on linux
       if: startsWith(matrix.os, 'ubuntu')
       shell: bash -l {0}
       run: |
+        conda install boa --yes
         conda mambabuild -q conda-recipe
-    - name: Extra setup settings for macOS and install boa
-      if: startsWith(matrix.os, 'macOS')
-      shell: bash -l {0}
-      run: |
-        conda config --prepend channels defaults
-        conda install boa conda-build==3.28 --yes
-    - name: Build recipe and run tests on macOS
+    - name: Build recipe and run test on Mac OS
       if: startsWith(matrix.os, 'macOS')
       shell: bash -l {0}
       run: |
         export CONDA_BUILD_SYSROOT=$CONDA_PREFIX/MacOSX10.9.sdk
+        conda config --prepend channels defaults
+        conda install boa conda-build==3.28 --yes
         conda build -q conda-recipe
-    - name: Upload conda package to NNPDF server
-      if: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')}}
+    - name: Upload noarch conda package to NNPDF server
+      if: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')}} && startsWith(matrix.os, 'ubuntu') && matrix.python-version == '3.11'
       shell: bash -l {0}
       run: |
         KEY=$( mktemp )
         echo "$NNPDF_SSH_KEY" | base64 --decode > "$KEY"
         scp -i "$KEY" -o StrictHostKeyChecking=no\
           $CONDA_PREFIX/conda-bld/noarch/*.tar.bz2 \
-          dummy@packages.nnpdf.science:~/packages/conda/${{matrix.CONDA_OS}}
+          dummy@packages.nnpdf.science:~/packages/conda/noarch
     - name: Build and upload sphinx documentation to NNPDF server
-      if: startsWith(matrix.os, 'ubuntu') && github.ref == 'refs/heads/master' && matrix.python-version == '3.9'
+      if: startsWith(matrix.os, 'ubuntu') && github.ref == 'refs/heads/master' && matrix.python-version == '3.11'
       shell: bash -l {0}
       run: |
         KEY=$( mktemp )


### PR DESCRIPTION
Since we are not compiling anymore, we only need the `noarch` package and so we only need to upload one package to the server every time we merge from master (instead of six).

For the tests, at the moment I've left 4: 3.9, 3.11 and ubuntu/mac. We are back to 4 tests with conda (+2 in python). We can get away with less of course. I just want to avoid the many false positives that we get when the server in Milan stops accepting connections because we are downloading too much stuff too quickly.