### PR TITLE
Enable python 3.12

### DIFF
--- a/.github/workflows/fitbot.yml
+++ b/.github/workflows/fitbot.yml
@@ -12,7 +12,7 @@ env:
   POSTFIT_NREP: 16 # requested replicas for postfit
   REFERENCE_SET: NNBOT-80553d777-2024-03-07 # reference set for exact results
   STABLE_REFERENCE_SET: NNBOT-c0f99b7b3-2024-02-28 # reference set for last tag
-  CONDA_PY: 310
+  CONDA_PY: 312
   PYTHONHASHSEED: "0"
 
 jobs:
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.10"]
+        python-version: ["3.12"]
     runs-on: ${{ matrix.os }}
     env:
       NETRC_FILE: ${{ secrets.NETRC_FILE }}

--- a/.github/workflows/fitbot.yml
+++ b/.github/workflows/fitbot.yml
@@ -27,10 +27,17 @@ jobs:
     env:
       NETRC_FILE: ${{ secrets.NETRC_FILE }}
     steps:
-    - uses: actions/checkout@v1
-    - uses: conda-incubator/setup-miniconda@v2
+    - uses: actions/checkout@v4
+      with:
+        fetch-tags: true
+        fetch-depth: 0
+    - uses: conda-incubator/setup-miniconda@v3
       with:
         python-version: ${{ matrix.python-version }}
+        use-mamba: true
+        channels: https://packages.nnpdf.science/public,conda-forge
+        show-channel-urls: true
+        auto-update-conda: true
     - name: Install SSH key
       uses: shimataro/ssh-key-action@v2
       with:
@@ -41,14 +48,11 @@ jobs:
       shell: bash -l {0}
       run: |
         echo "$NETRC_FILE" | base64 --decode > ~/.netrc
-        conda config --append channels conda-forge
-        conda config --prepend channels https://packages.nnpdf.science/public
-        conda config --set show_channel_urls true
-        conda install boa --yes
+        conda install conda-build --yes
     - name: Build recipe
       shell: bash -l {0}
       run: |
-        CONDA_PY=$CONDA_PY conda mambabuild --no-test -q conda-recipe
+        CONDA_PY=$CONDA_PY conda build --no-test -q conda-recipe
     # install local build
     - name: Installing NNPDF conda package
       shell: bash -l {0}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,28 +28,18 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         use-mamba: true
+        channels: https://packages.nnpdf.science/public,conda-forge
+        show-channel-urls: true
         auto-update-conda: true
         activate-environment: test
     - name: Setup conda
       shell: bash -l {0}
       run: |
         echo "$NETRC_FILE" | base64 --decode > ~/.netrc
-        conda config --remove channels defaults
-        conda config --append channels conda-forge
-        conda config --prepend channels https://packages.nnpdf.science/public
-        conda config --set show_channel_urls true
-    - name: Build recipe and run tests on linux
-      if: startsWith(matrix.os, 'ubuntu')
+        conda install conda-build --yes
+    - name: Build recipe
       shell: bash -l {0}
       run: |
-        conda install conda-build --yes
-        conda build -q conda-recipe
-    - name: Build recipe and run test on Mac OS
-      if: startsWith(matrix.os, 'macOS')
-      shell: bash -l {0}
-      run: |
-        conda config --prepend channels defaults
-        conda install conda-build --yes
         conda build -q conda-recipe
     - name: Upload noarch conda package to NNPDF server
       if: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')}} && startsWith(matrix.os, 'ubuntu') && matrix.python-version == '3.9'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.9", "3.11"] # only test for the outer values for the range we support to prevent the cluster from refusing connections due to too many requests
+        python-version: ["3.9", "3.12"] # only test for the outer values for the range we support to prevent the cluster from refusing connections due to too many requests
       fail-fast: false
     runs-on: ${{ matrix.os }}
     env:
@@ -52,7 +52,7 @@ jobs:
         conda install boa conda-build==3.28 --yes
         conda build -q conda-recipe
     - name: Upload noarch conda package to NNPDF server
-      if: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')}} && startsWith(matrix.os, 'ubuntu') && matrix.python-version == '3.11'
+      if: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')}} && startsWith(matrix.os, 'ubuntu') && matrix.python-version == '3.9'
       shell: bash -l {0}
       run: |
         KEY=$( mktemp )
@@ -61,7 +61,7 @@ jobs:
           $CONDA_PREFIX/conda-bld/noarch/*.tar.bz2 \
           dummy@packages.nnpdf.science:~/packages/conda/noarch
     - name: Build and upload sphinx documentation to NNPDF server
-      if: startsWith(matrix.os, 'ubuntu') && github.ref == 'refs/heads/master' && matrix.python-version == '3.11'
+      if: startsWith(matrix.os, 'ubuntu') && github.ref == 'refs/heads/master' && matrix.python-version == '3.9'
       shell: bash -l {0}
       run: |
         KEY=$( mktemp )

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,14 +42,14 @@ jobs:
       if: startsWith(matrix.os, 'ubuntu')
       shell: bash -l {0}
       run: |
-        conda install boa --yes
-        conda mambabuild -q conda-recipe
+        conda install conda-build --yes
+        conda build -q conda-recipe
     - name: Build recipe and run test on Mac OS
       if: startsWith(matrix.os, 'macOS')
       shell: bash -l {0}
       run: |
         conda config --prepend channels defaults
-        conda install boa conda-build==3.28 --yes
+        conda install conda-build --yes
         conda build -q conda-recipe
     - name: Upload noarch conda package to NNPDF server
       if: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')}} && startsWith(matrix.os, 'ubuntu') && matrix.python-version == '3.9'

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -16,12 +16,12 @@ build:
 
 requirements:
     host:
-        - python >=3.9,<3.12
+        - python >=3.9,<3.13
         - poetry-core >=1.0.0
         - poetry-dynamic-versioning >=1.2.0
         - pip
     run:
-        - python >=3.9,<3.12
+        - python >=3.9,<3.13
         - tensorflow >=2.10
         - psutil # to ensure n3fit affinity is with the right processors
         - blas==1.0 *mkl* # [osx] # Host's blas is mkl, force also runtime blas to be
@@ -33,8 +33,7 @@ requirements:
         - sqlite
         - numpy
         - pkg-config
-        - reportengine ==0.30.28  # see https://github.com/NNPDF/reportengine
-        - curio >=1.0 # reportengine uses it but it's not in its dependencies
+        - reportengine
         - matplotlib >=3.3.0,<3.8  # see https://github.com/NNPDF/nnpdf/pull/1809
         - blessings >=1.7
         - scipy >=0.19.1
@@ -42,8 +41,8 @@ requirements:
         - requests
         - prompt_toolkit
         - validobj
-        - pineappl >=0.6.2
-        - eko >=0.14.1
+        - pineappl >=0.7.3
+        - eko >=0.14.2
         - fiatlux
         - frozendict  # needed for caching of data loading
         - sphinx >=5.0.2,<6 # documentation. Needs pinning temporarily due to markdown

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,11 +72,8 @@ numpy = "*"
 validobj = "*"
 prompt_toolkit = "*"
 frozendict = "*"  # validphys: needed for caching of data loading
-# Reportengine (and its dependencies) need to be installed in a bit more manual way
-# the version of RE that we need requires curio, and the pypi package for curio is no longer updated
-curio = { git = "https://github.com/dabeaz/curio", rev = "8667999" }
-reportengine = { git = "https://github.com/NNPDF/reportengine", rev = "3bb2b1d"}
-ruamel_yaml = {version = "<0.18"}
+# Reportengine needs to be installed from git
+reportengine = { git = "https://github.com/NNPDF/reportengine" }
 # Fit
 psutil = "*"
 tensorflow = "*"

--- a/validphys2/src/validphys/dataplots.py
+++ b/validphys2/src/validphys/dataplots.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Plots of relations between data PDFs and fits.
 """
@@ -299,7 +298,9 @@ def _plot_fancy_impl(
         min_vals = []
         max_vals = []
         fig, ax = plotutils.subplots()
-        ax.set_title("%s %s" % (info.dataset_label, info.group_label(samefig_vals, info.figure_by)))
+        ax.set_title(
+            "{} {}".format(info.dataset_label, info.group_label(samefig_vals, info.figure_by))
+        )
 
         lineby = sane_groupby_iter(fig_data, info.line_by)
 
@@ -582,7 +583,7 @@ def plot_fits_chi2_spider(fits, fits_groups_chi2, fits_groups_data, processed_me
         exchi2 = [group_res.central_result / group_res.ndata for group_res in fitchi2]
         xticks = [group.name for group in fitgroup]
 
-        ax = plotutils.spiderplot(xticks, exchi2, fit)
+        ax = plotutils.spiderplot(xticks, exchi2, fit, ax)
 
     ax.set_title(rf"$\chi^2$ by {processed_metadata_group}")
 
@@ -599,7 +600,7 @@ def plot_fits_phi_spider(fits, fits_groups_data, fits_groups_data_phi, processed
         phi = [exp_phi for (exp_phi, _npoints) in fitphi]
         xticks = [group.name for group in fitgroup]
 
-        ax = plotutils.spiderplot(xticks, phi, fit)
+        ax = plotutils.spiderplot(xticks, phi, fit, ax)
 
     ax.set_title(rf"$\phi$ by {processed_metadata_group}")
 
@@ -615,7 +616,7 @@ def plot_groups_data_chi2_spider(groups_data, groups_chi2, processed_metadata_gr
 
     fig, ax = plotutils.add_subplot(projection='polar')
 
-    ax = plotutils.spiderplot(xticks, exchi2, pdf)
+    ax = plotutils.spiderplot(xticks, exchi2, pdf, ax)
     ax.set_title(rf"$\chi^2$ by {processed_metadata_group}")
     return fig
 
@@ -627,7 +628,7 @@ def plot_groups_data_phi_spider(groups_data, groups_data_phi, processed_metadata
     xticks = [group.name for group in groups_data]
     fig, ax = plotutils.add_subplot(projection='polar')
 
-    ax = plotutils.spiderplot(xticks, phi, pdf)
+    ax = plotutils.spiderplot(xticks, phi, pdf, ax)
     ax.set_title(rf"$\phi$ by {processed_metadata_group}")
     return fig
 
@@ -713,7 +714,7 @@ def plot_datasets_chi2_spider(groups_data, groups_chi2):
         dschi2 = [dsres.central_result / dsres.ndata for dsres in group_res]
 
     fig, ax = plotutils.add_subplot(figsize=(4, 4), projection='polar')
-    ax = plotutils.spiderplot(xticks, dschi2, label=[r'$\chi^2$'])
+    ax = plotutils.spiderplot(xticks, dschi2, label=[r'$\chi^2$'], ax=ax)
 
     ax.set_title(r"$\chi^2$ distribution for datasets")
 
@@ -741,7 +742,7 @@ def _plot_chi2s_spider_df(df, size=6):
     expnames = list(df.index.get_level_values(0))
     fig, ax = plotutils.add_subplot(figsize=(size, size), projection='polar')
     for dat, fitname in zip(data, fitnames):
-        ax = plotutils.spiderplot(expnames, dat, fitname)
+        ax = plotutils.spiderplot(expnames, dat, fitname, ax)
     ax.legend(bbox_to_anchor=(0.3, -0.2), fontsize=15)
     return fig, ax
 

--- a/validphys2/src/validphys/mc_gen.py
+++ b/validphys2/src/validphys/mc_gen.py
@@ -119,7 +119,7 @@ def art_data_comparison(art_rep_generation, nreplica: int):
     axes = [fig.add_subplot(nrows, 1, i + 1) for i in range(nrows)]
 
     for i, ax, datapoint, normartdatapoint in zip(
-        range(len(artrep_array.T)), axes.flatten(), artrep_array.T, normart_data
+        range(len(artrep_array.T)), axes, artrep_array.T, normart_data
     ):
         ax.hist(datapoint, bins=10, histtype="step", stacked=True, fill=False)
         extraString = f"Datapoint number = {i}"
@@ -129,11 +129,7 @@ def art_data_comparison(art_rep_generation, nreplica: int):
         ax.set_ylim(0, 0.5 * nreplica)
         ax.vlines(1, ax.get_ylim()[0], ax.get_ylim()[1])
         ax.vlines(
-            normartdatapoint,
-            ax.get_ylim()[0],
-            ax.get_ylim()[1],
-            linestyle="-",
-            color="darkorchid",
+            normartdatapoint, ax.get_ylim()[0], ax.get_ylim()[1], linestyle="-", color="darkorchid"
         )
         ax.vlines(0, ax.get_ylim()[0], ax.get_ylim()[1], linestyle="-", color="dodgerblue")
         ax.vlines(2, ax.get_ylim()[0], ax.get_ylim()[1], linestyle="-", color="dodgerblue")
@@ -185,12 +181,7 @@ def art_data_mean_table(art_rep_generation, groups_data):
         for dataset in group.datasets:
             Ndata = dataset.load_commondata().ndata
             for i in range(Ndata):
-                line = [
-                    dataset.name,
-                    art_data[i],
-                    real_data[i],
-                    abs(art_data[i] - real_data[i]),
-                ]
+                line = [dataset.name, art_data[i], real_data[i], abs(art_data[i] - real_data[i])]
                 data.append(line)
 
     df = pd.DataFrame(data, columns=["DataSet", "ArtData", "ExpData", "abs(residual)"])

--- a/validphys2/src/validphys/plotutils.py
+++ b/validphys2/src/validphys/plotutils.py
@@ -573,13 +573,14 @@ def kde_plot(a, height=0.05, ax=None, label=None, color=None, max_marks=100000):
     return ax
 
 
-def spiderplot(xticks, vals, label, ax=None):
+def spiderplot(xticks, vals, label, ax):
     """
     Makes a spider/radar plot.
 
     xticks: list of names of x tick labels, e.g. datasets
     vals: list of values to plot corresponding to each xtick
     label: label for values, e.g. fit name
+    ax: a `PolarAxes` instance
     """
     N = len(xticks)
 

--- a/validphys2/src/validphys/plotutils.py
+++ b/validphys2/src/validphys/plotutils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Basic utilities for plotting functions.
 Created on Thu Apr 21 18:41:43 2016
@@ -577,7 +576,6 @@ def kde_plot(a, height=0.05, ax=None, label=None, color=None, max_marks=100000):
     return ax
 
 
-@ax_or_gca
 def spiderplot(xticks, vals, label, ax=None):
     """
     Makes a spider/radar plot.
@@ -597,7 +595,7 @@ def spiderplot(xticks, vals, label, ax=None):
     ax.set_theta_offset(np.pi / 2)
     ax.set_theta_direction(-1)
 
-    ax.set_ticks(angles[:-1])
+    ax.set_xticks(angles[:-1])
     ax.set_xticklabels(xticks, size=8, zorder=6)
 
     # Draw ylabels

--- a/validphys2/src/validphys/plotutils.py
+++ b/validphys2/src/validphys/plotutils.py
@@ -1,8 +1,5 @@
 """
 Basic utilities for plotting functions.
-Created on Thu Apr 21 18:41:43 2016
-
-@author: Zahari Kassabov
 """
 from collections import namedtuple
 import functools

--- a/validphys2/src/validphys/tests/test_plots.py
+++ b/validphys2/src/validphys/tests/test_plots.py
@@ -18,7 +18,7 @@ def test_plotpdfs():
     Q = 10
     flavours = ['g']
     # plot_pdfs returns a generator with (figure, name_hint)
-    return API.plot_pdfs(pdfs=pdfs, Q=Q, flavours=flavours)[0]
+    return next(iter(API.plot_pdfs(pdfs=pdfs, Q=Q, flavours=flavours)))[0]
 
 
 @pytest.mark.linux
@@ -44,13 +44,13 @@ def test_dataspecschi2():
 @pytest.mark.linux
 @pytest.mark.mpl_image_compare(tolerance=TOLERANCE_VALUE)
 def test_plot_smpdf(single_data_internal_cuts_config):
-    return API.plot_smpdf(**single_data_internal_cuts_config)
+    return next(iter(API.plot_smpdf(**single_data_internal_cuts_config)))
 
 
 @pytest.mark.linux
 @pytest.mark.mpl_image_compare(tolerance=TOLERANCE_VALUE)
 def test_plot_smpdf_categorical(single_data_categorical_internal_cuts_config):
-    return API.plot_smpdf(**single_data_categorical_internal_cuts_config)
+    return next(iter(API.plot_smpdf(**single_data_categorical_internal_cuts_config)))
 
 
 @pytest.mark.linux

--- a/validphys2/src/validphys/tests/test_plots.py
+++ b/validphys2/src/validphys/tests/test_plots.py
@@ -18,7 +18,7 @@ def test_plotpdfs():
     Q = 10
     flavours = ['g']
     # plot_pdfs returns a generator with (figure, name_hint)
-    return next(API.plot_pdfs(pdfs=pdfs, Q=Q, flavours=flavours))[0]
+    return API.plot_pdfs(pdfs=pdfs, Q=Q, flavours=flavours)[0]
 
 
 @pytest.mark.linux
@@ -44,13 +44,13 @@ def test_dataspecschi2():
 @pytest.mark.linux
 @pytest.mark.mpl_image_compare(tolerance=TOLERANCE_VALUE)
 def test_plot_smpdf(single_data_internal_cuts_config):
-    return next(API.plot_smpdf(**single_data_internal_cuts_config))
+    return API.plot_smpdf(**single_data_internal_cuts_config)
 
 
 @pytest.mark.linux
 @pytest.mark.mpl_image_compare(tolerance=TOLERANCE_VALUE)
 def test_plot_smpdf_categorical(single_data_categorical_internal_cuts_config):
-    return next(API.plot_smpdf(**single_data_categorical_internal_cuts_config))
+    return API.plot_smpdf(**single_data_categorical_internal_cuts_config)
 
 
 @pytest.mark.linux


### PR DESCRIPTION
Now reportengine and pineappl are available for python 3.12
Let's see whether there's something else to be changed.

Closes #1970

edit: not sure why `boa<=0.14` is a problem when python <3.12 gets 0.16, but once the fit bot tests that everything run I'll check that