### PR TITLE
Enable apple silicon

### DIFF
--- a/.github/workflows/python_installation.yml
+++ b/.github/workflows/python_installation.yml
@@ -10,8 +10,8 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest]
-        python-version: ["3.11", "3.12"]
+        os: [ubuntu-latest, macos-14]
+        python-version: ["3.12"]
         include:
           - os: ubuntu-latest
             CONDA_OS: linux-64
@@ -33,12 +33,7 @@ jobs:
         conda config --set solver libmamba
         conda config --append channels conda-forge
         conda config --set show_channel_urls true
-        conda install lhapdf pandoc
-    - name: Install MongoDB for parallel hyperopts
-      shell: bash -l {0}
-      run: |
-        conda install mongodb
-        mongod --version
+        conda install lhapdf pandoc mongodb
     - name: Install nnpdf with testing and qed extras
       shell: bash -l {0}
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-14]
-        python-version: ["3.9", "3.12"] # only test for the outer values for the range we support to prevent the cluster from refusing connections due to too many requests
+        python-version: ["3.12"] # Test only the latest python in all system
+        include:
+          - os: ubuntu-latest # Test also the oldest python supported in ubuntu
+            python-version: "3.9"
       fail-fast: false
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-14]
         python-version: ["3.9", "3.12"] # only test for the outer values for the range we support to prevent the cluster from refusing connections due to too many requests
       fail-fast: false
     runs-on: ${{ matrix.os }}
@@ -42,7 +42,7 @@ jobs:
       run: |
         conda build -q conda-recipe
     - name: Upload noarch conda package to NNPDF server
-      if: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')}} && startsWith(matrix.os, 'ubuntu') && matrix.python-version == '3.9'
+      if: ${{ (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')) && startsWith(matrix.os, 'ubuntu') && matrix.python-version == '3.9' }}
       shell: bash -l {0}
       run: |
         KEY=$( mktemp )

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -10,9 +10,6 @@ build:
     script: {{ PYTHON }} -m pip install . -vv
     number: 0
     detect_binary_files_with_prefix: True
-    # import CONDA_BUILD_SYSROOT from env variable for osx
-    script_env:
-      - CONDA_BUILD_SYSROOT # [osx]
 
 requirements:
     host:
@@ -58,7 +55,6 @@ test:
 
     source_files:
         - "*"
-
 
 about:
     home: https://nnpdf.mi.infn.it/

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -24,7 +24,6 @@ requirements:
         - python >=3.9,<3.13
         - tensorflow >=2.10
         - psutil # to ensure n3fit affinity is with the right processors
-        - blas==1.0 *mkl* # [osx] # Host's blas is mkl, force also runtime blas to be
         - hyperopt
         - mongodb
         - pymongo <4

--- a/n3fit/src/n3fit/tests/test_hyperopt.py
+++ b/n3fit/src/n3fit/tests/test_hyperopt.py
@@ -173,7 +173,7 @@ def test_restart_from_pickle(tmp_path):
         assert restart_json[i]['misc']['idxs'] == direct_json[i]['misc']['idxs']
     # Note that it doesn't check the final loss of the second trial
 
-
+@pytest.mark.linux
 def test_parallel_hyperopt(tmp_path):
     """Ensure that the parallel implementation of hyperopt with MongoDB works as expected."""
     # Prepare the run


### PR DESCRIPTION
Given that we know now the code works in the M1/2/3 macs, that (almost) everyone in the collaboration with a mac uses one of those and that tensorflow will stop supporting the old macs from 2.17...
I think it is time to change the CI!

This is just a test to see whether it works.

It seems there is a problem with fiatlux in arm64. @niclaurenti this is probably the problem you mentioned the other day. Could you have a look to check whether the ci is installing the right version?