### PR TITLE
Allow nf 5 in produce_eko

### DIFF
--- a/n3fit/src/evolven3fit/utils.py
+++ b/n3fit/src/evolven3fit/utils.py
@@ -77,7 +77,7 @@ def generate_q2grid(Q0, Qfin, Q_points, match_dict, nf0=None, legacy40=False):
     if Qfin is None and Q_points is None:
         if legacy40:
             return Q2GRID_NNPDF40
-        elif nf0 in (3, 4):
+        elif nf0 in (3, 4, 5):
             return Q2GRID_DEFAULT
         elif nf0 is None:
             raise ValueError("In order to use a default grid, a value of nf0 must be provided")

--- a/n3fit/src/n3fit/tests/test_evolven3fit.py
+++ b/n3fit/src/n3fit/tests/test_evolven3fit.py
@@ -81,7 +81,7 @@ def test_generate_q2grid():
     grid = utils.generate_q2grid(None, None, None, {}, 4)
     assert grid[0] == 1.0**2
 
-    for nf in [1, 2, 5, 6]:
+    for nf in [1, 2, 6]:
         with pytest.raises(NotImplementedError):
             grid = utils.generate_q2grid(None, None, None, {}, nf)
 


### PR DESCRIPTION
The modified line prevented from computing evolution ekos with Q0 > mb and therefore from running a fit with Q0 > mb