### PR TITLE
Add unique log files for each mongo worker

### DIFF
--- a/n3fit/src/n3fit/hyper_optimization/mongofiletrials.py
+++ b/n3fit/src/n3fit/hyper_optimization/mongofiletrials.py
@@ -155,7 +155,7 @@ class MongoFileTrials(MongoTrials):
             f"mongo://{self.db_host}:{self.db_port}/{self._process_db_name(self.db_name)}/jobs"
         )
         self.workers = []
-        self.job_output_name = replica_path.parts[-3]
+        self.output_folder_name = replica_path.parts[-3]
 
         self._store_trial = False
         self._json_file = replica_path / "tries.json"

--- a/n3fit/src/n3fit/hyper_optimization/mongofiletrials.py
+++ b/n3fit/src/n3fit/hyper_optimization/mongofiletrials.py
@@ -197,7 +197,6 @@ class MongoFileTrials(MongoTrials):
 
         # write json to disk
         if self._store_trial:
-            # log.info("Storing scan in %s", self._json_file)
             local_trials = []
             for idx, t in enumerate(self._dynamic_trials):
                 local_trials.append(t)

--- a/n3fit/src/n3fit/hyper_optimization/mongofiletrials.py
+++ b/n3fit/src/n3fit/hyper_optimization/mongofiletrials.py
@@ -266,7 +266,7 @@ class MongoFileTrials(MongoTrials):
                     # my_env["TF_GPU_ALLOCATOR"] = "cuda_malloc_async"
 
                 # create log files to redirect the mongo-workers output
-                mongo_workers_logfile = f"mongo-worker_{i+1}_{self.job_output_name}.log"
+                mongo_workers_logfile = f"mongo-worker_{i+1}_{self.output_folder_name}.log"
                 with open(mongo_workers_logfile, mode='w', encoding="utf-8") as log_file:
                     # run mongo workers
                     worker = subprocess.Popen(

--- a/n3fit/src/n3fit/hyper_optimization/mongofiletrials.py
+++ b/n3fit/src/n3fit/hyper_optimization/mongofiletrials.py
@@ -154,6 +154,7 @@ class MongoFileTrials(MongoTrials):
             f"mongo://{self.db_host}:{self.db_port}/{self._process_db_name(self.db_name)}/jobs"
         )
         self.workers = []
+        self.log_files = []
 
         self._store_trial = False
         self._json_file = replica_path / "tries.json"
@@ -195,7 +196,7 @@ class MongoFileTrials(MongoTrials):
 
         # write json to disk
         if self._store_trial:
-            log.info("Storing scan in %s", self._json_file)
+            # log.info("Storing scan in %s", self._json_file)
             local_trials = []
             for idx, t in enumerate(self._dynamic_trials):
                 local_trials.append(t)
@@ -264,21 +265,28 @@ class MongoFileTrials(MongoTrials):
                     # avoid memory fragmentation issues?
                     # my_env["TF_GPU_ALLOCATOR"] = "cuda_malloc_async"
 
+                # create log files to redirect the mongo-workers output
+                mongo_workers_logfile = f"mongo-worker_{i+1}.log"
+                log_file = open(mongo_workers_logfile, 'w')
+                self.log_files.append(log_file)
                 # run mongo workers
-                # we could use stdout=subprocess.DEVNULL and stderr=subprocess.DEVNULL in Popen to suppress output info
-                worker = subprocess.Popen(args, env=my_env)
+                worker = subprocess.Popen(
+                    args, env=my_env, stdout=log_file, stderr=subprocess.STDOUT
+                )
                 self.workers.append(worker)
                 log.info(f"Started mongo worker {i+1}/{self.num_workers}")
             except OSError as err:
+                log_file.close()
                 msg = f"Failed to execute {args}. Make sure you have MongoDB installed."
                 raise EnvironmentError(msg) from err
 
     def stop_mongo_workers(self):
         """Terminates all active mongo workers."""
-        for worker in self.workers:
+        for worker, log_file in zip(self.workers, self.log_files):
             try:
                 worker.terminate()
                 worker.wait()
+                log_file.close()
                 log.info(f"Stopped mongo worker {self.workers.index(worker)+1}/{self.num_workers}")
             except Exception as err:
                 log.error(

--- a/n3fit/src/n3fit/hyper_optimization/mongofiletrials.py
+++ b/n3fit/src/n3fit/hyper_optimization/mongofiletrials.py
@@ -155,6 +155,7 @@ class MongoFileTrials(MongoTrials):
         )
         self.workers = []
         self.log_files = []
+        self.output_path = replica_path.parts[-3]
 
         self._store_trial = False
         self._json_file = replica_path / "tries.json"
@@ -266,7 +267,7 @@ class MongoFileTrials(MongoTrials):
                     # my_env["TF_GPU_ALLOCATOR"] = "cuda_malloc_async"
 
                 # create log files to redirect the mongo-workers output
-                mongo_workers_logfile = f"mongo-worker_{i+1}.log"
+                mongo_workers_logfile = f"mongo-worker_{i+1}_{self.output_path}.log"
                 log_file = open(mongo_workers_logfile, 'w')
                 self.log_files.append(log_file)
                 # run mongo workers

--- a/n3fit/src/n3fit/hyper_optimization/mongofiletrials.py
+++ b/n3fit/src/n3fit/hyper_optimization/mongofiletrials.py
@@ -2,6 +2,7 @@
     Hyperopt trial object for parallel hyperoptimization with MongoDB.
     Data are fetched from MongoDB databases and stored in the form of json and tar.gz files within the nnfit folder.
 """
+
 import json
 import logging
 import os
@@ -155,7 +156,7 @@ class MongoFileTrials(MongoTrials):
         )
         self.workers = []
         self.log_files = []
-        self.output_path = replica_path.parts[-3]
+        self.job_output_name = replica_path.parts[-3]
 
         self._store_trial = False
         self._json_file = replica_path / "tries.json"
@@ -267,7 +268,7 @@ class MongoFileTrials(MongoTrials):
                     # my_env["TF_GPU_ALLOCATOR"] = "cuda_malloc_async"
 
                 # create log files to redirect the mongo-workers output
-                mongo_workers_logfile = f"mongo-worker_{i+1}_{self.output_path}.log"
+                mongo_workers_logfile = f"mongo-worker_{i+1}_{self.job_output_name}.log"
                 log_file = open(mongo_workers_logfile, 'w')
                 self.log_files.append(log_file)
                 # run mongo workers


### PR DESCRIPTION
# Aim

Allow mongo workers to write output data to separate files.

# Idea

Redirect the output of each [subprocess.Popen](https://github.com/NNPDF/nnpdf/blob/760054c168848f8ff300cc1a5ef512093d825559/n3fit/src/n3fit/hyper_optimization/mongofiletrials.py#L273-L275) to unique log files (`stdout`) for each mongo worker. These files are named `mongo-worker_n_output_path.log`, where `n=0, 1, 2, ..., n` is the unique id of the worker and `output_path` corresponds to the runcard name or `OUTPUT` if `n3fit -o OUTPUT` was used.

# Notes/Drawbacks

The `mongo-worker_n_output_path.log` files will only contain data output by any function/method called by `fmin`, *i.e.*, by [ModelTrainer.hyperparametrizable](https://github.com/NNPDF/nnpdf/blob/760054c168848f8ff300cc1a5ef512093d825559/n3fit/src/n3fit/model_trainer.py#L838) which consists of details of the hyperparameters being evaluated and info about epochs. Other infos and warnings are still printed to standard output (screen), **including trial numbers** which might not be ideal.

**Either way, it appears that with this simple change we can prevent the overwhelming/chaotic information that was previously displayed on the screen.**

# Tasks
- [x] Add `stdout` redirection files to `start_mongo_workers` Popen.
- [x] Add name of the runcard/output to the mongo_worker log file
- [x] Test in snellius

