### PR TITLE
Fix for PDF without error type

### DIFF
--- a/validphys2/src/validphys/core.py
+++ b/validphys2/src/validphys/core.py
@@ -143,7 +143,7 @@ class PDF(TupleComp):
         try:
             return self.info["ErrorType"]
         except KeyError as e:
-            # If the error type is not defined _but_ the PDF only has one membe:
+            # If the error type is not defined _but_ the PDF only has one member:
             if self.info.get("NumMembers") == 1:
                 return "replicas"
             raise e

--- a/validphys2/src/validphys/core.py
+++ b/validphys2/src/validphys/core.py
@@ -140,7 +140,13 @@ class PDF(TupleComp):
     @property
     def error_type(self):
         """Error type as defined in the LHAPDF .info file"""
-        return self.info["ErrorType"]
+        try:
+            return self.info["ErrorType"]
+        except KeyError as e:
+            # If the error type is not defined _but_ the PDF only has one membe:
+            if self.info.get("NumMembers") == 1:
+                return "replicas"
+            raise e
 
     @property
     def alphas_mz(self):
@@ -151,7 +157,7 @@ class PDF(TupleComp):
     def alphas_vals(self):
         """List of alpha_s(Q) at various Q for interpolation based alphas.
         Values as defined in the LHAPDF .info file"""
-        self.info["AlphaS_Vals"]
+        return self.info["AlphaS_Vals"]
 
     @property
     def error_conf_level(self):

--- a/validphys2/src/validphys/scripts/vp_pdffromreplicas.py
+++ b/validphys2/src/validphys/scripts/vp_pdffromreplicas.py
@@ -11,13 +11,11 @@ source ``PDF`` will be downloaded if it cannot be found locally.
 This script will not overwrite any existing files, so a ``PDF`` cannot already
 exist with the same name as the output ``PDF``.
 
-Note that whilst in principle it is possible to create a single replica ``PDF``
-whose replica 0 is simply the same as replica 1, LHAPDF has a restriction which
-requires ``PDF`` s to have at least 2 replicas (plus replica 0). To handle this
-special case if ``replicas == 1``, then replica 2 will be a duplicate of replica
+Note that whilst in principle it is possible to create a single replica ``PDF``,
+some applications might rely on the existence of 2 members (in addition to replica 0).
+To handle this special case if ``replicas == 1``, then replica 2 will be a duplicate of replica
 1, satisfying the minimum number of replicas whilst retaining the property
 that replica 1 and replica 0 are identical.
-
 """
 
 import argparse


### PR DESCRIPTION
Some PDF don't define an error type (like CT14LO). Since these are 1-replica PDFs, I think it is safe to fallback to `replicas`.