### PR TITLE
Fix kinematic vs kinematic_coverage check

### DIFF
--- a/validphys2/src/validphys/commondataparser.py
+++ b/validphys2/src/validphys/commondataparser.py
@@ -433,9 +433,9 @@ class ObservableMetaData:
 
         # Ensure that all variables in the kinematic coverage exist
         for var in self.kinematic_coverage:
-            if var not in self.kinematics.variables:
+            if var not in self.kinematics.variables and not var.startswith("extra_"):
                 raise ValidationError(
-                    f"Variable {var} is in `kinematic_coverage` but not included in `kinematics` for {self.name}"
+                    f"Variable {var} is in `kinematic_coverage` but not included in `kinematics` nor part as `extra_` for {self.name}"
                 )
 
         if len(self.kinematic_coverage) > 3:

--- a/validphys2/src/validphys/commondataparser.py
+++ b/validphys2/src/validphys/commondataparser.py
@@ -435,7 +435,8 @@ class ObservableMetaData:
         for var in self.kinematic_coverage:
             if var not in self.kinematics.variables and not var.startswith("extra_"):
                 raise ValidationError(
-                    f"Variable {var} is in `kinematic_coverage` but not included in `kinematics` nor part as `extra_` for {self.name}"
+                    f"Variable {var} is in `kinematic_coverage` but not included in `kinematics`"
+                    f", nor it is a variable of type `extra_` for {self.name} dataset."
                 )
 
         if len(self.kinematic_coverage) > 3:

--- a/validphys2/src/validphys/process_options.py
+++ b/validphys2/src/validphys/process_options.py
@@ -85,6 +85,7 @@ class _Process:
         if kin_cov == ["k1", "k2", "k3"]:
             return True
         # We check if kin_cov is a subset of self.accepted_variables
+        kin_cov = [v for v in kin_cov if not v.startswith("extra_")]
         return set(self.accepted_variables).union(set(kin_cov)) == set(self.accepted_variables)
 
     def xq2map(self, kin_df, metadata):


### PR DESCRIPTION
Currently, when `kinematic_coverage` does not contain 3 variables and `len(kinematics.variable)<=3`, `extra_` variables are added to comply with vp.
https://github.com/NNPDF/nnpdf/blob/8b9b29fbbb55a59d6eb2d459307bc30ede977cbb/validphys2/src/validphys/commondataparser.py#L399

This, however, could be inconsistent with the following check:
https://github.com/NNPDF/nnpdf/blob/8b9b29fbbb55a59d6eb2d459307bc30ede977cbb/validphys2/src/validphys/commondataparser.py#L435-L439

This is a minimal fix by basically skipping `extra_` whenever `kinematics` and `kinematic_coverage` are compared.