### PR TITLE
Photon at Leading Order

### DIFF
--- a/n3fit/src/evolven3fit/eko_utils.py
+++ b/n3fit/src/evolven3fit/eko_utils.py
@@ -51,7 +51,6 @@ def construct_eko_cards(
     """
     theory, thresholds = load_theory(theoryID, theory_card_dict)
 
-    # if is eko_photon then mu0 = q_gamma
     mu0 = theory["Q0"]
 
     # Set nf_0 according to the fitting scale unless set explicitly
@@ -125,7 +124,7 @@ def construct_eko_photon_cards(
     theory, thresholds = load_theory(theoryID, theory_card_dict)
 
     # if is eko_photon then mu0 = q_gamma
-    mu0 = q_gamma
+    mu0 = float(q_gamma)
 
     # Set nf_0 according to mu0 unless set explicitly
     if "nf0" not in theory:
@@ -135,7 +134,7 @@ def construct_eko_photon_cards(
     legacy_class = runcards.Legacy(theory, {})
     theory_card = legacy_class.new_theory
 
-    q_fin = theory["Q0"]
+    q_fin = float(theory["Q0"])
 
     nf_fin = find_nf(q_fin, theory, thresholds)
 

--- a/nnpdf_data/nnpdf_data/theory_cards/390.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/390.yaml
@@ -3,7 +3,7 @@ PTO: 0
 FNS: ZM-VFNS
 DAMP: 1
 IC: 0
-ModEv: TRN
+ModEv: EXA
 XIR: 1.0
 XIF: 1.0
 NfFF: 5
@@ -20,7 +20,7 @@ SxOrd: LL
 HQ: POLE
 mc: 1.51
 Qmc: 1.51
-kcThr: 2.0
+kcThr: 1.0
 mb: 4.92
 Qmb: 4.92
 kbThr: 1.0

--- a/nnpdf_data/nnpdf_data/theory_cards/391.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/391.yaml
@@ -12,9 +12,9 @@ MaxNfPdf: 5
 Q0: 1.0
 alphas: 0.118
 Qref: 91.2
-QED: 0
-alphaqed: 0.007496252
-Qedref: 1.777
+QED: 2
+alphaqed: 0.0077553
+Qedref: 91.2
 SxRes: 0
 SxOrd: LL
 HQ: POLE

--- a/nnpdf_data/nnpdf_data/theory_cards/392.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/392.yaml
@@ -12,9 +12,9 @@ MaxNfPdf: 5
 Q0: 1.0
 alphas: 0.118
 Qref: 91.2
-QED: 0
-alphaqed: 0.007496252
-Qedref: 1.777
+QED: 2
+alphaqed: 0.0077553
+Qedref: 91.2
 SxRes: 0
 SxOrd: LL
 HQ: POLE

--- a/validphys2/src/validphys/photon/structure_functions.py
+++ b/validphys2/src/validphys/photon/structure_functions.py
@@ -115,3 +115,11 @@ class F2LO(StructureFunction):
         for i in range(1, nf + 1):
             res += self.eq2[i - 1] * (pdfs_values[i] + pdfs_values[-i])
         return res
+
+
+class FLLO(StructureFunction):
+    """Analytically compute the structure function FL at leading order., i.e. return zero."""
+
+    def fxq(self, x, q):
+        """FL_LO = 0"""
+        return 0.0


### PR DESCRIPTION
Currently the photon is computed using two FKtables, i.e. `FIATLUX_DIS_F2.pineappl.lz4` and `FIATLUX_DIS_FL.pineappl.lz4`.
However, at LO F2 and FL are trivial to compute (moreover the second is zero) so it does not make any sense to pre-compute them and interpolate

@scarlehoff 