### PR TITLE
Restore cut of CMS_TTBAR_8TEV_2L_DIF_MTTBAR-YT-NORM

### DIFF
--- a/validphys2/src/validphys/cuts/filters.yaml
+++ b/validphys2/src/validphys/cuts/filters.yaml
@@ -2,7 +2,7 @@
   reason: |
    We remove one bin from the normalised distribution because it is
    linearly dependent on the others
-  rule: "y_t<1.975 or m_ttBar<1075"
+  rule: "idat != 8"
 
 - dataset: ATLAS_TTBAR_8TEV_LJ_DIF_PTT-NORM
   reason: |


### PR DESCRIPTION
We restore the old cut of the dataset CMS_TTBAR_8TEV_2L_DIF_MTTBAR-YT-NORM.  The reason for this is that closure test fits produced for ongoing studies have the old cuts.  

@scarlehoff 
@RoyStegeman 