### PR TITLE
Use groups or reorder tests

### DIFF
--- a/validphys2/src/validphys/tests/conftest.py
+++ b/validphys2/src/validphys/tests/conftest.py
@@ -35,8 +35,9 @@ SINGLE_CATEGORICAL = {"dataset": "ATLAS_WZ_TOT_13TEV", 'cfac': ["QCD"]}
 DATA = [
     {'dataset': 'NMC'},
     {'dataset': 'ATLASTTBARTOT', 'cfac': ['QCD']},
-    SINGLE_DATAPOINT,
     {'dataset': 'CMSZDIFF12', 'cfac': ('QCD', 'NRM'), 'sys': 10},
+    # Explicitly put a CMS dataset between the two ATLAS
+    SINGLE_DATAPOINT,
 ]
 
 

--- a/validphys2/src/validphys/tests/conftest.py
+++ b/validphys2/src/validphys/tests/conftest.py
@@ -207,7 +207,7 @@ def pytest_runtest_setup(item):
     supported_platforms = ALL.intersection(mark.name for mark in item.iter_markers())
     plat = sys.platform
     if supported_platforms and plat not in supported_platforms:
-        pytest.skip("cannot run on platform {}".format(plat))
+        pytest.skip(f"cannot run on platform {plat}")
 
 
 def pytest_configure(config):

--- a/validphys2/src/validphys/tests/test_covmatreg.py
+++ b/validphys2/src/validphys/tests/test_covmatreg.py
@@ -3,19 +3,22 @@ test_covmatreg
 
 functions to test the covariance matrix regularization
 """
+
 import numpy as np
 import pandas as pd
 
-from validphys.tests.test_regressions import make_table_comp
-from validphys.tableloader import parse_exp_mat
-from validphys.calcutils import regularize_covmat, regularize_l2
 from validphys.api import API
+from validphys.calcutils import regularize_covmat, regularize_l2
+from validphys.tableloader import parse_exp_mat
+from validphys.tests.test_regressions import make_table_comp
+
 
 def test_withidentity():
     identity_mat = np.eye(3)
     np.testing.assert_allclose(identity_mat, regularize_l2(identity_mat, 1))
     np.testing.assert_allclose(identity_mat, regularize_covmat(identity_mat, 1))
-    np.testing.assert_allclose(2*identity_mat, regularize_l2(identity_mat, 0.5))
+    np.testing.assert_allclose(2 * identity_mat, regularize_l2(identity_mat, 0.5))
+
 
 @make_table_comp(parse_exp_mat)
 def test_regularize_expcov(data_config):
@@ -27,9 +30,10 @@ def test_regularize_expcov(data_config):
     assert ~np.allclose(df1.values, df2.values)
     # check that square of sqrt matches
     sqrt_df1 = API.groups_sqrtcovmat(**inp)
-    np.testing.assert_allclose(df1.values, sqrt_df1.values@sqrt_df1.values.T)
+    np.testing.assert_allclose(df1.values, sqrt_df1.values @ sqrt_df1.values.T)
     # check that same result obtained
     return df1
+
 
 @make_table_comp(parse_exp_mat)
 def test_regularized_covmat_generation(data_config):
@@ -37,15 +41,17 @@ def test_regularized_covmat_generation(data_config):
     index = API.groups_index(**data_config)
     return pd.DataFrame(covmat, index=index, columns=index)
 
+
 def test_regularization_matches_sane():
     """Check that regularizing the sqrt cov produces same result as regularizing
     on the covariance matrix with a fairly sane matrix
     """
     # choose some sensible matrix to be regularized
-    a = np.ones((3, 3)) + 0.5*np.diag(np.ones(3))
-    cov = a@a.T
+    a = np.ones((3, 3)) + 0.5 * np.diag(np.ones(3))
+    cov = a @ a.T
     a_reg = regularize_l2(a, 3)
-    np.testing.assert_allclose(regularize_covmat(cov, 3), a_reg@a_reg.T)
+    np.testing.assert_allclose(regularize_covmat(cov, 3), a_reg @ a_reg.T)
+
 
 def test_regularization_matches_zero_eig():
     """Check that regularizing the sqrt cov produces the same result as regularizing
@@ -53,9 +59,9 @@ def test_regularization_matches_zero_eig():
     """
     # choose matrix with ~zero eigenvalue
     a = np.arange(9).reshape(3, 3)
-    cov = a@a.T
+    cov = a @ a.T
     a_reg = regularize_l2(a, 3)
-    np.testing.assert_allclose(regularize_covmat(cov, 3), a_reg@a_reg.T)
+    np.testing.assert_allclose(regularize_covmat(cov, 3), a_reg @ a_reg.T)
 
 
 @make_table_comp(parse_exp_mat)

--- a/validphys2/src/validphys/tests/test_covmatreg.py
+++ b/validphys2/src/validphys/tests/test_covmatreg.py
@@ -33,7 +33,7 @@ def test_regularize_expcov(data_config):
 
 @make_table_comp(parse_exp_mat)
 def test_regularized_covmat_generation(data_config):
-    covmat = API.dataset_inputs_covariance_matrix(**data_config, norm_threshold=3)
+    covmat = API.groups_covmat(**data_config, norm_threshold=3)
     index = API.groups_index(**data_config)
     return pd.DataFrame(covmat, index=index, columns=index)
 

--- a/validphys2/src/validphys/tests/test_covmats.py
+++ b/validphys2/src/validphys/tests/test_covmats.py
@@ -3,16 +3,14 @@ test_covmats.py
 
 Tests related to the computation of the covariance matrix and its derivatives
 """
-import pytest
 
 import numpy as np
-
+import pytest
 
 from validphys.api import API
 from validphys.commondataparser import load_commondata
-from validphys.covmats import sqrt_covmat, dataset_t0_predictions, reorder_thcovmat_as_expcovmat
-from validphys.tests.conftest import THEORYID, PDF, HESSIAN_PDF, DATA
-
+from validphys.covmats import dataset_t0_predictions, reorder_thcovmat_as_expcovmat, sqrt_covmat
+from validphys.tests.conftest import DATA, HESSIAN_PDF, PDF, THEORYID
 
 # Experiments which have non trivial correlations between their datasets
 CORR_DATA = [
@@ -23,6 +21,7 @@ CORR_DATA = [
     {'dataset': 'CMSZDIFF12', 'cfac': ('QCD', 'NRM'), 'sys': 10},
     {'dataset': 'CMSJETS11', 'frac': 0.5, 'sys': 10},
 ]
+
 
 def reorder_as_input(covmat_df, input_config):
     """Reorder dataframe matrices as they come in the input"""
@@ -43,10 +42,8 @@ def test_self_consistent_covmat_from_systematics(data_internal_cuts_config):
     dataset_inputs = base_config.pop("dataset_inputs")
 
     for dsinp in dataset_inputs:
-        covmat_a = API.covmat_from_systematics(
-            **base_config, dataset_input=dsinp)
-        covmat_b = API.dataset_inputs_covmat_from_systematics(
-            **base_config, dataset_inputs=[dsinp])
+        covmat_a = API.covmat_from_systematics(**base_config, dataset_input=dsinp)
+        covmat_b = API.dataset_inputs_covmat_from_systematics(**base_config, dataset_inputs=[dsinp])
         np.testing.assert_allclose(covmat_a, covmat_b)
 
 
@@ -66,6 +63,7 @@ def test_covmat_from_systematics(data_config, use_cuts, dataset_inputs):
     another_covmat = reorder_as_input(API.groups_covmat(**config), config)
 
     np.testing.assert_allclose(another_covmat, covmat)
+
 
 def test_covmat_with_one_systematic():
     """Test that a dataset with 1 systematic successfully builds covmat.
@@ -106,8 +104,7 @@ def test_sqrt_covmat(data_config):
 
 @pytest.mark.parametrize("t0pdfset", [PDF, HESSIAN_PDF])
 @pytest.mark.parametrize("dataset_inputs", [DATA, CORR_DATA])
-def test_python_t0_covmat_matches_variations(
-    data_internal_cuts_config, t0pdfset, dataset_inputs):
+def test_python_t0_covmat_matches_variations(data_internal_cuts_config, t0pdfset, dataset_inputs):
     """Test which checks the python computation of the t0 covmat relating to a
     collection of datasets
 
@@ -124,15 +121,12 @@ def test_python_t0_covmat_matches_variations(
     # use allclose defaults or it fails
     np.testing.assert_allclose(another_covmat, covmat, rtol=1e-05, atol=1e-08)
     with pytest.raises(AssertionError):
-        np.testing.assert_allclose(
-            covmat, API.dataset_inputs_covmat_from_systematics(**config)
-        )
+        np.testing.assert_allclose(covmat, API.dataset_inputs_covmat_from_systematics(**config))
 
 
 @pytest.mark.parametrize("use_cuts", ["nocuts", "internal"])
 @pytest.mark.parametrize("dataset_input", DATA)
-def test_systematic_matrix(
-    data_config, use_cuts, dataset_input):
+def test_systematic_matrix(data_config, use_cuts, dataset_input):
     """Test which checks the python computation of the t0 covmat relating to a
     collection of datasets is equivalent using different functions
 

--- a/validphys2/src/validphys/tests/test_pythonmakereplica.py
+++ b/validphys2/src/validphys/tests/test_pythonmakereplica.py
@@ -4,6 +4,7 @@ test_pythonmakereplica.py
 Module for testing the python implementation of make replica
 
 """
+
 from copy import deepcopy
 
 import numpy as np
@@ -14,10 +15,9 @@ from validphys.api import API
 from validphys.tests.conftest import DATA
 from validphys.tests.test_covmats import CORR_DATA
 
-
 SEED = 123456
 
-#Datasets to be tested 
+# Datasets to be tested
 SINGLE_SYS_DATASETS = [
     {"dataset": "DYE886R"},
     {"dataset": "D0ZRAP", "cfac": ["QCD"]},
@@ -27,7 +27,7 @@ SINGLE_SYS_DATASETS = [
     {"dataset": "ATLASWZRAP36PB"},
     {"dataset": "ATLASZHIGHMASS49FB"},
     {"dataset": "CMSWEASY840PB"},
-    {"dataset": "CMSWMASY47FB"}
+    {"dataset": "CMSWMASY47FB"},
 ]
 
 

--- a/validphys2/src/validphys/tests/test_pythonmakereplica.py
+++ b/validphys2/src/validphys/tests/test_pythonmakereplica.py
@@ -102,7 +102,13 @@ def test_genrep_off(data_config, dataset_inputs, use_cuts):
     config["use_cuts"] = use_cuts
     config["replica_mcseed"] = SEED
     config["genrep"] = False
-    ld_cds = API.dataset_inputs_loaded_cd_with_cuts(**config)
+
+    # `make_replica` reorders the data according to the groups in the exp covmat
     not_replica = API.make_replica(**config)
+
+    # And so it needs to be tested against the central values loaded by group
+    ld_cds = API.groups_dataset_inputs_loaded_cd_with_cuts(**config)
+
+    central_data = []
     central_data = np.concatenate([d.central_values for d in ld_cds])
     np.testing.assert_allclose(not_replica, central_data)

--- a/validphys2/src/validphys/tests/test_pythonmakereplica.py
+++ b/validphys2/src/validphys/tests/test_pythonmakereplica.py
@@ -109,6 +109,5 @@ def test_genrep_off(data_config, dataset_inputs, use_cuts):
     # And so it needs to be tested against the central values loaded by group
     ld_cds = API.groups_dataset_inputs_loaded_cd_with_cuts(**config)
 
-    central_data = []
     central_data = np.concatenate([d.central_values for d in ld_cds])
     np.testing.assert_allclose(not_replica, central_data)


### PR DESCRIPTION
Closes #2052 

I've put now the CMS dataset between the two datasets in `DATA` in `conftest.py`. This makes some test fail, some of them it is clear that the bug was in the test itself (e.g., in `test_regularized_covmat_generation` the covmat was collected over dataset inputs and the index over groups), while for some other (like the `make_replica` one) it is more subtle (I think the bug was also the test).

Some of the tests are quite redundant, in the sense that they made sense when there were two sides of the code (C++ and python) but now everything goes through the same functions. Better than nothing I guess.

Anyway, I've separated the fixes to the tests and pre-commit in case we need to trace them back.