### PR TITLE
fix table chi2 grouped by

### DIFF
--- a/validphys2/src/validphys/results.py
+++ b/validphys2/src/validphys/results.py
@@ -799,8 +799,13 @@ def groups_chi2_table(groups_data, pdf, groups_chi2, groups_each_dataset_chi2):
     for group, groupres, dsresults in zip(groups_data, groups_chi2, groups_each_dataset_chi2):
         for dataset, dsres in zip(group, dsresults):
             stats = chi2_stats(dsres)
-            stats["group"] = dataset.name
+            stats["dataset"] = dataset.name
+            stats["group"] = str(group)
             records.append(stats)
+        stats = chi2_stats(groupres)
+        stats["group"] = str(group)
+        stats["dataset"] = ""
+        records.append(stats)
     return pd.DataFrame(records)
 
 

--- a/validphys2/src/validphys/results.py
+++ b/validphys2/src/validphys/results.py
@@ -804,7 +804,7 @@ def groups_chi2_table(groups_data, pdf, groups_chi2, groups_each_dataset_chi2):
             records.append(stats)
         stats = chi2_stats(groupres)
         stats["group"] = str(group)
-        stats["dataset"] = ""
+        stats["dataset"] = "Group Total"
         records.append(stats)
     return pd.DataFrame(records)
 


### PR DESCRIPTION
When using the function `groups_chi2_table`, the group information is being dropped. The list of chi2 is indeed grouped by the group you are interested in but the `dataset` is saved as the `group` key and the total-per-group is not being used.

This is a fix to #1532 (which uses this function and which was the original bug)

Before:

```
        central_mean    npoints chi2_per_data   perreplica_mean perreplica_std  group
0       105.6      121     0.87      109.29      3.14      NMC_NC_NOTFIXED_DW_EM-F2
1       320.0      204     1.56      323.24      12.31     NMC_NC_NOTFIXED_P_EM-SIGMARED
2       30.12      33      0.91      31.253      4.01      SLAC_NC_NOTFIXED_P_DW_EM-F2
3       20.74      34      0.61      22.02       2.583     SLAC_NC_NOTFIXED_D_DW_EM-F2
4       465.1      333     1.39      474.0       19.4      BCDMS_NC_NOTFIXED_P_DW_EM-F2
```


Now:
```
        central_mean    npoints chi2_per_data   perreplica_mean perreplica_std  dataset group
0       105.679      121     0.87      109.26      3.14     NMC_NC_NOTFIXED_DW_EM-F2        DIS NC
1       320.00       204     1.56      323.24      12.3     NMC_NC_NOTFIXED_P_EM-SIGMARED   DIS NC
2       30.122       33      0.91      31.25      4.012    SLAC_NC_NOTFIXED_P_DW_EM-F2     DIS NC
3       20.740       34      0.61      22.04       2.58     SLAC_NC_NOTFIXED_D_DW_EM-F2     DIS NC
4       465.127      333     1.39      474.08       19.      BCDMS_NC_NOTFIXED_P_DW_EM-F2    DIS NC
5       945.59       725     1.30      963.74       23.                                      DIS NC

```