### PR TITLE
check also for closure test data in read_replica_pseudodata

### DIFF
--- a/validphys2/src/validphys/pseudodata.py
+++ b/validphys2/src/validphys/pseudodata.py
@@ -18,8 +18,6 @@ from validphys.covmats import (
     sqrt_covmat,
 )
 
-FILE_PREFIX = "datacuts_theory_fitting_"
-
 log = logging.getLogger(__name__)
 
 DataTrValSpec = namedtuple('DataTrValSpec', ['pseudodata', 'tr_idx', 'val_idx'])

--- a/validphys2/src/validphys/pseudodata.py
+++ b/validphys2/src/validphys/pseudodata.py
@@ -80,25 +80,40 @@ def read_replica_pseudodata(fit, context_index, replica):
     log.debug(f"Reading pseudodata & training/validation splits from {fit.name}.")
     replica_path = fit.path / "nnfit" / f"replica_{replica}"
 
-    training_path = replica_path / (FILE_PREFIX + "training_pseudodata.csv")
-    validation_path = replica_path / (FILE_PREFIX + "validation_pseudodata.csv")
-
     try:
+        # The paths where sampled experimental data is stored
+        training_path = replica_path / "datacuts_theory_fitting_training_pseudodata.csv"
+        validation_path = replica_path / "datacuts_theory_fitting_validation_pseudodata.csv"
         tr = pd.read_csv(training_path, index_col=[0, 1, 2], sep="\t", header=0)
         val = pd.read_csv(validation_path, index_col=[0, 1, 2], sep="\t", header=0)
     except FileNotFoundError:
-        # Old 3.1 style fits had pseudodata called training.dat and validation.dat
-        training_path = replica_path / "training.dat"
-        validation_path = replica_path / "validation.dat"
-        tr = pd.read_csv(training_path, index_col=[0, 1, 2], sep="\t", names=[f"replica {replica}"])
-        val = pd.read_csv(
-            validation_path, index_col=[0, 1, 2], sep="\t", names=[f"replica {replica}"]
-        )
-    except FileNotFoundError as e:
-        raise FileNotFoundError(
-            "Could not find saved training and validation data files. "
-            f"Please ensure {fit} was generated with the savepseudodata flag set to true"
-        ) from e
+        try:
+            # Pseudodata generated in a closure test
+            training_path = (
+                replica_path / "datacuts_theory_closuretest_fitting_training_pseudodata.csv"
+            )
+            validation_path = (
+                replica_path / "datacuts_theory_closuretest_fitting_validation_pseudodata.csv"
+            )
+            tr = pd.read_csv(training_path, index_col=[0, 1, 2], sep="\t", header=0)
+            val = pd.read_csv(validation_path, index_col=[0, 1, 2], sep="\t", header=0)
+        except FileNotFoundError:
+            try:
+                # Old 3.1 style fits had pseudodata called training.dat and validation.dat
+                training_path = replica_path / "training.dat"
+                validation_path = replica_path / "validation.dat"
+                tr = pd.read_csv(
+                    training_path, index_col=[0, 1, 2], sep="\t", names=[f"replica {replica}"]
+                )
+                val = pd.read_csv(
+                    validation_path, index_col=[0, 1, 2], sep="\t", names=[f"replica {replica}"]
+                )
+            except FileNotFoundError as e:
+                raise FileNotFoundError(
+                    "Could not find saved training and validation data files. "
+                    f"Please ensure {fit} was generated with the savepseudodata flag set to true"
+                ) from e
+
     tr["type"], val["type"] = "training", "validation"
 
     pseudodata = pd.concat((tr, val))

--- a/validphys2/src/validphys/pseudodata.py
+++ b/validphys2/src/validphys/pseudodata.py
@@ -83,14 +83,14 @@ def read_replica_pseudodata(fit, context_index, replica):
     # If it's a closure test fit the pseudodata is fakedata stored under a different filename
     fakedata = fit.as_input().get("closuretest", {}).get("fakedata", False)
     if fakedata:
-        tr_path = replica_path / "datacuts_theory_closuretest_fitting_training_pseudodata.csv"
-        vl_path = replica_path / "datacuts_theory_closuretest_fitting_validation_pseudodata.csv"
+        tr_pseudodatafile = "datacuts_theory_closuretest_fitting_training_pseudodata.csv"
+        vl_pseudodatafile = "datacuts_theory_closuretest_fitting_validation_pseudodata.csv"
     else:
-        tr_path = replica_path / "datacuts_theory_fitting_training_pseudodata.csv"
-        vl_path = replica_path / "datacuts_theory_fitting_validation_pseudodata.csv"
+        tr_pseudodatafile = "datacuts_theory_fitting_training_pseudodata.csv"
+        vl_pseudodatafile = "datacuts_theory_fitting_validation_pseudodata.csv"
 
-    tr = pd.read_csv(tr_path, index_col=[0, 1, 2], sep="\t", header=0)
-    val = pd.read_csv(vl_path, index_col=[0, 1, 2], sep="\t", header=0)
+    tr = pd.read_csv(replica_path / tr_pseudodatafile, index_col=[0, 1, 2], sep="\t", header=0)
+    val = pd.read_csv(replica_path / vl_pseudodatafile, index_col=[0, 1, 2], sep="\t", header=0)
 
     tr["type"], val["type"] = "training", "validation"
 

--- a/validphys2/src/validphys/pseudodata.py
+++ b/validphys2/src/validphys/pseudodata.py
@@ -80,39 +80,17 @@ def read_replica_pseudodata(fit, context_index, replica):
     log.debug(f"Reading pseudodata & training/validation splits from {fit.name}.")
     replica_path = fit.path / "nnfit" / f"replica_{replica}"
 
-    try:
-        # The paths where sampled experimental data is stored
-        training_path = replica_path / "datacuts_theory_fitting_training_pseudodata.csv"
-        validation_path = replica_path / "datacuts_theory_fitting_validation_pseudodata.csv"
-        tr = pd.read_csv(training_path, index_col=[0, 1, 2], sep="\t", header=0)
-        val = pd.read_csv(validation_path, index_col=[0, 1, 2], sep="\t", header=0)
-    except FileNotFoundError:
-        try:
-            # Pseudodata generated in a closure test
-            training_path = (
-                replica_path / "datacuts_theory_closuretest_fitting_training_pseudodata.csv"
-            )
-            validation_path = (
-                replica_path / "datacuts_theory_closuretest_fitting_validation_pseudodata.csv"
-            )
-            tr = pd.read_csv(training_path, index_col=[0, 1, 2], sep="\t", header=0)
-            val = pd.read_csv(validation_path, index_col=[0, 1, 2], sep="\t", header=0)
-        except FileNotFoundError:
-            try:
-                # Old 3.1 style fits had pseudodata called training.dat and validation.dat
-                training_path = replica_path / "training.dat"
-                validation_path = replica_path / "validation.dat"
-                tr = pd.read_csv(
-                    training_path, index_col=[0, 1, 2], sep="\t", names=[f"replica {replica}"]
-                )
-                val = pd.read_csv(
-                    validation_path, index_col=[0, 1, 2], sep="\t", names=[f"replica {replica}"]
-                )
-            except FileNotFoundError as e:
-                raise FileNotFoundError(
-                    "Could not find saved training and validation data files. "
-                    f"Please ensure {fit} was generated with the savepseudodata flag set to true"
-                ) from e
+    # If it's a closure test fit the pseudodata is fakedata stored under a different filename
+    fakedata = fit.as_input().get("closuretest", {}).get("fakedata", False)
+    if fakedata:
+        tr_path = replica_path / "datacuts_theory_closuretest_fitting_training_pseudodata.csv"
+        vl_path = replica_path / "datacuts_theory_closuretest_fitting_validation_pseudodata.csv"
+    else:
+        tr_path = replica_path / "datacuts_theory_fitting_training_pseudodata.csv"
+        vl_path = replica_path / "datacuts_theory_fitting_validation_pseudodata.csv"
+
+    tr = pd.read_csv(tr_path, index_col=[0, 1, 2], sep="\t", header=0)
+    val = pd.read_csv(vl_path, index_col=[0, 1, 2], sep="\t", header=0)
 
     tr["type"], val["type"] = "training", "validation"
 

--- a/validphys2/src/validphys/pseudodata.py
+++ b/validphys2/src/validphys/pseudodata.py
@@ -87,8 +87,14 @@ def read_replica_pseudodata(fit, context_index, replica):
         tr_pseudodatafile = "datacuts_theory_fitting_training_pseudodata.csv"
         vl_pseudodatafile = "datacuts_theory_fitting_validation_pseudodata.csv"
 
-    tr = pd.read_csv(replica_path / tr_pseudodatafile, index_col=[0, 1, 2], sep="\t", header=0)
-    val = pd.read_csv(replica_path / vl_pseudodatafile, index_col=[0, 1, 2], sep="\t", header=0)
+    try:
+        tr = pd.read_csv(replica_path / tr_pseudodatafile, index_col=[0, 1, 2], sep="\t", header=0)
+        val = pd.read_csv(replica_path / vl_pseudodatafile, index_col=[0, 1, 2], sep="\t", header=0)
+    except FileNotFoundError as e:
+        raise FileNotFoundError(
+            "Could not find saved training and validation data files. "
+            f"Please ensure {fit} was generated with the savepseudodata flag set to true"
+        ) from e
 
     tr["type"], val["type"] = "training", "validation"
 


### PR DESCRIPTION
This adds functionality to the `read_replica_pseudodata` function to ensure it also checks for the existence of closure test pseuodata. 

Also, in the previous implementation the except statements were chained in a way that made the code act different from expected. Namely, both `except` statements correspond to the error raised under `try` (and not the second `except` corresponding to a potential error in the first `except`), as such the custom error was never raised. 

(yes I think the nesting is a bit ugly, but I'm not aware of a better way with try-except)