### PR TITLE
add resample_pseudodata flag

### DIFF
--- a/n3fit/runcards/examples/Basic_runcard.yml
+++ b/n3fit/runcards/examples/Basic_runcard.yml
@@ -23,6 +23,8 @@ datacuts:
 theory:
   theoryid: 708       # database id
 
+resample_negative_pseudodata: True
+
 sampling:
   separate_multiplicative: true
 parameters: # This defines the parameter dictionary that is passed to the Model Trainer

--- a/validphys2/src/validphys/pseudodata.py
+++ b/validphys2/src/validphys/pseudodata.py
@@ -129,6 +129,7 @@ def make_replica(
     sep_mult,
     genrep=True,
     max_tries=int(1e6),
+    resample_pseudodata=True,
 ):
     """Function that takes in a list of :py:class:`validphys.coredata.CommonData`
     objects and returns a pseudodata replica accounting for
@@ -162,6 +163,10 @@ def make_replica(
         The stochastic nature of replica generation means one can obtain (unphysical) negative predictions.
         If after max_tries (default=1e6) no physical configuration is found,
         it will raise a :py:class:`ReplicaGenerationError`
+
+
+    resample_pseudodata: bool
+        Set to False to allow for negative predictions and avoid resampling
 
     Returns
     -------
@@ -263,7 +268,10 @@ def make_replica(
         # Shifting pseudodata
         shifted_pseudodata = (all_pseudodata + shifts) * mult_part
         # positivity control
-        if np.all(shifted_pseudodata[full_mask] >= 0):
+        if resample_pseudodata:
+            if np.all(shifted_pseudodata[full_mask] >= 0):
+                return shifted_pseudodata
+        else:
             return shifted_pseudodata
 
     dfail = " ".join(i.setname for i in groups_dataset_inputs_loaded_cd_with_cuts)

--- a/validphys2/src/validphys/pseudodata.py
+++ b/validphys2/src/validphys/pseudodata.py
@@ -129,7 +129,7 @@ def make_replica(
     sep_mult,
     genrep=True,
     max_tries=int(1e6),
-    resample_pseudodata=True,
+    resample_negative_pseudodata=True,
 ):
     """Function that takes in a list of :py:class:`validphys.coredata.CommonData`
     objects and returns a pseudodata replica accounting for
@@ -164,10 +164,8 @@ def make_replica(
         If after max_tries (default=1e6) no physical configuration is found,
         it will raise a :py:class:`ReplicaGenerationError`
 
-
-    resample_pseudodata: bool
-        Set to False to allow for negative predictions and avoid resampling
-
+    resample_negative_pseudodata: bool
+        When True, replicas that produce negative predictions will be resampled for ``max_tries`` until all points are positive (default: True)
     Returns
     -------
     pseudodata: np.array
@@ -268,10 +266,7 @@ def make_replica(
         # Shifting pseudodata
         shifted_pseudodata = (all_pseudodata + shifts) * mult_part
         # positivity control
-        if resample_pseudodata:
-            if np.all(shifted_pseudodata[full_mask] >= 0):
-                return shifted_pseudodata
-        else:
+        if np.all(shifted_pseudodata[full_mask] >= 0) or not resample_negative_pseudodata:
             return shifted_pseudodata
 
     dfail = " ".join(i.setname for i in groups_dataset_inputs_loaded_cd_with_cuts)


### PR DESCRIPTION
For parameter fits it is important not to distort the pseudodata sampling distribution. This PR adds a flag `resample_negative_pseudodata` that can be set to False to also accept negative pseudodata values instead of resampling. 