### PR TITLE
Small fixes for TF

### DIFF
--- a/n3fit/src/n3fit/backends/keras_backend/MetaLayer.py
+++ b/n3fit/src/n3fit/backends/keras_backend/MetaLayer.py
@@ -8,8 +8,8 @@
     For instance: np_to_tensor is just a call to K.constant
 """
 
-from tensorflow.keras.layers import Layer
-from tensorflow.keras.initializers import Constant, RandomUniform, glorot_normal, glorot_uniform
+from keras.initializers import Constant, RandomUniform, glorot_normal, glorot_uniform
+from keras.layers import Layer
 
 # Define in this dictionary new initializers as well as the arguments they accept (with default values if needed be)
 initializers = {
@@ -25,7 +25,7 @@ class MetaLayer(Layer):
 
     In order to write a custom Keras layer you usually need to override:
         - __init__
-        - meta_call
+        - call
     """
 
     initializers = initializers

--- a/n3fit/src/n3fit/backends/keras_backend/MetaLayer.py
+++ b/n3fit/src/n3fit/backends/keras_backend/MetaLayer.py
@@ -8,8 +8,8 @@
     For instance: np_to_tensor is just a call to K.constant
 """
 
-from keras.initializers import Constant, RandomUniform, glorot_normal, glorot_uniform
-from keras.layers import Layer
+from tensorflow.keras.initializers import Constant, RandomUniform, glorot_normal, glorot_uniform
+from tensorflow.keras.layers import Layer
 
 # Define in this dictionary new initializers as well as the arguments they accept (with default values if needed be)
 initializers = {

--- a/n3fit/src/n3fit/backends/keras_backend/MetaModel.py
+++ b/n3fit/src/n3fit/backends/keras_backend/MetaModel.py
@@ -8,10 +8,10 @@
 from pathlib import Path
 import re
 
-from keras import optimizers as Kopt
-from keras.models import Model
 import numpy as np
 import tensorflow as tf
+from tensorflow.keras import optimizers as Kopt
+from tensorflow.keras.models import Model
 from tensorflow.python.keras.utils import tf_utils  # pylint: disable=no-name-in-module
 
 import n3fit.backends.keras_backend.operations as op

--- a/n3fit/src/n3fit/backends/keras_backend/base_layers.py
+++ b/n3fit/src/n3fit/backends/keras_backend/base_layers.py
@@ -135,7 +135,6 @@ layers = {
     "dense": (
         MultiDense,
         {
-            "input_shape": (1,),
             "replica_seeds": None,
             "base_seed": 0,
             "kernel_initializer": "glorot_normal",
@@ -148,7 +147,6 @@ layers = {
     "single_dense": (
         Dense,
         {
-            "input_shape": (1,),
             "kernel_initializer": "glorot_normal",
             "units": 5,
             "activation": "sigmoid",
@@ -158,7 +156,6 @@ layers = {
     "dense_per_flavour": (
         dense_per_flavour,
         {
-            "input_shape": (1,),
             "kernel_initializer": "glorot_normal",
             "units": 5,
             "activation": "sigmoid",

--- a/n3fit/src/n3fit/backends/keras_backend/base_layers.py
+++ b/n3fit/src/n3fit/backends/keras_backend/base_layers.py
@@ -191,7 +191,7 @@ def base_layer_selector(layer_name, **kwargs):
         layer_tuple = layers[layer_name]
     except KeyError as e:
         raise NotImplementedError(
-            "Layer not implemented in keras_backend/base_layers.py: {0}".format(layer_name)
+            f"Layer not implemented in keras_backend/base_layers.py: {layer_name}"
         ) from e
 
     layer_class = layer_tuple[0]
@@ -231,7 +231,7 @@ def regularizer_selector(reg_name, **kwargs):
         reg_tuple = regularizers[reg_name]
     except KeyError:
         raise NotImplementedError(
-            "Regularizer not implemented in keras_backend/base_layers.py: {0}".format(reg_name)
+            f"Regularizer not implemented in keras_backend/base_layers.py: {reg_name}"
         )
 
     reg_class = reg_tuple[0]

--- a/n3fit/src/n3fit/backends/keras_backend/multi_dense.py
+++ b/n3fit/src/n3fit/backends/keras_backend/multi_dense.py
@@ -4,11 +4,11 @@
     Dense layer from Keras even in the single replica case.
 """  # Tested last: Feb 2024
 
-from typing import List
+pass
 
-from keras.initializers import Initializer
-from keras.layers import Dense
 import tensorflow as tf
+from tensorflow.keras.initializers import Initializer
+from tensorflow.keras.layers import Dense
 
 # Note for developers:
 # This class plays with fire as it exploits the internals of Keras
@@ -51,7 +51,7 @@ class MultiDense(Dense):
 
     def __init__(
         self,
-        replica_seeds: List[int],
+        replica_seeds: list[int],
         kernel_initializer: Initializer,
         is_first_layer: bool = False,
         base_seed: int = 0,
@@ -176,7 +176,7 @@ class MultiInitializer(Initializer):
             Base seed for the single replica initializer to which the replica seeds are added.
     """
 
-    def __init__(self, single_initializer: Initializer, replica_seeds: List[int], base_seed: int):
+    def __init__(self, single_initializer: Initializer, replica_seeds: list[int], base_seed: int):
         self.initializer_class = type(single_initializer)
         self.initializer_config = single_initializer.get_config()
         self.base_seed = base_seed

--- a/n3fit/src/n3fit/backends/keras_backend/multi_dense.py
+++ b/n3fit/src/n3fit/backends/keras_backend/multi_dense.py
@@ -4,8 +4,6 @@
     Dense layer from Keras even in the single replica case.
 """  # Tested last: Feb 2024
 
-pass
-
 import tensorflow as tf
 from tensorflow.keras.initializers import Initializer
 from tensorflow.keras.layers import Dense

--- a/n3fit/src/n3fit/backends/keras_backend/operations.py
+++ b/n3fit/src/n3fit/backends/keras_backend/operations.py
@@ -25,10 +25,10 @@
 
 from typing import Optional
 
-import keras
 import numpy as np
 import numpy.typing as npt
 import tensorflow as tf
+from tensorflow import keras
 from tensorflow.keras import backend as K
 from tensorflow.keras.layers import Input
 from tensorflow.keras.layers import Lambda as keras_Lambda

--- a/n3fit/src/n3fit/backends/keras_backend/operations.py
+++ b/n3fit/src/n3fit/backends/keras_backend/operations.py
@@ -228,14 +228,21 @@ def reshape(x, shape):
     return tf.reshape(x, shape)
 
 
-def boolean_mask(*args, **kwargs):
+@tf.function
+def boolean_mask(*args, target_shape=None, **kwargs):
     """
     Applies a boolean mask to a tensor
 
     Relevant parameters: (tensor, mask, axis=None)
     see full `docs <https://www.tensorflow.org/api_docs/python/tf/boolean_mask>`_.
+
+    tensorflow's masking concatenates the masked dimensions, it is possible to
+    provide a `target_shape` to reshape the output to the desired shape
     """
-    return tf.boolean_mask(*args, **kwargs)
+    ret = tf.boolean_mask(*args, **kwargs)
+    if target_shape is not None:
+        ret = reshape(ret, target_shape)
+    return ret
 
 
 @tf.function

--- a/n3fit/src/n3fit/hyper_optimization/rewards.py
+++ b/n3fit/src/n3fit/hyper_optimization/rewards.py
@@ -32,7 +32,7 @@
 """
 
 import logging
-from typing import Callable, Dict, List
+from typing import Callable
 
 import numpy as np
 
@@ -194,10 +194,10 @@ class HyperLoss:
 
     def compute_loss(
         self,
-        penalties: Dict[str, np.ndarray],
+        penalties: dict[str, np.ndarray],
         experimental_loss: np.ndarray,
         pdf_model: MetaModel,
-        experimental_data: List[DataGroupSpec],
+        experimental_data: list[DataGroupSpec],
         fold_idx: int = 0,
     ) -> float:
         """
@@ -271,7 +271,7 @@ class HyperLoss:
         self,
         phi_per_fold: float,
         chi2_per_fold: np.ndarray,
-        penalties: Dict[str, np.ndarray],
+        penalties: dict[str, np.ndarray],
         fold_idx: int = 0,
     ) -> None:
         """

--- a/n3fit/src/n3fit/hyper_optimization/rewards.py
+++ b/n3fit/src/n3fit/hyper_optimization/rewards.py
@@ -403,7 +403,7 @@ def _set_central_value(n3pdf, model):
 
     # Get the input x
     for key, grid in model.x_in.items():
-        if key != "integration_grid":
+        if key != "xgrid_integration":
             input_x = grid.numpy()
             break
 

--- a/n3fit/src/n3fit/layers/mask.py
+++ b/n3fit/src/n3fit/layers/mask.py
@@ -43,7 +43,7 @@ class Mask(MetaLayer):
             self.masked_output_shape = [-1 if d is None else d for d in input_shape]
             self.masked_output_shape[-1] = self.last_dim
             self.masked_output_shape[-2] = self.mask.shape[-2]
-        super(Mask, self).build(input_shape)
+        super().build(input_shape)
 
     def call(self, ret):
         """

--- a/n3fit/src/n3fit/layers/mask.py
+++ b/n3fit/src/n3fit/layers/mask.py
@@ -58,8 +58,7 @@ class Mask(MetaLayer):
             Tensor of shape (batch_size, n_replicas, n_features)
         """
         if self.mask is not None:
-            flat_res = op.boolean_mask(ret, self.mask, axis=1)
-            ret = op.reshape(flat_res, shape=self.masked_output_shape)
+            ret = op.boolean_mask(ret, self.mask, axis=1, target_shape=self.masked_output_shape)
         if self.c is not None:
             ret = ret * self.kernel
         return ret

--- a/n3fit/src/n3fit/model_gen.py
+++ b/n3fit/src/n3fit/model_gen.py
@@ -547,13 +547,13 @@ def pdfNN_layer_generator(
     # Define the main input
     do_nothing = lambda x: x
     if use_feature_scaling:
-        pdf_input = Input(shape=(None, pdf_input_dimensions), batch_size=1, name='scaledx_x')
+        pdf_input = Input(shape=(None, pdf_input_dimensions), batch_size=1, name="scaledx_x")
         process_input = do_nothing
-        extract_nn_input = Lambda(lambda x: op.op_gather_keep_dims(x, 0, axis=-1), name='x_scaled')
-        extract_original = Lambda(lambda x: op.op_gather_keep_dims(x, 1, axis=-1), name='x')
+        extract_nn_input = Lambda(lambda x: op.op_gather_keep_dims(x, 0, axis=-1), name="x_scaled")
+        extract_original = Lambda(lambda x: op.op_gather_keep_dims(x, 1, axis=-1), name="pdf_input")
     else:  # add log(x)
-        pdf_input = Input(shape=(None, pdf_input_dimensions), batch_size=1, name='x')
-        process_input = Lambda(lambda x: op.concatenate([x, op.op_log(x)], axis=-1), name='x_logx')
+        pdf_input = Input(shape=(None, pdf_input_dimensions), batch_size=1, name="pdf_input")
+        process_input = Lambda(lambda x: op.concatenate([x, op.op_log(x)], axis=-1), name="x_logx")
         extract_original = do_nothing
         extract_nn_input = do_nothing
 
@@ -564,12 +564,12 @@ def pdfNN_layer_generator(
         if use_feature_scaling:
             input_x_eq_1 = scaler(input_x_eq_1)[0]
         # the layer that subtracts 1 from the NN output
-        subtract_one_layer = Lambda(op.op_subtract, name='subtract_one')
-        layer_x_eq_1 = op.numpy_to_input(np.array(input_x_eq_1).reshape(1, 1), name='x_eq_1')
+        subtract_one_layer = Lambda(op.op_subtract, name="subtract_one")
+        layer_x_eq_1 = op.numpy_to_input(np.array(input_x_eq_1).reshape(1, 1), name="x_eq_1")
         model_input["layer_x_eq_1"] = layer_x_eq_1
 
     # the layer that multiplies the NN output by the preprocessing factor
-    apply_preprocessing_factor = Lambda(op.op_multiply, name='prefactor_times_NN')
+    apply_preprocessing_factor = Lambda(op.op_multiply, name="prefactor_times_NN")
 
     # Photon layer
     layer_photon = AddPhoton(photons=photons, name="add_photon")
@@ -587,7 +587,7 @@ def pdfNN_layer_generator(
         sumrule_layer, integrator_input = generate_msr_model_and_grid(
             fitbasis=fitbasis, mode=impose_sumrule, scaler=scaler, replica_seeds=seed
         )
-        model_input["integrator_input"] = integrator_input
+        model_input["xgrid_integration"] = integrator_input
     else:
         sumrule_layer = lambda x: x
 
@@ -727,7 +727,7 @@ def generate_nn(
             Single model containing all replicas.
     """
     nodes_list = list(nodes)  # so we can modify it
-    x_input = Input(shape=(None, nodes_in), batch_size=1, name='xgrids_processed')
+    x_input = Input(shape=(None, nodes_in), batch_size=1, name="NN_input")
     reg = regularizer_selector(regularizer, **regularizer_args)
 
     if layer_type == "dense_per_flavour":

--- a/n3fit/src/n3fit/model_gen.py
+++ b/n3fit/src/n3fit/model_gen.py
@@ -11,7 +11,7 @@
 """
 
 from dataclasses import dataclass
-from typing import Callable, List
+from typing import Callable
 
 import numpy as np
 
@@ -320,8 +320,8 @@ def observable_generator(
 
 
 def generate_pdf_model(
-    nodes: List[int] = None,
-    activations: List[str] = None,
+    nodes: list[int] = None,
+    activations: list[str] = None,
     initializer_name: str = "glorot_normal",
     layer_type: str = "dense",
     flav_info: dict = None,
@@ -383,8 +383,8 @@ def generate_pdf_model(
 
 
 def pdfNN_layer_generator(
-    nodes: List[int] = None,
-    activations: List[str] = None,
+    nodes: list[int] = None,
+    activations: list[str] = None,
     initializer_name: str = "glorot_normal",
     layer_type: str = "dense",
     flav_info: dict = None,
@@ -684,10 +684,10 @@ def pdfNN_layer_generator(
 def generate_nn(
     layer_type: str,
     nodes_in: int,
-    nodes: List[int],
-    activations: List[str],
+    nodes: list[int],
+    activations: list[str],
     initializer_name: str,
-    replica_seeds: List[int],
+    replica_seeds: list[int],
     dropout: float,
     regularizer: str,
     regularizer_args: dict,

--- a/n3fit/src/n3fit/model_gen.py
+++ b/n3fit/src/n3fit/model_gen.py
@@ -580,7 +580,7 @@ def pdfNN_layer_generator(
     )
 
     # Evolution layer
-    layer_evln = FkRotation(input_shape=(last_layer_nodes,), output_dim=out, name="pdf_FK_basis")
+    layer_evln = FkRotation(output_dim=out, name="pdf_FK_basis")
 
     # Normalization and sum rules
     if impose_sumrule:
@@ -593,7 +593,6 @@ def pdfNN_layer_generator(
 
     compute_preprocessing_factor = Preprocessing(
         flav_info=flav_info,
-        input_shape=(1,),
         name=PREPROCESSING_LAYER_ALL_REPLICAS,
         replica_seeds=seed,
         large_x=not subtract_one,
@@ -753,7 +752,6 @@ def generate_nn(
                     kernel_initializer=initializers,
                     units=int(nodes_out),
                     activation=activation,
-                    input_shape=(nodes_in,),
                     basis_size=basis_size,
                 )
                 layers.append(layer)
@@ -775,7 +773,6 @@ def generate_nn(
                 ),
                 units=nodes_out,
                 activation=activation,
-                input_shape=(nodes_in,),
                 regularizer=reg,
             )
 

--- a/n3fit/src/n3fit/model_trainer.py
+++ b/n3fit/src/n3fit/model_trainer.py
@@ -352,7 +352,7 @@ class ModelTrainer:
         if self._scaler:
             # Apply feature scaling if given
             input_arr = self._scaler(input_arr)
-        input_layer = op.numpy_to_input(input_arr)
+        input_layer = op.numpy_to_input(input_arr, name="pdf_input")
 
         # The PDF model will be called with a concatenation of all inputs
         # now the output needs to be splitted so that each experiment takes its corresponding input

--- a/n3fit/src/n3fit/msr.py
+++ b/n3fit/src/n3fit/msr.py
@@ -88,7 +88,7 @@ def generate_msr_model_and_grid(
     )([x_divided, pdf_xgrid_integration])
 
     # 4. Integrate the pdf
-    pdf_integrated = xIntegrator(weights_array, input_shape=(nx,))(pdf_integrand)
+    pdf_integrated = xIntegrator(weights_array)(pdf_integrand)
 
     # 5. THe input for the photon integral, will be set to 0 if no photons
     photon_integral = Input(shape=(replicas, 1), batch_size=1, name='photon_integral')

--- a/n3fit/src/n3fit/msr.py
+++ b/n3fit/src/n3fit/msr.py
@@ -68,7 +68,7 @@ def generate_msr_model_and_grid(
         xgrid_integration = scaler(xgrid_integration)
 
     # Turn into input layer.
-    xgrid_integration = op.numpy_to_input(xgrid_integration, name="integration_grid")
+    xgrid_integration = op.numpy_to_input(xgrid_integration, name="xgrid_integration")
 
     # 1c Get the original grid
     if scaler:

--- a/n3fit/src/n3fit/tests/test_multireplica.py
+++ b/n3fit/src/n3fit/tests/test_multireplica.py
@@ -23,10 +23,10 @@ def test_replica_split():
     eps = 1e-9
     pdf_input = np.maximum(rng.random((1, 5, 1)), eps)
     int_input = np.maximum(rng.random((1, 2_000, 1)), eps)
-    
+
     fake_input = {
         'pdf_input': np.sort(pdf_input, axis=1),
-        'integrator_input': np.sort(int_input, axis=1),
+        'xgrid_integration': np.sort(int_input, axis=1),
     }
 
     output_full = pdf_model(fake_input)

--- a/n3fit/src/n3fit/tests/test_preprocessing.py
+++ b/n3fit/src/n3fit/tests/test_preprocessing.py
@@ -86,7 +86,7 @@ def test_constraint():
     x = Input(shape=test_x.shape[1:])
     prefactors = prepro(x)
     scalar = Lambda(lambda x: op.sum(x, axis=(1, 2, 3)))(prefactors)
-    model = MetaModel(input_tensors={'x': x}, output_tensors=scalar)
+    model = MetaModel(input_tensors={'pdf_input': x}, output_tensors=scalar)
     model.compile(loss='mse', learning_rate=1e-15)
 
     # Simulate training where weights of replica 1 are updated to violate the constraint

--- a/validphys2/src/validphys/calcutils.py
+++ b/validphys2/src/validphys/calcutils.py
@@ -4,6 +4,7 @@ calcutils.py
 Low level utilities to calculate χ² and such. These are used to implement the
 higher level functions in results.py
 """
+
 import logging
 from typing import Callable
 
@@ -15,7 +16,7 @@ log = logging.getLogger(__name__)
 
 
 def calc_chi2(sqrtcov, diffs):
-    """Elementary function to compute the chi², given a Cholesky decomposed
+    r"""Elementary function to compute the chi², given a Cholesky decomposed
     lower triangular part and a vector of differences.
 
     Parameters

--- a/validphys2/src/validphys/uploadutils.py
+++ b/validphys2/src/validphys/uploadutils.py
@@ -3,6 +3,7 @@ uploadutils.py
 
 Tools to upload resources to remote servers.
 """
+
 import base64
 import contextlib
 from glob import glob
@@ -431,7 +432,7 @@ def check_input(path):
     files = os.listdir(path)
     # Require that a .info file and replica 0 exist before admitting
     # the input is a valid LHAPDF set
-    info_reg, rep0_reg = map(re.compile, ('.+\.info', '.+0000\.dat'))
+    info_reg, rep0_reg = map(re.compile, (r'.+\.info', r'.+0000\.dat'))
 
     if 'meta.yaml' in files:
         return 'report'

--- a/validphys2/src/validphys/uploadutils.py
+++ b/validphys2/src/validphys/uploadutils.py
@@ -92,7 +92,7 @@ class Uploader:
                 % str_line
             ) from e
         except OSError as e:
-            raise BadSSH("Could not run the command\n%s\n: %s" % (str_line, e)) from e
+            raise BadSSH(f"Could not run the command\n{str_line}\n: {e}") from e
 
         log.info("Connection seems OK.")
 
@@ -300,7 +300,7 @@ class FitUploader(ArchiveUploader):
         """
         md5_path = output_path / "md5"
         try:
-            with open(md5_path, "r") as f:
+            with open(md5_path) as f:
                 saved_md5 = f.read()
         except FileNotFoundError as e:
             log.error(


### PR DESCRIPTION
These are some small fixes to TF. It fixes a few warnings but afaics they were not bugs.

The only one that made a bit of a difference (in that otherwise some tensorflow-cuda combinations fail) is adding the output shape to the boolean mask with a `tf.function` decorator.
Without that, (at least the Arch builds of) tensorflow 2.16.1 with Cuda 12.4 fail since it compiles away the boolean mask but then it calls the cuda kernel with the wrong shape.