### PR TITLE
use filter=data for extracting when the tar file includes links

### DIFF
--- a/validphys2/src/validphys/loader.py
+++ b/validphys2/src/validphys/loader.py
@@ -977,7 +977,14 @@ def download_and_extract(url, local_path, target_name=None):
             # Extract to a temporary directory
             folder_dest = tempfile.TemporaryDirectory(dir=local_path, suffix=name)
             dest_path = pathlib.Path(folder_dest.name)
-            res_tar.extractall(path=dest_path, filter="data")
+            try:
+                res_tar.extractall(path=dest_path, filter="data")
+            except tarfile.LinkOutsideDestinationError as e:
+                if sys.verson_info > (3, 11):
+                    raise e
+                # For older versions of python ``filter=data`` might be too restrictive
+                # for the links inside the ``postfit`` folder if you are using more than one disk
+                res_tar.extractall(path=dest_path, filter="tar")
 
             # Check there are no more than one item in the top level
             top_level_stuff = list(dest_path.glob("*"))


### PR DESCRIPTION
I really couldn't figure why, but this is solving an issue with the extraction of the `postfit` folder (which is a link to the `nnfit` folder). Since both `postfit` and `nnfit` are within the same folder it should be "inside the destination" and, indeed, when extracting with python 3.12, it works fine.

However, with python3.10, if my python installation is in one disk and the share folder is in another one, it seems `tarfile` looks at the path and says "I'm extracting a link from /media/other_disk to /media/other_disk/... but /media is not the same device as /media/otherdisk, it must be outside!"

Yes, my computer looks a bit like this 
![](https://imgs.xkcd.com/comics/porn_folder.png)
