### PR TITLE
Fix metadata of ATLAS Z pt 13 TeV 

### DIFF
--- a/nnpdf_data/nnpdf_data/new_commondata/ATLAS_Z0J_13TEV_PT/metadata.yaml
+++ b/nnpdf_data/nnpdf_data/new_commondata/ATLAS_Z0J_13TEV_PT/metadata.yaml
@@ -26,7 +26,7 @@ implemented_observables:
 
     ndata: 38
 
-    tables: [26]
+    tables: [5]
     process_type: DY_NC_PT
 
     plotting:


### PR DESCRIPTION
use the correct table for uncertainties.

@Radonirinaunimi I think we have two options here, either changing the number of the table in the metadata or hard code  line 83 in  `get_systematics` function to 

`hepdata_table = f"rawdata/HEPData-ins1768911-v{version}-Table_5.yaml"`