### PR TITLE
replace POS_F2 process with more inclusive POS_DIS

### DIFF
--- a/nnpdf_data/nnpdf_data/new_commondata/NNPDF_POS_2P24GEV/kinematics_FLL-19PTS.yaml
+++ b/nnpdf_data/nnpdf_data/new_commondata/NNPDF_POS_2P24GEV/kinematics_FLL-19PTS.yaml
@@ -1,229 +1,153 @@
 bins:
-- k1:
+- x:
     min: null
     mid: 1.940766723678e-06
     max: null
-  k2:
+  Q2:
     min: null
     mid: 5.0
     max: null
-  k3:
-    min: null
-    mid: 0.0
-    max: null
-- k1:
+- x:
     min: null
     mid: 7.533150951473e-06
     max: null
-  k2:
+  Q2:
     min: null
     mid: 5.0
     max: null
-  k3:
-    min: null
-    mid: 0.0
-    max: null
-- k1:
+- x:
     min: null
     mid: 2.924017738213e-05
     max: null
-  k2:
+  Q2:
     min: null
     mid: 5.0
     max: null
-  k3:
-    min: null
-    mid: 0.0
-    max: null
-- k1:
+- x:
     min: null
     mid: 0.0001134967265154
     max: null
-  k2:
+  Q2:
     min: null
     mid: 5.0
     max: null
-  k3:
-    min: null
-    mid: 0.0
-    max: null
-- k1:
+- x:
     min: null
     mid: 0.0004405413401349
     max: null
-  k2:
+  Q2:
     min: null
     mid: 5.0
     max: null
-  k3:
-    min: null
-    mid: 0.0
-    max: null
-- k1:
+- x:
     min: null
     mid: 0.001709975946677
     max: null
-  k2:
+  Q2:
     min: null
     mid: 5.0
     max: null
-  k3:
-    min: null
-    mid: 0.0
-    max: null
-- k1:
+- x:
     min: null
     mid: 0.006637328831201
     max: null
-  k2:
+  Q2:
     min: null
     mid: 5.0
     max: null
-  k3:
-    min: null
-    mid: 0.0
-    max: null
-- k1:
+- x:
     min: null
     mid: 0.02576301385941
     max: null
-  k2:
+  Q2:
     min: null
     mid: 5.0
     max: null
-  k3:
-    min: null
-    mid: 0.0
-    max: null
-- k1:
+- x:
     min: null
     mid: 0.1
     max: null
-  k2:
+  Q2:
     min: null
     mid: 5.0
     max: null
-  k3:
-    min: null
-    mid: 0.0
-    max: null
-- k1:
+- x:
     min: null
     mid: 0.18
     max: null
-  k2:
+  Q2:
     min: null
     mid: 5.0
     max: null
-  k3:
-    min: null
-    mid: 0.0
-    max: null
-- k1:
+- x:
     min: null
     mid: 0.26
     max: null
-  k2:
+  Q2:
     min: null
     mid: 5.0
     max: null
-  k3:
-    min: null
-    mid: 0.0
-    max: null
-- k1:
+- x:
     min: null
     mid: 0.34
     max: null
-  k2:
+  Q2:
     min: null
     mid: 5.0
     max: null
-  k3:
-    min: null
-    mid: 0.0
-    max: null
-- k1:
+- x:
     min: null
     mid: 0.42
     max: null
-  k2:
+  Q2:
     min: null
     mid: 5.0
     max: null
-  k3:
-    min: null
-    mid: 0.0
-    max: null
-- k1:
+- x:
     min: null
     mid: 0.5
     max: null
-  k2:
+  Q2:
     min: null
     mid: 5.0
     max: null
-  k3:
-    min: null
-    mid: 0.0
-    max: null
-- k1:
+- x:
     min: null
     mid: 0.58
     max: null
-  k2:
+  Q2:
     min: null
     mid: 5.0
     max: null
-  k3:
-    min: null
-    mid: 0.0
-    max: null
-- k1:
+- x:
     min: null
     mid: 0.66
     max: null
-  k2:
+  Q2:
     min: null
     mid: 5.0
     max: null
-  k3:
-    min: null
-    mid: 0.0
-    max: null
-- k1:
+- x:
     min: null
     mid: 0.74
     max: null
-  k2:
+  Q2:
     min: null
     mid: 5.0
     max: null
-  k3:
-    min: null
-    mid: 0.0
-    max: null
-- k1:
+- x:
     min: null
     mid: 0.82
     max: null
-  k2:
+  Q2:
     min: null
     mid: 5.0
     max: null
-  k3:
-    min: null
-    mid: 0.0
-    max: null
-- k1:
+- x:
     min: null
     mid: 0.9
     max: null
-  k2:
+  Q2:
     min: null
     mid: 5.0
-    max: null
-  k3:
-    min: null
-    mid: 0.0
     max: null

--- a/nnpdf_data/nnpdf_data/new_commondata/NNPDF_POS_2P24GEV/kinematics_FLL.yaml
+++ b/nnpdf_data/nnpdf_data/new_commondata/NNPDF_POS_2P24GEV/kinematics_FLL.yaml
@@ -1,241 +1,161 @@
 bins:
-- k1:
+- x:
     min: null
     mid: 5.0e-07
     max: null
-  k2:
+  Q2:
     min: null
     mid: 5.0
     max: null
-  k3:
-    min: null
-    mid: 0.0
-    max: null
-- k1:
+- x:
     min: null
     mid: 1.940766723678e-06
     max: null
-  k2:
+  Q2:
     min: null
     mid: 5.0
     max: null
-  k3:
-    min: null
-    mid: 0.0
-    max: null
-- k1:
+- x:
     min: null
     mid: 7.533150951473e-06
     max: null
-  k2:
+  Q2:
     min: null
     mid: 5.0
     max: null
-  k3:
-    min: null
-    mid: 0.0
-    max: null
-- k1:
+- x:
     min: null
     mid: 2.924017738213e-05
     max: null
-  k2:
+  Q2:
     min: null
     mid: 5.0
     max: null
-  k3:
-    min: null
-    mid: 0.0
-    max: null
-- k1:
+- x:
     min: null
     mid: 0.0001134967265154
     max: null
-  k2:
+  Q2:
     min: null
     mid: 5.0
     max: null
-  k3:
-    min: null
-    mid: 0.0
-    max: null
-- k1:
+- x:
     min: null
     mid: 0.0004405413401349
     max: null
-  k2:
+  Q2:
     min: null
     mid: 5.0
     max: null
-  k3:
-    min: null
-    mid: 0.0
-    max: null
-- k1:
+- x:
     min: null
     mid: 0.001709975946677
     max: null
-  k2:
+  Q2:
     min: null
     mid: 5.0
     max: null
-  k3:
-    min: null
-    mid: 0.0
-    max: null
-- k1:
+- x:
     min: null
     mid: 0.006637328831201
     max: null
-  k2:
+  Q2:
     min: null
     mid: 5.0
     max: null
-  k3:
-    min: null
-    mid: 0.0
-    max: null
-- k1:
+- x:
     min: null
     mid: 0.02576301385941
     max: null
-  k2:
+  Q2:
     min: null
     mid: 5.0
     max: null
-  k3:
-    min: null
-    mid: 0.0
-    max: null
-- k1:
+- x:
     min: null
     mid: 0.1
     max: null
-  k2:
+  Q2:
     min: null
     mid: 5.0
     max: null
-  k3:
-    min: null
-    mid: 0.0
-    max: null
-- k1:
+- x:
     min: null
     mid: 0.18
     max: null
-  k2:
+  Q2:
     min: null
     mid: 5.0
     max: null
-  k3:
-    min: null
-    mid: 0.0
-    max: null
-- k1:
+- x:
     min: null
     mid: 0.26
     max: null
-  k2:
+  Q2:
     min: null
     mid: 5.0
     max: null
-  k3:
-    min: null
-    mid: 0.0
-    max: null
-- k1:
+- x:
     min: null
     mid: 0.34
     max: null
-  k2:
+  Q2:
     min: null
     mid: 5.0
     max: null
-  k3:
-    min: null
-    mid: 0.0
-    max: null
-- k1:
+- x:
     min: null
     mid: 0.42
     max: null
-  k2:
+  Q2:
     min: null
     mid: 5.0
     max: null
-  k3:
-    min: null
-    mid: 0.0
-    max: null
-- k1:
+- x:
     min: null
     mid: 0.5
     max: null
-  k2:
+  Q2:
     min: null
     mid: 5.0
     max: null
-  k3:
-    min: null
-    mid: 0.0
-    max: null
-- k1:
+- x:
     min: null
     mid: 0.58
     max: null
-  k2:
+  Q2:
     min: null
     mid: 5.0
     max: null
-  k3:
-    min: null
-    mid: 0.0
-    max: null
-- k1:
+- x:
     min: null
     mid: 0.66
     max: null
-  k2:
+  Q2:
     min: null
     mid: 5.0
     max: null
-  k3:
-    min: null
-    mid: 0.0
-    max: null
-- k1:
+- x:
     min: null
     mid: 0.74
     max: null
-  k2:
+  Q2:
     min: null
     mid: 5.0
     max: null
-  k3:
-    min: null
-    mid: 0.0
-    max: null
-- k1:
+- x:
     min: null
     mid: 0.82
     max: null
-  k2:
+  Q2:
     min: null
     mid: 5.0
     max: null
-  k3:
-    min: null
-    mid: 0.0
-    max: null
-- k1:
+- x:
     min: null
     mid: 0.9
     max: null
-  k2:
+  Q2:
     min: null
     mid: 5.0
-    max: null
-  k3:
-    min: null
-    mid: 0.0
     max: null

--- a/nnpdf_data/nnpdf_data/new_commondata/NNPDF_POS_2P24GEV/metadata.yaml
+++ b/nnpdf_data/nnpdf_data/new_commondata/NNPDF_POS_2P24GEV/metadata.yaml
@@ -207,22 +207,17 @@ implemented_observables:
       $F_L^l$'
     plot_x: k1
   kinematic_coverage:
-  - k1
-  - k2
-  - k3
+  - x
+  - Q2
   kinematics:
     variables:
-      k1:
-        description: Variable k1
-        label: k1
+      x:
+        description: Bjorken x
+        label: x
         units: ''
-      k2:
-        description: Variable k2
-        label: k2
-        units: ''
-      k3:
-        description: Variable k3
-        label: k3
+      Q2:
+        description: Factorization scale
+        label: Q2
         units: ''
     file: kinematics_FLL.yaml
   theory:
@@ -570,22 +565,17 @@ implemented_observables:
       $F_L^l$'
     plot_x: k1
   kinematic_coverage:
-  - k1
-  - k2
-  - k3
+  - x
+  - Q2
   kinematics:
     variables:
-      k1:
-        description: Variable k1
-        label: k1
+      x:
+        description: Bjorken x
+        label: x
         units: ''
-      k2:
-        description: Variable k2
-        label: k2
-        units: ''
-      k3:
-        description: Variable k3
-        label: k3
+      Q2:
+        description: Factorization scale
+        label: Q2
         units: ''
     file: kinematics_FLL-19PTS.yaml
   theory:

--- a/nnpdf_data/nnpdf_data/new_commondata/NNPDF_POS_2P24GEV/metadata.yaml
+++ b/nnpdf_data/nnpdf_data/new_commondata/NNPDF_POS_2P24GEV/metadata.yaml
@@ -56,7 +56,7 @@ implemented_observables:
     description: Deep Inelastic Scattering
     label: 'positivity dataset: DIS $c+\bar{c}$ structure function $F_2^c$'
     units: ''
-  process_type: POS_F2
+  process_type: POS_DIS
   tables: []
   npoints: []
   ndata: 20
@@ -91,7 +91,7 @@ implemented_observables:
     description: Deep Inelastic Scattering
     label: 'positivity dataset: DIS $c$ structure function $F_2^{W^-,c}$'
     units: ''
-  process_type: POS_F2
+  process_type: POS_DIS
   tables: []
   npoints: []
   ndata: 17
@@ -126,7 +126,7 @@ implemented_observables:
     description: Deep Inelastic Scattering
     label: 'positivity dataset: DIS $d+\bar{d}$ structure function $F_2^d$'
     units: ''
-  process_type: POS_F2
+  process_type: POS_DIS
   tables: []
   npoints: []
   ndata: 20
@@ -161,7 +161,7 @@ implemented_observables:
     description: Deep Inelastic Scattering
     label: 'positivity dataset: DIS $s+\bar{s}$ structure function $F_2^s$'
     units: ''
-  process_type: POS_F2
+  process_type: POS_DIS
   tables: []
   npoints: []
   ndata: 20
@@ -196,7 +196,7 @@ implemented_observables:
     description: Deep Inelastic Scattering
     label: 'positivity dataset: DIS light quark longitudinal structure function $F_L^l$'
     units: ''
-  process_type: POS_FLL
+  process_type: POS_DIS
   tables: []
   npoints: []
   ndata: 20
@@ -454,7 +454,7 @@ implemented_observables:
     description: Deep Inelastic Scattering
     label: 'positivity dataset: DIS $c+\bar{c}$ structure function $F_2^c$'
     units: ''
-  process_type: POS_F2
+  process_type: POS_DIS
   tables: []
   npoints: []
   ndata: 17
@@ -489,7 +489,7 @@ implemented_observables:
     description: Deep Inelastic Scattering
     label: 'positivity dataset: CC DIS $\bar{c}$ structure function $F_2^{W^+,c}$'
     units: ''
-  process_type: POS_F2
+  process_type: POS_DIS
   tables: []
   npoints: []
   ndata: 17
@@ -524,7 +524,7 @@ implemented_observables:
     description: Deep Inelastic Scattering
     label: 'positivity dataset: DIS $u+\bar{u}$ structure function $F_2^u$'
     units: ''
-  process_type: POS_F2
+  process_type: POS_DIS
   tables: []
   npoints: []
   ndata: 20
@@ -559,7 +559,7 @@ implemented_observables:
     description: Deep Inelastic Scattering
     label: 'positivity dataset: DIS light quark longitudinal structure function $F_L^l$'
     units: ''
-  process_type: POS_FLL
+  process_type: POS_DIS
   tables: []
   npoints: []
   ndata: 19

--- a/validphys2/src/validphys/process_options.py
+++ b/validphys2/src/validphys/process_options.py
@@ -5,7 +5,7 @@
 """
 
 import dataclasses
-from typing import Callable, Optional, Tuple, Union
+from typing import Callable, Optional, Union
 
 import numpy as np
 from validobj.custom import Parser
@@ -71,7 +71,7 @@ class _KinematicsInformation:
 class _Process:
     name: str
     description: str
-    accepted_variables: Tuple[str]
+    accepted_variables: tuple[str]
     xq2map_function: Optional[Callable] = None
 
     def __hash__(self):
@@ -206,7 +206,6 @@ def _displusjet_xq2map(kin_info):
     return x, q2
 
 
-
 def _dyboson_xq2map(kin_info):
     """
     Computes x and q2 mapping for pseudo rapidity observables
@@ -259,7 +258,14 @@ DIJET = _Process(
 HQP_YQ = _Process(
     "HQP_YQ",
     "(absolute) rapidity of top quark in top pair production",
-    accepted_variables=(_Vars.y_t, _Vars.y_ttBar, _Vars.m_t2, _Vars.sqrts, _Vars.m_ttBar, _Vars.pT_t),
+    accepted_variables=(
+        _Vars.y_t,
+        _Vars.y_ttBar,
+        _Vars.m_t2,
+        _Vars.sqrts,
+        _Vars.m_ttBar,
+        _Vars.pT_t,
+    ),
     xq2map_function=_hqp_yq_xq2map,
 )
 
@@ -310,7 +316,9 @@ DY_PT = _Process(
 
 POS_XPDF = _Process("POS_XPDF", "Positivity of MS bar PDFs", accepted_variables=(_Vars.x, _Vars.Q2))
 
-POS_DIS = _Process("POS_DIS", "Positivity of F2 structure functions", accepted_variables=(_Vars.x, _Vars.Q2))
+POS_DIS = _Process(
+    "POS_DIS", "Positivity of F2 structure functions", accepted_variables=(_Vars.x, _Vars.Q2)
+)
 
 PROCESSES = {
     "DIS": DIS,
@@ -328,7 +336,9 @@ PROCESSES = {
     "HERAJET": HERAJET,
     "HERADIJET": dataclasses.replace(HERAJET, name="HERADIJET", description="DIS + jj production"),
     "DY_Z_Y": dataclasses.replace(DY_2L, name="DY_Z_Y", description="DY Z -> ll (pseudo)rapidity"),
-    "DY_W_ETA": dataclasses.replace(DY_2L, name="DY_W_ETA", description="DY W -> l nu (pseudo)rapidity"),
+    "DY_W_ETA": dataclasses.replace(
+        DY_2L, name="DY_W_ETA", description="DY W -> l nu (pseudo)rapidity"
+    ),
     "DY_NC_PT": dataclasses.replace(DY_PT, name="DY_NC_PT", description="DY Z (ll) + j"),
     "POS_XPDF": POS_XPDF,
     "POS_DIS": POS_DIS,

--- a/validphys2/src/validphys/process_options.py
+++ b/validphys2/src/validphys/process_options.py
@@ -180,7 +180,7 @@ def _hqp_ptq_xq2map(kin_info):
 def _hqp_mqq_xq2map(kin_info):
     # Compute x, Q2
     #
-    # Theory predictions computed with HT/4 ~ m_ttbar/4 
+    # Theory predictions computed with HT/4 ~ m_ttbar/4
     Q = kin_info[_Vars.m_ttBar] / 4
     return Q / kin_info[_Vars.sqrts], Q * Q
 
@@ -310,7 +310,7 @@ DY_PT = _Process(
 
 POS_XPDF = _Process("POS_XPDF", "Positivity of MS bar PDFs", accepted_variables=(_Vars.x, _Vars.Q2))
 
-POS_F2 = _Process("POS_F2", "Positivity of F2 structure functions", accepted_variables=(_Vars.x, _Vars.Q2))
+POS_DIS = _Process("POS_DIS", "Positivity of F2 structure functions", accepted_variables=(_Vars.x, _Vars.Q2))
 
 PROCESSES = {
     "DIS": DIS,
@@ -331,7 +331,7 @@ PROCESSES = {
     "DY_W_ETA": dataclasses.replace(DY_2L, name="DY_W_ETA", description="DY W -> l nu (pseudo)rapidity"),
     "DY_NC_PT": dataclasses.replace(DY_PT, name="DY_NC_PT", description="DY Z (ll) + j"),
     "POS_XPDF": POS_XPDF,
-    "POS_F2": POS_F2,
+    "POS_DIS": POS_DIS,
 }
 
 


### PR DESCRIPTION
Currently only `POS_F2` exists in the `PROCESSES` dict in process_options.py, so `POS_FLL` would need to be added as well, that this is missing is simply a bug. 

Then, it doesn't make much sense to make `POS_FLL` exclusive in  "heaviness/flavour", while using the more inclusive definition for `POS_F2`. However, they are both just DIS structure functions so there is no need to separate them by type. Because of this I introduced a single `POS_DIS` (which only has to supports structure functions and not xsecs).