### PR TITLE
Allow for a 4th optional kinematic variable.

### DIFF
--- a/validphys2/src/validphys/commondataparser.py
+++ b/validphys2/src/validphys/commondataparser.py
@@ -445,8 +445,10 @@ class ObservableMetaData:
                 )
 
         if len(self.kinematic_coverage) > 3:
-            raise ValidationError(
-                "Only a maximum of 3 variables can be used for `kinematic_coverage`"
+            logging.warning(
+                """Only a maximum of 3 variables can be used in `CommonData`
+                discarding the others. Access the full kinematic with
+                `kinematic_coverage`"""
             )
 
     def apply_variant(self, variant_name):
@@ -869,9 +871,10 @@ def load_commondata_new(metadata):
 
     procname = metadata.process_type  # nnpdf_metadata["nnpdf31_process"]
     kin_df = kin_df[metadata.kinematic_coverage]
-    kin_df.columns = KIN_NAMES
+    kin_df.columns = [f"kin{i+1}" for i in range(len(metadata.kinematic_coverage))]
     kin_df["process"] = procname
 
+    # NOTE: here we keep only the first 3 variables for compatibility
     kin_df = kin_df[["process"] + KIN_NAMES]
 
     # For the uncertainties, create a simplified version to concatenate


### PR DESCRIPTION
To properly descrive some `dijets` measurements I'd like to allow for a 4th kinematic variable.
This would only be needed to produce the kinematic coverage and can be drop everywhere else. 

The new commodata format allows to have more than 3 kinematic variables, however the parse still 
parser to load such data. 

This would be a very minimal fix that allows to store as many kinematic variables you want,
be able to load the data correctly (and eventually access the full kinematics), but keep using 
in `CommonData` only the first 3 variables.

Would be this trick be sufficient ? Or am I going to break the entire machine? 

