### PR TITLE
New ht thcovmat

### DIFF
--- a/doc/sphinx/source/references.bib
+++ b/doc/sphinx/source/references.bib
@@ -749,3 +749,14 @@ Through $O(\alpha^4_S)$}",
     pages = "109061",
     year = "2024"
 }
+@article{Ball:2025xtj,
+    author = "Ball, Richard D. and Chiefa, Amedeo and Stegeman, Roy",
+    title = "{Parton distributions with higher twist and jet power corrections}",
+    eprint = "2511.14387",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ph",
+    reportNumber = "Edinburgh 2025/29",
+    journal = "Eur. Phys. J. C",
+    month = "11",
+    year = "2025"
+}

--- a/doc/sphinx/source/vp/theorycov/index.rst
+++ b/doc/sphinx/source/vp/theorycov/index.rst
@@ -1,9 +1,9 @@
  .. _vptheorycov-index:
- 
+
 The `theorycovariance` module
 ===============================
 
-The ``theorycovariance`` module deals with constructing, testing and 
+The ``theorycovariance`` module deals with constructing, testing and
 outputting theory covariance matrices (covmats). Primarily, it is concerned
 with scale variation covariance matrices used to model missing higher order
 uncertainties. See the `short
@@ -27,10 +27,10 @@ Summary
       the NNLO-NLO shift
 
 -  Theoretical covariance matrices are built according to the various prescriptions
-   in :ref:`prescrips`. 
- 
--  The prescription must be one of 3(f, r) point, 5(bar) point, 7(original) point or 9 point, see  :ref:`definitions <prescrips>`. 
-   You can specify this using ``point_prescription: "x point"`` in the runcard. The translation of this flag 
+   in :ref:`prescrips`.
+
+-  The prescription must be one of 3(f, r) point, 5(bar) point, 7(original) point or 9 point, see  :ref:`definitions <prescrips>`.
+   You can specify this using ``point_prescription: "x point"`` in the runcard. The translation of this flag
    into the relevant ``theoryids`` is handled by the ``scalevariations`` module in ``validphys``.
 
 -  As input you need theories for the relevant scale combinations which
@@ -45,16 +45,16 @@ Summary
 
 -  Renormalisation scales should be correlated within each
    process type. These process types are categorised as {DIS CC, DIS NC,
-   Drell-Yan, Jets, Top}. 
+   Drell-Yan, Jets, Top}.
 
 -  :ref:`Outputs <thcov_outputs>` includes tables and heat plots of theoretical and combined
    (theoretical + experimental) covariance matrices, comparisons of
    theoretical and experimental errors, and plots and tables of
    :math:`\chi^2` values.
 
--  Various :ref:`testing <vptheorycov-tests>` outputs also exist, including tables of eigenvalues, 
+-  Various :ref:`testing <vptheorycov-tests>` outputs also exist, including tables of eigenvalues,
    plots of eigenvectors and shift vs theory comparisons.
-   
+
 
 More information
 -----------------
@@ -64,5 +64,6 @@ More information
    ./runcard_layout.rst
    ./outputs.rst
    ./point_prescrip.rst
+   ./power_corrections.rst
    ./tests.rst
    ./examples.rst

--- a/doc/sphinx/source/vp/theorycov/power_corrections.rst
+++ b/doc/sphinx/source/vp/theorycov/power_corrections.rst
@@ -1,0 +1,238 @@
+.. _vptheorycov-pc:
+
+Power corrections
+=================
+
+Power corrections (also referred to as higher twist corrections for DIS-like
+processes) model contributions from non-perturbative effects that scale as
+inverse powers of the hard scale. They are implemented in the
+``theorycovariance`` module and can be included as a theory covariance matrix in
+a fit. Power corrections for jets and higher twists for DIS data have been
+determined in :cite:p:`Ball:2025xtj`, based on NNPDF4.0, where the reader can
+find further details on the methodology and phenomenological implications.
+
+The implementation is in
+`higher_twist_functions.py <https://github.com/NNPDF/nnpdf/tree/master/validphys2/src/validphys/theorycovariance/higher_twist_functions.py>`_
+and
+`construction.py <https://github.com/NNPDF/nnpdf/tree/master/validphys2/src/validphys/theorycovariance/construction.py>`_.
+
+
+Overview
+--------
+
+In NNPDF, power corrections modify theoretical predictions by introducing multiplicative
+shifts. For a generic observable :math:`O`, the corrected prediction is
+
+.. math:: O \to O \times (1 + \mathrm{PC}),
+
+where :math:`\mathrm{PC}` is the power correction. The shift to the prediction
+is therefore
+
+.. math:: \Delta O = O \times \mathrm{PC}.
+
+Different functional forms for the power correction are used depending on the
+process type:
+
+- **DIS** (neutral current and charged current): the correction depends on
+  Bjorken-:math:`x` and :math:`Q^2`, and scales as :math:`1/Q^2`.
+- **Single-inclusive jets**: the correction depends on rapidity and transverse
+  momentum :math:`p_T`, and scales as :math:`1/p_T`.
+- **Dijets**: the correction depends on a rapidity variable and the dijet
+  invariant mass :math:`m_{jj}`, and scales as :math:`1/m_{jj}`.
+
+
+Parametrisation
+---------------
+
+Power corrections are parametrised using a piecewise-linear interpolation
+between a set of nodes. The node positions (``nodes``) and the function values
+at each node (``yshift``) are specified in the runcard.
+
+The interpolation is constructed as a sum of triangular basis functions: each
+node :math:`i` is associated with a triangle that peaks at the node position
+with value ``yshift[i]`` and drops linearly to zero at the two neighbouring
+nodes. The resulting function is continuous and piecewise-linear.
+
+For DIS processes, the nodes are placed in Bjorken-:math:`x` and the power
+correction for a data point at :math:`(x, Q^2)` is
+
+.. math:: \mathrm{PC}(x, Q^2) = \frac{h(x)}{Q^2},
+
+where :math:`h(x)` is the piecewise-linear interpolation.
+
+For jet processes, the nodes are placed in rapidity and the correction at
+:math:`(y, p_T)` is
+
+.. math:: \mathrm{PC}(y, p_T) = \frac{h(y)}{p_T}.
+
+For dijets, the same functional form is used but the suppression scale is the
+dijet invariant mass :math:`m_{jj}`.
+
+
+Dataset routing
+---------------
+
+Each dataset is mapped to one or more power correction parameter keys via the
+function ``get_pc_type``. The mapping depends on the process type and dataset
+name:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 30 40
+
+   * - Process type
+     - PC type key
+     - Datasets
+   * - DIS NC (proton :math:`F_2`)
+     - ``f2p``
+     - SLAC, BCDMS proton :math:`F_2`; NMC, HERA :math:`\sigma_{\mathrm{red}}`
+   * - DIS NC (deuteron :math:`F_2`)
+     - ``f2d``
+     - SLAC, BCDMS deuteron :math:`F_2`
+   * - DIS NC (NMC ratio :math:`F_2^d / F_2^p`)
+     - ``(f2p, f2d)``
+     - NMC ratio dataset
+   * - DIS CC
+     - ``dis_cc``
+     - CHORUS, NuTeV, HERA CC
+   * - Jets
+     - ``Hj``
+     - Single-inclusive jet datasets
+   * - Dijets (ATLAS)
+     - ``H2j_ATLAS``
+     - ATLAS dijet datasets (falls back to ``H2j`` if key absent)
+   * - Dijets (CMS)
+     - ``H2j_CMS``
+     - CMS dijet datasets (falls back to ``H2j`` if key absent)
+
+
+Special case: NMC ratio
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+The NMC ratio dataset :math:`F_2^d / F_2^p` receives contributions from both
+the proton and deuteron power corrections. The corrected ratio is
+
+.. math::
+
+   \frac{F_2^d}{F_2^p} \to \frac{F_2^d \,(1 + \mathrm{PC}_d)}{F_2^p \,(1 + \mathrm{PC}_p)},
+
+and the shift is
+
+.. math::
+
+   \Delta\!\left(\frac{F_2^d}{F_2^p}\right) = \frac{F_2^d}{F_2^p} \,
+   \frac{\mathrm{PC}_d - \mathrm{PC}_p}{1 + \mathrm{PC}_p}.
+
+
+Covariance matrix construction
+------------------------------
+
+The theory covariance matrix is constructed from the shifts :math:`\Delta O` by
+taking outer products. For each combination of power correction parameters, a
+shift vector is computed per dataset. The sub-matrix between datasets :math:`i`
+and :math:`j` is then
+
+.. math::
+
+   S_{ij} = \sum_k \Delta_i^{(k)} \otimes \Delta_j^{(k)},
+
+where :math:`k` runs over all parameter combinations (one non-zero ``yshift``
+entry at a time, with all others set to zero). This corresponds to the
+``covmat_power_corrections`` function in ``construction.py``.
+
+
+Runcard configuration
+---------------------
+
+Power corrections are included via the ``theorycovmatconfig`` section of the
+runcard. The key ``"power corrections"`` must be added to the
+``point_prescriptions`` list, alongside any scale variation prescriptions.
+
+The following keys are used:
+
+- ``pc_parameters``: a dictionary mapping PC type keys to their parametrisation
+  (``yshift`` and ``nodes`` arrays). The length of ``yshift`` must match the
+  length of ``nodes``.
+- ``pc_included_procs``: list of process types to which power corrections
+  are applied (e.g. ``["DIS NC", "DIS CC", "JETS", "DIJET"]``).
+- ``pc_excluded_datasets``: list of dataset names to exclude from power corrections
+  even if their process type is included.
+- ``pdf``: the PDF used for computing the theory predictions that enter the
+  multiplicative shifts.
+
+Example
+~~~~~~~
+
+.. code:: yaml
+
+    theorycovmatconfig:
+      point_prescriptions: ["9 point", "power corrections"]
+      pc_parameters:
+        f2p:
+          yshift: [0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.0]
+          nodes:  [0.0, 0.001, 0.01, 0.1, 0.3, 0.5, 0.7, 0.9, 1.0]
+        f2d:
+          yshift: [0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.0]
+          nodes:  [0.0, 0.001, 0.01, 0.1, 0.3, 0.5, 0.7, 0.9, 1.0]
+        dis_cc:
+          yshift: [0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.0]
+          nodes:  [0.0, 0.001, 0.01, 0.1, 0.3, 0.5, 0.7, 0.9, 1.0]
+        Hj:
+          yshift: [2.0, 2.0, 2.0, 2.0, 2.0, 2.0]
+          nodes:  [0.25, 0.75, 1.25, 1.75, 2.25, 2.75]
+        H2j_ATLAS:
+          yshift: [2.0, 2.0, 2.0, 2.0, 2.0, 2.0]
+          nodes:  [0.25, 0.75, 1.25, 1.75, 2.25, 2.75]
+        H2j_CMS:
+          yshift: [2.0, 2.0, 2.0, 2.0, 2.0]
+          nodes:  [0.25, 0.75, 1.25, 1.75, 2.25]
+      pc_included_procs: ["JETS", "DIJET", "DIS NC", "DIS CC"]
+      pc_excluded_datasets:
+        - HERA_NC_318GEV_EAVG_CHARM-SIGMARED
+        - HERA_NC_318GEV_EAVG_BOTTOM-SIGMARED
+      pdf: NNPDF40_nnlo_as_01180
+      use_thcovmat_in_fitting: true
+      use_thcovmat_in_sampling: true
+
+.. warning::
+   The lengths of ``yshift`` and ``nodes`` must be equal for each PC type.
+   A mismatch will raise an error at initialisation time.
+
+.. note::
+   Power corrections can be combined with scale variation prescriptions.
+   Both contributions are summed into a single theory covariance matrix.
+   See the tutorial on :ref:`including a theory covmat in a fit <thcov_tutorial>`.
+
+
+Module reference
+----------------
+
+``higher_twist_functions.py`` provides the following public functions:
+
+- ``get_pc_type(exp_name, process_type, experiment, pc_dict)``:
+  determines which PC type key(s) apply to a given dataset.
+- ``linear_bin_function(a, y_shift, bin_edges)``:
+  evaluates the piecewise-linear triangular interpolation at points ``a``.
+- ``dis_pc_func(delta_h, nodes, x, Q2)``:
+  computes the DIS power correction :math:`h(x)/Q^2`.
+- ``jets_pc_func(delta_h, nodes, pT, rap)``:
+  computes the jet power correction :math:`h(y)/p_T`.
+- ``mult_dis_pc(nodes, x, q2, dataset_sp, pdf)``:
+  returns a function that computes the multiplicative DIS shift given node values.
+- ``mult_dis_ratio_pc(p_nodes, d_nodes, x, q2, dataset_sp, pdf)``:
+  returns a function that computes the shift for the :math:`F_2^d/F_2^p` ratio.
+- ``mult_jet_pc(nodes, pT, rap, dataset_sp, pdf)``:
+  returns a function that computes the multiplicative jet shift given node values.
+- ``construct_pars_combs(parameters_dict)``:
+  builds the list of one-at-a-time parameter combinations used to construct
+  the covariance matrix.
+- ``compute_deltas_pc(dataset_sp, pdf, pc_dict)``:
+  computes the full set of shifts for a single dataset.
+
+``construction.py`` provides:
+
+- ``covmat_power_corrections(deltas1, deltas2)``:
+  computes the theory covariance sub-matrix between two datasets from their
+  shift dictionaries.
+- ``covs_pt_prescrip_pc(combine_by_type, point_prescription, pdf, pc_parameters, pc_included_procs, pc_excluded_datasets)``:
+  assembles the full power correction covariance matrix across all datasets.

--- a/n3fit/runcards/examples/Basic_runcard_pc_covmat.yml
+++ b/n3fit/runcards/examples/Basic_runcard_pc_covmat.yml
@@ -1,0 +1,113 @@
+#
+# Configuration file for n3fit
+#
+######################################################################################
+description: NNPDF4.1 with TCM higher twists and jet power corrections
+
+######################################################################################
+dataset_inputs:
+- {dataset: NMC_NC_NOTFIXED_EM-F2, variant: legacy_dw}
+- {dataset: NMC_NC_NOTFIXED_P_EM-SIGMARED, variant: legacy}
+- {dataset: SLAC_NC_NOTFIXED_P_EM-F2, variant: legacy_dw}
+- {dataset: SLAC_NC_NOTFIXED_D_EM-F2, variant: legacy_dw}
+- {dataset: BCDMS_NC_NOTFIXED_P_EM-F2, variant: legacy_dw}
+- {dataset: BCDMS_NC_NOTFIXED_D_EM-F2, variant: legacy_dw}
+- {dataset: CHORUS_CC_NOTFIXED_PB_NU-SIGMARED, variant: legacy_dw}
+- {dataset: CHORUS_CC_NOTFIXED_PB_NB-SIGMARED, variant: legacy_dw}
+- {dataset: NUTEV_CC_NOTFIXED_FE_NU-SIGMARED, cfac: [MAS], variant: legacy_dw}
+- {dataset: NUTEV_CC_NOTFIXED_FE_NB-SIGMARED, cfac: [MAS], variant: legacy_dw}
+- {dataset: HERA_NC_318GEV_EM-SIGMARED}
+- {dataset: ATLAS_1JET_8TEV_R06_PTY, variant: decorrelated}
+- {dataset: ATLAS_2JET_7TEV_R06_M12Y}
+- {dataset: CMS_1JET_8TEV_PTY}
+- {dataset: CMS_2JET_7TEV_M12-Y}
+- {dataset: CMS_2JET_13TEV_M12-YSTAR-YB-R08}
+
+################################################################################
+diagonal_frac: 0.75
+
+datacuts:
+  t0pdfset: 260202-jk-nnpdf41-mhou
+  q2min: 2.5
+  w2min: 3.24
+
+theory:
+  theoryid: 41_000_000
+
+theorycovmatconfig:
+  point_prescriptions: ["power corrections"]
+  pc_parameters:
+    f2p:        {yshift: [0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.0], nodes: [0.0, 0.001, 0.01, 0.1, 0.3, 0.5, 0.7, 0.9, 1]}
+    f2d:        {yshift: [0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.0], nodes: [0.0, 0.001, 0.01, 0.1, 0.3, 0.5, 0.7, 0.9, 1]}
+    dis_cc:     {yshift: [0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.0], nodes: [0.0, 0.001, 0.01, 0.1, 0.3, 0.5, 0.7, 0.9, 1]}
+    Hj:         {yshift: [2.0, 2.0, 2.0, 2.0, 2.0, 2.0], nodes: [0.25, 0.75, 1.25, 1.75, 2.25, 2.75]}
+    H2j_ystar:  {yshift: [2.0, 2.0, 2.0, 2.0, 2.0, 2.0], nodes: [0.25, 0.75, 1.25, 1.75, 2.25, 2.75]}
+    H2j_yb:   {yshift: [2.0, 2.0, 2.0, 2.0, 2.0], nodes: [0.25, 0.75, 1.25, 1.75, 2.25]}
+  pc_included_procs: ["DIS NC", "DIS CC", "JETS", "DIJET"]
+  pc_excluded_datasets: []
+  pdf: 260202-jk-nnpdf41-mhou
+  use_thcovmat_in_fitting: true
+  use_thcovmat_in_sampling: true
+resample_negative_pseudodata: false
+
+trvlseed: 130582403
+nnseed: 953262798
+mcseed: 1437981271
+genrep: true
+parameters: # This defines the parameter dictionary that is passed to the Model Trainer
+  nodes_per_layer: [25, 20, 9]
+  activation_per_layer: [tanh, tanh, linear]
+  initializer: glorot_normal
+  optimizer:
+    clipnorm: 6.073e-6
+    learning_rate: 2.621e-3
+    optimizer_name: Nadam
+  epochs: 27000
+  positivity:
+    initial: 184.8
+    multiplier:
+  integrability:
+    initial: 10
+    multiplier:
+  stopping_patience: 0.1
+  layer_type: dense
+  dropout: 0.0
+  threshold_chi2: 3.5
+  feature_scaling_points: 5
+
+fitting:
+  fitbasis: CCBAR_ASYMM  # EVOL (7), EVOLQED (8), etc.
+  savepseudodata: true
+  basis:
+  - {fl: sng, trainable: false, smallx: [1.058, 1.155]}
+  - {fl: g, trainable: false, smallx: [0.9017, 1.084]}
+  - {fl: v, trainable: false, smallx: [0.481, 0.6499]}
+  - {fl: v3, trainable: false, smallx: [0.08225, 0.502]}
+  - {fl: v8, trainable: false, smallx: [0.5823, 0.7928]}
+  - {fl: t3, trainable: false, smallx: [-0.3987, 0.9689]}
+  - {fl: t8, trainable: false, smallx: [0.6077, 0.9459]}
+  - {fl: t15, trainable: false, smallx: [1.023, 1.147]}
+  - {fl: v15, trainable: false, smallx: [0.5005, 0.7189]}
+
+################################################################################
+positivity:
+  posdatasets:
+  # Positivity of MSbar PDFs
+  - {dataset: NNPDF_POS_100GEV_XUQ, maxlambda: 1e6}
+  - {dataset: NNPDF_POS_100GEV_XUB, maxlambda: 1e6}
+  - {dataset: NNPDF_POS_100GEV_XDQ, maxlambda: 1e6}
+  - {dataset: NNPDF_POS_100GEV_XDB, maxlambda: 1e6}
+  - {dataset: NNPDF_POS_100GEV_XSQ, maxlambda: 1e6}
+  - {dataset: NNPDF_POS_100GEV_XSB, maxlambda: 1e6}
+  - {dataset: NNPDF_POS_100GEV_XCQ, maxlambda: 1e6}
+  - {dataset: NNPDF_POS_100GEV_XCB, maxlambda: 1e6}
+  - {dataset: NNPDF_POS_100GEV_XGL, maxlambda: 1e6}
+
+integrability:
+  integdatasets:
+  - {dataset: NNPDF_INTEG_3GEV_XT8, maxlambda: 1e2}
+  - {dataset: NNPDF_INTEG_3GEV_XT3, maxlambda: 1e2}
+
+################################################################################
+debug: false
+maxcores: 16

--- a/nnpdf_data/nnpdf_data/commondata/CMS_2JET_7TEV/kinematics.yaml
+++ b/nnpdf_data/nnpdf_data/commondata/CMS_2JET_7TEV/kinematics.yaml
@@ -1,5 +1,5 @@
 bins:
-- ydiff:
+- ymax:
     min: 0.0
     mid: 0.25
     max: 0.5
@@ -11,7 +11,7 @@ bins:
     min: null
     mid: 7000.0
     max: null
-- ydiff:
+- ymax:
     min: 0.0
     mid: 0.25
     max: 0.5
@@ -23,7 +23,7 @@ bins:
     min: null
     mid: 7000.0
     max: null
-- ydiff:
+- ymax:
     min: 0.0
     mid: 0.25
     max: 0.5
@@ -35,7 +35,7 @@ bins:
     min: null
     mid: 7000.0
     max: null
-- ydiff:
+- ymax:
     min: 0.0
     mid: 0.25
     max: 0.5
@@ -47,7 +47,7 @@ bins:
     min: null
     mid: 7000.0
     max: null
-- ydiff:
+- ymax:
     min: 0.0
     mid: 0.25
     max: 0.5
@@ -59,7 +59,7 @@ bins:
     min: null
     mid: 7000.0
     max: null
-- ydiff:
+- ymax:
     min: 0.0
     mid: 0.25
     max: 0.5
@@ -71,7 +71,7 @@ bins:
     min: null
     mid: 7000.0
     max: null
-- ydiff:
+- ymax:
     min: 0.0
     mid: 0.25
     max: 0.5
@@ -83,7 +83,7 @@ bins:
     min: null
     mid: 7000.0
     max: null
-- ydiff:
+- ymax:
     min: 0.0
     mid: 0.25
     max: 0.5
@@ -95,7 +95,7 @@ bins:
     min: null
     mid: 7000.0
     max: null
-- ydiff:
+- ymax:
     min: 0.0
     mid: 0.25
     max: 0.5
@@ -107,7 +107,7 @@ bins:
     min: null
     mid: 7000.0
     max: null
-- ydiff:
+- ymax:
     min: 0.0
     mid: 0.25
     max: 0.5
@@ -119,7 +119,7 @@ bins:
     min: null
     mid: 7000.0
     max: null
-- ydiff:
+- ymax:
     min: 0.0
     mid: 0.25
     max: 0.5
@@ -131,7 +131,7 @@ bins:
     min: null
     mid: 7000.0
     max: null
-- ydiff:
+- ymax:
     min: 0.0
     mid: 0.25
     max: 0.5
@@ -143,7 +143,7 @@ bins:
     min: null
     mid: 7000.0
     max: null
-- ydiff:
+- ymax:
     min: 0.0
     mid: 0.25
     max: 0.5
@@ -155,7 +155,7 @@ bins:
     min: null
     mid: 7000.0
     max: null
-- ydiff:
+- ymax:
     min: 0.5
     mid: 0.75
     max: 1.0
@@ -167,7 +167,7 @@ bins:
     min: null
     mid: 7000.0
     max: null
-- ydiff:
+- ymax:
     min: 0.5
     mid: 0.75
     max: 1.0
@@ -179,7 +179,7 @@ bins:
     min: null
     mid: 7000.0
     max: null
-- ydiff:
+- ymax:
     min: 0.5
     mid: 0.75
     max: 1.0
@@ -191,7 +191,7 @@ bins:
     min: null
     mid: 7000.0
     max: null
-- ydiff:
+- ymax:
     min: 0.5
     mid: 0.75
     max: 1.0
@@ -203,7 +203,7 @@ bins:
     min: null
     mid: 7000.0
     max: null
-- ydiff:
+- ymax:
     min: 0.5
     mid: 0.75
     max: 1.0
@@ -215,7 +215,7 @@ bins:
     min: null
     mid: 7000.0
     max: null
-- ydiff:
+- ymax:
     min: 0.5
     mid: 0.75
     max: 1.0
@@ -227,7 +227,7 @@ bins:
     min: null
     mid: 7000.0
     max: null
-- ydiff:
+- ymax:
     min: 0.5
     mid: 0.75
     max: 1.0
@@ -239,7 +239,7 @@ bins:
     min: null
     mid: 7000.0
     max: null
-- ydiff:
+- ymax:
     min: 0.5
     mid: 0.75
     max: 1.0
@@ -251,7 +251,7 @@ bins:
     min: null
     mid: 7000.0
     max: null
-- ydiff:
+- ymax:
     min: 0.5
     mid: 0.75
     max: 1.0
@@ -263,7 +263,7 @@ bins:
     min: null
     mid: 7000.0
     max: null
-- ydiff:
+- ymax:
     min: 0.5
     mid: 0.75
     max: 1.0
@@ -275,7 +275,7 @@ bins:
     min: null
     mid: 7000.0
     max: null
-- ydiff:
+- ymax:
     min: 0.5
     mid: 0.75
     max: 1.0
@@ -287,7 +287,7 @@ bins:
     min: null
     mid: 7000.0
     max: null
-- ydiff:
+- ymax:
     min: 0.5
     mid: 0.75
     max: 1.0
@@ -299,7 +299,7 @@ bins:
     min: null
     mid: 7000.0
     max: null
-- ydiff:
+- ymax:
     min: 1.0
     mid: 1.25
     max: 1.5
@@ -311,7 +311,7 @@ bins:
     min: null
     mid: 7000.0
     max: null
-- ydiff:
+- ymax:
     min: 1.0
     mid: 1.25
     max: 1.5
@@ -323,7 +323,7 @@ bins:
     min: null
     mid: 7000.0
     max: null
-- ydiff:
+- ymax:
     min: 1.0
     mid: 1.25
     max: 1.5
@@ -335,7 +335,7 @@ bins:
     min: null
     mid: 7000.0
     max: null
-- ydiff:
+- ymax:
     min: 1.0
     mid: 1.25
     max: 1.5
@@ -347,7 +347,7 @@ bins:
     min: null
     mid: 7000.0
     max: null
-- ydiff:
+- ymax:
     min: 1.0
     mid: 1.25
     max: 1.5
@@ -359,7 +359,7 @@ bins:
     min: null
     mid: 7000.0
     max: null
-- ydiff:
+- ymax:
     min: 1.0
     mid: 1.25
     max: 1.5
@@ -371,7 +371,7 @@ bins:
     min: null
     mid: 7000.0
     max: null
-- ydiff:
+- ymax:
     min: 1.0
     mid: 1.25
     max: 1.5
@@ -383,7 +383,7 @@ bins:
     min: null
     mid: 7000.0
     max: null
-- ydiff:
+- ymax:
     min: 1.0
     mid: 1.25
     max: 1.5
@@ -395,7 +395,7 @@ bins:
     min: null
     mid: 7000.0
     max: null
-- ydiff:
+- ymax:
     min: 1.0
     mid: 1.25
     max: 1.5
@@ -407,7 +407,7 @@ bins:
     min: null
     mid: 7000.0
     max: null
-- ydiff:
+- ymax:
     min: 1.0
     mid: 1.25
     max: 1.5
@@ -419,7 +419,7 @@ bins:
     min: null
     mid: 7000.0
     max: null
-- ydiff:
+- ymax:
     min: 1.0
     mid: 1.25
     max: 1.5
@@ -431,7 +431,7 @@ bins:
     min: null
     mid: 7000.0
     max: null
-- ydiff:
+- ymax:
     min: 1.5
     mid: 1.75
     max: 2.0
@@ -443,7 +443,7 @@ bins:
     min: null
     mid: 7000.0
     max: null
-- ydiff:
+- ymax:
     min: 1.5
     mid: 1.75
     max: 2.0
@@ -455,7 +455,7 @@ bins:
     min: null
     mid: 7000.0
     max: null
-- ydiff:
+- ymax:
     min: 1.5
     mid: 1.75
     max: 2.0
@@ -467,7 +467,7 @@ bins:
     min: null
     mid: 7000.0
     max: null
-- ydiff:
+- ymax:
     min: 1.5
     mid: 1.75
     max: 2.0
@@ -479,7 +479,7 @@ bins:
     min: null
     mid: 7000.0
     max: null
-- ydiff:
+- ymax:
     min: 1.5
     mid: 1.75
     max: 2.0
@@ -491,7 +491,7 @@ bins:
     min: null
     mid: 7000.0
     max: null
-- ydiff:
+- ymax:
     min: 1.5
     mid: 1.75
     max: 2.0
@@ -503,7 +503,7 @@ bins:
     min: null
     mid: 7000.0
     max: null
-- ydiff:
+- ymax:
     min: 1.5
     mid: 1.75
     max: 2.0
@@ -515,7 +515,7 @@ bins:
     min: null
     mid: 7000.0
     max: null
-- ydiff:
+- ymax:
     min: 1.5
     mid: 1.75
     max: 2.0
@@ -527,7 +527,7 @@ bins:
     min: null
     mid: 7000.0
     max: null
-- ydiff:
+- ymax:
     min: 1.5
     mid: 1.75
     max: 2.0
@@ -539,7 +539,7 @@ bins:
     min: null
     mid: 7000.0
     max: null
-- ydiff:
+- ymax:
     min: 1.5
     mid: 1.75
     max: 2.0
@@ -551,7 +551,7 @@ bins:
     min: null
     mid: 7000.0
     max: null
-- ydiff:
+- ymax:
     min: 2.0
     mid: 2.25
     max: 2.5
@@ -563,7 +563,7 @@ bins:
     min: null
     mid: 7000.0
     max: null
-- ydiff:
+- ymax:
     min: 2.0
     mid: 2.25
     max: 2.5
@@ -575,7 +575,7 @@ bins:
     min: null
     mid: 7000.0
     max: null
-- ydiff:
+- ymax:
     min: 2.0
     mid: 2.25
     max: 2.5
@@ -587,7 +587,7 @@ bins:
     min: null
     mid: 7000.0
     max: null
-- ydiff:
+- ymax:
     min: 2.0
     mid: 2.25
     max: 2.5
@@ -599,7 +599,7 @@ bins:
     min: null
     mid: 7000.0
     max: null
-- ydiff:
+- ymax:
     min: 2.0
     mid: 2.25
     max: 2.5
@@ -611,7 +611,7 @@ bins:
     min: null
     mid: 7000.0
     max: null
-- ydiff:
+- ymax:
     min: 2.0
     mid: 2.25
     max: 2.5
@@ -623,7 +623,7 @@ bins:
     min: null
     mid: 7000.0
     max: null
-- ydiff:
+- ymax:
     min: 2.0
     mid: 2.25
     max: 2.5
@@ -635,7 +635,7 @@ bins:
     min: null
     mid: 7000.0
     max: null
-- ydiff:
+- ymax:
     min: 2.0
     mid: 2.25
     max: 2.5

--- a/nnpdf_data/nnpdf_data/commondata/CMS_2JET_7TEV/metadata.yaml
+++ b/nnpdf_data/nnpdf_data/commondata/CMS_2JET_7TEV/metadata.yaml
@@ -26,16 +26,16 @@ implemented_observables:
   tables: [6, 7, 8, 9, 10]
   process_type: DIJET
   # Plotting
-  kinematic_coverage: [ydiff, m_jj, sqrts]
+  kinematic_coverage: [ymax, m_jj, sqrts]
   plotting:
     dataset_label: "CMS dijets 7 TeV"
     x_scale: log
     plot_x: m_jj
     figure_by:
-    - ydiff
+    - ymax
   kinematics:
     variables:
-      ydiff: {description: "rapidity separation", label: "$y$", units: ""}
+      ymax: {description: "rapidity separation", label: "$y$", units: ""}
       m_jj: {description: "dijet mass", label: "$m_{jj}$", units: "GeV"}
       sqrts: {description: "center of mass energy", label: r"$\sqrt(s)$", units: "GeV"}
     file: kinematics.yaml

--- a/nnpdf_data/nnpdf_data/filter_utils/legacy_jets_utils.py
+++ b/nnpdf_data/nnpdf_data/filter_utils/legacy_jets_utils.py
@@ -98,11 +98,11 @@ def get_kinematics_CMS_2JET_7TEV(tables, version):
             input = yaml.safe_load(file)
 
         rapidity_interval = input['dependent_variables'][0]['qualifiers'][0]['value']
-        ydiff = {}
+        ymax = {}
         if rapidity_interval == '< 0.5':
-            ydiff['min'], ydiff['max'], ydiff['mid'] = 0.0, 0.5, 0.25
+            ymax['min'], ymax['max'], ymax['mid'] = 0.0, 0.5, 0.25
         else:
-            ydiff = range_str_to_floats(rapidity_interval)
+            ymax = range_str_to_floats(rapidity_interval)
 
         sqrts = float(input['dependent_variables'][0]['qualifiers'][2]['value'])
 
@@ -115,7 +115,7 @@ def get_kinematics_CMS_2JET_7TEV(tables, version):
             m_jj['mid'] = float(f"{0.5 * (m_jj['low']+m_jj['high']):.3f}")
 
             kin_value = {
-                'ydiff': {'min': ydiff['min'], 'mid': ydiff['mid'], 'max': ydiff['max']},
+                'ymax': {'min': ymax['min'], 'mid': ymax['mid'], 'max': ymax['max']},
                 'm_jj': {'min': m_jj['low'], 'mid': m_jj['mid'], 'max': m_jj['high']},
                 'sqrts': {'min': None, 'mid': sqrts, 'max': None},
             }

--- a/validphys2/src/validphys/checks.py
+++ b/validphys2/src/validphys/checks.py
@@ -361,3 +361,15 @@ def check_darwin_single_process(NPROC):
     """
     if platform.system() == "Darwin" and NPROC != 1:
         raise CheckError("NPROC must be set to 1 on OSX, because multithreading is not supported.")
+
+
+@make_argcheck
+def check_pc_parameters(pc_parameters):
+    """Check that the parameters for the PC method are set correctly"""
+    for par in pc_parameters.values():
+        # Check that the length of shifts is the same as the length of nodes
+        if len(par['yshift']) != len(par['nodes']):
+            raise ValueError(
+                f"The length of nodes does not match that of the list in {par['ht']}."
+                f"Check the runcard. Got {len(par['yshift'])} != {len(par['nodes'])}"
+            )

--- a/validphys2/src/validphys/config.py
+++ b/validphys2/src/validphys/config.py
@@ -1387,6 +1387,25 @@ class CoreConfig(configparser.Config):
 
         return f
 
+    def produce_mult_factor_user_covmat(
+        self, mult_factor: float = 1.0, user_covmat_path: str = None
+    ):
+        """
+        Multiplicative factors for the user covmat provided by mult_factors_user_covmat in the runcard.
+        If no factors are provided, returns None.
+        For use in theorycovariance.construction.user_covmat.
+        """
+        # Check that if mult_factors is provided, user_covmat_paths is also provided
+        if mult_factor is not None and user_covmat_path is None:
+            raise ConfigError(
+                "If mult_factors is provided, user_covmat_paths must also be provided."
+            )
+
+        if mult_factor is None:
+            return 1.0 if user_covmat_path is not None else None
+        else:
+            return mult_factor
+
     def produce_fitthcovmat(
         self, use_thcovmat_if_present: bool = False, fit: (str, type(None)) = None
     ):
@@ -1909,6 +1928,8 @@ class CoreConfig(configparser.Config):
         prescription. The options for the latter are defined in pointprescriptions.yaml.
         This hard codes the theories needed for each prescription to avoid user error."""
         th = t0id.id
+        if point_prescription == 'power corrections':
+            return NSList([t0id], nskey="theoryid")
 
         lsv = yaml_safe.load(read_text(validphys.scalevariations, "scalevariationtheoryids.yaml"))
 
@@ -2018,6 +2039,19 @@ class CoreConfig(configparser.Config):
         if fitthcovmat is None:
             return validphys.results.total_phi_data_from_experiments
         return validphys.results.dataset_inputs_phi_data
+
+    @configparser.explicit_node
+    def produce_covs_pt_prescrip(self, point_prescription):
+        if point_prescription == 'power corrections':
+            from validphys.theorycovariance.construction import covs_pt_prescrip_pc
+
+            f = covs_pt_prescrip_pc
+        else:
+            from validphys.theorycovariance.construction import covs_pt_prescrip_mhou
+
+            f = covs_pt_prescrip_mhou
+
+        return f
 
 
 class Config(report.Config, CoreConfig):

--- a/validphys2/src/validphys/config.py
+++ b/validphys2/src/validphys/config.py
@@ -1402,7 +1402,7 @@ class CoreConfig(configparser.Config):
             )
 
         if mult_factor is None:
-            return 1.0 if user_covmat_path is not None else None
+            return 1.0
         else:
             return mult_factor
 

--- a/validphys2/src/validphys/dataplots.py
+++ b/validphys2/src/validphys/dataplots.py
@@ -2,8 +2,6 @@
 Plots of relations between data PDFs and fits.
 """
 
-from __future__ import generator_stop
-
 from collections import defaultdict
 from collections.abc import Sequence
 import itertools
@@ -25,13 +23,13 @@ from reportengine.figure import figure, figuregen
 from reportengine.floatformatting import format_number
 from validphys import plotutils
 from validphys.checks import check_not_using_pdferr
+from validphys.commondata import loaded_commondata_with_cuts
 from validphys.core import CutsPolicy, MCStats, cut_mask, load_commondata
+from validphys.covmats import shifts_from_systematics
 from validphys.plotoptions.core import get_info, kitable, transform_result
 from validphys.results import chi2_stat_labels, chi2_stats
-from validphys.sumrules import POL_LIMS, partial_polarized_sum_rules
+from validphys.sumrules import POL_LIMS
 from validphys.utils import sane_groupby_iter, scale_from_grid, split_ranges
-from validphys.commondata import loaded_commondata_with_cuts
-from validphys.covmats import shifts_from_systematics
 
 log = logging.getLogger(__name__)
 
@@ -226,12 +224,12 @@ def check_normalize_to(ns, **kwargs):
 # TODO: This interface is horrible.
 # We need to think how to adapt it to make this use case easier
 def _plot_fancy_impl(
-        results,
-        commondata,
-        cutlist,
-        normalize_to: (int, type(None)) = None,
-        labellist=None,
-        with_shift: bool = True,
+    results,
+    commondata,
+    cutlist,
+    normalize_to: (int, type(None)) = None,
+    labellist=None,
+    with_shift: bool = True,
 ):
     """Implementation of the data-theory comparison plots. Providers are
     supposed to call (yield from) this.
@@ -253,8 +251,8 @@ def _plot_fancy_impl(
         (from the PDF names) if None is given.
     with_shift: bool
         This option specifies wheter one wants (True) or not (False) to shift
-        the theoretical predictions by a shift due to the correlated part of 
-        the experimental uncertainty. The default is True. 
+        the theoretical predictions by a shift due to the correlated part of
+        the experimental uncertainty. The default is True.
     Returns
     -------
     A generator over figures.
@@ -266,13 +264,13 @@ def _plot_fancy_impl(
     ndata = len(table)
 
     # Compute shifts due to the correlated part of the exp cov matrix
-    lcd_wc = loaded_commondata_with_cuts(commondata,cutlist[0])
+    lcd_wc = loaded_commondata_with_cuts(commondata, cutlist[0])
     theory_predictions = results[1].central_value
-    
+
     # This is easier than cheking every time
     if labellist is None:
         labellist = [None] * len(results)
-        
+
     if normalize_to is not None:
         norm_result = results[normalize_to]
         mask = cut_mask(cutlist[normalize_to])
@@ -282,7 +280,7 @@ def _plot_fancy_impl(
         err[mask] = norm_result.std_error
         # We modify the table, so we pass only the label columns
         norm_cv, _ = transform_result(cv, err, table.iloc[:, :nkinlabels], info)
-        
+
     cvcols = []
 
     # Compute systematic shifts
@@ -291,30 +289,32 @@ def _plot_fancy_impl(
     # the final plot.
     if with_shift:
         try:
-            shifts, alpha = shifts_from_systematics(lcd_wc,theory_predictions)
+            shifts, alpha = shifts_from_systematics(lcd_wc, theory_predictions)
         except np.linalg.LinAlgError:
-            log.warning("Error occurred in computing systematic shifts for " \
-                        f"{info.ds_metadata.name}. These will be disregarded in the plots.")
+            log.warning(
+                "Error occurred in computing systematic shifts for "
+                f"{info.ds_metadata.name}. These will be disregarded in the plots."
+            )
             with_shift = False
-    
+
     for i, (result, cuts) in enumerate(zip(results, cutlist)):
         # We modify the table, so we pass only the label columns
         mask = cut_mask(cuts)
         cv = np.full(ndata, np.nan)
         err = np.full(ndata, np.nan)
         # Shift the theory when with_shift option is True
-        if i==1 and with_shift:
+        if i == 1 and with_shift:
             cv[mask] = result.central_value - shifts
         else:
-            cv[mask] = result.central_value           
+            cv[mask] = result.central_value
         # Retain only the uncorrelated part of the error if shifting the data
-        if i==0 and with_shift:
+        if i == 0 and with_shift:
             err[mask] = alpha
         else:
             err[mask] = result.std_error
 
         cv, err = transform_result(cv, err, table.iloc[:, :nkinlabels], info)
-        
+
         # By doing tuple keys we avoid all possible name collisions
         cvcol = ('cv', i)
         if normalize_to is None:
@@ -326,7 +326,7 @@ def _plot_fancy_impl(
         cvcols.append(cvcol)
 
     figby = sane_groupby_iter(table, info.figure_by)
-    
+
     for samefig_vals, fig_data in figby:
         # Nothing to plot if all data is cut away
         if np.all(np.isnan(fig_data[cvcols])):
@@ -341,7 +341,9 @@ def _plot_fancy_impl(
         else:
             shift_label = "(unshifted)"
         ax.set_title(
-            "{} {} {}".format(info.dataset_label, info.group_label(samefig_vals, info.figure_by), shift_label)
+            "{} {} {}".format(
+                info.dataset_label, info.group_label(samefig_vals, info.figure_by), shift_label
+            )
         )
 
         lineby = sane_groupby_iter(fig_data, info.line_by)
@@ -373,7 +375,7 @@ def _plot_fancy_impl(
             # and follow the cycle for
             # the rest.
             next_color = itertools.chain(['#262626'], plotutils.color_iter())
-            
+
             for i, (res, lb, color) in enumerate(zip(results, labellist, next_color)):
                 if labels:
                     if lb:
@@ -382,7 +384,7 @@ def _plot_fancy_impl(
                         label = res.label
                 else:
                     label = None
-                    
+
                 cv = line_data[('cv', i)].values
                 err = line_data[('err', i)].values
                 ax.errorbar(
@@ -556,7 +558,7 @@ def plot_fancy_dataspecs(
         - or None (default) to plot absolute values.
 
     ``with_shift`` be either:
-        
+
         - True (default): this shifts theoretical predictions by an amount that
           depends on the correlated part of the experimental uncertainty,
           according to Eqs.(7)-(9) of arXiv:hep-ph/0201195. In this case only
@@ -1344,7 +1346,7 @@ def _check_display_cuts_requires_use_cuts(display_cuts, use_cuts):
 
 @make_argcheck
 def _check_marker_by(marker_by):
-    markers = ('process type', 'experiment', 'dataset', 'group')
+    markers = ('process type', 'experiment', 'dataset', 'group', 'kinematics')
     if marker_by not in markers:
         raise CheckError("Unknown marker_by value", marker_by, markers)
 
@@ -1403,7 +1405,8 @@ def plot_xq2(
     will be displaed and marked.
 
     The points are grouped according to the `marker_by` option. The possible
-    values are: "process type", "experiment", "group" or "dataset".
+    values are: "process type", "experiment", "group" or "dataset" for discrete
+    colors, or "kinematics" for coloring by 1/(Q2(1-x))
 
     Some datasets can be made to appear highlighted in the figure: Define a key
     called ``highlight_datasets`` containing the names of the datasets to be
@@ -1534,6 +1537,7 @@ def plot_xq2(
 
     xh = defaultdict(list)
     q2h = defaultdict(list)
+    cvdict = defaultdict(list)
 
     if not highlight_datasets:
         highlight_datasets = set()
@@ -1564,6 +1568,8 @@ def plot_xq2(
         elif marker_by == "group":
             # if group is None then make sure that shows on legend.
             key = str(group)
+        elif marker_by == "kinematics":
+            key = None
         else:
             raise ValueError('Unknown marker_by value')
 
@@ -1579,6 +1585,7 @@ def plot_xq2(
             xdict = x
             q2dict = q2
 
+        cvdict[key].append(commondata.load().get_cv())
         xdict[key].append(fitted[0])
         q2dict[key].append(fitted[1])
         if display_cuts:
@@ -1593,6 +1600,13 @@ def plot_xq2(
         else:
             # This is to get the label key
             coords = [], []
+        if marker_by == "kinematics":
+            ht_magnitude = np.concatenate(cvdict[key]) / (coords[1] * (1 - coords[0]))
+            out = ax.scatter(
+                *coords, marker='.', c=ht_magnitude, cmap="viridis", norm=mcolors.LogNorm()
+            )
+            clb = fig.colorbar(out)
+            clb.ax.set_title(r'$F_\mathrm{exp}\frac{1}{Q^2(1-x)}$')
         ax.plot(*coords, label=key, markeredgewidth=1, markeredgecolor=None, **key_options[key])
 
     # Iterate again so highlights are printed on top.

--- a/validphys2/src/validphys/filters.py
+++ b/validphys2/src/validphys/filters.py
@@ -125,7 +125,6 @@ class FilterDefaults:
 class FilterRule:
     """
     Dataclass which carries the filter rule information.
-
     """
 
     dataset: str = None
@@ -172,6 +171,9 @@ def default_filter_rules_input():
     are unique, i.d. if there are no multiple rules for the same dataset of
     process with the same rule (`reason` and `local_variables` are not hashed).
     """
+    # TODO: This should be done using a more sophisticated comparison
+    # that checks if two rules are actually the same, regardless of the
+    # order in which the cuts are defined.
     list_rules = yaml_safe.load(read_text(validphys.cuts, "filters.yaml"))
     unique_rules = set(FilterRule(**rule) for rule in list_rules)
     if len(unique_rules) != len(list_rules):
@@ -482,9 +484,9 @@ def check_luxset(luxset):
 def check_luxset_exists(fiatlux):
     """Check that the Photon QED set for this theoryid and luxset exists"""
     if fiatlux is not None:
-      luxset = fiatlux['luxset']
-      luxset.load()
-      log.info(f'{luxset} Lux pdf checked.')
+        luxset = fiatlux['luxset']
+        luxset.load()
+        log.info(f'{luxset} Lux pdf checked.')
 
 
 def check_unpolarized_bc(unpolarized_bc):

--- a/validphys2/src/validphys/results.py
+++ b/validphys2/src/validphys/results.py
@@ -239,7 +239,7 @@ groups_data = collect("data", ("group_dataset_inputs_by_metadata",))
 
 experiments_data = collect("data", ("group_dataset_inputs_by_experiment",))
 
-procs_data = collect("data", ("group_dataset_inputs_by_process",))
+groups_data_by_process = collect("data", ("group_dataset_inputs_by_process",))
 
 
 def groups_index(groups_data):
@@ -277,8 +277,8 @@ def experiments_index(experiments_data):
     return groups_index(experiments_data)
 
 
-def procs_index(procs_data):
-    return groups_index(procs_data)
+def procs_index(groups_data_by_process):
+    return groups_index(groups_data_by_process)
 
 
 def groups_data_values(group_result_table):
@@ -811,10 +811,12 @@ experiments_chi2_table = collect("groups_chi2_table", ("group_dataset_inputs_by_
 
 
 @table
-def procs_chi2_table(procs_data, pdf, groups_chi2_by_process, groups_each_dataset_chi2_by_process):
+def procs_chi2_table(
+    groups_data_by_process, pdf, groups_chi2_by_process, groups_each_dataset_chi2_by_process
+):
     """Same as groups_chi2_table but by process"""
     return groups_chi2_table(
-        procs_data, pdf, groups_chi2_by_process, groups_each_dataset_chi2_by_process
+        groups_data_by_process, pdf, groups_chi2_by_process, groups_each_dataset_chi2_by_process
     )
 
 

--- a/validphys2/src/validphys/theorycovariance/construction.py
+++ b/validphys2/src/validphys/theorycovariance/construction.py
@@ -3,7 +3,8 @@ construction.py
 Tools for constructing theory covariance matrices and computing their chi2s.
 """
 
-from collections import defaultdict, namedtuple
+from collections import defaultdict
+import dataclasses
 import logging
 
 import numpy as np
@@ -11,9 +12,9 @@ import pandas as pd
 
 from reportengine import collect
 from reportengine.table import table
-
-pass
+from validphys.checks import check_pc_parameters
 from validphys.results import results, results_central
+from validphys.theorycovariance.higher_twist_functions import compute_deltas_pc
 from validphys.theorycovariance.theorycovarianceutils import (
     check_correct_theory_combination,
     check_fit_dataset_order_matches_grouped,
@@ -47,11 +48,18 @@ def theory_covmat_dataset(results, results_central_bytheoryids, point_prescripti
     return thcovmat
 
 
-ProcessInfo = namedtuple("ProcessInfo", ("preds", "namelist", "sizes"))
+@dataclasses.dataclass(frozen=True)
+class ProcessInfo:
+    """Dataclass containing the information needed to construct the theory covariance matrix."""
+
+    preds: dict
+    namelist: dict
+    sizes: dict
+    data_spec: dict
 
 
-def combine_by_type(each_dataset_results_central_bytheory):
-    """Groups the datasets bu process and returns an instance of the ProcessInfo class
+def combine_by_type(each_dataset_results_central_bytheory, groups_data_by_process):
+    """Groups the datasets by process and returns an instance of the ProcessInfo class
 
     Parameters
     ----------
@@ -68,6 +76,7 @@ def combine_by_type(each_dataset_results_central_bytheory):
     dataset_size = defaultdict(list)
     theories_by_process = defaultdict(list)
     ordered_names = defaultdict(list)
+    data_spec = {}
     for dataset in each_dataset_results_central_bytheory:
         name = dataset[0][0].name
         theory_centrals = [x[1].central_value for x in dataset]
@@ -77,8 +86,14 @@ def combine_by_type(each_dataset_results_central_bytheory):
         theories_by_process[proc_type].append(theory_centrals)
     for key, item in theories_by_process.items():
         theories_by_process[key] = np.concatenate(item, axis=1)
+
+    # Store DataGroupSpecs instances
+    for group_proc in groups_data_by_process:
+        for ds in group_proc.datasets:
+            data_spec[ds.name] = ds
+
     process_info = ProcessInfo(
-        preds=theories_by_process, namelist=ordered_names, sizes=dataset_size
+        preds=theories_by_process, namelist=ordered_names, sizes=dataset_size, data_spec=data_spec
     )
     return process_info
 
@@ -206,6 +221,35 @@ def covmat_n3lo_ad(name1, name2, deltas1, deltas2):
     return 1 / norm * s
 
 
+def covmat_power_corrections(deltas1, deltas2):
+    """Returns the the theory covariance sub-matrix for power
+    corrections. The two arguments ``deltas1`` and ``deltas2`` contain the
+    shifts for the first and second experiment, respectively.
+
+    The shifts are given in this form: ``` deltas1 = [array1_of_shifts1,
+               array1_of_shifts2, array1_of_shifts3, ...]
+    deltas2 = [array2_of_shifts1,
+               array2_of_shifts2, array2_of_shifts3, ...]
+    ``` The sub-matrix is computed as
+
+      s = array1_of_shifts1 X array2_of_shifts1 + array1_of_shifts2 X
+      array2_of_shifts2 + ...
+
+    where ``X`` is the outer product. This is equivalent to a generalised 5
+    point prescription. Since corrections are linearised, plus and minus
+    variations are not distinguished and all variations are treated as
+    independent, hence the sum over all variations without any additional
+    factors.
+    """
+
+    size1 = deltas1[0].size
+    size2 = deltas2[0].size
+    s = np.zeros(shape=(size1, size2))
+    for shift1, shift2 in zip(deltas1, deltas2):
+        s += np.outer(shift1, shift2)
+    return s
+
+
 def compute_covs_pt_prescrip(point_prescription, name1, deltas1, name2=None, deltas2=None):
     """Utility to compute the covariance matrix by prescription given the
     shifts with respect to the central value for a pair of processes.
@@ -276,28 +320,31 @@ def compute_covs_pt_prescrip(point_prescription, name1, deltas1, name2=None, del
         # alphas is correlated for all datapoints and the covmat construction is
         # therefore equivalent to that of the factorization scale variations
         s = covmat_3fpt(deltas1, deltas2)
+    elif point_prescription == 'power corrections':
+        # Shifts computed from power corrected predictions
+        s = covmat_power_corrections(deltas1, deltas2)
     return s
 
 
 @check_correct_theory_combination
-def covs_pt_prescrip(combine_by_type, point_prescription):
+def covs_pt_prescrip_mhou(combine_by_type, point_prescription):
     """Produces the sub-matrices of the theory covariance matrix according
-    to a point prescription which matches the number of input theories.
-    If 5 theories are provided, a scheme 'bar' or 'nobar' must be
-    chosen in the runcard in order to specify the prescription. Sub-matrices
-    correspond to applying the scale variation prescription to each pair of
-    processes in turn, using a different procedure for the case where the
-    processes are the same relative to when they are different."""
-
+    to a point prescription which matches the number of input theories. If 5
+    theories are provided, a scheme 'bar' or 'nobar' must be chosen in the
+    runcard in order to specify the prescription. Sub-matrices correspond to
+    applying the scale variation prescription to each pair of processes in turn,
+    using a different procedure for the case where the processes are the same
+    relative to when they are different."""
     process_info = combine_by_type
     running_index = 0
+
+    covmats = defaultdict(list)
     start_proc = defaultdict(list)
     for name in process_info.preds:
         size = len(process_info.preds[name][0])
         start_proc[name] = running_index
         running_index += size
 
-    covmats = defaultdict(list)
     for name1 in process_info.preds:
         for name2 in process_info.preds:
             central1, *others1 = process_info.preds[name1]
@@ -307,6 +354,50 @@ def covs_pt_prescrip(combine_by_type, point_prescription):
             s = compute_covs_pt_prescrip(point_prescription, name1, deltas1, name2, deltas2)
             start_locs = (start_proc[name1], start_proc[name2])
             covmats[start_locs] = s
+
+    return covmats
+
+
+@check_pc_parameters
+def covs_pt_prescrip_pc(
+    combine_by_type, point_prescription, pdf, pc_parameters, pc_included_procs, pc_excluded_datasets
+):
+    """Produces the sub-matrices of the theory covariance matrix for power
+    corrections. Sub-matrices correspond to applying power corrected shifts
+    to each pair of `datasets`."""
+    process_info = combine_by_type
+    datagroup_spec = process_info.data_spec
+    running_index = 0
+
+    covmats = defaultdict(list)
+    start_proc_by_dsname = {}
+    for ds_name, ds_spec in datagroup_spec.items():
+        start_proc_by_dsname[ds_name] = running_index
+        running_index += ds_spec.load_commondata().ndata  # takes cuts into account
+
+    for ds_name1, ds_spec1 in datagroup_spec.items():
+        for ds_name2, ds_spec2 in datagroup_spec.items():
+            process_type1 = process_lookup(ds_name1)
+            process_type2 = process_lookup(ds_name2)
+
+            is_excluded_ds = any(name in pc_excluded_datasets for name in [ds_name1, ds_name2])
+            is_excluded_proc = any(
+                proc not in pc_included_procs for proc in [process_type1, process_type2]
+            )
+            if is_excluded_ds or is_excluded_proc:
+                continue
+
+            deltas1_dict = compute_deltas_pc(ds_spec1, pdf, pc_parameters)
+            deltas2_dict = compute_deltas_pc(ds_spec2, pdf, pc_parameters)
+
+            # Convert deltas1 and deltas2 to the format expected by compute_covs_pt_prescrip
+            deltas1 = [np.array(deltas1_dict[shift]) for shift in sorted(deltas1_dict.keys())]
+            deltas2 = [np.array(deltas2_dict[shift]) for shift in sorted(deltas2_dict.keys())]
+
+            s = compute_covs_pt_prescrip(point_prescription, ds_name1, deltas1, ds_name2, deltas2)
+            start_locs = (start_proc_by_dsname[ds_name1], start_proc_by_dsname[ds_name2])
+            covmats[start_locs] = s
+
     return covmats
 
 
@@ -329,7 +420,7 @@ def theory_covmat_custom_per_prescription(covs_pt_prescrip, procs_index, combine
     covmat_index = pd.MultiIndex.from_tuples(indexlist, names=procs_index.names)
 
     # Put the covariance matrices between two process into a single covariance matrix
-    total_datapoints = sum(combine_by_type.sizes.values())
+    total_datapoints = sum(process_info.sizes.values())
     mat = np.zeros((total_datapoints, total_datapoints), dtype=np.float32)
     for locs, cov in covs_pt_prescrip.items():
         xsize, ysize = cov.shape
@@ -339,7 +430,7 @@ def theory_covmat_custom_per_prescription(covs_pt_prescrip, procs_index, combine
 
 
 @table
-def fromfile_covmat(covmatpath, procs_data, procs_index):
+def fromfile_covmat(covmatpath, groups_data_by_process, procs_index):
     """Reads a general theory covariance matrix from file. Then
     1: Applies cuts to match experiment covariance matrix
     2: Expands dimensions to match experiment covariance matrix
@@ -353,7 +444,7 @@ def fromfile_covmat(covmatpath, procs_data, procs_index):
     # Reordering covmat to match exp order in runcard
     # Datasets in exp covmat
     dslist = []
-    for group in procs_data:
+    for group in groups_data_by_process:
         for ds in group.datasets:
             dslist.append(ds.name)
     # Datasets in filecovmat in exp covmat order
@@ -368,7 +459,7 @@ def fromfile_covmat(covmatpath, procs_data, procs_index):
     # ------------- #
     # Loading cuts to apply to covariance matrix
     indextuples = []
-    for group in procs_data:
+    for group in groups_data_by_process:
         for ds in group.datasets:
             # Load cuts for each dataset in the covmat
             if ds.name in filecovmat.index.get_level_values(1):
@@ -434,7 +525,9 @@ def fromfile_covmat(covmatpath, procs_data, procs_index):
 
 
 @table
-def user_covmat(procs_data, procs_index, loaded_user_covmat_path):
+def user_covmat(
+    groups_data_by_process, procs_index, loaded_user_covmat_path, mult_factor_user_covmat
+):
     """
     General theory covariance matrix provided by the user.
     Useful for testing the impact of externally produced
@@ -444,7 +537,9 @@ def user_covmat(procs_data, procs_index, loaded_user_covmat_path):
     ``user_covmat_path`` in ``theorycovmatconfig`` in the
     runcard. For more information see documentation.
     """
-    return fromfile_covmat(loaded_user_covmat_path, procs_data, procs_index)
+    return mult_factor_user_covmat * fromfile_covmat(
+        loaded_user_covmat_path, groups_data_by_process, procs_index
+    )
 
 
 @table

--- a/validphys2/src/validphys/theorycovariance/higher_twist_functions.py
+++ b/validphys2/src/validphys/theorycovariance/higher_twist_functions.py
@@ -1,0 +1,825 @@
+"""
+Utilities for the computation of shifts in theoretical predictions due to power
+corrections. Contrary to scale variations, the multiplicative shifts due to
+power corrections are computed at runtime during vp-setupfit. Once the shifts
+are computed using the function ``compute_deltas_pc``, the covmat can be
+constructed using the same functions implemented for scale variations (e.g.
+`covs_pt_prescrip`).
+
+In the case of power corrections, shifts and covmat constructions are computed
+using a 5-point prescription extended to every parameter used to define the
+power correction.
+
+This module extracts the dataset-to-power-correction-type routing into a
+reusable function ``get_pc_type``. It also comprehends a bunch of
+``factory`` functions such as `mult_dis_pc`. Each of these functions returns
+another function that computes the shifts taking as arguments the values of the
+parameters used to parametrise the power corrections. In other words, these
+factory functions hard-code the dependence on the kinematic and leave the
+dependence on the parameters free. In this way, the shifts can be computed using
+different combinations of parameters (i.e. different prescriptions) if needed.
+
+"""
+
+from collections import defaultdict
+import operator
+from typing import Optional, Tuple, Union
+
+import numpy as np
+import numpy.typing as npt
+
+from validphys.convolution import central_fk_predictions
+from validphys.core import PDF, DataSetSpec
+
+# ---------------------------------------------------------------------------
+# Dataset name constants
+# ---------------------------------------------------------------------------
+
+F2P_exps = ['SLAC_NC_NOTFIXED_P_EM-F2', 'BCDMS_NC_NOTFIXED_P_EM-F2']
+F2D_exps = ['SLAC_NC_NOTFIXED_D_EM-F2', 'BCDMS_NC_NOTFIXED_D_EM-F2']
+NC_SIGMARED_P_EM = ['NMC_NC_NOTFIXED_P_EM-SIGMARED', 'HERA_NC_318GEV_EM-SIGMARED']
+NC_SIGMARED_P_EP = [
+    'HERA_NC_225GEV_EP-SIGMARED',
+    'HERA_NC_251GEV_EP-SIGMARED',
+    'HERA_NC_300GEV_EP-SIGMARED',
+    'HERA_NC_318GEV_EP-SIGMARED',
+]
+NC_SIGMARED_P_EAVG = ['HERA_NC_318GEV_EAVG_CHARM-SIGMARED', 'HERA_NC_318GEV_EAVG_BOTTOM-SIGMARED']
+
+# Combined list for convenience (avoids repeated np.concatenate)
+NC_SIGMARED_P_ALL = NC_SIGMARED_P_EM + NC_SIGMARED_P_EP + NC_SIGMARED_P_EAVG
+
+# CC experiment prefixes (merged from three identical branches)
+DIS_CC_PREFIXES = ('CHORUS_CC', 'NUTEV_CC', 'HERA_CC')
+
+# Dijet rapidity variable name per experiment
+DIJET_RAPIDITY_VAR = {'ATLAS': 'ystar', 'CMS': 'ymax'}
+
+# ---------------------------------------------------------------------------
+# Dataset -> PC type routing
+# ---------------------------------------------------------------------------
+
+PCTypeResult = Union[str, Tuple[str, str]]
+
+
+def get_pc_type(
+    exp_name: str,
+    process_type: str,
+    experiment: Optional[str] = None,
+    pc_dict: Optional[dict] = None,
+) -> PCTypeResult:
+    """
+    Determine which power correction type(s) apply to a given dataset.
+
+    This is the single source of truth for mapping dataset names and process
+    types to power correction parameter keys.
+
+    Parameters
+    ----------
+    exp_name : str
+        Dataset name (e.g. ``'BCDMS_NC_NOTFIXED_P_EM-F2'``).
+    process_type : str
+        Process type string (e.g. ``'DIS_NCE'``, ``'JET'``, ``'DIJET'``).
+    experiment : str, optional
+        Experiment name, required for DIJET (e.g. ``'ATLAS'``, ``'CMS'``).
+    pc_dict : dict, optional
+        Power correction parameter dictionary. When provided, enables
+        fallback logic for DIJET (``H2j_ATLAS`` -> ``H2j`` if the
+        experiment-specific key is absent).
+
+    Returns
+    -------
+    str or tuple of (str, str)
+        The PC type key(s). For the NMC ratio dataset
+        (``NMC_NC_NOTFIXED_EM-F2``), returns ``("f2p", "f2d")``.
+        For all other datasets, returns a single string key.
+
+    Raises
+    ------
+    NotImplementedError
+        For EMC datasets (not yet implemented).
+    ValueError
+        For unknown DIS experiments or unknown DIJET experiments.
+    RuntimeError
+        For unsupported process types.
+    """
+    if process_type.startswith('DIS'):
+        return _get_dis_pc_type(exp_name)
+    elif process_type == 'JET':
+        return 'Hj'
+    elif process_type == 'DIJET':
+        if experiment is None:
+            raise ValueError("The 'experiment' argument is required for DIJET process type.")
+        return _get_dijet_pc_type(experiment, pc_dict)
+    elif process_type == "DIJET_3D":
+        if not (pc_dict.get("H2j_ystar") and pc_dict.get("H2j_yb")):
+            raise ValueError(
+                "For DIJET_3D, both 'H2j_ystar' and 'H2j_yb' keys must be present in pc_dict."
+            )
+        return ("H2j_ystar", "H2j_yb")
+
+    raise RuntimeError(f"{exp_name}: {process_type} has not been implemented.")
+
+
+def _get_dis_pc_type(exp_name: str) -> PCTypeResult:
+    """Resolve DIS dataset name to PC type key(s)."""
+    if exp_name == "NMC_NC_NOTFIXED_EM-F2":
+        return ("f2p", "f2d")
+    if exp_name in F2P_exps:
+        return "f2p"
+    if exp_name in F2D_exps:
+        return "f2d"
+    if exp_name.startswith('EMC_NC_250GEV'):
+        raise NotImplementedError(f"The DIS observable for {exp_name} has not been implemented.")
+    if exp_name in NC_SIGMARED_P_ALL:
+        return "f2p"
+    if any(exp_name.startswith(prefix) for prefix in DIS_CC_PREFIXES):
+        return "dis_cc"
+    raise ValueError(f"The DIS observable for {exp_name} has not been implemented.")
+
+
+def _get_dijet_pc_type(experiment: str, pc_dict: Optional[dict] = {}) -> str:
+    """Resolve DIJET experiment to PC type key with optional fallback."""
+    if pc_dict.get("H2j_ystar") and pc_dict.get("H2j_yb"):
+        return ("H2j_ystar", "H2j_yb")
+
+    if experiment == 'ATLAS':
+        specific_key = "H2j_ystar"
+    elif experiment == 'CMS':
+        specific_key = "H2j_ymax"
+    else:
+        raise ValueError(f"{experiment} is not implemented for DIJET.")
+
+    return specific_key
+
+
+def linear_bin_function(
+    a: npt.ArrayLike, y_shift: npt.ArrayLike, nodes: npt.ArrayLike
+) -> np.ndarray:
+    """
+    This function defines the linear bin function used to construct the prior. Specifically,
+    the prior is constructed using a triangular function whose value at the peak of the node
+    is linked to the right and left nodes using a straight line.
+
+    Parameters
+    ----------
+    a:  ArrayLike of float
+      A one-dimensional array of points at which the function is evaluated.
+    y_shift:  ArrayLike of float
+      A one-dimensional array whose elements represent the y-value of each bin
+    nodes: ArrayLike of float
+      A one-dimensional array containing the edges of the bins. The bins are
+      constructed using pairs of consecutive points.
+
+    Return
+    ------
+    A one-dimensional array containing the function values evaluated at the points
+    specified in `a`.
+    """
+    a = np.asarray(a, dtype=float)
+    res = np.interp(a, nodes, y_shift)
+    res[(a < nodes[0]) | (a > nodes[-1])] = 0.0
+    return res
+
+
+# ---------------------------------------------------------------------------
+# Power correction pure functions by process type
+# ---------------------------------------------------------------------------
+def dis_pc_func(
+    delta_h: npt.ArrayLike, nodes: npt.ArrayLike, x: npt.ArrayLike, Q2: npt.ArrayLike
+) -> npt.ArrayLike:
+    """
+    This function builds the functional form of the power corrections for DIS-like processes.
+    Power corrections are modelled using a linear function, which interpolates between the nodes
+    of the parametrisation. The y-values for each node are given
+    by the array `delta_h`. The power corrections will be computed for the pairs (xb, Q2),
+    where `xb` is the Bjorken x. The power correction for DIS processes is divided by Q2.
+
+    Parameters
+    ----------
+    delta_h: ArrayLike
+      One-dimensional array containing the shifts for each bin.
+    nodes: ArrayLike
+      One-dimensional array containing the edges of the bins in x-Bjorken.
+    x: ArrayLike
+      List of x-Bjorken points at which the power correction function is evaluated.
+    Q2: ArrayLike
+      List of scales where the power correction function is evaluated.
+
+    Returns
+    -------
+    A one-dimensional array of power corrections for DIS-like processes where each point is
+    evaluated at the kinematic pair (x,Q2).
+    """
+    PC = linear_bin_function(x, delta_h, nodes) / Q2
+    return PC
+
+
+def jets_pc_func(
+    delta_h: npt.ArrayLike, nodes: npt.ArrayLike, pT: npt.ArrayLike, rap: npt.ArrayLike
+) -> npt.ArrayLike:
+    """
+    Same as `dis_pc_func`, but for jet data. Here, the kinematic pair consists of the rapidity
+    `rap` and the transverse momentum `pT`.
+
+    Parameters
+    ----------
+    delta_h: ArrayLike
+      One-dimensional array containing the shifts for each bin.
+    nodes: ArrayLike
+     One-dimensional array containing the edges of the bins in rapidity.
+    pT: ArrayLike
+      List of pT points at which the power correction is evaluated.
+    rap: ArrayLike
+      List of rapidity points at which the power correction is evaluated.
+
+    Returns
+    -------
+    A one-dimensional array of power corrections for jet processes where each point is
+    evaluated at the kinematic pair (y, pT).
+    """
+    PC = linear_bin_function(rap, delta_h, nodes) / pT
+    return PC
+
+
+def dijet3D_pc_func(
+    ystar_shifts: npt.ArrayLike,
+    yb_shifts: npt.ArrayLike,
+    ystar_nodes: npt.ArrayLike,
+    yb_nodes: npt.ArrayLike,
+    m_jj: npt.ArrayLike,
+    ystar: npt.ArrayLike,
+    yb: npt.ArrayLike,
+) -> npt.ArrayLike:
+    """
+    Similar to `jets_pc_func`, but for dijet 3D data the correction is a
+    function on the two-dimensional grid in (ystar, yb).
+
+    Parameters
+    ----------
+    ystar_shifts: ArrayLike
+      One-dimensional array containing the shifts for each bin in ystar.
+    yb_shifts: ArrayLike
+      One-dimensional array containing the shifts for each bin in yb.
+    ystar_nodes: ArrayLike
+      One-dimensional array containing the edges of the bins in ystar.
+    yb_nodes: ArrayLike
+      One-dimensional array containing the edges of the bins in yb.
+    ystar: ArrayLike
+      List of ystar points at which the power correction is evaluated.
+    yb: ArrayLike
+      List of yb points at which the power correction is evaluated.
+    """
+    f_ystar = linear_bin_function(ystar, ystar_shifts, ystar_nodes)
+    f_yb = linear_bin_function(yb, yb_shifts, yb_nodes)
+    PC = np.multiply(f_ystar, f_yb) / m_jj
+    return PC
+
+
+def dijet_ystar_pc_func(
+    ystar_shifts: npt.ArrayLike,
+    yb_shifts: npt.ArrayLike,
+    ystar_nodes: npt.ArrayLike,
+    yb_nodes: npt.ArrayLike,
+    m_jj: npt.ArrayLike,
+    ystar: npt.ArrayLike,
+) -> npt.ArrayLike:
+    """
+    Integrate the two-dimensional power correction function
+    over the nodes in yb to obtain a one-dimensional function of ystar.
+    It uses trapezoidal integration.
+
+    Parameters
+    ----------
+    ystar_shifts: ArrayLike
+      One-dimensional array containing the shifts for each bin in ystar.
+    yb_shifts: ArrayLike
+      One-dimensional array containing the shifts for each bin in yb.
+    ystar_nodes: ArrayLike
+      One-dimensional array containing the edges of the bins in ystar.
+    yb_nodes: ArrayLike
+      One-dimensional array containing the edges of the bins in yb.
+    ystar: ArrayLike
+      List of ystar points at which the power correction is evaluated.
+    """
+    f_ystar = linear_bin_function(ystar, ystar_shifts, ystar_nodes)
+    Dyb = yb_nodes[-1] - yb_nodes[0]
+    deltas_yb = [y2 - y1 for y1, y2 in zip(yb_nodes[:-1], yb_nodes[1:])]
+    Hb_integrated = (
+        np.sum(
+            np.concatenate(
+                [
+                    [yb_shifts[0] * deltas_yb[0] / 2],  # Left most node
+                    [yb_shifts[-1] * deltas_yb[-1] / 2],  # Right most node
+                    [
+                        yb_shifts[i] * (deltas_yb[i] + deltas_yb[i - 1]) / 2
+                        for i in range(1, len(yb_nodes) - 1, 1)
+                    ],
+                ]
+            )
+        )
+        / Dyb
+    )
+    PC = Hb_integrated * f_ystar / m_jj
+    return PC
+
+
+def dijet_ymax_pc_func(
+    ystar_shifts: npt.ArrayLike,
+    yb_shifts: npt.ArrayLike,
+    ystar_nodes: npt.ArrayLike,
+    yb_nodes: npt.ArrayLike,
+    m_jj: npt.ArrayLike,
+    ymax: npt.ArrayLike,
+) -> npt.ArrayLike:
+    """
+    Compute the two-dimensional power correction for the double-differential
+    dijet distribution in y_max. The following convention is used: x = y*,
+    y = y_b, and z = y_max.
+
+    The 2D power correction H(x, y) is integrated along the diagonal y = z - x
+    using per-cell Simpson's rule (exact for the quadratic integrand):
+
+        H(z) = (1/Delta_x_total) * sum_{cells (a,b)} (b-a)/6 * [F(a) + 4*F(mid) + F(b)]
+
+    where F(x) = F_alpha^x(t_x(x)) * F_beta^y(t_y(x)) is the product of the
+    two local linear interpolants within the cell, and [a, b] is the overlap
+    between the cell column and the diagonal line y = z - x.
+
+    Parameters
+    ----------
+    ystar_shifts : ArrayLike
+        Node values h_alpha^(y*) of the 2D power correction grid.
+    yb_shifts : ArrayLike
+        Node values h_beta^(y_b) of the 2D power correction grid.
+    ystar_nodes : ArrayLike
+        Grid nodes in y* (= x in the notes).
+    yb_nodes : ArrayLike
+        Grid nodes in y_b (= y in the notes).
+    m_jj : ArrayLike
+        Dijet invariant mass for each data point (used as the overall 1/m_jj factor).
+    ymax : ArrayLike
+        y_max values (= z in the notes) at which H(z) is evaluated.
+
+    Returns
+    -------
+    np.ndarray
+        Power correction H(z) / m_jj evaluated at each data point.
+    """
+    ystar_nodes = np.asarray(ystar_nodes)
+    yb_nodes = np.asarray(yb_nodes)
+    ystar_shifts = np.asarray(ystar_shifts)
+    yb_shifts = np.asarray(yb_shifts)
+    ymax = np.asarray(ymax)
+
+    Delta_x_total = ystar_nodes[-1] - ystar_nodes[0]
+    H_z = np.zeros(len(ymax))
+
+    for z_idx, z in enumerate(ymax):
+        integral = 0.0
+        for alpha in range(len(ystar_nodes) - 1):
+            x0, x1 = ystar_nodes[alpha], ystar_nodes[alpha + 1]
+            dx = x1 - x0
+            hx0, hx1 = ystar_shifts[alpha], ystar_shifts[alpha + 1]
+
+            for beta in range(len(yb_nodes) - 1):
+                y0, y1 = yb_nodes[beta], yb_nodes[beta + 1]
+                dy = y1 - y0
+                hy0, hy1 = yb_shifts[beta], yb_shifts[beta + 1]
+
+                # Check if the line y = z - x intersects the cell defined by (x0, x1) and (y0, y1)
+                a = max(x0, z - y1)
+                b = min(x1, z - y0)
+                if a >= b:
+                    continue
+
+                # Local coordinates at the two endpoints and midpoint
+                tx_a = (a - x0) / dx
+                tx_b = (b - x0) / dx
+                ty_a = (z - a - y0) / dy
+                ty_b = (z - b - y0) / dy
+                tx_m = 0.5 * (tx_a + tx_b)
+                ty_m = 0.5 * (ty_a + ty_b)
+
+                def _F(tx, ty):
+                    return (hx0 * (1.0 - tx) + hx1 * tx) * (hy0 * (1.0 - ty) + hy1 * ty)
+
+                # Simpson's rule (exact for the quadratic product of two linears)
+                integral += (b - a) / 6.0 * (_F(tx_a, ty_a) + 4.0 * _F(tx_m, ty_m) + _F(tx_b, ty_b))
+
+        H_z[z_idx] = integral / Delta_x_total
+
+    return H_z / m_jj
+
+
+# ---------------------------------------------------------------------------
+# Power correction callable factories
+# If these functions are used to compute c-factors,
+# no need to multiply by the observable.
+# ---------------------------------------------------------------------------
+def mult_dis_pc(nodes, x, q2, dataset_sp, pdf, cfactors: bool = False) -> callable:
+    """
+    Returns the function that computes the shift to observables due to
+    power corrections. Power corrections are treated as multiplicative
+    shifts. Hence if `O` is the observable, the prediction is shifted as
+
+      O -> O * (1 + PC),
+
+    and the shift is defined as
+
+      Delta(O) = O * (1 + PC) - O = O * PC.
+
+    This function returns a function that computes the shift
+    given the y-values of the nodes used to define the power corrections.
+    """
+    cuts = dataset_sp.cuts
+    (fkspec,) = dataset_sp.fkspecs
+    fk = fkspec.load_with_cuts(cuts)
+    th_preds = central_fk_predictions(fk, pdf)
+
+    def func(y_values):
+        result = dis_pc_func(y_values, nodes, x, q2)
+        if cfactors:
+            return np.sum([np.ones_like(result), result], axis=0)
+        return np.multiply(result, th_preds.to_numpy()[:, 0])
+
+    return func
+
+
+def mult_dis_ratio_pc(p_nodes, d_nodes, x, q2, dataset_sp, pdf, cfactors: bool = False) -> callable:
+    """
+    Returns the function that computes the shift for the ratio of structure
+    functions F2_d / F2_p. For this observable, power corrections are defined
+    such that
+
+      F2_d / F2_p -> F2_d * (1 + PC2_d) / F2_p * (1 + PC2_p) ,
+
+    and the shift is the defined as
+
+      Delta(F2 ratio) = F2_d / F2_p * (PC2_d - PC2_p) / (1 + PC2_d).
+
+    As for `mult_dis_pc`, this function returns a function that computes the shift
+    for the ratio of structure functions F2_d / F2_p given a set of y-values.
+
+    Parameters
+    ----------
+    p_nodes: list[float]
+      The list of nodes in x-Bjorken used to define the parametrization of the
+      power correction for the proton (see `dis_pc_func`).
+    d_nodes: list[float]
+      The list of nodes in x-Bjorken used to define the parametrization of the
+      power correction for the deuteron (see `dis_pc_func`).
+    x: list[float]
+      Set of points in x-Bjorken where the power corrections will be evaluated.
+    q2: list[float]
+      Set of points in Q2 where the power corrections will be evaluated.
+    dataset_sp: DataSetSpec
+      An instance of DataSetSpec used to extract information such as cuts
+      and fk tables.
+    pdf: PDF
+      An instance of the class PDF. This specifies the PDF to bo convoluted
+      with the FK tables.
+
+    Returns
+    -------
+    The function the computes the shift for this observable. It depends on the
+    y-values for the parameterization of P2_d and P2_p.
+    """
+    cuts = dataset_sp.cuts
+    fkspec_F2D, fkspec_F2P = dataset_sp.fkspecs
+    fk_F2D = fkspec_F2D.load_with_cuts(cuts)
+    fk_F2P = fkspec_F2P.load_with_cuts(cuts)
+    F2D = central_fk_predictions(fk_F2D, pdf)
+    F2P = central_fk_predictions(fk_F2P, pdf)
+
+    F2D = np.concatenate(F2D.values)
+    F2P = np.concatenate(F2P.values)
+    F2_ratio = operator.truediv(F2D, F2P)
+
+    def func(y_values_p, y_values_d):
+        h2d = dis_pc_func(y_values_d, d_nodes, x, q2)
+        h2p = dis_pc_func(y_values_p, p_nodes, x, q2)
+        if cfactors:
+            num = np.sum([np.ones_like(h2d), h2d], axis=0)
+            denom = np.sum([np.ones_like(h2p), h2p], axis=0)
+            return (num, denom)
+        num = np.sum([h2d, -h2p], axis=0)
+        denom = np.sum([np.ones_like(h2p), h2p], axis=0)
+        div = operator.truediv(num, denom)
+        result = np.multiply(div, F2_ratio)
+        return result
+
+    return func
+
+
+def mult_jet_pc(nodes, pT, rap, dataset_sp, pdf, cfactors: bool = False) -> callable:
+    """
+    As `mult_dis_pc`, but for jet data. The power corrections are defined as
+
+      xsec -> xsec * ( 1 + PC ),
+
+    and the shift is defined as
+
+      Delta(xsec) = (xsec + xsec) - xsec = PC.
+
+    The power correction is a function of the rapidity.
+    """
+    cuts = dataset_sp.cuts
+    (fkspec,) = dataset_sp.fkspecs
+    fk = fkspec.load_with_cuts(cuts)
+    xsec = central_fk_predictions(fk, pdf)
+
+    def func(y_values):
+        result = jets_pc_func(y_values, nodes, pT, rap)
+        if cfactors:
+            return np.sum([np.ones_like(result), result], axis=0)
+        return np.multiply(result, xsec.to_numpy()[:, 0])
+
+    return func
+
+
+def mult_dijet_pc(
+    ystar_nodes,
+    yb_nodes,
+    m_jj,
+    dataset_sp,
+    pdf,
+    ystar: npt.ArrayLike = np.array([]),
+    yb: npt.ArrayLike = np.array([]),
+    ymax: npt.ArrayLike = np.array([]),
+    distrb: str = '3D',
+    cfactors: bool = False,
+) -> callable:
+    cuts = dataset_sp.cuts
+    (fkspec,) = dataset_sp.fkspecs
+    fk = fkspec.load_with_cuts(cuts)
+    th_preds = central_fk_predictions(fk, pdf)
+
+    if distrb == '3D':
+        if len(ystar) == 0 or len(yb) == 0:
+            raise ValueError("For 3D distributions, ystar and yb must be provided.")
+    elif distrb == "ystar":
+        if len(ystar) == 0:
+            raise ValueError("For ystar distributions, ystar must be provided.")
+    elif distrb == "ymax":
+        if len(ymax) == 0:
+            raise ValueError("For ymax distributions, ymax must be provided.")
+    else:
+        raise ValueError(f"Unknown distrb value: {distrb!r}. Expected '3D', 'ystar', or 'ymax'.")
+
+    def func(ystar_shifts, y_b_shifts):
+        if distrb == '3D':
+            result = dijet3D_pc_func(
+                ystar_shifts=ystar_shifts,
+                yb_shifts=y_b_shifts,
+                ystar_nodes=ystar_nodes,
+                yb_nodes=yb_nodes,
+                ystar=ystar,
+                yb=yb,
+                m_jj=m_jj,
+            )
+        elif distrb == "ystar":
+            result = dijet_ystar_pc_func(
+                ystar_shifts=ystar_shifts,
+                yb_shifts=y_b_shifts,
+                ystar_nodes=ystar_nodes,
+                yb_nodes=yb_nodes,
+                m_jj=m_jj,
+                ystar=ystar,
+            )
+        elif distrb == "ymax":
+            result = dijet_ymax_pc_func(
+                ystar_shifts=ystar_shifts,
+                yb_shifts=y_b_shifts,
+                ystar_nodes=ystar_nodes,
+                yb_nodes=yb_nodes,
+                m_jj=m_jj,
+                ymax=ymax,
+            )
+
+        if cfactors:
+            return np.sum([np.ones_like(result), result], axis=0)
+        return np.multiply(result, th_preds.to_numpy()[:, 0])
+
+    return func
+
+
+# ---------------------------------------------------------------------------
+# Point prescription utilities
+# ---------------------------------------------------------------------------
+def construct_pars_combs(parameters_dict: dict, pc_types_2d=None) -> list[dict]:
+    """Construct the combination of parameters (the ones that parametrize the power
+    corrections) used to compute the shifts.
+
+    Example
+    -------
+    Given the following dictionary that specifies the power corrections::
+
+        pc_dict = {
+          'H1': {'yshift': [1,2],   'nodes': [1, 2]},
+          'H2': {'yshift': [3,4,5], 'nodes': [1, 2, 3]},
+        }
+
+    then this function constructs a list as follows::
+
+        pars_combs = [
+         {'label': 'H1(0)', 'comb': {'H1': [1,0], 'H2': [0,0,0]}},
+         {'label': 'H1(1)', 'comb': {'H1': [0,2], 'H2': [0,0,0]}},
+         {'label': 'H2(0)', 'comb': {'H1': [0,0], 'H2': [3,0,0]}},
+         {'label': 'H2(1)', 'comb': {'H1': [0,0], 'H2': [0,4,0]}},
+         {'label': 'H2(2)', 'comb': {'H1': [0,0], 'H2': [0,0,5]}},
+        ]
+    """
+    combinations = []
+    for key, values in parameters_dict.items():
+        if pc_types_2d is None or key not in pc_types_2d:
+            for i in range(len(values['yshift'])):
+                # Create a new dictionary with all keys and zeroed-out values
+                new_dict = {k: np.zeros_like(v['yshift']) for k, v in parameters_dict.items()}
+                # Set the specific value for the current index
+                label = key + f'({i})'
+                new_dict[key][i] = values['yshift'][i]
+                new_dict = {'label': label, 'comb': new_dict}
+                combinations.append(new_dict)
+
+    if pc_types_2d is not None:
+        for i in range(len(parameters_dict[pc_types_2d[0]]['yshift'])):
+            for j in range(len(parameters_dict[pc_types_2d[1]]['yshift'])):
+                new_dict = {k: np.zeros_like(v['yshift']) for k, v in parameters_dict.items()}
+                label = f"{pc_types_2d[0]}({i})_{pc_types_2d[1]}({j})"
+                new_dict[pc_types_2d[0]][i] = parameters_dict[pc_types_2d[0]]['yshift'][i]
+                new_dict[pc_types_2d[1]][j] = parameters_dict[pc_types_2d[1]]['yshift'][j]
+                new_dict = {'label': label, 'comb': new_dict}
+                combinations.append(new_dict)
+
+    return combinations
+
+
+def _apply_pars_combs(pars_combs, pc_keys, pc_func):
+    """Apply parameter combinations to a PC function, returning deltas dict.
+
+    This eliminates the repeated pattern::
+
+        for pars_pc in pars_combs:
+            deltas[pars_pc['label']] = pc_func(pars_pc['comb'][key])
+
+    Parameters
+    ----------
+    pars_combs : list of dict
+        Output of ``construct_pars_combs``.
+    pc_keys : list of str
+        The keys into ``pars_pc['comb']`` to extract the parameter values.
+    pc_func : callable
+        A function that takes a single array of y-values and returns shifts.
+
+    Returns
+    -------
+    dict
+        ``{label: array_of_shifts}``
+    """
+    deltas = {}
+
+    if isinstance(pc_keys, str):
+        pc_keys = [pc_keys]
+
+    for pars_pc in pars_combs:
+        arg = [pars_pc['comb'][pc_key] for pc_key in pc_keys]
+        deltas[pars_pc['label']] = pc_func(*arg)
+    return deltas
+
+
+# ---------------------------------------------------------------------------
+# Main function
+# ---------------------------------------------------------------------------
+def compute_deltas_pc(
+    dataset_sp: DataSetSpec,
+    pdf: PDF,
+    pc_dict: dict,
+    pars_comb_func: callable = construct_pars_combs,
+    cfactors: bool = False,
+) -> dict:
+    """
+    Computes the shifts due to power corrections for a single dataset given
+    the set of parameters that model the power corrections. The result is
+    a dictionary containing as many arrays of shifts as the number of
+    combinations of the parameters. For instance, the final dictionary
+    may look like::
+
+        deltas1 = {comb1_label: array_of_shifts1,
+                   comb2_label: array_of_shifts2,
+                   comb3_label: array_of_shifts3,
+                   ...}
+
+    Note that, as of now, we don't need to specify different prescriptions.
+    Hence, the prescription adopted to construct the shifts is hard
+    coded in the function ``construct_pars_combs``, and the prescription used to
+    compute the sub-matrix is hard-coded in ``covmat_power_corrections``.
+    """
+    exp_name = dataset_sp.name
+    process_type = dataset_sp.commondata.metadata.process_type.name
+    experiment = getattr(dataset_sp.commondata.metadata, 'experiment', None)
+    cuts = dataset_sp.cuts.load()
+
+    deltas = defaultdict(list)
+
+    if "H2j_ystar" in pc_dict and "H2j_yb" in pc_dict:
+        pars_combs = pars_comb_func(pc_dict, ("H2j_ystar", "H2j_yb"))
+    else:
+        pars_combs = pars_comb_func(pc_dict)
+
+    pc_type = get_pc_type(exp_name, process_type, experiment=experiment, pc_dict=pc_dict)
+
+    if process_type.startswith('DIS'):
+        try:
+            x = dataset_sp.commondata.metadata.load_kinematics()['x'].to_numpy().reshape(-1)[cuts]
+            q2 = dataset_sp.commondata.metadata.load_kinematics()['Q2'].to_numpy().reshape(-1)[cuts]
+        except KeyError as e:
+            raise ValueError(f"Required kinematic variable not found: {e}")
+
+        # NMC ratio: special case with two PC types (proton and deuteron)
+        if isinstance(pc_type, tuple):
+            p_key, d_key = pc_type
+            f2_p_nodes = pc_dict[p_key]['nodes']
+            f2_d_nodes = pc_dict[d_key]['nodes']
+            pc_func_ratio = mult_dis_ratio_pc(
+                f2_p_nodes, f2_d_nodes, x, q2, dataset_sp, pdf, cfactors=cfactors
+            )
+            for pars_pc in pars_combs:
+                deltas[pars_pc['label']] = pc_func_ratio(
+                    pars_pc['comb'][p_key], pars_pc['comb'][d_key]
+                )
+        else:
+            nodes = pc_dict[pc_type]['nodes']
+            pc_func = mult_dis_pc(nodes, x, q2, dataset_sp, pdf, cfactors=cfactors)
+            deltas.update(_apply_pars_combs(pars_combs, pc_type, pc_func))
+
+    elif process_type == 'JET':
+
+        eta = dataset_sp.commondata.metadata.load_kinematics()['y'].to_numpy().reshape(-1)[cuts]
+        pT = dataset_sp.commondata.metadata.load_kinematics()['pT'].to_numpy().reshape(-1)[cuts]
+        nodes = pc_dict[pc_type]['nodes']
+        pc_func = mult_jet_pc(nodes, pT, eta, dataset_sp, pdf, cfactors=cfactors)
+        deltas.update(_apply_pars_combs(pars_combs, pc_type, pc_func))
+
+    elif process_type == 'DIJET':
+        rap_var = DIJET_RAPIDITY_VAR.get(experiment)
+        if rap_var is None:
+            raise ValueError(f"{experiment} is not implemented for DIJET.")
+
+        kinematics = dataset_sp.commondata.metadata.load_kinematics()
+        rap = kinematics[rap_var].to_numpy().reshape(-1)[cuts]
+        m_jj = kinematics['m_jj'].to_numpy().reshape(-1)[cuts]
+
+        if isinstance(pc_type, tuple):
+            # 2D case
+            ystar_nodes = pc_dict[pc_type[0]]['nodes']
+            yb_nodes = pc_dict[pc_type[1]]['nodes']
+            pc_func = mult_dijet_pc(
+                ystar_nodes=ystar_nodes,
+                yb_nodes=yb_nodes,
+                m_jj=m_jj,
+                dataset_sp=dataset_sp,
+                pdf=pdf,
+                ystar=rap if rap_var == 'ystar' else np.array([]),
+                yb=np.array([]),
+                ymax=rap if rap_var == 'ymax' else np.array([]),
+                distrb=rap_var,
+                cfactors=cfactors,
+            )
+            # Both ystar and yb parameters contribute for all 2D distributions
+            deltas.update(_apply_pars_combs(pars_combs, ["H2j_ystar", "H2j_yb"], pc_func))
+
+        # Fallback to the case where power corrections have same structure
+        # as single-inclusice jets, with pT replaced by m_jj.
+        else:
+            nodes = pc_dict[pc_type]['nodes']
+            pc_func = mult_jet_pc(nodes, m_jj, rap, dataset_sp, pdf, cfactors=cfactors)
+            deltas.update(_apply_pars_combs(pars_combs, pc_type, pc_func))
+
+    elif process_type == "DIJET_3D":
+        kinematics = dataset_sp.commondata.metadata.load_kinematics()
+        ystar = kinematics['ystar'].to_numpy().reshape(-1)[cuts]
+        yb = kinematics['yb'].to_numpy().reshape(-1)[cuts]
+        m_jj = kinematics['m_jj'].to_numpy().reshape(-1)[cuts]
+
+        ystar_nodes = pc_dict[pc_type[0]]['nodes']
+        yb_nodes = pc_dict[pc_type[1]]['nodes']
+
+        pc_func = mult_dijet_pc(
+            ystar_nodes=ystar_nodes,
+            yb_nodes=yb_nodes,
+            m_jj=m_jj,
+            dataset_sp=dataset_sp,
+            pdf=pdf,
+            ystar=ystar,
+            yb=yb,
+            ymax=np.array([]),
+            distrb="3D",
+            cfactors=cfactors,
+        )
+        deltas.update(_apply_pars_combs(pars_combs, ["H2j_ystar", "H2j_yb"], pc_func))
+
+    else:
+        raise RuntimeError(f"{process_type} has not been implemented.")
+
+    return deltas


### PR DESCRIPTION
This PR allows for the inclusion of theory uncertainties due to the effect of power corrections. The theory covariance matrix is constructed by computing the shifts for the theoretical predictions as done for the MHOUs. The shift is computed at the level of the structure functions. Then, the shifts for the structure functions are combined to reconstruct the shift for the xsec. For this reason, the calculation of the shift depends on the dataset. Currently, only 1-JET and DIS (NC and CC) are supported.

At the level of the runcard, power corrections are specified as follows

```yaml
theorycovmatconfig:
  point_prescriptions: ["power corrections"]
  pc_parameters:
  - {ht: H2p, yshift: [0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.0], nodes: [0.0, 0.001, 0.01, 0.1, 0.3, 0.5, 0.7, 0.9, 1]}
  - {ht: H2d, yshift: [0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.0], nodes: [0.0, 0.001, 0.01, 0.1, 0.3, 0.5, 0.7, 0.9, 1]}
  - {ht: HLp, yshift: [0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.0], nodes: [0.0, 0.001, 0.01, 0.1, 0.3, 0.5, 0.7, 0.9, 1]}
  - {ht: HLd, yshift: [0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.0], nodes: [0.0, 0.001, 0.01, 0.1, 0.3, 0.5, 0.7, 0.9, 1]}
  - {ht: H3p, yshift: [0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.0], nodes: [0.0, 0.001, 0.01, 0.1, 0.3, 0.5, 0.7, 0.9, 1]}
  - {ht: H3d, yshift: [0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.0], nodes: [0.0, 0.001, 0.01, 0.1, 0.3, 0.5, 0.7, 0.9, 1]}
  - {ht: Hj, yshift: [2.0, 2.0, 2.0, 2.0, 2.0, 2.0], nodes: [0.25, 0.75, 1.25, 1.75, 2.25, 2.75]}
  pc_included_procs: ["JETS", "DIS NC", "DIS CC"]
  pc_excluded_exps: [HERA_NC_318GEV_EAVG_CHARM-SIGMARED,
                     HERA_NC_318GEV_EAVG_BOTTOM-SIGMARED]
  pdf: 240701-02-rs-nnpdf40-baseline
  use_thcovmat_in_fitting: true
  use_thcovmat_in_sampling: true
```
For each process/sf implemented, we need to specify a series of information:
1. The name of the power correction, under the key `ht`. This is useful to identify the type of power correction, in particular when computing the posterior.
2. The values in `yshift` are the magnitudes of the prior.
3. `nodes` contains the points where the prior is shifted
 
The array `pc_included_procs` specifies the processes for which the shifts are computed. I've also implemented the possibility to exclude some particular datasets within the selected processes, and this can be done by specifying the names in `pc_excluded_exps`.

~~The key `func_type` is temporary and will be deleted once we decide which function to use to construct the prior.~~

All the relevant details for this PR are contained in the module `higher_twist_functions.py`. For each observable for which the shift has to be computed, I implemented a factory that constructs a function which will then compute the shift. I thought it was kind of necessary to make the shift dependent on the shift parameters (`yshift` and `nodes`) and on the prescription according to which we vary the parameters (which for now is fixed), and not on the kinematics (I think this is known as _currying_ in computer science).

TO DO
=====
- [x] Add documentation
- ~~[x] Remove `func_type`~~
- [x] What happens if `power_corrections` is specified but the parameters are not given?
- [x] Change the name `ht` to `name` (?)
- [x] Something else?