### PR TITLE
move `separate_multiplicative` key outside `sampling` key in runcard

### DIFF
--- a/extra_tests/regression_fits/trainable_prepro.yml
+++ b/extra_tests/regression_fits/trainable_prepro.yml
@@ -35,7 +35,7 @@ mcseed: 1
 
 load: "weights.weights.h5"
 
-sep_mult: True
+separate_multiplicative: True
 
 parameters: # This defines the parameter dictionary that is passed to the Model Trainer
   nodes_per_layer: [15, 10, 8]

--- a/extra_tests/regression_fits/trainable_prepro.yml
+++ b/extra_tests/regression_fits/trainable_prepro.yml
@@ -35,8 +35,7 @@ mcseed: 1
 
 load: "weights.weights.h5"
 
-sampling:
-  separate_multiplicative: True
+sep_mult: True
 
 parameters: # This defines the parameter dictionary that is passed to the Model Trainer
   nodes_per_layer: [15, 10, 8]

--- a/n3fit/runcards/examples/Basic_feature_scaling.yml
+++ b/n3fit/runcards/examples/Basic_feature_scaling.yml
@@ -22,7 +22,7 @@ datacuts:
 ############################################################
 theory:
   theoryid: 708       # database id
-sep_mult: True
+separate_multiplicative: True
 
 ############################################################
 trvlseed: 1

--- a/n3fit/runcards/examples/Basic_feature_scaling.yml
+++ b/n3fit/runcards/examples/Basic_feature_scaling.yml
@@ -22,8 +22,7 @@ datacuts:
 ############################################################
 theory:
   theoryid: 708       # database id
-sampling:
-  separate_multiplicative: true
+sep_mult: True
 
 ############################################################
 trvlseed: 1

--- a/n3fit/runcards/examples/Basic_hyperopt.yml
+++ b/n3fit/runcards/examples/Basic_hyperopt.yml
@@ -40,7 +40,7 @@ datacuts:
 theory:
   theoryid: 708        # database id
 
-sep_mult: True
+separate_multiplicative: True
 
 ############################################################
 hyperscan_config:

--- a/n3fit/runcards/examples/Basic_hyperopt.yml
+++ b/n3fit/runcards/examples/Basic_hyperopt.yml
@@ -40,8 +40,7 @@ datacuts:
 theory:
   theoryid: 708        # database id
 
-sampling:
-  separate_multiplicative: true
+sep_mult: True
 
 ############################################################
 hyperscan_config:

--- a/n3fit/runcards/examples/Basic_runcard.yml
+++ b/n3fit/runcards/examples/Basic_runcard.yml
@@ -24,7 +24,7 @@ theory:
   theoryid: 708       # database id
 
 resample_negative_pseudodata: True
-sep_mult: True
+separate_multiplicative: True
 
 parameters: # This defines the parameter dictionary that is passed to the Model Trainer
   nodes_per_layer: [15, 10, 8]

--- a/n3fit/runcards/examples/Basic_runcard.yml
+++ b/n3fit/runcards/examples/Basic_runcard.yml
@@ -24,9 +24,8 @@ theory:
   theoryid: 708       # database id
 
 resample_negative_pseudodata: True
+sep_mult: True
 
-sampling:
-  separate_multiplicative: true
 parameters: # This defines the parameter dictionary that is passed to the Model Trainer
   nodes_per_layer: [15, 10, 8]
   activation_per_layer: ['sigmoid', 'sigmoid', 'linear']

--- a/n3fit/runcards/examples/Basic_runcard_closure_test.yml
+++ b/n3fit/runcards/examples/Basic_runcard_closure_test.yml
@@ -23,8 +23,7 @@ datacuts:
 theory:
   theoryid: 708       # database id
 
-sampling:
-  separate_multiplicative: true
+sep_mult: True
 parameters: # This defines the parameter dictionary that is passed to the Model Trainer
   nodes_per_layer: [15, 10, 8]
   activation_per_layer: ['sigmoid', 'sigmoid', 'linear']

--- a/n3fit/runcards/examples/Basic_runcard_closure_test.yml
+++ b/n3fit/runcards/examples/Basic_runcard_closure_test.yml
@@ -23,7 +23,7 @@ datacuts:
 theory:
   theoryid: 708       # database id
 
-sep_mult: True
+separate_multiplicative: True
 parameters: # This defines the parameter dictionary that is passed to the Model Trainer
   nodes_per_layer: [15, 10, 8]
   activation_per_layer: ['sigmoid', 'sigmoid', 'linear']

--- a/n3fit/runcards/examples/Basic_runcard_parallel.yml
+++ b/n3fit/runcards/examples/Basic_runcard_parallel.yml
@@ -24,7 +24,7 @@ datacuts:
 theory:
   theoryid: 708        # database id
 
-sep_mult: True
+separate_multiplicative: True
 ############################################################
 trvlseed: 1
 nnseed: 2

--- a/n3fit/runcards/examples/Basic_runcard_parallel.yml
+++ b/n3fit/runcards/examples/Basic_runcard_parallel.yml
@@ -24,8 +24,7 @@ datacuts:
 theory:
   theoryid: 708        # database id
 
-sampling:
-  separate_multiplicative: true
+sep_mult: True
 ############################################################
 trvlseed: 1
 nnseed: 2

--- a/n3fit/runcards/examples/DIS_diagonal_l2reg_example.yml
+++ b/n3fit/runcards/examples/DIS_diagonal_l2reg_example.yml
@@ -39,7 +39,7 @@ datacuts:
 theory:
   theoryid: 708        # database id
 
-sep_mult: True
+separate_multiplicative: True
 ############################################################
 trvlseed: 1
 nnseed: 2

--- a/n3fit/runcards/examples/DIS_diagonal_l2reg_example.yml
+++ b/n3fit/runcards/examples/DIS_diagonal_l2reg_example.yml
@@ -39,8 +39,7 @@ datacuts:
 theory:
   theoryid: 708        # database id
 
-sampling:
-  separate_multiplicative: true
+sep_mult: True
 ############################################################
 trvlseed: 1
 nnseed: 2

--- a/n3fit/runcards/examples/developing.yml
+++ b/n3fit/runcards/examples/developing.yml
@@ -52,7 +52,7 @@ datacuts:
 theory:
   theoryid: 40000000
 
-sep_mult: True
+separate_multiplicative: True
 ############################################################
 trvlseed: 1
 nnseed: 2

--- a/n3fit/runcards/examples/developing.yml
+++ b/n3fit/runcards/examples/developing.yml
@@ -52,8 +52,7 @@ datacuts:
 theory:
   theoryid: 40000000
 
-sampling:
-  separate_multiplicative: true
+sep_mult: True
 ############################################################
 trvlseed: 1
 nnseed: 2

--- a/n3fit/src/n3fit/scripts/n3fit_exec.py
+++ b/n3fit/src/n3fit/scripts/n3fit_exec.py
@@ -76,8 +76,8 @@ class N3FitEnvironment(Environment):
         # create output folder for the fit
         self.replica_path = self.output_path / "nnfit"
         for replica in self.replicas:
-            path = self.replica_path / "replica_{0}".format(replica)
-            log.info("Creating replica output folder in {0}".format(path))
+            path = self.replica_path / f"replica_{replica}"
+            log.info(f"Creating replica output folder in {path}")
             try:
                 path.mkdir(exist_ok=True)
             except OSError as e:
@@ -177,11 +177,6 @@ class N3FitConfig(Config):
             N3FIT_FIXED_CONFIG['use_scalevar_uncertainties'] = thconfig.get(
                 'use_scalevar_uncertainties', True
             )
-        # Sampling flags
-        if (sam_t0 := file_content.get('sampling')) is not None:
-            N3FIT_FIXED_CONFIG['separate_multiplicative'] = sam_t0.get(
-                'separate_multiplicative', False
-            )
         # Fitting flag
         file_content.update(N3FIT_FIXED_CONFIG)
         return cls(file_content, *args, **kwargs)
@@ -261,7 +256,7 @@ class N3FitApp(App):
     config_class = N3FitConfig
 
     def __init__(self):
-        super(N3FitApp, self).__init__(name="n3fit", providers=N3FIT_PROVIDERS)
+        super().__init__(name="n3fit", providers=N3FIT_PROVIDERS)
 
     @property
     def argparser(self):

--- a/n3fit/src/n3fit/tests/regressions/quickcard-sequential.yml
+++ b/n3fit/src/n3fit/tests/regressions/quickcard-sequential.yml
@@ -31,8 +31,7 @@ nnseed: 2
 mcseed: 1
 
 save: weights.weights.h5
-sampling:
-  separate_multiplicative: true
+sep_mult: True
 
 parameters: # This defines the parameter dictionary that is passed to the Model Trainer
   nodes_per_layer: [15, 10, 8]

--- a/n3fit/src/n3fit/tests/regressions/quickcard-sequential.yml
+++ b/n3fit/src/n3fit/tests/regressions/quickcard-sequential.yml
@@ -31,7 +31,7 @@ nnseed: 2
 mcseed: 1
 
 save: weights.weights.h5
-sep_mult: True
+separate_multiplicative: True
 
 parameters: # This defines the parameter dictionary that is passed to the Model Trainer
   nodes_per_layer: [15, 10, 8]

--- a/n3fit/src/n3fit/tests/regressions/quickcard.yml
+++ b/n3fit/src/n3fit/tests/regressions/quickcard.yml
@@ -34,7 +34,7 @@ nnseed: 2
 mcseed: 1
 
 load: "weights.weights.h5"
-sep_mult: True
+separate_multiplicative: True
 
 parameters: # This defines the parameter dictionary that is passed to the Model Trainer
   nodes_per_layer: [15, 10, 8]

--- a/n3fit/src/n3fit/tests/regressions/quickcard.yml
+++ b/n3fit/src/n3fit/tests/regressions/quickcard.yml
@@ -34,8 +34,7 @@ nnseed: 2
 mcseed: 1
 
 load: "weights.weights.h5"
-sampling:
-  separate_multiplicative: true
+sep_mult: True
 
 parameters: # This defines the parameter dictionary that is passed to the Model Trainer
   nodes_per_layer: [15, 10, 8]

--- a/n3fit/src/n3fit/tests/regressions/quickcard_pol.yml
+++ b/n3fit/src/n3fit/tests/regressions/quickcard_pol.yml
@@ -32,7 +32,7 @@ nnseed: 2
 mcseed: 1
 
 load: "weights_pol.weights.h5"
-sep_mult: True
+separate_multiplicative: True
 
 parameters:
   nodes_per_layer: [25, 20, 4]

--- a/n3fit/src/n3fit/tests/regressions/quickcard_pol.yml
+++ b/n3fit/src/n3fit/tests/regressions/quickcard_pol.yml
@@ -32,8 +32,7 @@ nnseed: 2
 mcseed: 1
 
 load: "weights_pol.weights.h5"
-sampling:
-  separate_multiplicative: true
+sep_mult: True
 
 parameters:
   nodes_per_layer: [25, 20, 4]

--- a/n3fit/src/n3fit/tests/regressions/quickcard_qed.yml
+++ b/n3fit/src/n3fit/tests/regressions/quickcard_qed.yml
@@ -34,7 +34,7 @@ nnseed: 2
 mcseed: 1
 
 load: "weights.weights.h5"
-sep_mult: True
+separate_multiplicative: True
 
 parameters: # This defines the parameter dictionary that is passed to the Model Trainer
   nodes_per_layer: [15, 10, 8]

--- a/n3fit/src/n3fit/tests/regressions/quickcard_qed.yml
+++ b/n3fit/src/n3fit/tests/regressions/quickcard_qed.yml
@@ -34,8 +34,7 @@ nnseed: 2
 mcseed: 1
 
 load: "weights.weights.h5"
-sampling:
-  separate_multiplicative: true
+sep_mult: True
 
 parameters: # This defines the parameter dictionary that is passed to the Model Trainer
   nodes_per_layer: [15, 10, 8]

--- a/validphys2/src/validphys/config.py
+++ b/validphys2/src/validphys/config.py
@@ -701,6 +701,11 @@ class CoreConfig(configparser.Config):
             return covmats.dataset_inputs_t0_total_covmat
         return covmats.dataset_inputs_t0_exp_covmat
 
+    def produce_separate_multiplicative(self, sep_mult=False):
+        if sep_mult is False:
+            return False
+        return True
+
     @configparser.explicit_node
     def produce_dataset_inputs_sampling_covmat(
         self,

--- a/validphys2/src/validphys/config.py
+++ b/validphys2/src/validphys/config.py
@@ -701,17 +701,14 @@ class CoreConfig(configparser.Config):
             return covmats.dataset_inputs_t0_total_covmat
         return covmats.dataset_inputs_t0_exp_covmat
 
-    def produce_separate_multiplicative(self, sep_mult=False):
-        if sep_mult is False:
+    def produce_sep_mult(self, separate_multiplicative=False):
+        if separate_multiplicative is False:
             return False
         return True
 
     @configparser.explicit_node
     def produce_dataset_inputs_sampling_covmat(
-        self,
-        separate_multiplicative=False,
-        theory_covmat_flag=False,
-        use_thcovmat_in_sampling=False,
+        self, sep_mult=False, theory_covmat_flag=False, use_thcovmat_in_sampling=False
     ):
         """
         Produces the correct covmat to be used in make_replica according
@@ -721,12 +718,12 @@ class CoreConfig(configparser.Config):
         from validphys import covmats
 
         if theory_covmat_flag and use_thcovmat_in_sampling:
-            if separate_multiplicative:
+            if sep_mult:
                 return covmats.dataset_inputs_total_covmat_separate
             else:
                 return covmats.dataset_inputs_total_covmat
         else:
-            if separate_multiplicative:
+            if sep_mult:
                 return covmats.dataset_inputs_exp_covmat_separate
             else:
                 return covmats.dataset_inputs_exp_covmat

--- a/validphys2/src/validphys/filters.py
+++ b/validphys2/src/validphys/filters.py
@@ -191,7 +191,7 @@ def export_mask(path, mask):
     np.savetxt(path, mask, fmt='%d')
 
 
-def filter_closure_data(filter_path, data, fakepdf, fakenoise, filterseed, separate_multiplicative):
+def filter_closure_data(filter_path, data, fakepdf, fakenoise, filterseed, sep_mult):
     """Filter closure data. In addition to cutting data points, the data is
     generated from an underlying ``fakepdf``, applying a shift to the data
     if ``fakenoise`` is ``True``, which emulates the experimental central values
@@ -199,19 +199,11 @@ def filter_closure_data(filter_path, data, fakepdf, fakenoise, filterseed, separ
 
     """
     log.info('Filtering closure-test data.')
-    return _filter_closure_data(
-        filter_path, data, fakepdf, fakenoise, filterseed, separate_multiplicative
-    )
+    return _filter_closure_data(filter_path, data, fakepdf, fakenoise, filterseed, sep_mult)
 
 
 def filter_closure_data_by_experiment(
-    filter_path,
-    experiments_data,
-    fakepdf,
-    fakenoise,
-    filterseed,
-    data_index,
-    separate_multiplicative,
+    filter_path, experiments_data, fakepdf, fakenoise, filterseed, data_index, sep_mult
 ):
     """
     Like :py:func:`filter_closure_data` except filters data by experiment.
@@ -228,13 +220,7 @@ def filter_closure_data_by_experiment(
         experiment_index = data_index[data_index.isin([exp.name], level=0)]
         res.append(
             _filter_closure_data(
-                filter_path,
-                exp,
-                fakepdf,
-                fakenoise,
-                filterseed,
-                experiment_index,
-                separate_multiplicative,
+                filter_path, exp, fakepdf, fakenoise, filterseed, experiment_index, sep_mult
             )
         )
 
@@ -285,9 +271,7 @@ def _filter_real_data(filter_path, data):
     return total_data_points, total_cut_data_points
 
 
-def _filter_closure_data(
-    filter_path, data, fakepdf, fakenoise, filterseed, data_index, separate_multiplicative
-):
+def _filter_closure_data(filter_path, data, fakepdf, fakenoise, filterseed, data_index, sep_mult):
     """
     This function is accessed within a closure test only, that is, the fakedata
     namespace has to be True (If fakedata = False, the _filter_real_data function
@@ -352,9 +336,7 @@ def _filter_closure_data(
     if fakenoise:
         # ======= Level 1 closure test =======#
 
-        closure_data = make_level1_data(
-            data, closure_data, filterseed, data_index, separate_multiplicative
-        )
+        closure_data = make_level1_data(data, closure_data, filterseed, data_index, sep_mult)
 
     # ====== write commondata and systype files ======#
     if fakenoise:
@@ -411,7 +393,9 @@ def check_positivity(posdatasets):
     log.info('Verifying positivity tables:')
     for pos in posdatasets:
         pos.load_commondata()
-        log.info(f'{pos.name} checked, {len(pos.cuts.load())}/{pos.commondata.ndata} datapoints passed kinematic cuts.')
+        log.info(
+            f'{pos.name} checked, {len(pos.cuts.load())}/{pos.commondata.ndata} datapoints passed kinematic cuts.'
+        )
 
 
 def check_integrability(integdatasets):

--- a/validphys2/src/validphys/tests/test_overfit_metric.py
+++ b/validphys2/src/validphys/tests/test_overfit_metric.py
@@ -17,7 +17,7 @@ config = {
     "t0pdfset": {"from_": "datacuts"},
     "pdf": {"from_": "fit"},
     "dataset_inputs": {"from_": "fit"},
-    "separate_multiplicative": True
+    "sep_mult": True,
 }
 
 

--- a/validphys2/src/validphys/tests/test_overfit_metric.py
+++ b/validphys2/src/validphys/tests/test_overfit_metric.py
@@ -17,7 +17,7 @@ config = {
     "t0pdfset": {"from_": "datacuts"},
     "pdf": {"from_": "fit"},
     "dataset_inputs": {"from_": "fit"},
-    "sep_mult": True,
+    "separate_multiplicative": True,
 }
 
 

--- a/validphys2/src/validphys/tests/test_pseudodata.py
+++ b/validphys2/src/validphys/tests/test_pseudodata.py
@@ -75,7 +75,7 @@ def test_no_savepseudodata():
 
 def test_read_matches_recreate():
     reads = API.read_fit_pseudodata(fit=PSEUDODATA_FIT)
-    recreates = API.recreate_fit_pseudodata(fit=PSEUDODATA_FIT, sep_mult=True)
+    recreates = API.recreate_fit_pseudodata(fit=PSEUDODATA_FIT, separate_multiplicative=True)
     for read, recreate in zip(reads, recreates):
         # We ignore the absolute ordering of the dataframes and just check
         # that they contain identical elements.

--- a/validphys2/src/validphys/tests/test_pseudodata.py
+++ b/validphys2/src/validphys/tests/test_pseudodata.py
@@ -7,6 +7,7 @@ which has the pseudodata saved as training and validation splits.
 This is used to benchmark the correctness of the pseudodata
 recreation.
 """
+
 from numpy.testing import assert_allclose
 import pandas as pd
 import pytest
@@ -74,7 +75,7 @@ def test_no_savepseudodata():
 
 def test_read_matches_recreate():
     reads = API.read_fit_pseudodata(fit=PSEUDODATA_FIT)
-    recreates = API.recreate_fit_pseudodata(fit=PSEUDODATA_FIT, separate_multiplicative=True)
+    recreates = API.recreate_fit_pseudodata(fit=PSEUDODATA_FIT, sep_mult=True)
     for read, recreate in zip(reads, recreates):
         # We ignore the absolute ordering of the dataframes and just check
         # that they contain identical elements.


### PR DESCRIPTION
This fixes vp-setupfit since there `separate_multiplicative` was not parsed from the `sampling` key and thus it was not found. This was broken in https://github.com/NNPDF/nnpdf/pull/2107

This also resolves #2106 by removing the sampling namespace all together, though since we never use it we may also want to drop the `separate_multiplicative` keyword all together. 