### PR TITLE
Bump pineappl version

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -36,7 +36,7 @@ requirements:
         - requests
         - prompt_toolkit
         - validobj
-        - pineappl >=0.7.3
+        - pineappl >=0.8.2
         - eko >=0.14.2
         - fiatlux
         - sphinx >=5.0.2,<6 # documentation. Needs pinning temporarily due to markdown

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ vp-deltachi2 = "validphys.scripts.vp_deltachi2:main"
 # Generic dependencies (i.e., validphys)
 python = "^3.9"
 matplotlib = ">=3.3.0,<3.8"
-pineappl = "^0.7.0"
+pineappl = "^0.8.1"
 pandas = "*"
 numpy = "*"
 validobj = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ vp-deltachi2 = "validphys.scripts.vp_deltachi2:main"
 # Generic dependencies (i.e., validphys)
 python = "^3.9"
 matplotlib = ">=3.3.0,<3.8"
-pineappl = "^0.8.1"
+pineappl = "^0.8.2"
 pandas = "*"
 numpy = "*"
 validobj = "*"

--- a/validphys2/examples/API_extension_Pineappl.ipynb
+++ b/validphys2/examples/API_extension_Pineappl.ipynb
@@ -85,7 +85,7 @@
     "        bin_norm = self._grid.bin_normalizations().reshape(-1, 1)\n",
     "        \n",
     "        for i, member in enumerate(pdf.members):\n",
-    "            tmp = self._grid.convolute_with_one(2212, member.xfxQ2, member.alphasQ2, xi=all_scales).reshape(-1, len(all_scales))\n",
+    "            tmp = self._grid.convolve_with_one(2212, member.xfxQ2, member.alphasQ2, xi=all_scales).reshape(-1, len(all_scales))\n",
     "\n",
     "            if self._apply_bin:\n",
     "                tmp *= bin_norm\n",

--- a/validphys2/src/validphys/photon/structure_functions.py
+++ b/validphys2/src/validphys/photon/structure_functions.py
@@ -43,7 +43,7 @@ class InterpStructureFunction(StructureFunction):
 
         self.q2_max = max(q2)
 
-        predictions = self.fktable.convolute_with_one(2212, pdfs.xfxQ2)
+        predictions = self.fktable.convolve_with_one(2212, pdfs.xfxQ2)
 
         grid2D = predictions.reshape(len(x), len(q2))
         self.interpolator = RectBivariateSpline(x, q2, grid2D)

--- a/validphys2/src/validphys/pineparser.py
+++ b/validphys2/src/validphys/pineparser.py
@@ -159,9 +159,16 @@ def pineappl_reader(fkspec):
     is_polarized = pine_rep.key_values().get("polarized") == "True"
 
     # Is it hadronic? (at the moment only hadronic and DIS are considered)
-    hadronic = pine_rep.key_values()["initial_state_1"] == pine_rep.key_values()["initial_state_2"]
+    try:
+        parton1 = pine_rep.key_values()["convolution_particle_1"]
+        parton2 = pine_rep.key_values()["convolution_particle_2"]
+    except KeyError:
+        parton1 = pine_rep.key_values()["initial_state_1"]
+        parton2 = pine_rep.key_values()["initial_state_2"]
+    hadronic = parton1 == parton2
+
     # Sanity check (in case at some point we start fitting things that are not protons)
-    if hadronic and pine_rep.key_values()["initial_state_1"] != "2212":
+    if hadronic and parton1 != "2212":
         raise ValueError(
             "pineappl_reader is not prepared to read a hadronic fktable with no protons!"
         )

--- a/validphys2/src/validphys/pineparser.py
+++ b/validphys2/src/validphys/pineparser.py
@@ -223,7 +223,7 @@ def pineappl_reader(fkspec):
         # Create the multi-index for the dataframe
         # for optimized pineappls different grids can potentially have different indices
         # so they need to be indexed separately and then concatenated only at the end
-        lumi_columns = _pinelumi_to_columns(p.lumi(), hadronic)
+        lumi_columns = _pinelumi_to_columns(p.channels(), hadronic)
         lf = len(lumi_columns)
         data_idx = np.arange(ndata, ndata + n)
         if hadronic:

--- a/validphys2/src/validphys/tests/photon/test_structurefunctions.py
+++ b/validphys2/src/validphys/tests/photon/test_structurefunctions.py
@@ -35,7 +35,7 @@ class ZeroFKTable:
         else:
             return 0
 
-    def convolute_with_one(self, pdgid, xfxQ2):
+    def convolve_with_one(self, pdgid, xfxQ2):
         return np.zeros((10, 10))
 
 
@@ -99,7 +99,7 @@ def test_interpolation_grid():
             fktable = pineappl.fk_table.FkTable.read(path_to_fktable)
             x = np.unique(fktable.bin_left(1))
             q2 = np.unique(fktable.bin_left(0))
-            predictions = fktable.convolute_with_one(2212, pdfs.members[replica].xfxQ2)
+            predictions = fktable.convolve_with_one(2212, pdfs.members[replica].xfxQ2)
             grid2D = predictions.reshape(len(x), len(q2))
 
             struct_func = sf.InterpStructureFunction(path_to_fktable, pdfs.members[replica])


### PR DESCRIPTION
Now that pineappl [v0.8.1](https://github.com/NNPDF/pineappl/releases/tag/v0.8.1) is out we can update here. In principle, these changes are also introduced in https://github.com/NNPDF/nnpdf/pull/2110 but given that this is needed to make pineko work (https://github.com/NNPDF/pineko/pull/181) it would be better to have this in master first.

Tests relying on conda are still failing because of https://github.com/NNPDF/pineappl/issues/300.