### PR TITLE
Disable jit compilation in tf > 2.16

### DIFF
--- a/n3fit/src/n3fit/backends/keras_backend/MetaModel.py
+++ b/n3fit/src/n3fit/backends/keras_backend/MetaModel.py
@@ -25,6 +25,10 @@ elif hasattr(tf_utils, "sync_to_numpy_or_python_type"):  # from TF 2.5
 else:  # in case of disaster
     _to_numpy_or_python_type = lambda ret: {k: i.numpy() for k, i in ret.items()}
 
+# Starting with TF 2.16, a memory leak in TF https://github.com/tensorflow/tensorflow/issues/64170
+# makes jit compilation unusable in GPU.
+# Before TF 2.16 it was set to `False` by default. From 2.16 onwards, it is set to `True`
+JIT_COMPILE = False
 
 # Define in this dictionary new optimizers as well as the arguments they accept
 # (with default values if needed be)
@@ -307,7 +311,7 @@ class MetaModel(Model):
                 target_output = [target_output]
             self.target_tensors = target_output
 
-        super().compile(optimizer=opt, loss=loss)
+        super().compile(optimizer=opt, loss=loss, jit_compile=JIT_COMPILE)
 
     def set_masks_to(self, names, val=0.0):
         """Set all mask value to the selected value

--- a/n3fit/src/n3fit/stopping.py
+++ b/n3fit/src/n3fit/stopping.py
@@ -27,6 +27,7 @@
     which will tell `Validation` that no validation set was found and that the training is to
     be used instead.
 """
+
 import logging
 
 import numpy as np
@@ -345,6 +346,8 @@ class Stopping:
         self._threshold_chi2 = threshold_chi2
         self._stopping_degrees = np.zeros(self._n_replicas, dtype=int)
         self._counts = np.zeros(self._n_replicas, dtype=int)
+        # Keep track of the replicas that should not be stopped yet
+        self._dont_stop_me_now = np.ones(self._n_replicas, dtype=bool)
 
         self._dont_stop = dont_stop
         self._stop_now = False
@@ -451,6 +454,8 @@ class Stopping:
         passes &= fitstate.vl_loss < self._best_val_chi2s
         # And the ones that pass positivity
         passes &= self._positivity(fitstate)
+        # Stop replicas that are ok being stopped (because they are finished or otherwise)
+        passes &= self._dont_stop_me_now
 
         self._stopping_degrees += self._counts
 
@@ -470,6 +475,7 @@ class Stopping:
         for i_replica in np.where(stop_replicas)[0]:
             self._stop_epochs[i_replica] = epoch
             self._counts[i_replica] = 0
+            self._dont_stop_me_now[i_replica] = False
 
         # By using the stopping degree we only stop when none of the replicas are improving anymore
         if min(self._stopping_degrees) > self.stopping_patience:


### PR DESCRIPTION
This is enough to run fits in GPU with TF > 2.16. At least in my systems. I can run 120 replicas (it took me a few iterations of cuda drivers to make it work).

This disables XLA _also_ in CPU (if it is active, which at the moment I think it isn't by default)
```
--tf_xla_cpu_global_jit=false           bool    Enables global JIT compilation for CPU via SessionOptions.
```

I would keep running with 2.15 since that one we know for sure it works and I've only tested in one system for now (python 3.12, TF 2.17, RTX 3070).

I don't appreciate any degradation of performance but this GPU only has 8 GB of RAM so maybe I was already bottlenecked due to the memory before.

Note that before TF 2.16, XLA compilation was disabled by default. Funny thing is, if you enable it for TF 2.15 we also see some problems (even in CPU).
I don't know whether this is a fundamental problem with XLA (and thus nothing we can do) or whether there is a problem _in our code_ that makes XLA not work.
If someone wants to investigate, probably the best thing to do is to try TF 2.15 and set `JIT_COMPILE=True`, because from 2.16 onwards it will work but it will just crash due to the memory leak.