### PR TITLE
Saving pseudodata of replicas whit multiple fits

### DIFF
--- a/n3fit/src/n3fit/scripts/n3fit_exec.py
+++ b/n3fit/src/n3fit/scripts/n3fit_exec.py
@@ -140,8 +140,8 @@ class N3FitConfig(Config):
                 #    "to `false` or fit replicas one at a time."
                 #)
                 # take same namespace configuration on the pseudodata_table action.
-            training_action = namespace + "training_pseudodata"
-            validation_action = namespace + "validation_pseudodata"
+            training_action = namespace + "replicas_training_pseudodata"
+            validation_action = namespace + "replicas_validation_pseudodata"
 
             N3FIT_FIXED_CONFIG['actions_'].extend((training_action, validation_action))
 

--- a/n3fit/src/n3fit/scripts/n3fit_exec.py
+++ b/n3fit/src/n3fit/scripts/n3fit_exec.py
@@ -11,7 +11,7 @@ import shutil
 import sys
 import warnings
 
-from reportengine import colors
+from reportengine import colors, collect
 from reportengine.compat import yaml
 from reportengine.namespaces import NSList
 from validphys.app import App
@@ -134,14 +134,17 @@ class N3FitConfig(Config):
             if fps != True:
                 raise TypeError(f"fitting::savepseudodata is neither True nor False ({fps})")
             if len(kwargs["environment"].replicas) != 1:
-                raise ConfigError(
-                    "Cannot request that multiple replicas are fitted and that "
-                    "pseudodata is saved. Either set `fitting::savepseudodata` "
-                    "to `false` or fit replicas one at a time."
-                )
-            # take same namespace configuration on the pseudodata_table action.
-            training_action = namespace + "training_pseudodata"
-            validation_action = namespace + "validation_pseudodata"
+                #raise ConfigError(
+                #    "Cannot request that multiple replicas are fitted and that "
+                #    "pseudodata is saved. Either set `fitting::savepseudodata` "
+                #    "to `false` or fit replicas one at a time."
+                #)
+                training_action = collect(namespace + "training_pseudodata", ("replicas",))
+                validation_action = collect(namespace + "validation_pseudodata", ("replicas",))
+            else:
+                # take same namespace configuration on the pseudodata_table action.
+                training_action = namespace + "training_pseudodata"
+                validation_action = namespace + "validation_pseudodata"
 
             N3FIT_FIXED_CONFIG['actions_'].extend((training_action, validation_action))
 

--- a/n3fit/src/n3fit/scripts/n3fit_exec.py
+++ b/n3fit/src/n3fit/scripts/n3fit_exec.py
@@ -133,18 +133,15 @@ class N3FitConfig(Config):
         if fps := file_content["fitting"].get("savepseudodata", True):
             if fps != True:
                 raise TypeError(f"fitting::savepseudodata is neither True nor False ({fps})")
-            if len(kwargs["environment"].replicas) != 1:
+            #if len(kwargs["environment"].replicas) != 1:
                 #raise ConfigError(
                 #    "Cannot request that multiple replicas are fitted and that "
                 #    "pseudodata is saved. Either set `fitting::savepseudodata` "
                 #    "to `false` or fit replicas one at a time."
                 #)
-                training_action = collect(namespace + "training_pseudodata", ("replicas",))
-                validation_action = collect(namespace + "validation_pseudodata", ("replicas",))
-            else:
                 # take same namespace configuration on the pseudodata_table action.
-                training_action = namespace + "training_pseudodata"
-                validation_action = namespace + "validation_pseudodata"
+            training_action = namespace + "training_pseudodata"
+            validation_action = namespace + "validation_pseudodata"
 
             N3FIT_FIXED_CONFIG['actions_'].extend((training_action, validation_action))
 

--- a/validphys2/src/validphys/n3fit_data.py
+++ b/validphys2/src/validphys/n3fit_data.py
@@ -341,7 +341,7 @@ def replica_nnseed_fitting_data_dict(replica, exps_fitting_data_dict, replica_nn
     return (replica, exps_fitting_data_dict, replica_nnseed)
 
 replicas_training_pseudodata = collect("training_pseudodata", ("replicas",))
-replicas_validationf_pseudodata = collect("validation_pseudodata", ("replicas",))
+replicas_validation_pseudodata = collect("validation_pseudodata", ("replicas",))
 replicas_nnseed_fitting_data_dict = collect("replica_nnseed_fitting_data_dict", ("replicas",))
 groups_replicas_indexed_make_replica = collect(
     "indexed_make_replica", ("replicas", "group_dataset_inputs_by_experiment")

--- a/validphys2/src/validphys/n3fit_data.py
+++ b/validphys2/src/validphys/n3fit_data.py
@@ -340,7 +340,8 @@ def replica_nnseed_fitting_data_dict(replica, exps_fitting_data_dict, replica_nn
     """
     return (replica, exps_fitting_data_dict, replica_nnseed)
 
-
+replicas_training_pseudodata = collect("training_pseudodata", ("replicas",))
+replicas_validationf_pseudodata = collect("validation_pseudodata", ("replicas",))
 replicas_nnseed_fitting_data_dict = collect("replica_nnseed_fitting_data_dict", ("replicas",))
 groups_replicas_indexed_make_replica = collect(
     "indexed_make_replica", ("replicas", "group_dataset_inputs_by_experiment")


### PR DESCRIPTION
When using parallel models, pseudodata are not saved for each replica, resulting in the following error when running multiple fits with n3fit.
```shell
Cannot request that multiple replicas are fitted and that pseudodata is saved. Either set `fitting::savepseudodata` to `false` or fit replicas one at a time.
```

This branch ensures that pseudodata for each replica are saved, even when `parallel_models=true` is set.