### PR TITLE
Only return lhapdf data paths that do exist

### DIFF
--- a/validphys2/src/validphys/lhaindex.py
+++ b/validphys2/src/validphys/lhaindex.py
@@ -133,6 +133,10 @@ def parse_info(name):
 def get_lha_datapath():
     """Return an existing datapath from LHAPDF, starting from the end.
     If no path is found to exist, recover the old behaviour and returns the last path.
+
+    The check for existence intends to solve problems where a previously filled `LHAPATH`
+    or `LHAPDF_DATA_PATH` environment variable is pointing to a non-existent path or shared
+    systems where LHAPDF might be compiled with hard-coded paths not available to all users.
     """
     for lhapath in lhapdf.paths()[::-1]:
         if Path(lhapath).exists():

--- a/validphys2/src/validphys/lhaindex.py
+++ b/validphys2/src/validphys/lhaindex.py
@@ -10,6 +10,7 @@ from functools import lru_cache
 import glob
 import os
 import os.path as osp
+from pathlib import Path
 import re
 
 from reportengine.compat import yaml
@@ -130,6 +131,12 @@ def parse_info(name):
 
 
 def get_lha_datapath():
+    """Return an existing datapath from LHAPDF, starting from the end.
+    If no path is found to exist, recover the old behaviour and returns the last path.
+    """
+    for lhapath in lhapdf.paths()[::-1]:
+        if Path(lhapath).exists():
+            return lhapath
     return lhapdf.paths()[-1]
 
 

--- a/validphys2/src/validphys/lhapdf_compatibility.py
+++ b/validphys2/src/validphys/lhapdf_compatibility.py
@@ -6,6 +6,7 @@
         `lhapdf-management` and `pdfflow`
     which cover all the features of LHAPDF used during the fit (and likely most of validphys)
 """
+
 from functools import cached_property
 
 import numpy as np
@@ -86,7 +87,7 @@ class _PDFFlowPDF:
 
         if isinstance(a, int):
             return ret_dict.get(a, zeros)
-        return [ret_dict.get(i, zeros) for i in a]
+        return np.array([ret_dict.get(i, zeros) for i in a]).T
 
     def xfxQ2(self, a, b, c=None):
         """Wrapper for LHAPDF xfxQ2 function, like xfxQ for Q2"""


### PR DESCRIPTION
I haven't modified the behaviour of starting from the end.

Use case (or situation in which this is a problem): if you happen to use some shared system with lhapdf data paths you don't have access to (like in some lxplus views).