### PR TITLE
Skip the iterations argument if not given

### DIFF
--- a/n3fit/src/n3fit/scripts/evolven3fit.py
+++ b/n3fit/src/n3fit/scripts/evolven3fit.py
@@ -136,12 +136,10 @@ def main():
     args = parser.parse_args()
 
     op_card_info = {
-        "configs": {
-            "n_integration_cores": args.n_cores,
-            "ev_op_iterations": args.ev_op_iterations,
-            "polarized": args.use_polarized,
-        }
+        "configs": {"n_integration_cores": args.n_cores, "polarized": args.use_polarized}
     }
+    if args.ev_op_iterations is not None:
+        op_card_info["configs"]["ev_op_iterations"] = args.ev_op_iterations
 
     theory_card_info = {}
     if args.use_fhmruvv:


### PR DESCRIPTION
At the moment when using an `EXA` theory the number of iterations is taken from the theory card but if the user gives an explicit value to the cli, that takes precedence.

The problem is that not giving any value at all was also taking precedence. This PR fixes that.