### PR TITLE
Modify how losses are computed in a multi-replicas hyperopt

### DIFF
--- a/doc/sphinx/source/n3fit/hyperopt.rst
+++ b/doc/sphinx/source/n3fit/hyperopt.rst
@@ -300,26 +300,12 @@ The loss function was then computed as
 .. math::
     L_{\rm hyperopt} = \frac{1}{2} (L_{\rm validation} + L_{\rm testing})
 
-The group of datasets that were left out followed the algorithm :ref:`mentioned above<hyperextrapolation-label>` with only one fold:
-
-
-* NMC
-* BCDMSP
-* BCDMSD
-* HERACOMBNCEP460
-* H1HERAF2B
-* D0ZRap
-* CDFR2KT
-* D0WMASY
-* ATLASZHIGHMASS49FB
-* CMSZDIFF12
-* ATLASTTBARTOT
-
-These were chosen attending to their `process type` as defined in their :ref:`commondata files <exp_data_files>`.
+While the group of datasets that were left out followed the algorithm :ref:`mentioned above<hyperextrapolation-label>` but
+with only one fold leaving out a dataset per type of process.
 
 
 Changing the hyperoptimization target
------------------------------------
+-------------------------------------
 
 Beyond the usual :math:`\chi2`-based optimization figures above, it is possible to utilize other measures as the target for hyperoptimization.
 
@@ -401,7 +387,8 @@ In NNPDF, this hyperoptimisation metrics is selected via the following generic r
 
         kfold:
           loss_type: chi2
-          replica_statistic: average_best
+          replica_statistic: average
+          reduce_proportion: 0.85
           fold_statistic: average
           penalties_in_loss: False
           partitions:
@@ -414,9 +401,9 @@ In NNPDF, this hyperoptimisation metrics is selected via the following generic r
 
 
 The key ``replica_statistic`` defines how to combine all replicas when perform a multireplica hyperopt.
-With ``average`` a simple average will be taken, ``average_best`` instead will take the 90% best replicas,
-mimicking what is done in a real post-fit selection.
-
+In this case, the ``average`` across replicas.
+In order to mimic a real PDF fit, the ``reduce_proportion`` key is used to select the best ``reduce_proportion`` replicas of the set. If set to ``1.0`` all replicas will be used.
+It defaults to 0.85 (or the 85% best replicas).
 The ``fold_statistic`` instead defines how to combine the loss of the different folds.
 While the values for the ``penalties`` are always saved during the hyperopt run, by default they are not
 considered by the hyoperoptimizaton algorithm.

--- a/n3fit/runcards/examples/nnpdfpol20_hyperopt.yml
+++ b/n3fit/runcards/examples/nnpdfpol20_hyperopt.yml
@@ -119,7 +119,8 @@ hyperscan_config:
 ############################################################
 kfold:
   loss_type: chi2
-  replica_statistic: average_best
+  replica_statistic: average
+  reduce_proportion: 0.8
   fold_statistic: average
   penalties_in_loss: True
   penalties:

--- a/n3fit/runcards/hyperopt_studies/renew_hyperopt.yml
+++ b/n3fit/runcards/hyperopt_studies/renew_hyperopt.yml
@@ -158,7 +158,8 @@ hyperscan_config:
 
 kfold:
       loss_type: chi2
-      replica_statistic: average_best
+      replica_statistic: average
+      reduce_proportion: 0.85
       fold_statistic: average
       penalties_in_loss: True
       penalties:

--- a/n3fit/runcards/hyperopt_studies/restricted_search_space_renew_hyperopt.yml
+++ b/n3fit/runcards/hyperopt_studies/restricted_search_space_renew_hyperopt.yml
@@ -97,7 +97,7 @@ datacuts:
 
 ############################################################
 theory:
-  theoryid: 700     # database id
+  theoryid: 40_000_000
 
 hyperscan_config:
   architecture:
@@ -243,33 +243,55 @@ fitting:
   savepseudodata: false
   fitbasis: EVOL
   basis:
-  - {fl: sng, trainable: false, smallx: [1.091, 1.119], largex: [1.471, 3.021]}
-  - {fl: g, trainable: false, smallx: [0.7795, 1.095], largex: [2.742, 5.547]}
-  - {fl: v, trainable: false, smallx: [0.472, 0.7576], largex: [1.571, 3.559]}
-  - {fl: v3, trainable: false, smallx: [0.07483, 0.4501], largex: [1.714, 3.467]}
-  - {fl: v8, trainable: false, smallx: [0.5731, 0.779], largex: [1.555, 3.465]}
-  - {fl: t3, trainable: false, smallx: [-0.5498, 1.0], largex: [1.778, 3.5]}
-  - {fl: t8, trainable: false, smallx: [0.5469, 0.857], largex: [1.555, 3.391]}
-  - {fl: t15, trainable: false, smallx: [1.081, 1.142], largex: [1.491, 3.092]}
+  - {fl: sng, trainable: false, smallx: [1.089, 1.119], largex: [1.475, 3.119]}
+  - {fl: g, trainable: false, smallx: [0.7504, 1.098], largex: [2.814, 5.669]}
+  - {fl: v, trainable: false, smallx: [0.479, 0.7384], largex: [1.549, 3.532]}
+  - {fl: v3, trainable: false, smallx: [0.1073, 0.4397], largex: [1.733, 3.458]}
+  - {fl: v8, trainable: false, smallx: [0.5507, 0.7837], largex: [1.516, 3.356]}
+  - {fl: t3, trainable: false, smallx: [-0.4506, 0.9305], largex: [1.745, 3.424]}
+  - {fl: t8, trainable: false, smallx: [0.5877, 0.8687], largex: [1.522, 3.515]}
+  - {fl: t15, trainable: false, smallx: [1.089, 1.141], largex: [1.492, 3.222]}
 
-############################################################
+################################################################################
 positivity:
   posdatasets:
-  - {dataset: NNPDF_POS_2P24GEV_F2U, maxlambda: 1e6}        # Positivity Lagrange Multiplier
+  # Positivity Lagrange Multiplier
+  - {dataset: NNPDF_POS_2P24GEV_F2U, maxlambda: 1e6}
   - {dataset: NNPDF_POS_2P24GEV_F2D, maxlambda: 1e6}
   - {dataset: NNPDF_POS_2P24GEV_F2S, maxlambda: 1e6}
-  - {dataset: NNPDF_POS_2P24GEV_FLL-19PTS, maxlambda: 1e6}
+  - {dataset: NNPDF_POS_2P24GEV_FLL, maxlambda: 1e6}
   - {dataset: NNPDF_POS_2P24GEV_DYU, maxlambda: 1e10}
   - {dataset: NNPDF_POS_2P24GEV_DYD, maxlambda: 1e10}
   - {dataset: NNPDF_POS_2P24GEV_DYS, maxlambda: 1e10}
-  - {dataset: NNPDF_POS_2P24GEV_F2C-17PTS, maxlambda: 1e6}
-  - {dataset: NNPDF_POS_2P24GEV_XUQ, maxlambda: 1e6}        # Positivity of MSbar PDFs
+  - {dataset: NNPDF_POS_2P24GEV_F2C, maxlambda: 1e6}
+  # Positivity of MSbar PDFs
+  - {dataset: NNPDF_POS_2P24GEV_XUQ, maxlambda: 1e6}
   - {dataset: NNPDF_POS_2P24GEV_XUB, maxlambda: 1e6}
   - {dataset: NNPDF_POS_2P24GEV_XDQ, maxlambda: 1e6}
   - {dataset: NNPDF_POS_2P24GEV_XDB, maxlambda: 1e6}
   - {dataset: NNPDF_POS_2P24GEV_XSQ, maxlambda: 1e6}
   - {dataset: NNPDF_POS_2P24GEV_XSB, maxlambda: 1e6}
   - {dataset: NNPDF_POS_2P24GEV_XGL, maxlambda: 1e6}
+
+added_filter_rules:
+  - dataset: NNPDF_POS_2P24GEV_FLL
+    rule: "x > 5.0e-7"
+  - dataset: NNPDF_POS_2P24GEV_F2C
+    rule: "x < 0.74"
+  - dataset: NNPDF_POS_2P24GEV_XGL
+    rule: "x > 0.1"
+  - dataset: NNPDF_POS_2P24GEV_XUQ
+    rule: "x > 0.1"
+  - dataset: NNPDF_POS_2P24GEV_XUB
+    rule: "x > 0.1"
+  - dataset: NNPDF_POS_2P24GEV_XDQ
+    rule: "x > 0.1"
+  - dataset: NNPDF_POS_2P24GEV_XDB
+    rule: "x > 0.1"
+  - dataset: NNPDF_POS_2P24GEV_XSQ
+    rule: "x > 0.1"
+  - dataset: NNPDF_POS_2P24GEV_XSB
+    rule: "x > 0.1"
 
 ############################################################
 integrability:

--- a/n3fit/runcards/hyperopt_studies/restricted_search_space_renew_hyperopt.yml
+++ b/n3fit/runcards/hyperopt_studies/restricted_search_space_renew_hyperopt.yml
@@ -126,7 +126,8 @@ hyperscan_config:
 
 kfold:
       loss_type: chi2
-      replica_statistic: average_best
+      replica_statistic: average
+      reduce_proportion: 0.85
       fold_statistic: average
       threshold: 20
       partitions:

--- a/n3fit/runcards/hyperopt_studies/restricted_search_space_renew_hyperopt.yml
+++ b/n3fit/runcards/hyperopt_studies/restricted_search_space_renew_hyperopt.yml
@@ -128,7 +128,6 @@ kfold:
       loss_type: chi2
       replica_statistic: average_best
       fold_statistic: average
-      penalties_in_loss: True
       penalties:
         - saturation
         - patience

--- a/n3fit/runcards/hyperopt_studies/restricted_search_space_renew_hyperopt.yml
+++ b/n3fit/runcards/hyperopt_studies/restricted_search_space_renew_hyperopt.yml
@@ -128,11 +128,7 @@ kfold:
       loss_type: chi2
       replica_statistic: average_best
       fold_statistic: average
-      penalties:
-        - saturation
-        - patience
-        - integrability
-      threshold: 10
+      threshold: 20
       partitions:
       - datasets:
         # DIS

--- a/n3fit/src/n3fit/hyper_optimization/rewards.py
+++ b/n3fit/src/n3fit/hyper_optimization/rewards.py
@@ -268,7 +268,7 @@ class HyperLoss:
             ### Experiment:
             # Use the validation loss as the loss
             # summed with how far from 2 are we for the kfold
-            validation_loss_average = self.reduce_over_replicas(validation_loss, proportion=0.9)
+            validation_loss_average = self.reduce_over_replicas(validation_loss, proportion=0.8)
             kfold_loss_average = self.reduce_over_replicas(kfold_loss, proportion=0.1)
             loss = validation_loss_average + (max(kfold_loss_average, 2.0) - 2.0)
         elif self.loss_type == "phi2":

--- a/n3fit/src/n3fit/hyper_optimization/rewards.py
+++ b/n3fit/src/n3fit/hyper_optimization/rewards.py
@@ -72,7 +72,7 @@ def _average_best(fold_losses: np.ndarray, proportion: float = 0.05, axis: int =
     return _average(best_losses, axis=axis)
 
 
-def _average(fold_losses: np.ndarray, axis: int = 0) -> float:
+def _average(fold_losses: np.ndarray, axis: int = 0, **kwargs) -> float:
     """
     Compute the average of the input array along the specified axis.
 
@@ -90,7 +90,7 @@ def _average(fold_losses: np.ndarray, axis: int = 0) -> float:
     return np.average(fold_losses, axis=axis).item()
 
 
-def _best_worst(fold_losses: np.ndarray, axis: int = 0) -> float:
+def _best_worst(fold_losses: np.ndarray, axis: int = 0, **kwargs) -> float:
     """
     Compute the maximum value of the input array along the specified axis.
 
@@ -108,7 +108,7 @@ def _best_worst(fold_losses: np.ndarray, axis: int = 0) -> float:
     return np.max(fold_losses, axis=axis).item()
 
 
-def _std(fold_losses: np.ndarray, axis: int = 0) -> float:
+def _std(fold_losses: np.ndarray, axis: int = 0, **kwargs) -> float:
     """
     Compute the standard deviation of the input array along the specified axis.
 
@@ -265,9 +265,14 @@ class HyperLoss:
         if self.loss_type == "chi2":
             # calculate statistics of chi2 over replicas for a given k-fold_statistic
 
-            ### Experiment:
-            # Use the validation loss as the loss
-            # summed with how far from 2 are we for the kfold
+            # Construct the final loss as a sum of
+            # 1. The validation chi2
+            # 2. The distance to 2 for the kfold chi2
+            # If a proportion allow as a keyword argument, use 80% and 10%
+            # as a proxy of
+            # "80% of the replicas should be good, but only a small % has to cover the folds"
+            # The values of 80% and 10% are completely empirical and should be investigated further
+
             validation_loss_average = self.reduce_over_replicas(validation_loss, proportion=0.8)
             kfold_loss_average = self.reduce_over_replicas(kfold_loss, proportion=0.1)
             loss = validation_loss_average + (max(kfold_loss_average, 2.0) - 2.0)

--- a/n3fit/src/n3fit/hyper_optimization/rewards.py
+++ b/n3fit/src/n3fit/hyper_optimization/rewards.py
@@ -1,34 +1,34 @@
 """
-    Target functions to minimize during hyperparameter scan
+Target functions to minimize during hyperparameter scan
 
-    These are implemented in the HyperLoss class which incorporates
-    various statistics (average, standard deviation, best/worst case)
-    both across multiple replicas of a model and across different folds.
+These are implemented in the HyperLoss class which incorporates
+various statistics (average, standard deviation, best/worst case)
+both across multiple replicas of a model and across different folds.
 
-    Key functionalities include:
-    - Support for different loss types such as Chi-square (chi2) and phi-square (phi2).
-    - Calculation of statistical measures (average, best_worst, std) over replicas and folds.
-    - Incorporation of penalties into the loss computation.
-    - Detailed tracking and storage of loss metrics for further analysis.
+Key functionalities include:
+- Support for different loss types such as Chi-square (chi2) and phi-square (phi2).
+- Calculation of statistical measures (average, best_worst, std) over replicas and folds.
+- Incorporation of penalties into the loss computation.
+- Detailed tracking and storage of loss metrics for further analysis.
 
-    New statistics can be added directly in this class as staticmethods and
-    via `IMPLEMENTED_STATS`; their name in the runcard must
-    match the name in the module
+New statistics can be added directly in this class as staticmethods and
+via `IMPLEMENTED_STATS`; their name in the runcard must
+match the name in the module
 
-    Example
-    -------
-    >>> import numpy as np
-    >>> from n3fit.hyper_optimization.rewards import HyperLoss
-    >>> losses = np.array([1.0, 2.0, 3.0])
-    >>> loss_average = HyperLoss(fold_statistic="average")
-    >>> loss_best_worst = HyperLoss(fold_statistic="best_worst")
-    >>> loss_std = HyperLoss(fold_statistic="std")
-    >>> print(f"{loss_average.reduce_over_folds.__name__} {loss_average.reduce_over_folds(losses)}")
-    >>> print(f"{loss_best_worst.reduce_over_folds.__name__} {loss_best_worst.reduce_over_folds(losses)}")
-    >>> print(f"{loss_std.reduce_over_folds.__name__} {loss_std.reduce_over_folds(losses)}")
-    _average 2.0
-    _best_worst 3.0
-    _std 0.816496580927726
+Example
+-------
+>>> import numpy as np
+>>> from n3fit.hyper_optimization.rewards import HyperLoss
+>>> losses = np.array([1.0, 2.0, 3.0])
+>>> loss_average = HyperLoss(fold_statistic="average")
+>>> loss_best_worst = HyperLoss(fold_statistic="best_worst")
+>>> loss_std = HyperLoss(fold_statistic="std")
+>>> print(f"{loss_average.reduce_over_folds.__name__} {loss_average.reduce_over_folds(losses)}")
+>>> print(f"{loss_best_worst.reduce_over_folds.__name__} {loss_best_worst.reduce_over_folds(losses)}")
+>>> print(f"{loss_std.reduce_over_folds.__name__} {loss_std.reduce_over_folds(losses)}")
+_average 2.0
+_best_worst 3.0
+_std 0.816496580927726
 """
 
 import logging
@@ -36,7 +36,6 @@ from typing import Callable
 
 import numpy as np
 
-from n3fit.backends import MetaModel
 from n3fit.vpinterface import N3PDF, compute_phi
 from validphys.core import DataGroupSpec
 from validphys.pdfgrids import distance_grids, xplotting_grid
@@ -385,11 +384,12 @@ class HyperLoss:
 
         if self.loss_type == "chi2":
             return selected_statistic
-
         elif self.loss_type == "phi2":
             # In case of phi2, calculate the inverse of the applied statistics
             # This is only used when calculating statistics over folds
             return lambda x: np.reciprocal(selected_statistic(x))
+        else:
+            raise ValueError(f"{self.loss_type} is not a valid hyperopt loss.")
 
 
 def fit_distance(pdfs_per_fold=None, **_kwargs):

--- a/n3fit/src/n3fit/hyper_optimization/rewards.py
+++ b/n3fit/src/n3fit/hyper_optimization/rewards.py
@@ -43,34 +43,6 @@ from validphys.pdfgrids import distance_grids, xplotting_grid
 log = logging.getLogger(__name__)
 
 
-def _average_best(fold_losses: np.ndarray, proportion: float = 0.05, axis: int = 0) -> float:
-    """
-    Compute the average of the input array along the specified axis, among the best `proportion`
-    of replicas.
-
-    Parameters
-    ----------
-        fold_losses: np.ndarray
-            Per replica losses for a single fold.
-        proportion: float
-            The proportion of best replicas to take into account (rounded up).
-        axis: int, optional
-            Axis along which the mean is computed. Default is 0.
-
-    Returns
-    -------
-        float: The average along the specified axis.
-    """
-    # TODO: use directly `validphys.fitveto.determine_vetoes`
-    num_best = int(np.ceil(proportion * len(fold_losses)))
-
-    if np.isnan(fold_losses).any():
-        log.warning(f"{np.isnan(fold_losses).sum()} replicas have NaNs losses")
-    sorted_losses = np.sort(fold_losses, axis=axis)
-    best_losses = sorted_losses[:num_best]
-    return _average(best_losses, axis=axis)
-
-
 def _average(fold_losses: np.ndarray, axis: int = 0, **kwargs) -> float:
     """
     Compute the average of the input array along the specified axis.
@@ -384,7 +356,7 @@ class HyperLoss:
         """
         if statistic is None:
             statistic = default
-            log.warning(f"No {name} selected in HyperLoss, defaulting to {statistic}")
+            log.warning(f"No {target} selected in HyperLoss, defaulting to {statistic}")
 
         if statistic not in IMPLEMENTED_STATS:
             valid_options = ", ".join(IMPLEMENTED_STATS.keys())

--- a/n3fit/src/n3fit/model_trainer.py
+++ b/n3fit/src/n3fit/model_trainer.py
@@ -1064,7 +1064,8 @@ class ModelTrainer:
                 # Compute per replica hyper losses
                 hyper_loss = self._hyper_loss.compute_loss(
                     penalties=penalties,
-                    experimental_loss=experimental_loss,
+                    kfold_loss=experimental_loss,
+                    validation_loss=validation_loss,
                     pdf_object=vplike_pdf,
                     experimental_data=experimental_data,
                     fold_idx=k,

--- a/n3fit/src/n3fit/model_trainer.py
+++ b/n3fit/src/n3fit/model_trainer.py
@@ -1129,7 +1129,7 @@ class ModelTrainer:
                     "trvl_losses_phi": np.array(trvl_phi_per_fold),
                     "experimental_losses": l_exper,
                     "hyper_losses": np.array(self._hyper_loss.chi2_matrix),
-                    "hyper_losses_phi": np.array(self._hyper_loss.phi_vector),
+                    "hyper_losses_phi": np.array(self._hyper_loss.phi2_vector),
                     "penalties": {
                         name: np.array(values)
                         for name, values in self._hyper_loss.penalties.items()

--- a/n3fit/src/n3fit/model_trainer.py
+++ b/n3fit/src/n3fit/model_trainer.py
@@ -200,6 +200,7 @@ class ModelTrainer:
                 loss_type=loss_type,
                 replica_statistic=replica_statistic,
                 fold_statistic=fold_statistic,
+                reduce_proportion=kfold_parameters.get("reduce_proportion", 0.85),
                 penalties_in_loss=kfold_parameters.get("penalties_in_loss", False),
             )
 

--- a/n3fit/src/n3fit/tests/test_hyperopt.py
+++ b/n3fit/src/n3fit/tests/test_hyperopt.py
@@ -79,7 +79,11 @@ def test_compute_per_fold_loss(loss_type, replica_statistic, expected_per_fold_l
     # calculate statistic loss for one specific fold
     pdf_object = N3PDF(pdf_model.split_replicas())
     predicted_per_fold_loss = loss.compute_loss(
-        penalties, experimental_loss, pdf_object, experimental_data
+        penalties,
+        kfold_loss=experimental_loss,
+        validation_loss=experimental_loss,
+        pdf_object=pdf_object,
+        experimental_data=experimental_data,
     )
 
     # Assert

--- a/n3fit/src/n3fit/vpinterface.py
+++ b/n3fit/src/n3fit/vpinterface.py
@@ -1,20 +1,20 @@
 """
-    n3fit interface to validphys
+n3fit interface to validphys
 
-    Example
-    -------
+Example
+-------
 
-    >>> import numpy as np
-    >>> from n3fit.vpinterface import N3PDF
-    >>> from n3fit.model_gen import pdfNN_layer_generator
-    >>> from validphys.pdfgrids import xplotting_grid
-    >>> fake_fl = [{'fl' : i, 'largex' : [0,1], 'smallx': [1,2]} for i in ['u', 'ubar', 'd', 'dbar', 'c', 'cbar', 's', 'sbar']]
-    >>> fake_x = np.linspace(1e-3,0.8,3)
-    >>> pdf_model = pdfNN_layer_generator(nodes=[8], activations=['linear'], seed=0, flav_info=fake_fl)
-    >>> n3pdf = N3PDF(pdf_model)
-    >>> res = xplotting_grid(n3pdf, 1.6, fake_x)
-    >>> res.grid_values.error_members().shape
-    (1, 8, 3)
+>>> import numpy as np
+>>> from n3fit.vpinterface import N3PDF
+>>> from n3fit.model_gen import pdfNN_layer_generator
+>>> from validphys.pdfgrids import xplotting_grid
+>>> fake_fl = [{'fl' : i, 'largex' : [0,1], 'smallx': [1,2]} for i in ['u', 'ubar', 'd', 'dbar', 'c', 'cbar', 's', 'sbar']]
+>>> fake_x = np.linspace(1e-3,0.8,3)
+>>> pdf_model = pdfNN_layer_generator(nodes=[8], activations=['linear'], seed=0, flav_info=fake_fl)
+>>> n3pdf = N3PDF(pdf_model)
+>>> res = xplotting_grid(n3pdf, 1.6, fake_x)
+>>> res.grid_values.error_members().shape
+(1, 8, 3)
 
 
 """
@@ -386,7 +386,7 @@ def compute_phi(n3pdf, experimental_data):
 
             # calculate phi and store phi**2
             phi, ndat = phi_data(chi2)
-            sum_phi += np.sqrt(ndat) * phi
+            sum_phi += ndat * phi**2
             ndat_tot += ndat
 
-    return sum_phi / np.sqrt(ndat_tot)
+    return np.sqrt(sum_phi / ndat_tot)


### PR DESCRIPTION
Addresses the following:

- [x] include the Positivity filter in the hyperopt card
- [x] select a fraction of the replicas to compute the hyperopt $\chi^2$ losses
- [x] fix how $\varphi^2$ of the hold out folds are computed during hyperopt ([this line](https://github.com/NNPDF/nnpdf/blob/a89d1c7a25e1c8dfb791b28c14b46882a482e069/n3fit/src/n3fit/vpinterface.py#L388-L392))
- [x] select a fraction of the replica models to evaluate $\varphi^2$ 