### PR TITLE
Fix for old theories

### DIFF
--- a/n3fit/src/n3fit/tests/regressions/quickcard_old.yml
+++ b/n3fit/src/n3fit/tests/regressions/quickcard_old.yml
@@ -1,6 +1,6 @@
 #
 # Configuration file for n3fit regression tests
-# This runcard includes two DIS datasets, one Hadronic dataset
+# This runcard includes one DIS dataset, one Hadronic dataset
 # and two positivity datasets
 #
 

--- a/n3fit/src/n3fit/tests/regressions/quickcard_old.yml
+++ b/n3fit/src/n3fit/tests/regressions/quickcard_old.yml
@@ -1,0 +1,72 @@
+#
+# Configuration file for n3fit regression tests
+# This runcard includes two DIS datasets, one Hadronic dataset
+# and two positivity datasets
+#
+
+############################################################
+description: n3fit test with an old fktable, just test that it runs
+
+############################################################
+# frac: training fraction
+# ewk: apply ewk k-factors
+# sys: systematics treatment (see systypes)
+dataset_inputs:
+- {dataset: NMC_NC_NOTFIXED_P_EM-SIGMARED, frac: 0.5, variant: legacy}
+- {dataset: ATLAS_TTBAR_8TEV_TOT_X-SEC, frac: 1.0, variant: legacy}
+
+############################################################
+datacuts:
+  t0pdfset: NNPDF40_nnlo_as_01180     # PDF set to generate t0 covmat
+  q2min        : 3.49                # Q2 minimum
+  w2min        : 12.5                # W2 minimum
+
+############################################################
+theory:
+  theoryid: 162        # database id
+
+############################################################
+genrep: False   # on = generate MC replicas, False = use real data
+trvlseed: 3
+nnseed: 2
+mcseed: 1
+
+parameters: # This defines the parameter dictionary that is passed to the Model Trainer
+  nodes_per_layer: [15, 10, 8]
+  activation_per_layer: ['sigmoid', 'tanh', 'linear']
+  initializer: 'glorot_normal'
+  optimizer:
+    optimizer_name: 'RMSprop'
+    learning_rate: 0.00001
+    clipnorm: 1e-4
+  epochs: 100
+  positivity:
+    multiplier: 1.05
+    initial: 1.5
+  stopping_patience: 0.10 # percentage of the number of epochs
+  layer_type: 'dense'
+  dropout: 0.0
+  threshold_chi2: 10.0
+
+fitting:
+  savepseudodata: false
+  fitbasis: EVOL
+  basis:
+  - {fl: sng, trainable: false, smallx: [1.094, 1.118], largex: [1.46, 3.003]}
+  - {fl: g, trainable: false, smallx: [0.8189, 1.044], largex: [2.791, 5.697]}
+  - {fl: v, trainable: false, smallx: [0.457, 0.7326], largex: [1.56, 3.431]}
+  - {fl: v3, trainable: true, smallx: [0.1462, 0.4061], largex: [1.745, 3.452]}
+  - {fl: v8, trainable: false, smallx: [0.5401, 0.7665], largex: [1.539, 3.393]}
+  - {fl: t3, trainable: false, smallx: [-0.4401, 0.9163], largex: [1.773, 3.333]}
+  - {fl: t8, trainable: false, smallx: [0.5852, 0.8537], largex: [1.533, 3.436]}
+  - {fl: t15, trainable: false, smallx: [1.082, 1.142], largex: [1.461, 3.1]}
+
+############################################################
+positivity:
+  posdatasets:
+    - {dataset: NNPDF_POS_2P24GEV_F2U, maxlambda: 1e6}        # Positivity Lagrange Multiplier
+    - {dataset: NNPDF_POS_2P24GEV_DYS, maxlambda: 1e5}
+
+integrability:
+  integdatasets:
+    - {dataset: NNPDF_INTEG_3GEV_XT8, maxlambda: 1e2}

--- a/n3fit/src/n3fit/tests/test_fit.py
+++ b/n3fit/src/n3fit/tests/test_fit.py
@@ -169,6 +169,15 @@ def test_performfit_and_timing(tmp_path, runcard, replica):
     _auxiliary_performfit(tmp_path, runcard=runcard, replica=replica, timing=True)
 
 
+@pytest.mark.linux
+def test_performfit_with_old_theory(tmp_path):
+    """Checks that a fit with an old fktable can actually run. Don't check the results"""
+    quickcard = "quickcard_old.yml"
+    quickpath = REGRESSION_FOLDER / quickcard
+    shutil.copy(quickpath, tmp_path)
+    sp.run(f"{EXE} {quickcard} 5".split(), cwd=tmp_path, check=True)
+
+
 @pytest.mark.skip(reason="Still not implemented in parallel mode")
 def test_hyperopt(tmp_path):
     # Prepare the run

--- a/n3fit/src/n3fit/tests/test_layers.py
+++ b/n3fit/src/n3fit/tests/test_layers.py
@@ -34,6 +34,10 @@ class _fake_FKTableData:
     xgrid: np.array
     convolution_types: tuple = ("UnpolPDF",)
 
+    @property
+    def hadronic(self):
+        return len(self.convolution_types) == 2
+
 
 # Helper functions
 def generate_input_had(flavs=3, xsize=2, ndata=4, n_combinations=None):
@@ -116,10 +120,7 @@ def generate_had(nfk=1):
         fk, comb = generate_input_had(flavs=FLAVS, xsize=XSIZE, ndata=NDATA, n_combinations=FLAVS)
         fktables.append(
             _fake_FKTableData(
-                fk,
-                comb,
-                np.ones((1, XSIZE)),
-                convolution_types=("UnpolPDF", "UnpolPDF"),
+                fk, comb, np.ones((1, XSIZE)), convolution_types=("UnpolPDF", "UnpolPDF")
             )
         )
     return fktables

--- a/validphys2/src/validphys/coredata.py
+++ b/validphys2/src/validphys/coredata.py
@@ -51,7 +51,7 @@ class FKTableData:
     convolution_types: tuple[str]
         The type of convolution that the FkTable is expecting for each of the
         functions to be convolved with (usually the two types of PDF from the two
-        incoming particles).
+        incoming hadrons).
 
     metadata : dict
         Other information contained in the FKTable.

--- a/validphys2/src/validphys/coredata.py
+++ b/validphys2/src/validphys/coredata.py
@@ -48,6 +48,11 @@ class FKTableData:
         ``xgrid`` indicating the points in ``x`` where the PDF should be
         evaluated.
 
+    convolution_types: tuple[str]
+        The type of convolution that the FkTable is expecting for each of the
+        functions to be convolved with (usually the two types of PDF from the two
+        incoming particles).
+
     metadata : dict
         Other information contained in the FKTable.
 


### PR DESCRIPTION
After the changes for polarized PDFs old theories were no longer working because they are missing some of the pineappl info that we are now expecting.

Now... I'm thinking of dropping support for old theories altogether once we drop support for the old data (which will happen in about a month) because it is a lot of extra work for something nobody seems to care about, but for now let's keep it. I've added a test so that we are checking for now that the old theories do run.