### PR TITLE
fix ModSV in polarized  theories

### DIFF
--- a/nnpdf_data/nnpdf_data/theory_cards/41100001.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/41100001.yaml
@@ -22,7 +22,7 @@ MW: 80.398
 MZ: 91.1876
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: null
+ModSV: expanded
 NfFF: 4
 PTO: 2
 Q0: 1.0

--- a/nnpdf_data/nnpdf_data/theory_cards/41100002.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/41100002.yaml
@@ -22,7 +22,7 @@ MW: 80.398
 MZ: 91.1876
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: null
+ModSV: expanded
 NfFF: 4
 PTO: 2
 Q0: 1.0

--- a/nnpdf_data/nnpdf_data/theory_cards/41100003.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/41100003.yaml
@@ -22,7 +22,7 @@ MW: 80.398
 MZ: 91.1876
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: null
+ModSV: expanded
 NfFF: 4
 PTO: 2
 Q0: 1.0

--- a/nnpdf_data/nnpdf_data/theory_cards/41100006.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/41100006.yaml
@@ -22,7 +22,7 @@ MW: 80.398
 MZ: 91.1876
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: null
+ModSV: expanded
 NfFF: 4
 PTO: 2
 Q0: 1.0

--- a/nnpdf_data/nnpdf_data/theory_cards/41100007.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/41100007.yaml
@@ -22,7 +22,7 @@ MW: 80.398
 MZ: 91.1876
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: null
+ModSV: expanded
 NfFF: 4
 PTO: 2
 Q0: 1.0

--- a/nnpdf_data/nnpdf_data/theory_cards/41100008.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/41100008.yaml
@@ -22,7 +22,7 @@ MW: 80.398
 MZ: 91.1876
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: null
+ModSV: expanded
 NfFF: 4
 PTO: 2
 Q0: 1.0

--- a/nnpdf_data/nnpdf_data/theory_cards/41100011.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/41100011.yaml
@@ -22,7 +22,7 @@ MW: 80.398
 MZ: 91.1876
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: null
+ModSV: expanded
 NfFF: 4
 PTO: 1
 Q0: 1.0

--- a/nnpdf_data/nnpdf_data/theory_cards/41100012.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/41100012.yaml
@@ -22,7 +22,7 @@ MW: 80.398
 MZ: 91.1876
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: null
+ModSV: expanded
 NfFF: 4
 PTO: 1
 Q0: 1.0

--- a/nnpdf_data/nnpdf_data/theory_cards/41100013.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/41100013.yaml
@@ -22,7 +22,7 @@ MW: 80.398
 MZ: 91.1876
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: null
+ModSV: expanded
 NfFF: 4
 PTO: 1
 Q0: 1.0

--- a/nnpdf_data/nnpdf_data/theory_cards/41100016.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/41100016.yaml
@@ -22,7 +22,7 @@ MW: 80.398
 MZ: 91.1876
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: null
+ModSV: expanded
 NfFF: 4
 PTO: 1
 Q0: 1.0

--- a/nnpdf_data/nnpdf_data/theory_cards/41100017.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/41100017.yaml
@@ -22,7 +22,7 @@ MW: 80.398
 MZ: 91.1876
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: null
+ModSV: expanded
 NfFF: 4
 PTO: 1
 Q0: 1.0

--- a/nnpdf_data/nnpdf_data/theory_cards/41100018.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/41100018.yaml
@@ -22,7 +22,7 @@ MW: 80.398
 MZ: 91.1876
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: null
+ModSV: expanded
 NfFF: 4
 PTO: 1
 Q0: 1.0


### PR DESCRIPTION
Fix `ModSV` in poalrised theories with `xif != 1.0`