### PR TITLE
Accept more than one mapping per dataset in dataset_names.yml

### DIFF
--- a/nnpdf_data/nnpdf_data/__init__.py
+++ b/nnpdf_data/nnpdf_data/__init__.py
@@ -41,23 +41,33 @@ def legacy_to_new_map(dataset_name, sys=None):
 
 @lru_cache
 def new_to_legacy_map(dataset_name, variant_used):
-    """Loop over the dictionary and find the right dataset"""
-    # It is not possible to reverse the dictionary because
-    # we can have 2 old dataset mapped to the same new one
+    """Loop over the dictionary and find the right dataset.
 
-    possible_match = None
+    Since it is posible to have more than 1 dataset mapped to the same new one,
+    returns a list of everything that matches.
+
+    This function will loop over the entire dictionary of mappings and selects
+    1. All datasets that match exactly what's in the runcard (dataset & variant): exact_matches
+    2. All datasets that match the dataset name: matches
+    If there are any `exact_matches`, it will return only those; otherwise, return all matches
+    if there are no matches at all, return None
+    """
+
+    matches = []
+    exact_matches = []
+
     for old_name, new_info in legacy_to_new_mapping.items():
         new_name = new_info["dataset"]
         variant = new_info.get("variant")
 
         if new_name == dataset_name:
+            matches.append(old_name)
             if variant_used == variant:
-                return old_name
-            # Now, for legacy variants we might want to match (sys,)
-            # so accept anything that starts with `legacy_`
-            # so variant `legacy_10` will match `legacy` in the dictionary
-            # but if an exact match if found before, the search ends
-            if variant_used is not None and variant_used.startswith("legacy_"):
-                possible_match = old_name
+                exact_matches.append(old_name)
 
-    return possible_match
+    # If we found exact matches, return those
+    if exact_matches:
+        return exact_matches
+    elif matches:
+        return matches
+    return None

--- a/validphys2/src/validphys/commondataparser.py
+++ b/validphys2/src/validphys/commondataparser.py
@@ -911,11 +911,9 @@ def load_commondata_new(metadata):
             100 / commondata_table["data"], axis="index"
         )
 
-    # TODO: For the time being, fill `legacy_name` with the new name if not found
-    legacy_name = metadata.name
-
-    if (old_name := new_to_legacy_map(metadata.name, metadata.applied_variant)) is not None:
-        legacy_name = old_name
+    # The old -> new map is not biyective, as different old dataset can refer to the same new one
+    # therefore "legacy_names", when filled, will be a list. With None otherwise.
+    legacy_names = new_to_legacy_map(metadata.name, metadata.applied_variant)
 
     return CommonData(
         setname=metadata.name,
@@ -925,7 +923,7 @@ def load_commondata_new(metadata):
         nsys=nsys,
         commondata_table=commondata_table,
         systype_table=systype_table,
-        legacy_name=legacy_name,
+        legacy_names=legacy_names,
         kin_variables=metadata.kinematic_coverage,
     )
 

--- a/validphys2/src/validphys/config.py
+++ b/validphys2/src/validphys/config.py
@@ -459,9 +459,13 @@ class CoreConfig(configparser.Config):
         if variant is not None and sysnum is not None:
             raise ConfigError(f"The 'variant' and 'sys' keys cannot be used together ({name})")
 
+        # The old->new name can be used for two reasons:
+        # 1. To use the old names, in that case one recieves a name and, maybe a variant
+        # 2. To correct a wrong (but new-style) name.
+        # In both cases the varaint is overwritten if and only if the variant is None
+        name, map_variant = legacy_to_new_map(name, sysnum)
         if variant is None:
-            # If a variant is not given this could be an old commondata, try to translate it!
-            name, variant = legacy_to_new_map(name, sysnum)
+            variant = map_variant
 
         return DataSetInput(
             name=name,

--- a/validphys2/src/validphys/core.py
+++ b/validphys2/src/validphys/core.py
@@ -336,10 +336,8 @@ class CommonDataSpec(TupleComp):
         return self._metadata
 
     @functools.cached_property
-    def legacy_name(self):
-        if self.legacy:
-            raise ValueError(f"This is already a legacy dataset: {self}")
-        return self.load().legacy_name
+    def legacy_names(self):
+        return self.load().legacy_names
 
     @property
     def theory_metadata(self):

--- a/validphys2/src/validphys/coredata.py
+++ b/validphys2/src/validphys/coredata.py
@@ -298,16 +298,14 @@ class CommonData:
     systype_table: pd.DataFrame = dataclasses.field(repr=False)
     legacy: bool = False
     systematics_table: Optional[pd.DataFrame] = dataclasses.field(init=None, repr=False)
-    legacy_name: Optional[str] = None
+    legacy_names: Optional[list] = None
     kin_variables: Optional[list] = None
 
     def __post_init__(self):
         self.systematics_table = self.commondata_table.drop(
             columns=["process", "data", "stat"] + KIN_NAMES
         )
-        if self.legacy_name is None:
-            self.legacy_name = self.setname
-        # TODO: set for now commondataproc as a string as well
+        # TODO: set for now commondataproc as a string
         self.commondataproc = str(self.commondataproc)
 
     def with_cuts(self, cuts):

--- a/validphys2/src/validphys/filters.py
+++ b/validphys2/src/validphys/filters.py
@@ -645,11 +645,14 @@ class Rule:
         # is different to the case where the rule does apply,
         # but the point was cut out by the rule.
         if (
-            dataset.setname != self.dataset
+            not (
+                dataset.setname == self.dataset
+                or
+                # for old rules, we might be using an old name of this dataset
+                (dataset.legacy_names is not None and self.dataset in dataset.legacy_names)
+            )
             and process_name != self.process_type
             and self.process_type != "DIS_ALL"
-            # for old rules, we might be using an old name of this dataset
-            and self.dataset not in dataset.legacy_names
         ):
             return None
 

--- a/validphys2/src/validphys/filters.py
+++ b/validphys2/src/validphys/filters.py
@@ -645,9 +645,11 @@ class Rule:
         # is different to the case where the rule does apply,
         # but the point was cut out by the rule.
         if (
-            (dataset.setname != self.dataset and dataset.legacy_name != self.dataset)
+            dataset.setname != self.dataset
             and process_name != self.process_type
             and self.process_type != "DIS_ALL"
+            # for old rules, we might be using an old name of this dataset
+            and self.dataset not in dataset.legacy_names
         ):
             return None
 

--- a/validphys2/src/validphys/pseudodata.py
+++ b/validphys2/src/validphys/pseudodata.py
@@ -198,10 +198,10 @@ def make_replica(
     # Only when the sets are legacy (or coming from a legacy runcard) this shall be used
     names_for_salt = []
     for loaded_cd in groups_dataset_inputs_loaded_cd_with_cuts:
-        if loaded_cd.legacy:
+        if loaded_cd.legacy_names is None:
             names_for_salt.append(loaded_cd.setname)
         else:
-            names_for_salt.append(loaded_cd.legacy_name)
+            names_for_salt.append(loaded_cd.legacy_names[0])
     name_salt = "-".join(names_for_salt)
 
     name_seed = int(hashlib.sha256(name_salt.encode()).hexdigest(), 16) % 10**8


### PR DESCRIPTION
At the moment only one mapping can be used per dataset in `dataset_names.yml` but, in principle, several old dataset names could refer to the same new dataset (it is strange, but it _could_ happen).

In particular, it is like this for `ATLAS_WP_JET_8TEV_PT` because that name was wrong at some point and since fits like e.g., `240701-02-rs-nnpdf40-baseline`  used it we added it to `dataset_names.yml`. This PR fixes that by letting `legacy_names` be a list.

In addition, now `legacy_names` is only used when something fails (e.g., filters not found).

Since I was at it, I also removed a bunch of `.legacy` that won't work anymore anyway because I removed all `.dat` files.

@Radonirinaunimi this would fix the comparefit you were doing for instance. Hopefully it doesn't break anything in the way.

Btw: we should add also closure tests to the extra_tests that act as regeressions because they are not fully tested...