### PR TITLE
Minor fix evolven3fit with loaded eko

### DIFF
--- a/n3fit/src/n3fit/scripts/evolven3fit.py
+++ b/n3fit/src/n3fit/scripts/evolven3fit.py
@@ -152,10 +152,9 @@ def main():
 
     if args.actions == "evolve":
 
+        fit_folder = pathlib.Path(args.configuration_folder)
         if args.load is None:
-            fit_folder = pathlib.Path(args.configuration_folder)
             theoryID = utils.get_theoryID_from_runcard(fit_folder)
-
             _logger.info(f"Loading eko from theory {theoryID}")
             eko_path = loader.check_eko(theoryID)
         else:


### PR DESCRIPTION
Minor fix in evolven3fit with loaded eko. `fit_folder` is needed also below.