### PR TITLE
Introduce inconsistent fit closure test data 

### DIFF
--- a/validphys2/src/validphys/closuretest/inconsistent_closuretest/inconsistent_ct.py
+++ b/validphys2/src/validphys/closuretest/inconsistent_closuretest/inconsistent_ct.py
@@ -3,7 +3,7 @@ This module contains the InconsistentCommonData class which is meant to have all
 methods needed in order to introduce an inconsistency within a Closure Test.
 """
 
-import yaml
+from validphys.utils import yaml_safe
 import dataclasses
 from validphys.coredata import CommonData
 import pandas as pd
@@ -212,4 +212,4 @@ class InconsistentCommonData(CommonData):
             "type": "UNCORR",
         }
         ret = {"definitions": sorted_definitions, "bins": bins}
-        yaml.safe_dump(ret, buffer)
+        yaml_safe.dump(ret, buffer)

--- a/validphys2/src/validphys/closuretest/inconsistent_closuretest/inconsistent_ct.py
+++ b/validphys2/src/validphys/closuretest/inconsistent_closuretest/inconsistent_ct.py
@@ -1,0 +1,162 @@
+"""
+This module contains the InconsistentCommonData class which is meant to have all the
+methods needed in order to introduce an inconsistency within a Closure Test.
+"""
+import dataclasses
+from validphys.coredata import CommonData
+import pandas as pd
+
+
+@dataclasses.dataclass(eq=False)
+class InconsistentCommonData(CommonData):
+    """
+    Class that inherits all of the methods
+    of coredata.CommonData class.
+
+    This class is meant to have all the
+    methods needed in order to introduce
+    an inconsistency within a Closure Test.
+    """
+
+    setname: str
+    ndata: int
+    commondataproc: str
+    nkin: int
+    nsys: int
+    commondata_table: pd.DataFrame = dataclasses.field(repr=False)
+    systype_table: pd.DataFrame = dataclasses.field(repr=False)
+    systematics_table: pd.DataFrame = dataclasses.field(init=None, repr=False)
+
+    def with_MULT_sys(self, mult_sys):
+        """
+        returns an InconsistentCommonData instance
+        with MULT systematics replaced by mult_sys
+
+        Parameters
+        ----------
+        mult_sys : pd.DataFrame()
+                 all MULT columns of
+                 InconsistentCommonData.commondata_table
+        """
+        table = self.commondata_table.copy()
+        table["MULT"] = mult_sys
+        return dataclasses.replace(self, commondata_table=table)
+
+    def with_ADD_sys(self, add_sys):
+        """
+        returns an InconsistentCommonData instance
+        with ADD systematics replaced by add_sys
+
+        Parameters
+        ----------
+        add_sys : pd.DataFrame()
+                 all ADD columns of
+                 InconsistentCommonData.commondata_table
+        """
+        table = self.commondata_table.copy()
+        table["ADD"] = add_sys
+        return dataclasses.replace(self, commondata_table=table)
+
+    def rescale_sys(self, type_err, CORR, UNCORR, SPECIAL, sys_rescaling_factor):
+        """
+        rescale the sys (MULT or ADD) by constant factor, sys_rescaling_factor,
+        a distinction is done between CORR, UNCORR and SPECIAL systematics
+
+        Parameters
+        ----------
+
+        type_err : str
+                e.g. 'MULT' or 'ADD'
+
+        CORR : bool
+
+        UNCORR : bool
+
+        SPECIAL : bool
+
+        sys_rescaling_factor : float, int
+
+        Returns
+        -------
+        pd.DataFrame corresponding to the rescaled MULT systematics
+        """
+        # avoid circular import error
+        from validphys.covmats import INTRA_DATASET_SYS_NAME
+
+        err_table = self.systematics_table.loc[:, [type_err]].copy()
+        # get indices of CORR / UNCORR sys
+        systype_corr = self.systype_table[
+            (self.systype_table["type"] == type_err)
+            & (self.systype_table["name"].isin(["CORR", "THEORYCORR"]))
+        ]
+
+        systype_uncorr = self.systype_table[
+            (self.systype_table["type"] == type_err)
+            & (self.systype_table["name"].isin(["UNCORR", "THEORYUNCORR"]))
+        ]
+
+        # get indices of special (intra datasets) correlations
+        systype_special = self.systype_table[
+            (self.systype_table["type"] == type_err)
+            & (~self.systype_table["name"].isin(INTRA_DATASET_SYS_NAME))
+        ]
+
+        # rescale systematics
+        if CORR:
+            err_table.iloc[:, systype_corr.index - 1] *= sys_rescaling_factor
+        if UNCORR:
+            err_table.iloc[:, systype_uncorr.index - 1] *= sys_rescaling_factor
+        if SPECIAL:
+            err_table.iloc[:, systype_special.index - 1] *= sys_rescaling_factor
+
+        return err_table
+
+    def process_commondata(
+        self, ADD, MULT, CORR, UNCORR, SPECIAL, inconsistent_datasets, sys_rescaling_factor
+    ):
+        """
+        returns a commondata instance
+        with modified systematics.
+        Note that if commondata.setname
+        is not within the inconsistent_datasets or if both ADD and
+        MULT are False, then the commondata object
+        will not be modified.
+
+        Parameters
+        ----------
+
+        ADD : bool
+
+        MULT : bool
+
+        CORR : bool
+
+        UNCORR : bool
+
+        SPECIAL : bool
+
+        inconsistent_datasets : list
+                            list of the datasets for which an inconsistency should be introduced
+
+        sys_rescaling_factor : float, int
+
+        Returns
+        -------
+        validphys.inconsistent_ct.InconsistentCommonData
+        """
+        new_commondata = self
+
+        if not self.setname in inconsistent_datasets:
+            return self
+
+        if MULT:
+            new_commondata = new_commondata.with_MULT_sys(
+                self.rescale_sys("MULT", CORR, UNCORR, SPECIAL, sys_rescaling_factor)
+            )
+
+        if ADD:
+            new_commondata = new_commondata.with_ADD_sys(
+                self.rescale_sys("ADD", CORR, UNCORR, SPECIAL, sys_rescaling_factor)
+            )
+
+        return new_commondata

--- a/validphys2/src/validphys/closuretest/inconsistent_closuretest/inconsistent_ct.py
+++ b/validphys2/src/validphys/closuretest/inconsistent_closuretest/inconsistent_ct.py
@@ -3,10 +3,12 @@ This module contains the InconsistentCommonData class which is meant to have all
 methods needed in order to introduce an inconsistency within a Closure Test.
 """
 
-from validphys.utils import yaml_safe
 import dataclasses
-from validphys.coredata import CommonData
+
 import pandas as pd
+
+from validphys.coredata import CommonData
+from validphys.utils import yaml_safe
 
 
 @dataclasses.dataclass(eq=False)

--- a/validphys2/src/validphys/closuretest/inconsistent_closuretest/inconsistent_ct.py
+++ b/validphys2/src/validphys/closuretest/inconsistent_closuretest/inconsistent_ct.py
@@ -2,6 +2,7 @@
 This module contains the InconsistentCommonData class which is meant to have all the
 methods needed in order to introduce an inconsistency within a Closure Test.
 """
+
 import dataclasses
 from validphys.coredata import CommonData
 import pandas as pd
@@ -57,7 +58,7 @@ class InconsistentCommonData(CommonData):
         table["ADD"] = add_sys
         return dataclasses.replace(self, commondata_table=table)
 
-    def rescale_sys(self, type_err, CORR, UNCORR, SPECIAL, sys_rescaling_factor):
+    def rescale_sys(self, treatment_err, CORR, UNCORR, SPECIAL, sys_rescaling_factor):
         """
         rescale the sys (MULT or ADD) by constant factor, sys_rescaling_factor,
         a distinction is done between CORR, UNCORR and SPECIAL systematics
@@ -65,7 +66,7 @@ class InconsistentCommonData(CommonData):
         Parameters
         ----------
 
-        type_err : str
+        treatment_err : str
                 e.g. 'MULT' or 'ADD'
 
         CORR : bool
@@ -83,31 +84,35 @@ class InconsistentCommonData(CommonData):
         # avoid circular import error
         from validphys.covmats import INTRA_DATASET_SYS_NAME
 
-        err_table = self.systematics_table.loc[:, [type_err]].copy()
+        # err_table = self.systematics_table.loc[:, [treatment_err]].copy()
         # get indices of CORR / UNCORR sys
         systype_corr = self.systype_table[
-            (self.systype_table["type"] == type_err)
+            (self.systype_table["treatment"] == treatment_err)
             & (self.systype_table["name"].isin(["CORR", "THEORYCORR"]))
         ]
 
         systype_uncorr = self.systype_table[
-            (self.systype_table["type"] == type_err)
+            (self.systype_table["treatment"] == treatment_err)
             & (self.systype_table["name"].isin(["UNCORR", "THEORYUNCORR"]))
         ]
 
         # get indices of special (intra datasets) correlations
         systype_special = self.systype_table[
-            (self.systype_table["type"] == type_err)
+            (self.systype_table["treatment"] == treatment_err)
             & (~self.systype_table["name"].isin(INTRA_DATASET_SYS_NAME))
         ]
 
         # rescale systematics
+
         if CORR:
-            err_table.iloc[:, systype_corr.index - 1] *= sys_rescaling_factor
+            err_table = self.systematics_table.iloc[:, systype_corr.index - 1]
+            err_table *= sys_rescaling_factor
         if UNCORR:
-            err_table.iloc[:, systype_uncorr.index - 1] *= sys_rescaling_factor
+            err_table = self.systematics_table.iloc[:, systype_uncorr.index - 1]
+            err_table *= sys_rescaling_factor
         if SPECIAL:
-            err_table.iloc[:, systype_special.index - 1] *= sys_rescaling_factor
+            err_table = self.systematics_table.iloc[:, systype_special.index - 1]
+            err_table *= sys_rescaling_factor
 
         return err_table
 

--- a/validphys2/src/validphys/config.py
+++ b/validphys2/src/validphys/config.py
@@ -485,11 +485,8 @@ class CoreConfig(configparser.Config):
         Parse the inconsistent data settings from the yaml file.
         """
         known_keys = {
-            "ADD",
-            "MULT",
-            "CORR",
-            "UNCORR",
-            "SPECIAL",
+            "treatment_names",
+            "names_uncertainties",
             "inconsistent_datasets",
             "sys_rescaling_factor",
         }
@@ -502,11 +499,8 @@ class CoreConfig(configparser.Config):
 
         ict_data_settings = {}
 
-        ict_data_settings["ADD"] = settings.get("ADD", False)
-        ict_data_settings["MULT"] = settings.get("MULT", False)
-        ict_data_settings["CORR"] = settings.get("CORR", False)
-        ict_data_settings["UNCORR"] = settings.get("UNCORR", False)
-        ict_data_settings["SPECIAL"] = settings.get("SPECIAL", False)
+        ict_data_settings["treatment_names"] = settings.get("treatment_names", [])
+        ict_data_settings["names_uncertainties"] = settings.get("names_uncertainties", [])
 
         ict_data_settings["inconsistent_datasets"] = settings.get("inconsistent_datasets", [])
         ict_data_settings["sys_rescaling_factor"] = settings.get("sys_rescaling_factor", 1)

--- a/validphys2/src/validphys/config.py
+++ b/validphys2/src/validphys/config.py
@@ -1759,10 +1759,21 @@ class CoreConfig(configparser.Config):
     def produce_filter_data(
         self, fakedata: bool = False, theorycovmatconfig=None, inconsistent_fakedata: bool = False
     ):
-        """Set the action used to filter the data to filter either real or
+        """
+        Set the action used to filter the data to filter either real or
         closure data. If the closure data filter is being used and if the
         theory covariance matrix is not being closure tested then filter
-        data by experiment for efficiency"""
+        data by experiment for efficiency.
+        
+        Parameters
+        ----------
+        fakedata: bool, default False
+            whether to use closure test data in a fit.
+        theorycovmatconfig: dict
+        inconsitent_fakedata: bool, default False
+            When true it allows for the introduction of inconsistencies in a closure test fit
+            and returns filter_inconsistent_closure_data_by_experiment.
+        """
         import validphys.filters
 
         if not fakedata:
@@ -1778,7 +1789,7 @@ class CoreConfig(configparser.Config):
                     "covariance matrix has not been implemented yet."
                 )
             elif inconsistent_fakedata:
-                log.warning("Using filter for inconsistent closure data")
+                log.info("Using filter for inconsistent closure data")
                 return validphys.filters.filter_inconsistent_closure_data_by_experiment
 
             return validphys.filters.filter_closure_data_by_experiment

--- a/validphys2/src/validphys/config.py
+++ b/validphys2/src/validphys/config.py
@@ -480,6 +480,39 @@ class CoreConfig(configparser.Config):
             sys=sysnum,
         )
 
+    def parse_inconsistent_data_settings(self, settings):
+        """
+        Parse
+        """
+        known_keys = {
+            "ADD",
+            "MULT",
+            "CORR",
+            "UNCORR",
+            "SPECIAL",
+            "inconsistent_datasets",
+            "sys_rescaling_factor",
+        }
+
+        kdiff = settings.keys() - known_keys
+        for k in kdiff:
+            log.warning(
+                ConfigError(f"Key '{k}' in inconsistent_data_settings not known.", k, known_keys)
+            )
+
+        ict_data_settings = {}
+
+        ict_data_settings["ADD"] = settings.get("ADD", False)
+        ict_data_settings["MULT"] = settings.get("MULT", False)
+        ict_data_settings["CORR"] = settings.get("CORR", False)
+        ict_data_settings["UNCORR"] = settings.get("UNCORR", False)
+        ict_data_settings["SPECIAL"] = settings.get("SPECIAL", False)
+
+        ict_data_settings["inconsistent_datasets"] = settings.get("inconsistent_datasets", [])
+        ict_data_settings["sys_rescaling_factor"] = settings.get("sys_rescaling_factor", 1)
+
+        return ict_data_settings
+
     def parse_use_fitcommondata(self, do_use: bool):
         """Use the commondata files in the fit instead of those in the data
         directory."""

--- a/validphys2/src/validphys/config.py
+++ b/validphys2/src/validphys/config.py
@@ -1764,7 +1764,7 @@ class CoreConfig(configparser.Config):
         closure data. If the closure data filter is being used and if the
         theory covariance matrix is not being closure tested then filter
         data by experiment for efficiency.
-        
+
         Parameters
         ----------
         fakedata: bool, default False

--- a/validphys2/src/validphys/config.py
+++ b/validphys2/src/validphys/config.py
@@ -492,10 +492,8 @@ class CoreConfig(configparser.Config):
         }
 
         kdiff = settings.keys() - known_keys
-        for k in kdiff:
-            log.warning(
-                ConfigError(f"Key '{k}' in inconsistent_data_settings not known.", k, known_keys)
-            )
+        if kdiff:
+            raise ConfigError(f"Remove these unknown / bad keys from dataset: {kdiff}")
 
         ict_data_settings = {}
 

--- a/validphys2/src/validphys/config.py
+++ b/validphys2/src/validphys/config.py
@@ -483,6 +483,20 @@ class CoreConfig(configparser.Config):
     def parse_inconsistent_data_settings(self, settings):
         """
         Parse the inconsistent data settings from the yaml file.
+
+        Known keys:
+        -----------
+        - treatment_names: list
+            list of the names of the treatments that should be rescaled
+            possible values are: MULT, ADD.
+        - names_uncertainties: list
+            list of the names of the uncertainties that should be rescaled
+            possible values are: CORR, UNCORR, THEORYCORR, THEORYUNCORR, SPECIAL
+            SPECIAL is used for intra-dataset systematics.
+        - inconsistent_datasets: list
+            list of the datasets for which an inconsistency should be introduced.
+        - sys_rescaling_factor: float, int
+            the factor by which the systematics should be rescaled.
         """
         known_keys = {
             "treatment_names",

--- a/validphys2/src/validphys/config.py
+++ b/validphys2/src/validphys/config.py
@@ -1786,6 +1786,7 @@ class CoreConfig(configparser.Config):
                     "covariance matrix has not been implemented yet."
                 )
             elif inconsistent_fakedata:
+                log.warning("Using filter for inconsistent closure data")
                 return validphys.filters.filter_inconsistent_closure_data_by_experiment
 
             return validphys.filters.filter_closure_data_by_experiment

--- a/validphys2/src/validphys/config.py
+++ b/validphys2/src/validphys/config.py
@@ -482,7 +482,7 @@ class CoreConfig(configparser.Config):
 
     def parse_inconsistent_data_settings(self, settings):
         """
-        Parse
+        Parse the inconsistent data settings from the yaml file.
         """
         known_keys = {
             "ADD",
@@ -1764,7 +1764,9 @@ class CoreConfig(configparser.Config):
         return NSList(theoryids, nskey="theoryid")
 
     @configparser.explicit_node
-    def produce_filter_data(self, fakedata: bool = False, theorycovmatconfig=None):
+    def produce_filter_data(
+        self, fakedata: bool = False, theorycovmatconfig=None, inconsistent_fakedata: bool = False
+    ):
         """Set the action used to filter the data to filter either real or
         closure data. If the closure data filter is being used and if the
         theory covariance matrix is not being closure tested then filter
@@ -1783,6 +1785,9 @@ class CoreConfig(configparser.Config):
                     "Generating closure test data which samples from the theory "
                     "covariance matrix has not been implemented yet."
                 )
+            elif inconsistent_fakedata:
+                return validphys.filters.filter_inconsistent_closure_data_by_experiment
+
             return validphys.filters.filter_closure_data_by_experiment
 
     @configparser.explicit_node

--- a/validphys2/src/validphys/config.py
+++ b/validphys2/src/validphys/config.py
@@ -1784,8 +1784,8 @@ class CoreConfig(configparser.Config):
         fakedata: bool, default False
             whether to use closure test data in a fit.
         theorycovmatconfig: dict
-        inconsitent_fakedata: bool, default False
-            When true it allows for the introduction of inconsistencies in a closure test fit
+        inconsistent_fakedata: bool, default False
+            If true it allows for the introduction of inconsistencies in a closure test fit
             and returns filter_inconsistent_closure_data_by_experiment.
         """
         import validphys.filters

--- a/validphys2/src/validphys/coredata.py
+++ b/validphys2/src/validphys/coredata.py
@@ -445,6 +445,7 @@ class CommonData:
             k: v for k, v in sorted(definitions.items(), key=lambda item: item[1]["treatment"])
         }
         bins = []
+
         for idx, row in self.systematic_errors().iterrows():
             tmp = {"stat": float(self.stat_errors[idx])}
             # Hope things come in the right order...

--- a/validphys2/src/validphys/filters.py
+++ b/validphys2/src/validphys/filters.py
@@ -211,7 +211,14 @@ def filter_closure_data_by_experiment(
         experiment_index = data_index[data_index.isin([exp.name], level=0)]
         res.append(
             _filter_closure_data(
-                filter_path, exp, fakepdf, fakenoise, filterseed, experiment_index, sep_mult
+                filter_path,
+                exp,
+                fakepdf,
+                fakenoise,
+                filterseed,
+                experiment_index,
+                sep_mult,
+                inconsistent_data_settings=None,
             )
         )
 
@@ -236,7 +243,7 @@ def filter_inconsistent_closure_data_by_experiment(
     for exp in experiments_data:
         experiment_index = data_index[data_index.isin([exp.name], level=0)]
         res.append(
-            _filter_inconsistent_closure_data(
+            _filter_closure_data(
                 filter_path,
                 exp,
                 fakepdf,
@@ -295,7 +302,16 @@ def _filter_real_data(filter_path, data):
     return total_data_points, total_cut_data_points
 
 
-def _filter_closure_data(filter_path, data, fakepdf, fakenoise, filterseed, data_index, sep_mult):
+def _filter_closure_data(
+    filter_path,
+    data,
+    fakepdf,
+    fakenoise,
+    filterseed,
+    data_index,
+    sep_mult,
+    inconsistent_data_settings=None,
+):
     """
     This function is accessed within a closure test only, that is, the fakedata
     namespace has to be True (If fakedata = False, the _filter_real_data function
@@ -330,6 +346,8 @@ def _filter_closure_data(filter_path, data, fakepdf, fakenoise, filterseed, data
 
     data_index : pandas.MultiIndex
 
+    inconsistent_data_settings: dict, default is None
+        Settings for the inconsistent closure test. If None, the closure test is consistent.
 
     Returns
     -------
@@ -362,94 +380,30 @@ def _filter_closure_data(filter_path, data, fakepdf, fakenoise, filterseed, data
 
         closure_data = make_level1_data(data, closure_data, filterseed, data_index, sep_mult)
 
-    # ====== write commondata and systype files ======#
-    if fakenoise:
-        log.info("Writing Level1 data")
-    else:
-        log.info("Writing Level0 data")
-    for cd in closure_data:
-        # Write the full dataset, not only the points that pass the filter
-        data_path, unc_path = generate_path_filtered_data(filter_path.parent, cd.setname)
-        data_path.parent.mkdir(exist_ok=True, parents=True)
-
-        raw_cd = all_raw_commondata[cd.setname]
-
-        data_range = np.arange(1, 1 + raw_cd.ndata)
-
-        # Now put the closure data into the raw original commondata
-        new_cv = cd.central_values.reindex(data_range, fill_value=0.0).values
-        output_cd = raw_cd.with_central_value(new_cv)
-
-        # And export it to file
-        with open(data_path, "w", encoding="utf-8") as f:
-            output_cd.export_data(f)
-        with open(unc_path, "w", encoding="utf-8") as f:
-            output_cd.export_uncertainties(f)
-
-    return total_data_points, total_cut_data_points
-
-
-def _filter_inconsistent_closure_data(
-    filter_path,
-    data,
-    fakepdf,
-    fakenoise,
-    filterseed,
-    data_index,
-    sep_mult,
-    inconsistent_data_settings,
-):
-    """
-    Same as _filter_closure_data, but for inconsistent closure tests.
-    Is used when `inconsitent_fakedata` is set to True in the closure settings specs
-    of the runcard.
-    """
-    total_data_points = 0
-    total_cut_data_points = 0
-
-    # circular import generated @ core.py
-    from validphys.pseudodata import level0_commondata_wc, make_level1_data
-
-    closure_data = level0_commondata_wc(data, fakepdf)
-
-    # Keep track of the original commondata, since it is what will be used to export
-    # the data afterwards
-    all_raw_commondata = {}
-
-    for dataset in data.datasets:
-        # == print number of points passing cuts, make dataset directory and write FKMASK  ==#
-        path = filter_path / dataset.name
-        nfull, ncut = _write_ds_cut_data(path, dataset)
-        total_data_points += nfull
-        total_cut_data_points += ncut
-        all_raw_commondata[dataset.name] = dataset.commondata.load()
-
-    if fakenoise:
-        # ======= Level 1 closure test =======#
-
-        closure_data = make_level1_data(data, closure_data, filterseed, data_index, sep_mult)
-
-        # avoid circular import
-        from validphys.closuretest.inconsistent_closuretest.inconsistent_ct import (
-            InconsistentCommonData,
-        )
-
-        # Convert the commondata to InconsistentCommonData
-        closure_data = [
-            InconsistentCommonData(
-                setname=cd.setname,
-                ndata=cd.ndata,
-                commondataproc=cd.commondataproc,
-                nkin=cd.nkin,
-                nsys=cd.nsys,
-                commondata_table=cd.commondata_table,
-                systype_table=cd.systype_table,
+        if inconsistent_data_settings:
+            # avoid circular import
+            from validphys.closuretest.inconsistent_closuretest.inconsistent_ct import (
+                InconsistentCommonData,
             )
-            for cd in closure_data
-        ]
 
-        # Process the commondata
-        closure_data = [cd.process_commondata(**inconsistent_data_settings) for cd in closure_data]
+            # Convert the commondata to InconsistentCommonData
+            closure_data = [
+                InconsistentCommonData(
+                    setname=cd.setname,
+                    ndata=cd.ndata,
+                    commondataproc=cd.commondataproc,
+                    nkin=cd.nkin,
+                    nsys=cd.nsys,
+                    commondata_table=cd.commondata_table,
+                    systype_table=cd.systype_table,
+                )
+                for cd in closure_data
+            ]
+
+            # Process the commondata
+            closure_data = [
+                cd.process_commondata(**inconsistent_data_settings) for cd in closure_data
+            ]
 
         log.info("Writing Level1 data")
 
@@ -473,23 +427,24 @@ def _filter_inconsistent_closure_data(
         # And export it to file
         output_cd.export_data(data_path.open("w", encoding="utf-8"))
 
-        if cd.setname in inconsistent_data_settings["inconsistent_datasets"]:
-            # convert output_cd to InconsistentCommonData  (which has systematic_errors as a property and it's own export_uncertainties method)
-            # this is done for the inconsistent datasets only as the systematics of the other datasets are not modified
+        if inconsistent_data_settings:
+            if cd.setname in inconsistent_data_settings["inconsistent_datasets"]:
+                # convert output_cd to InconsistentCommonData  (which has systematic_errors as a property and it's own export_uncertainties method)
+                # this is done for the inconsistent datasets only as the systematics of the other datasets are not modified
 
-            output_cd = InconsistentCommonData(
-                setname=output_cd.setname,
-                ndata=output_cd.ndata,
-                commondataproc=output_cd.commondataproc,
-                nkin=output_cd.nkin,
-                nsys=output_cd.nsys,
-                commondata_table=output_cd.commondata_table,
-                systype_table=output_cd.systype_table,
-            )
+                output_cd = InconsistentCommonData(
+                    setname=output_cd.setname,
+                    ndata=output_cd.ndata,
+                    commondataproc=output_cd.commondataproc,
+                    nkin=output_cd.nkin,
+                    nsys=output_cd.nsys,
+                    commondata_table=output_cd.commondata_table,
+                    systype_table=output_cd.systype_table,
+                )
 
-            # put the inconsistent closure systematics into the raw systematics
-            new_sys = cd.systematic_errors.reindex(data_range, fill_value=0.0)
-            output_cd.systematic_errors = new_sys
+                # put the inconsistent closure systematics into the raw systematics
+                new_sys = cd.systematic_errors.reindex(data_range, fill_value=0.0)
+                output_cd.systematic_errors = new_sys
 
         # export it to file
         output_cd.export_uncertainties(unc_path.open("w", encoding="utf-8"))

--- a/validphys2/src/validphys/filters.py
+++ b/validphys2/src/validphys/filters.py
@@ -16,8 +16,6 @@ from reportengine.checks import check, make_check
 import validphys.cuts
 from validphys.process_options import PROCESSES
 from validphys.utils import generate_path_filtered_data, yaml_safe
-from validphys.utils import generate_path_filtered_data
-
 
 log = logging.getLogger(__name__)
 
@@ -380,7 +378,7 @@ def _filter_closure_data(
 
         closure_data = make_level1_data(data, closure_data, filterseed, data_index, sep_mult)
 
-        if inconsistent_data_settings:
+        if inconsistent_data_settings is not None:
             # avoid circular import
             from validphys.closuretest.inconsistent_closuretest.inconsistent_ct import (
                 InconsistentCommonData,
@@ -425,7 +423,8 @@ def _filter_closure_data(
         output_cd = raw_cd.with_central_value(new_cv)
 
         # And export it to file
-        output_cd.export_data(data_path.open("w", encoding="utf-8"))
+        with open(data_path, "w", encoding="utf-8") as f:
+            output_cd.export_data(f)
 
         if inconsistent_data_settings:
             if cd.setname in inconsistent_data_settings["inconsistent_datasets"]:
@@ -447,7 +446,8 @@ def _filter_closure_data(
                 output_cd.systematic_errors = new_sys
 
         # export it to file
-        output_cd.export_uncertainties(unc_path.open("w", encoding="utf-8"))
+        with open(unc_path, "w", encoding="utf-8") as f:
+            output_cd.export_uncertainties(f)
 
     return total_data_points, total_cut_data_points
 

--- a/validphys2/src/validphys/filters.py
+++ b/validphys2/src/validphys/filters.py
@@ -229,13 +229,7 @@ def filter_inconsistent_closure_data_by_experiment(
     inconsistent_data_settings,
 ):
     """
-    Like :py:func:`filter_closure_data` except filters data by experiment.
-
-    This function just peforms a ``for`` loop over ``experiments``, the reason
-    we don't use ``reportengine.collect`` is that it can permute the order
-    in which closure data is generate, which means that the pseudodata is
-    not reproducible.
-
+    Like :py:func:`filter_closure_data_by_experiment` except for inconsistent closure tests.
     """
 
     res = []
@@ -407,6 +401,8 @@ def _filter_inconsistent_closure_data(
 ):
     """
     Same as _filter_closure_data, but for inconsistent closure tests.
+    Is used when `inconsitent_fakedata` is set to True in the closure settings specs
+    of the runcard.
     """
     total_data_points = 0
     total_cut_data_points = 0

--- a/validphys2/src/validphys/filters.py
+++ b/validphys2/src/validphys/filters.py
@@ -17,7 +17,6 @@ import validphys.cuts
 from validphys.process_options import PROCESSES
 from validphys.utils import generate_path_filtered_data, yaml_safe
 from validphys.utils import generate_path_filtered_data
-from validphys.closuretest.inconsistent_closuretest.inconsistent_ct import InconsistentCommonData
 
 
 log = logging.getLogger(__name__)
@@ -407,7 +406,7 @@ def _filter_inconsistent_closure_data(
     inconsistent_data_settings,
 ):
     """
-    TODO
+    Same as _filter_closure_data, but for inconsistent closure tests.
     """
     total_data_points = 0
     total_cut_data_points = 0
@@ -433,6 +432,10 @@ def _filter_inconsistent_closure_data(
         # ======= Level 1 closure test =======#
 
         closure_data = make_level1_data(data, closure_data, filterseed, data_index, sep_mult)
+
+        from validphys.closuretest.inconsistent_closuretest.inconsistent_ct import (
+            InconsistentCommonData,
+        )
 
         closure_data = [
             InconsistentCommonData(

--- a/validphys2/src/validphys/tests/test_inconsistent_ct.py
+++ b/validphys2/src/validphys/tests/test_inconsistent_ct.py
@@ -6,27 +6,20 @@ from numpy.testing import assert_allclose
 
 from validphys.tests.conftest import SINGLE_DATASET
 from validphys.closuretest.inconsistent_closuretest.inconsistent_ct import InconsistentCommonData
+from validphys.api import API
 
 
-def load_cd():
-    """
-    Load a commondata instance and an inconsistent commondata instance.
-    """
-    # avoid circular import
-    from validphys.api import API
+cd = API.commondata(**{"dataset_input": {**SINGLE_DATASET}}).load()
 
-    cd = API.commondata(**{"dataset_input": {**SINGLE_DATASET}}).load()
-
-    inconsys_cd = InconsistentCommonData(
-        setname=cd.setname,
-        ndata=cd.ndata,
-        commondataproc=cd.commondataproc,
-        nkin=cd.nkin,
-        nsys=cd.nsys,
-        commondata_table=cd.commondata_table,
-        systype_table=cd.systype_table,
-    )
-    return cd, inconsys_cd
+inconsys_cd = InconsistentCommonData(
+    setname=cd.setname,
+    ndata=cd.ndata,
+    commondataproc=cd.commondataproc,
+    nkin=cd.nkin,
+    nsys=cd.nsys,
+    commondata_table=cd.commondata_table,
+    systype_table=cd.systype_table,
+)
 
 
 def test_with_MULT_sys():
@@ -35,7 +28,6 @@ def test_with_MULT_sys():
     replaced correctly by
     dataclasses.replace(self, commondata_table = new_table)
     """
-    cd, inconsys_cd = load_cd()
 
     mult_sys_tab = 3 * cd.commondata_table["MULT"].to_numpy()
 
@@ -50,7 +42,7 @@ def test_with_ADD_sys():
     replaced correctly by
     dataclasses.replace(self, commondata_table = new_table)
     """
-    cd, inconsys_cd = load_cd()
+
     mult_sys_tab = 3 * cd.commondata_table["ADD"].to_numpy()
 
     inc_mult_sys_tab = inconsys_cd.with_ADD_sys(mult_sys_tab).commondata_table["ADD"].to_numpy()
@@ -64,7 +56,6 @@ def test_rescale_sys_CORR_MULT():
     CORR MULT uncertainties works
     as expected
     """
-    cd, inconsys_cd = load_cd()
 
     rescaling_factor = 2.0
     treatment_err = "MULT"
@@ -97,7 +88,6 @@ def test_rescale_sys_CORR_ADD():
     CORR ADD uncertainties works
     as expected
     """
-    cd, inconsys_cd = load_cd()
 
     rescaling_factor = 2.0
     treatment_err = "ADD"
@@ -130,7 +120,7 @@ def test_process_commondata():
     leaves the commondata instance
     unchanged when told to do so.
     """
-    cd, inconsys_cd = load_cd()
+
     new_icd = inconsys_cd.process_commondata(
         ADD=False,
         MULT=False,
@@ -153,7 +143,7 @@ def test_process_commondata_CORR_MULT():
     as expected with process_commondata
     method
     """
-    cd, inconsys_cd = load_cd()
+
     treatment_err = "MULT"
     rescaling_factor = 2.0
     new_icd = inconsys_cd.process_commondata(
@@ -186,7 +176,7 @@ def test_process_commondata_CORR_ADD():
     as expected with process_commondata
     method
     """
-    cd, inconsys_cd = load_cd()
+
     treatment_err = "ADD"
     rescaling_factor = 2.0
     new_icd = inconsys_cd.process_commondata(

--- a/validphys2/src/validphys/tests/test_inconsistent_ct.py
+++ b/validphys2/src/validphys/tests/test_inconsistent_ct.py
@@ -3,10 +3,11 @@ Module for testing the InconsistentCommonData class in the inconsistent_closuret
 Testing is done by mocking the class's methods and properties.
 """
 
+from io import StringIO
 import unittest
 from unittest.mock import MagicMock, patch
+
 import pandas as pd
-from io import StringIO
 
 
 class TestInconsistentCommonData(unittest.TestCase):

--- a/validphys2/src/validphys/tests/test_inconsistent_ct.py
+++ b/validphys2/src/validphys/tests/test_inconsistent_ct.py
@@ -1,0 +1,190 @@
+"""
+Module to test the InconsistentCommonData class.
+"""
+
+from numpy.testing import assert_allclose
+
+from validphys.tests.conftest import SINGLE_DATASET
+from validphys.closuretest.inconsistent_closuretest.inconsistent_ct import InconsistentCommonData
+
+
+def load_cd():
+    """
+    Load a commondata instance and an inconsistent commondata instance.
+    """
+    # avoid circular import
+    from validphys.api import API
+
+    cd = API.commondata(**{"dataset_input": {**SINGLE_DATASET}}).load()
+
+    inconsys_cd = InconsistentCommonData(
+        setname=cd.setname,
+        ndata=cd.ndata,
+        commondataproc=cd.commondataproc,
+        nkin=cd.nkin,
+        nsys=cd.nsys,
+        commondata_table=cd.commondata_table,
+        systype_table=cd.systype_table,
+    )
+    return cd, inconsys_cd
+
+
+def test_with_MULT_sys():
+    """
+    test if MULT commondata_table is
+    replaced correctly by
+    dataclasses.replace(self, commondata_table = new_table)
+    """
+    cd, inconsys_cd = load_cd()
+
+    mult_sys_tab = 3 * cd.commondata_table["MULT"].to_numpy()
+
+    inc_mult_sys_tab = inconsys_cd.with_MULT_sys(mult_sys_tab).commondata_table["MULT"].to_numpy()
+
+    assert_allclose(mult_sys_tab, inc_mult_sys_tab)
+
+
+def test_with_ADD_sys():
+    """
+    test if ADD commondata_table is
+    replaced correctly by
+    dataclasses.replace(self, commondata_table = new_table)
+    """
+    cd, inconsys_cd = load_cd()
+    mult_sys_tab = 3 * cd.commondata_table["ADD"].to_numpy()
+
+    inc_mult_sys_tab = inconsys_cd.with_ADD_sys(mult_sys_tab).commondata_table["ADD"].to_numpy()
+
+    assert_allclose(mult_sys_tab, inc_mult_sys_tab)
+
+
+def test_rescale_sys_CORR_MULT():
+    """
+    Check whether rescaling of
+    CORR MULT uncertainties works
+    as expected
+    """
+    cd, inconsys_cd = load_cd()
+
+    rescaling_factor = 2.0
+    type_err = "MULT"
+    new_icd = inconsys_cd.with_MULT_sys(
+        inconsys_cd.rescale_sys(
+            type_err=type_err,
+            CORR=True,
+            UNCORR=False,
+            SPECIAL=False,
+            sys_rescaling_factor=rescaling_factor,
+        )
+    )
+
+    # get indices of CORR sys
+    systype_corr = cd.systype_table[
+        (cd.systype_table["treatment"] == type_err)
+        & (~cd.systype_table["name"].isin(["UNCORR", "THEORYUNCORR"]))
+    ]
+
+    tab2 = rescaling_factor * cd.systematics_table.iloc[:, systype_corr.index - 1].to_numpy()
+
+    tab1 = new_icd.systematics_table.iloc[:, systype_corr.index - 1]
+
+    assert_allclose(tab1, tab2)
+
+
+def test_rescale_sys_CORR_ADD():
+    """
+    Check whether rescaling of
+    CORR ADD uncertainties works
+    as expected
+    """
+    cd, inconsys_cd = load_cd()
+
+    rescaling_factor = 2.0
+    type_err = "ADD"
+    new_icd = inconsys_cd.with_ADD_sys(
+        inconsys_cd.rescale_sys(
+            type_err, CORR=True, UNCORR=False, SPECIAL=False, sys_rescaling_factor=rescaling_factor
+        )
+    )
+
+    # get indices of CORR sys
+    systype_corr = cd.systype_table[
+        (cd.systype_table["treatment"] == type_err)
+        & (~cd.systype_table["name"].isin(["UNCORR", "THEORYUNCORR"]))
+    ]
+
+    tab2 = rescaling_factor * cd.systematics_table.iloc[:, systype_corr.index - 1].to_numpy()
+
+    tab1 = new_icd.systematics_table.iloc[:, systype_corr.index - 1]
+
+    assert_allclose(tab1, tab2)
+
+
+def test_process_commondata():
+    """
+    Check whether process_commondata
+    leaves the commondata instance
+    unchanged when told to do so.
+    """
+    cd, inconsys_cd = load_cd()
+    new_icd = inconsys_cd.process_commondata(
+        ADD=False, MULT=False, CORR=False, UNCORR=False, SPECIAL=False, inconsistent_datasets=[SINGLE_DATASET['dataset']], sys_rescaling_factor=1
+    )
+    tab1 = new_icd.commondata_table.drop(['process'], axis=1).to_numpy()
+    tab2 = inconsys_cd.commondata_table.drop(['process'], axis=1).to_numpy()
+
+    assert_allclose(tab1, tab2)
+
+
+def test_process_commondata_CORR_MULT():
+    """
+    Check whether rescaling of
+    CORR MULT uncertainties works
+    as expected with process_commondata
+    method
+    """
+    cd, inconsys_cd = load_cd()
+    type_err = "MULT"
+    rescaling_factor = 2.0
+    new_icd = inconsys_cd.process_commondata(
+        ADD=False, MULT=True, CORR=True, UNCORR=False, SPECIAL=False, inconsistent_datasets=[SINGLE_DATASET['dataset']], sys_rescaling_factor=rescaling_factor
+    )
+
+    # get indices of CORR sys
+    systype_corr = cd.systype_table[
+        (cd.systype_table["treatment"] == type_err)
+        & (~cd.systype_table["name"].isin(["UNCORR", "THEORYUNCORR"]))
+    ]
+
+    tab2 = rescaling_factor * cd.systematics_table.iloc[:, systype_corr.index - 1].to_numpy()
+
+    tab1 = new_icd.systematics_table.iloc[:, systype_corr.index - 1]
+
+    assert_allclose(tab1, tab2)
+
+
+def test_process_commondata_CORR_ADD():
+    """
+    Check whether rescaling of
+    CORR ADD uncertainties works
+    as expected with process_commondata
+    method
+    """
+    cd, inconsys_cd = load_cd()
+    type_err = "ADD"
+    rescaling_factor = 2.0
+    new_icd = inconsys_cd.process_commondata(
+        ADD=True, MULT=False, CORR=True, UNCORR=False, SPECIAL=False, inconsistent_datasets=[SINGLE_DATASET['dataset']], sys_rescaling_factor=rescaling_factor
+    )
+
+    # get indices of CORR sys
+    systype_corr = cd.systype_table[
+        (cd.systype_table["treatment"] == type_err)
+        & (~cd.systype_table["name"].isin(["UNCORR", "THEORYUNCORR"]))
+    ]
+
+    tab2 = rescaling_factor * cd.systematics_table.iloc[:, systype_corr.index - 1].to_numpy()
+
+    tab1 = new_icd.systematics_table.iloc[:, systype_corr.index - 1]
+
+    assert_allclose(tab1, tab2)

--- a/validphys2/src/validphys/tests/test_inconsistent_ct.py
+++ b/validphys2/src/validphys/tests/test_inconsistent_ct.py
@@ -67,10 +67,10 @@ def test_rescale_sys_CORR_MULT():
     cd, inconsys_cd = load_cd()
 
     rescaling_factor = 2.0
-    type_err = "MULT"
+    treatment_err = "MULT"
     new_icd = inconsys_cd.with_MULT_sys(
         inconsys_cd.rescale_sys(
-            type_err=type_err,
+            treatment_err=treatment_err,
             CORR=True,
             UNCORR=False,
             SPECIAL=False,
@@ -80,7 +80,7 @@ def test_rescale_sys_CORR_MULT():
 
     # get indices of CORR sys
     systype_corr = cd.systype_table[
-        (cd.systype_table["treatment"] == type_err)
+        (cd.systype_table["treatment"] == treatment_err)
         & (~cd.systype_table["name"].isin(["UNCORR", "THEORYUNCORR"]))
     ]
 
@@ -100,16 +100,20 @@ def test_rescale_sys_CORR_ADD():
     cd, inconsys_cd = load_cd()
 
     rescaling_factor = 2.0
-    type_err = "ADD"
+    treatment_err = "ADD"
     new_icd = inconsys_cd.with_ADD_sys(
         inconsys_cd.rescale_sys(
-            type_err, CORR=True, UNCORR=False, SPECIAL=False, sys_rescaling_factor=rescaling_factor
+            treatment_err,
+            CORR=True,
+            UNCORR=False,
+            SPECIAL=False,
+            sys_rescaling_factor=rescaling_factor,
         )
     )
 
     # get indices of CORR sys
     systype_corr = cd.systype_table[
-        (cd.systype_table["treatment"] == type_err)
+        (cd.systype_table["treatment"] == treatment_err)
         & (~cd.systype_table["name"].isin(["UNCORR", "THEORYUNCORR"]))
     ]
 
@@ -128,7 +132,13 @@ def test_process_commondata():
     """
     cd, inconsys_cd = load_cd()
     new_icd = inconsys_cd.process_commondata(
-        ADD=False, MULT=False, CORR=False, UNCORR=False, SPECIAL=False, inconsistent_datasets=[SINGLE_DATASET['dataset']], sys_rescaling_factor=1
+        ADD=False,
+        MULT=False,
+        CORR=False,
+        UNCORR=False,
+        SPECIAL=False,
+        inconsistent_datasets=[SINGLE_DATASET['dataset']],
+        sys_rescaling_factor=1,
     )
     tab1 = new_icd.commondata_table.drop(['process'], axis=1).to_numpy()
     tab2 = inconsys_cd.commondata_table.drop(['process'], axis=1).to_numpy()
@@ -144,15 +154,21 @@ def test_process_commondata_CORR_MULT():
     method
     """
     cd, inconsys_cd = load_cd()
-    type_err = "MULT"
+    treatment_err = "MULT"
     rescaling_factor = 2.0
     new_icd = inconsys_cd.process_commondata(
-        ADD=False, MULT=True, CORR=True, UNCORR=False, SPECIAL=False, inconsistent_datasets=[SINGLE_DATASET['dataset']], sys_rescaling_factor=rescaling_factor
+        ADD=False,
+        MULT=True,
+        CORR=True,
+        UNCORR=False,
+        SPECIAL=False,
+        inconsistent_datasets=[SINGLE_DATASET['dataset']],
+        sys_rescaling_factor=rescaling_factor,
     )
 
     # get indices of CORR sys
     systype_corr = cd.systype_table[
-        (cd.systype_table["treatment"] == type_err)
+        (cd.systype_table["treatment"] == treatment_err)
         & (~cd.systype_table["name"].isin(["UNCORR", "THEORYUNCORR"]))
     ]
 
@@ -171,15 +187,21 @@ def test_process_commondata_CORR_ADD():
     method
     """
     cd, inconsys_cd = load_cd()
-    type_err = "ADD"
+    treatment_err = "ADD"
     rescaling_factor = 2.0
     new_icd = inconsys_cd.process_commondata(
-        ADD=True, MULT=False, CORR=True, UNCORR=False, SPECIAL=False, inconsistent_datasets=[SINGLE_DATASET['dataset']], sys_rescaling_factor=rescaling_factor
+        ADD=True,
+        MULT=False,
+        CORR=True,
+        UNCORR=False,
+        SPECIAL=False,
+        inconsistent_datasets=[SINGLE_DATASET['dataset']],
+        sys_rescaling_factor=rescaling_factor,
     )
 
     # get indices of CORR sys
     systype_corr = cd.systype_table[
-        (cd.systype_table["treatment"] == type_err)
+        (cd.systype_table["treatment"] == treatment_err)
         & (~cd.systype_table["name"].isin(["UNCORR", "THEORYUNCORR"]))
     ]
 


### PR DESCRIPTION
Reimplements #1682

This pull request introduces a new class, `InconsistentCommonData`, to handle inconsistencies within closure tests and includes several related changes across multiple files. The most important changes include the addition of the new class, updates to the configuration parsing, and new filtering methods for handling inconsistent closure data.

### New Class and Methods:

* [`validphys2/src/validphys/closuretest/inconsistent_closuretest/inconsistent_ct.py`](diffhunk://#diff-f7e10ed1dfd131c18f0dadad40dbbc31159ef57f5fd045e3dbea548c0bc9fa25R1-R215): Added `InconsistentCommonData` class with methods to introduce inconsistencies in closure tests, including `systematic_errors` property, `select_systype_table_indices`, `rescale_systematics`, `process_commondata`, and `export_uncertainties`.

### Configuration Updates:

* [`validphys2/src/validphys/config.py`](diffhunk://#diff-72836a845f52a625f839a3569b52e6d147f9073cf3c6dd52e278e0dcc97f1795R480-R506): Added `parse_inconsistent_data_settings` method to parse inconsistent data settings from the YAML file.
* [`validphys2/src/validphys/config.py`](diffhunk://#diff-72836a845f52a625f839a3569b52e6d147f9073cf3c6dd52e278e0dcc97f1795L1719-R1748): Updated `produce_filter_data` to include `inconsistent_fakedata` parameter for filtering inconsistent closure data. [[1]](diffhunk://#diff-72836a845f52a625f839a3569b52e6d147f9073cf3c6dd52e278e0dcc97f1795L1719-R1748) [[2]](diffhunk://#diff-72836a845f52a625f839a3569b52e6d147f9073cf3c6dd52e278e0dcc97f1795R1767-R1770)

### Filtering Methods:

* [`validphys2/src/validphys/filters.py`](diffhunk://#diff-c921099aff605d30b60c690010719281d27b4266fa411e9ed0d1ef37f411dd7aR221-R259): Added `filter_inconsistent_closure_data_by_experiment` and `_filter_inconsistent_closure_data` methods to handle filtering of inconsistent closure data. [[1]](diffhunk://#diff-c921099aff605d30b60c690010719281d27b4266fa411e9ed0d1ef37f411dd7aR221-R259) [[2]](diffhunk://#diff-c921099aff605d30b60c690010719281d27b4266fa411e9ed0d1ef37f411dd7aR397-R502)

### Testing:

* [`validphys2/src/validphys/tests/test_inconsistent_ct.py`](diffhunk://#diff-1c356efd2d97174d62bd426e393c72173524eb81be2d17f6322f66ef87dadd8dR1-R154): Added unit tests for `InconsistentCommonData` class methods, including tests for the getter and setter of `systematic_errors`, `select_systype_table_indices`, `rescale_systematics`, `process_commondata`, and `export_uncertainties`.


## Benchmarking of Code

- [x] Test against old code to see whether we reproduce it, eg the same Ratio bias variance results.


#### Test 0.0
Test that an inconsistent ct fit (using the inconsistent closure test filter) with lambda = 1.0 gives the same results as a consistent closure test:

https://vp.nnpdf.science/VIdN_z0ETx6Ph0szzKLY0g==


#### Multiclosure Test
DIS multiclosure test with maximal lambda inconsistency parameter (lambda=0)

https://vp.nnpdf.science/idXftjIBTp6r2ufbFIhMaA==

Also note that for a single fit with the same L1 data

This is the type of agreement found between old and new branch for a DIS only inconsistent closure test with lambda = 0
https://vp.nnpdf.science/sH-C_csbTGCPCdEGFXj_1w==


Example of inconsistent closure test runcard:


```
inconsistent_data_settings:

  treatment_names: [MULT]
  names_uncertainties: [CORR, SPECIAL]

  inconsistent_datasets:
    - HERA_NC_318GEV_EM-SIGMARED
    - HERA_NC_251GEV_EP-SIGMARED
    - HERA_NC_300GEV_EP-SIGMARED
    - HERA_NC_318GEV_EP-SIGMARED

  sys_rescaling_factor: 0.0


closuretest:
  errorsize: 1.0
  fakedata: true
  inconsistent_fakedata: true
  fakenoise: true
  fakepdf: 210223-mw-000_fakepdf
  filterseed: 1
  printpdf4gen: false
  rancutmethod: 0
  rancutprob: 1.0
  rancuttrnval: false

datacuts:
  q2min: 3.49
  t0pdfset: 210223-mw-000_fakepdf
  use_cuts: internal
  w2min: 12.5

dataset_inputs:
- dataset: NMCPD_dw_ite
  frac: 0.75
- dataset: SLACP_dwsh
  frac: 0.75
- dataset: SLACD_dw_ite
  frac: 0.75
- dataset: BCDMSP_dwsh
  frac: 0.75
- dataset: BCDMSD_dw_ite
  frac: 0.75
- dataset: CHORUSNUPb_dw_ite
  frac: 0.75
- dataset: CHORUSNBPb_dw_ite
  frac: 0.75
- cfac:
  - MAS
  dataset: NTVNUDMNFe_dw_ite
  frac: 0.75
- dataset: HERACOMBNCEM
  frac: 0.75
- dataset: HERACOMBNCEP575
  frac: 0.75
- dataset: HERACOMBNCEP820
  frac: 0.75
- dataset: HERACOMBNCEP920
  frac: 0.75
- dataset: HERACOMBCCEP
  frac: 0.75
- dataset: HERACOMB_SIGMARED_C
  frac: 0.75

debug: false

description: DIS only data. Some datasets (see partition) are left out of the fit.
  Partition is chosen as in NNPDF40_hyperopt. An inconsistency of type 2 is introduced
  for some of the in-sample datasets, namely all of the HERA NC ones.

fitting:
  savepseudodata: true
  basis:
  - fl: sng
    largex:
    - 1.498
    - 3.138
    smallx:
    - 1.121
    - 1.154
    trainable: false
  - fl: g
    largex:
    - 3.266
    - 6.214
    smallx:
    - 0.9224
    - 1.149
    trainable: false
  - fl: v
    largex:
    - 1.6
    - 3.588
    smallx:
    - 0.5279
    - 0.8017
    trainable: false
  - fl: v3
    largex:
    - 1.761
    - 3.427
    smallx:
    - 0.2011
    - 0.4374
    trainable: false
  - fl: v8
    largex:
    - 1.589
    - 3.378
    smallx:
    - 0.5775
    - 0.8357
    trainable: false
  - fl: t3
    largex:
    - 1.763
    - 3.397
    smallx:
    - -0.484
    - 1.0
    trainable: false
  - fl: t8
    largex:
    - 1.572
    - 3.496
    smallx:
    - 0.6714
    - 0.9197
    trainable: false
  - fl: t15
    largex:
    - 1.503
    - 3.636
    smallx:
    - 1.073
    - 1.164
    trainable: false
  fitbasis: EVOL

genrep: true

integrability:
  integdatasets:
  - dataset: INTEGXT8
    maxlambda: 1e2
  - dataset: INTEGXT3
    maxlambda: 1e2

maxcores: 4
mcseed: 75955222
nnseed: 2080989803

parameters:
  activation_per_layer:
  - tanh
  - tanh
  - linear
  dropout: 0.0
  epochs: 17000
  initializer: glorot_normal
  integrability:
    initial: 10
    multiplier: null
  layer_type: dense
  nodes_per_layer:
  - 25
  - 20
  - 8
  optimizer:
    clipnorm: 6.073e-06
    learning_rate: 0.002621
    optimizer_name: Nadam
  positivity:
    initial: 184.8
    multiplier: null
  stopping_patience: 0.1
  threshold_chi2: 3.5
positivity:
  posdatasets:
  - dataset: POSF2U
    maxlambda: 1e6
  - dataset: POSF2DW
    maxlambda: 1e6
  - dataset: POSF2S
    maxlambda: 1e6
  - dataset: POSFLL
    maxlambda: 1e6
  - dataset: POSDYU
    maxlambda: 1e10
  - dataset: POSDYD
    maxlambda: 1e10
  - dataset: POSDYS
    maxlambda: 1e10
  - dataset: POSF2C
    maxlambda: 1e6
  - dataset: POSXUQ
    maxlambda: 1e6
  - dataset: POSXUB
    maxlambda: 1e6
  - dataset: POSXDQ
    maxlambda: 1e6
  - dataset: POSXDB
    maxlambda: 1e6
  - dataset: POSXSQ
    maxlambda: 1e6
  - dataset: POSXSB
    maxlambda: 1e6
  - dataset: POSXGL
    maxlambda: 1e6

save: weights.h5

theory:
  theoryid: 200
trvlseed: 376191634
```