### PR TITLE
Apple Silicon GPU compatibility for Tensorflow

### DIFF
--- a/doc/sphinx/source/n3fit/runcard_detailed.rst
+++ b/doc/sphinx/source/n3fit/runcard_detailed.rst
@@ -332,9 +332,9 @@ top-level option:
 
   parallel_models: true
 
-
-And then run ``n3fit`` with a replica range to be parallelized
-(in this case from replica 1 to replica 4).
+Note that currently, in order to run with parallel models, one has to set ``savepseudodata: false``
+in the ``fitting`` section of the runcard. Once this is done, the user can run ``n3fit`` with a 
+replica range to be parallelized (in this case from replica 1 to replica 4).
 
 .. code-block:: bash
 

--- a/doc/sphinx/source/n3fit/runcard_detailed.rst
+++ b/doc/sphinx/source/n3fit/runcard_detailed.rst
@@ -346,7 +346,7 @@ should run by setting the environment variable ``CUDA_VISIBLE_DEVICES``
 to the right index (usually ``0, 1, 2``) or leaving it explicitly empty
 to avoid running on GPU: ``export CUDA_VISIBLE_DEVICES=""``
 
-Note that in order to run the replicas in parallel using the GPUs of a M1/M2 Mac, it is necessary to also install 
+Note that in order to run the replicas in parallel using the GPUs of an Apple Silicon computer (like M1 Mac), it is necessary to also install 
 the following packages:
 
 .. code-block:: bash
@@ -355,6 +355,7 @@ the following packages:
    pip install tensorflow-macos==2.13.0 tensorflow-metal wandb==0.15.9
 
 
+See also the following issue for more information: `protobuf issue <https://github.com/wandb/wandb/issues/5935>`_.
 
 .. _otheroptions-label:
 

--- a/doc/sphinx/source/n3fit/runcard_detailed.rst
+++ b/doc/sphinx/source/n3fit/runcard_detailed.rst
@@ -346,6 +346,15 @@ should run by setting the environment variable ``CUDA_VISIBLE_DEVICES``
 to the right index (usually ``0, 1, 2``) or leaving it explicitly empty
 to avoid running on GPU: ``export CUDA_VISIBLE_DEVICES=""``
 
+Note that in order to run the replicas in parallel using the GPUs of a M1/M2 Mac, it is necessary to also install 
+the following packages:
+
+.. code-block:: bash
+
+   conda install -c apple tensorflow-deps
+   pip install tensorflow-macos==2.13.0 tensorflow-metal wandb==0.15.9
+
+
 
 .. _otheroptions-label:
 


### PR DESCRIPTION
This pull request includes updates to the `doc/sphinx/source/n3fit/runcard_detailed.rst` file to clarify instructions for running parallel models and using GPUs on M1/M2 Macs.

Updates to parallel model instructions:

* Added a note that `savepseudodata` must be set to `false` in the `fitting` section of the runcard to run with parallel models. (`doc/sphinx/source/n3fit/runcard_detailed.rst`)

Updates for GPU usage on M1/M2 Macs:

* Added instructions to install specific packages (`tensorflow-deps`, `tensorflow-macos`, `tensorflow-metal`, and `wandb`) to run replicas in parallel using GPUs on M1/M2 Macs. (`doc/sphinx/source/n3fit/runcard_detailed.rst`)