### PR TITLE
Remove pointless `fivetheories` and `seventheories`

### DIFF
--- a/validphys2/src/validphys/config.py
+++ b/validphys2/src/validphys/config.py
@@ -1153,13 +1153,7 @@ class CoreConfig(configparser.Config):
 
             f = user_covmat_fitting
 
-        @functools.wraps(f)
-        def res(*args, **kwargs):
-            return f(*args, **kwargs)
-
-        # Set this to get the same filename regardless of the action.
-        res.__name__ = "theory_covmat"
-        return res
+        return f
 
     def produce_fitthcovmat(
         self, use_thcovmat_if_present: bool = False, fit: (str, type(None)) = None

--- a/validphys2/src/validphys/config.py
+++ b/validphys2/src/validphys/config.py
@@ -1127,14 +1127,13 @@ class CoreConfig(configparser.Config):
 
     @configparser.explicit_node
     def produce_nnfit_theory_covmat(
-        self,
-        use_thcovmat_in_sampling: bool,
-        use_thcovmat_in_fitting: bool,
-        inclusive_use_scalevar_uncertainties,
-        use_user_uncertainties: bool = False,
+        self, inclusive_use_scalevar_uncertainties, use_user_uncertainties: bool = False
     ):
         """
         Return the theory covariance matrix used in the fit.
+
+        This function is only used in vp-setupfit to store the necessary covmats as .csv files in
+        the tables directory.
         """
         if inclusive_use_scalevar_uncertainties:
             if use_user_uncertainties:
@@ -1623,21 +1622,6 @@ class CoreConfig(configparser.Config):
             {"data_input": NSList(group, nskey="dataset_input"), "group_name": name}
             for name, group in res.items()
         ]
-
-    def produce_fivetheories(self, point_prescription):
-        if point_prescription == "5bar point":
-            return "bar"
-        elif point_prescription == "5 point":
-            return "nobar"
-        return None
-
-    def produce_seventheories(self, point_prescription):
-        if point_prescription == "7 point":
-            # This is None because is the default choice
-            return None
-        elif point_prescription == "7original point":
-            return "original"
-        return None
 
     def produce_group_dataset_inputs_by_experiment(self, data_input):
         return self.produce_group_dataset_inputs_by_metadata(data_input, "experiment")

--- a/validphys2/src/validphys/theorycovariance/construction.py
+++ b/validphys2/src/validphys/theorycovariance/construction.py
@@ -27,12 +27,7 @@ each_dataset_results_central_bytheory = collect("results_central_bytheoryids", (
 
 @check_using_theory_covmat
 def theory_covmat_dataset(
-    results,
-    results_central_bytheoryids,
-    use_theorycovmat,  # for the check
-    point_prescription,
-    fivetheories=None,
-    seventheories=None,
+    results, results_central_bytheoryids, use_theorycovmat, point_prescription  # for the check
 ):
     """
     Compute the theory covmat for a collection of theoryids for a single dataset.
@@ -50,9 +45,7 @@ def theory_covmat_dataset(
 
     # Compute the theory contribution to the covmats
     deltas = list(t.central_value - cv for t in theory_results)
-    thcovmat = compute_covs_pt_prescrip(
-        point_prescription, l, "A", deltas, fivetheories=fivetheories, seventheories=seventheories
-    )
+    thcovmat = compute_covs_pt_prescrip(point_prescription, l, "A", deltas)
 
     return thcovmat
 
@@ -242,16 +235,7 @@ def covmat_n3lo_ad(name1, name2, deltas1, deltas2):
     return 1 / norm * s
 
 
-def compute_covs_pt_prescrip(
-    point_prescription,
-    l,
-    name1,
-    deltas1,
-    name2=None,
-    deltas2=None,
-    fivetheories=None,
-    seventheories=None,
-):
+def compute_covs_pt_prescrip(point_prescription, l, name1, deltas1, name2=None, deltas2=None):
     """Utility to compute the covariance matrix by prescription given the
     shifts with respect to the central value for a pair of processes.
 
@@ -275,10 +259,6 @@ def compute_covs_pt_prescrip(
             Process name of the second set of shifts
         deltas2: list(np.ndarray)
             list of shifts for each of the non-central theories
-        fivetheories: str
-            5-point prescription variation
-        seventheories: str
-            7-point prescription variation
     """
     if name2 is None and deltas2 is not None:
         raise ValueError(
@@ -302,7 +282,7 @@ def compute_covs_pt_prescrip(
             s = covmat_3pt(name1, name2, deltas1, deltas2)
     elif l == 5:
         # 5 point --------------------------------------------------------------
-        if fivetheories == "nobar":
+        if point_prescription == "5 point":
             s = covmat_5pt(name1, name2, deltas1, deltas2)
         # 5bar-point -----------------------------------------------------------
         else:
@@ -310,7 +290,7 @@ def compute_covs_pt_prescrip(
     #  ---------------------------------------------------------------------
     elif l == 7:
         # Outdated 7pts implementation: left for posterity ---------------------
-        if seventheories == "original":
+        if point_prescription == "7original point":
             s = covmat_7pt_orig(name1, name2, deltas1, deltas2)
         # 7pt (Gavin) ----------------------------------------------------------
         else:
@@ -361,7 +341,7 @@ def compute_covs_pt_prescrip(
 
 
 @check_correct_theory_combination
-def covs_pt_prescrip(combine_by_type, theoryids, point_prescription, fivetheories, seventheories):
+def covs_pt_prescrip(combine_by_type, theoryids, point_prescription):
     """Produces the sub-matrices of the theory covariance matrix according
     to a point prescription which matches the number of input theories.
     If 5 theories are provided, a scheme 'bar' or 'nobar' must be
@@ -386,14 +366,7 @@ def covs_pt_prescrip(combine_by_type, theoryids, point_prescription, fivetheorie
             central2, *others2 = process_info.preds[name2]
             deltas2 = list(other - central2 for other in others2)
             s = compute_covs_pt_prescrip(
-                point_prescription,
-                len(theoryids),
-                name1,
-                deltas1,
-                name2,
-                deltas2,
-                fivetheories,
-                seventheories,
+                point_prescription, len(theoryids), name1, deltas1, name2, deltas2
             )
             start_locs = (start_proc[name1], start_proc[name2])
             covmats[start_locs] = s

--- a/validphys2/src/validphys/theorycovariance/construction.py
+++ b/validphys2/src/validphys/theorycovariance/construction.py
@@ -27,7 +27,7 @@ each_dataset_results_central_bytheory = collect("results_central_bytheoryids", (
 
 @check_using_theory_covmat
 def theory_covmat_dataset(
-    results, results_central_bytheoryids, use_theorycovmat, point_prescription  # for the check
+    results, results_central_bytheoryids, point_prescription, use_theorycovmat  # for the check
 ):
     """
     Compute the theory covmat for a collection of theoryids for a single dataset.
@@ -278,22 +278,19 @@ def compute_covs_pt_prescrip(point_prescription, l, name1, deltas1, name2=None, 
             s = covmat_3fpt(name1, name2, deltas1, deltas2)
         elif point_prescription == "3r point":
             s = covmat_3rpt(name1, name2, deltas1, deltas2)
-        else:
+        elif point_prescription == "3 point":
             s = covmat_3pt(name1, name2, deltas1, deltas2)
     elif l == 5:
-        # 5 point --------------------------------------------------------------
         if point_prescription == "5 point":
             s = covmat_5pt(name1, name2, deltas1, deltas2)
-        # 5bar-point -----------------------------------------------------------
-        else:
+        elif point_prescription == "5bar point":
             s = covmat_5barpt(name1, name2, deltas1, deltas2)
-    #  ---------------------------------------------------------------------
     elif l == 7:
         # Outdated 7pts implementation: left for posterity ---------------------
         if point_prescription == "7original point":
             s = covmat_7pt_orig(name1, name2, deltas1, deltas2)
         # 7pt (Gavin) ----------------------------------------------------------
-        else:
+        elif point_prescription == "7 point":
             s = covmat_7pt(name1, name2, deltas1, deltas2)
     elif l == 9:
         s = covmat_9pt(name1, name2, deltas1, deltas2)

--- a/validphys2/src/validphys/theorycovariance/output.py
+++ b/validphys2/src/validphys/theorycovariance/output.py
@@ -2,7 +2,6 @@
 output.py
 Basic tools for plotting theory covariance matrices and their properties.
 """
-from __future__ import generator_stop
 
 import logging
 from math import inf
@@ -195,22 +194,22 @@ def plot_expcorrmat_heatmap(procs_corrmat):
 
 
 @figure
-def plot_normthcovmat_heatmap_custom(theory_normcovmat_custom, theoryids, fivetheories):
+def plot_normthcovmat_heatmap_custom(theory_normcovmat_custom, theoryids, point_prescription):
     """Matrix plot for block diagonal theory covariance matrix by process type"""
     l = len(theoryids)
     if l == 5:
-        if fivetheories == "bar":
+        if point_prescription == "5bar point":
             l = r"$\bar{5}$"
     fig = plot_covmat_heatmap(theory_normcovmat_custom, f"Theory Covariance matrix ({l} pt)")
     return fig
 
 
 @figure
-def plot_thcorrmat_heatmap_custom(theory_corrmat_custom, theoryids, fivetheories):
+def plot_thcorrmat_heatmap_custom(theory_corrmat_custom, theoryids, point_prescription):
     """Matrix plot of the theory correlation matrix, correlations by process type"""
     l = len(theoryids)
     if l == 5:
-        if fivetheories == "bar":
+        if point_prescription == "5bar point":
             l = r"$\bar{5}$"
     fig = plot_corrmat_heatmap(theory_corrmat_custom, f"Theory Correlation matrix ({l} pt)")
     return fig
@@ -218,12 +217,12 @@ def plot_thcorrmat_heatmap_custom(theory_corrmat_custom, theoryids, fivetheories
 
 @figure
 def plot_expplusthcorrmat_heatmap_custom(
-    experimentplustheory_corrmat_custom, theoryids, fivetheories
+    experimentplustheory_corrmat_custom, theoryids, point_prescription
 ):
     """Matrix plot of the exp + theory correlation matrix"""
     l = len(theoryids)
     if l == 5:
-        if fivetheories == "bar":
+        if point_prescription == "5bar point":
             l = r"$\bar{5}$"
     fig = plot_corrmat_heatmap(
         experimentplustheory_corrmat_custom, f"Experimental + Theory Correlation Matrix ({l} pt)"
@@ -233,12 +232,12 @@ def plot_expplusthcorrmat_heatmap_custom(
 
 @figure
 def plot_diag_cov_comparison(
-    theory_covmat_custom, procs_covmat, procs_data_values, theoryids, fivetheories
+    theory_covmat_custom, procs_covmat, procs_data_values, theoryids, point_prescription
 ):
     """Plot of sqrt(cov_ii)/|data_i| for cov = exp, theory, exp+theory"""
     l = len(theoryids)
     if l == 5:
-        if fivetheories == "bar":
+        if point_prescription == "5bar point":
             l = r"$\bar{5}$"
     data = np.abs(procs_data_values)
     sqrtdiags_th = np.sqrt(np.diag(theory_covmat_custom)) / data

--- a/validphys2/src/validphys/theorycovariance/theorycovarianceutils.py
+++ b/validphys2/src/validphys/theorycovariance/theorycovarianceutils.py
@@ -14,7 +14,7 @@ log = logging.getLogger(__name__)
 
 
 def check_correct_theory_combination_internal(
-    theoryids, fivetheories, point_prescription: (str, type(None)) = None
+    theoryids, point_prescription: (str, type(None)) = None
 ):
     """Checks that a valid theory combination corresponding to an existing
     prescription has been inputted"""
@@ -40,18 +40,10 @@ def check_correct_theory_combination_internal(
             correct_xifs = [1.0, 2.0, 0.5]
             correct_xirs = [1.0, 2.0, 0.5]
     elif l == 5:
-        check(
-            fivetheories is not None,
-            "For five input theories a prescription bar or nobar"
-            "for the flag fivetheories must be specified.",
-        )
-        check(
-            fivetheories in opts, "Invalid choice of prescription for 5 points", fivetheories, opts
-        )
-        if fivetheories == "nobar":
+        if point_prescription == "5 point":
             correct_xifs = [1.0, 2.0, 0.5, 1.0, 1.0]
             correct_xirs = [1.0, 1.0, 1.0, 2.0, 0.5]
-        elif fivetheories == "bar":
+        elif point_prescription == "5bar point":
             correct_xifs = [1.0, 2.0, 0.5, 2.0, 0.5]
             correct_xirs = [1.0, 2.0, 0.5, 0.5, 2.0]
     elif l == 7:


### PR DESCRIPTION
This cleans up the theory covmat implementation by removing `fivetheories` and `seventheories` from the namespace and instead directly checking for the value of `pointprescription`. 