### PR TITLE
Added basis to display PDG-style PDF plots for polarised PDFs

### DIFF
--- a/validphys2/src/validphys/pdfbases.py
+++ b/validphys2/src/validphys/pdfbases.py
@@ -702,6 +702,16 @@ r'\bar{d}': {'dbar':1},
 'c': {'c':1},
 })
 
+pdg_pol = LinearBasis.from_mapping({
+'\Delta g': {'g':1},
+'\Delta u_{v}': {'u':1, 'ubar':-1},
+'\Delta d_{v}': {'d':1, 'dbar': -1},
+'\Delta s': {'s':1},
+r'\Delta\bar{u}': {'ubar':1},
+r'\Delta\bar{d}': {'dbar':1},
+'\Delta c': {'c':1},
+})
+
 @scalar_function_transformation(label="u_V")
 def u_valence(func, xmat, qmat):
     gv = func([2, -2], xmat, qmat)


### PR DESCRIPTION
As the title says. A typical output, obtained with this runcard
```
meta:
  title: NNPDFpol2.0
  author: Emanuele R. Nocera
  keywords: [NNPDFpol2.0]

pdf:  {id: "240727-tr-nnlo-global-mhou-001", label: "NNPDFpol2.0 aNNLO"}

Q: 1

basis: pdg_pol      # [g, u_v, d_v, s, ubar, dbar, c] plots well on same axis
xmin: 0.005

ymin: -0.2
ymax: 0.5

xscale: log

template_text: |
  {@plot_flavours@}     

actions_:
  - report(main=True)
```
is [here](https://vp.nnpdf.science/Qy_wZDNUTM62d4LxRaeyeA==)