### PR TITLE
Don't change the input variable when checking old-new for DW datasets

### DIFF
--- a/nnpdf_data/nnpdf_data/__init__.py
+++ b/nnpdf_data/nnpdf_data/__init__.py
@@ -64,7 +64,7 @@ def new_to_legacy_map(dataset_name, variant_used):
             matches.append(old_name)
             # if it's a nuclear DIS data promote legacy to be legacy_dw
             if "_DW_" in old_name and variant_used == "legacy":
-                variant_used = "legacy_dw"
+                variant = "legacy_dw"
 
             if variant_used == variant:
                 exact_matches.append(old_name)

--- a/validphys2/src/validphys/tests/test_commondataparser.py
+++ b/validphys2/src/validphys/tests/test_commondataparser.py
@@ -128,3 +128,5 @@ def test_variant_nnpdf_metadata():
         assert pcd2.experiment != pcd1.experiment
         # but the real experiment is the same
         assert cd1.metadata.experiment == cd2.metadata.experiment
+        # And check that the legacy names are _not_ the same
+        assert cd1.legacy_names != cd2.legacy_names


### PR DESCRIPTION
For the exact check we want `(_DW_, legacy)` to match `legacy_dw`. We were doing this by modifying `variant_used` instead of `variant`.

I found this while looking for possible issues that could mess up the makereplica test, I don't know whether it is related (the NMC loaded in that test had the wrong legacy name, but it is the _second_ one while the seed in make replica is set with the first... but maybe every now and then the order changes?). This is one of the things that will be modified in #2156 btw.

In any case, this is a somewhat trivial bug that this fixes.