### PR TITLE
dynamically set year for the docs

### DIFF
--- a/doc/sphinx/source/conf.py
+++ b/doc/sphinx/source/conf.py
@@ -16,9 +16,10 @@
 #
 
 # -- Project information -----------------------------------------------------
+from datetime import datetime
 
 project = "NNPDF"
-copyright = "2021, NNPDF collaboration"
+copyright = f"{datetime.now().year}, NNPDF collaboration"
 author = "NNPDF collaboration"
 
 # The short X.Y version


### PR DESCRIPTION
For some reason `%Y` as suggested in the [sphinx documentation](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-project_copyright) doesn't seem to work