### PR TITLE
Fix kinematics EIC data

### DIFF
--- a/nnpdf_data/nnpdf_data/commondata/EICC_NC_15GEV_EP/metadata.yaml
+++ b/nnpdf_data/nnpdf_data/commondata/EICC_NC_15GEV_EP/metadata.yaml
@@ -14,7 +14,7 @@ hepdata:
 
 nnpdf_metadata:
   nnpdf31_process: "DIS NC"
-  experiment: "EIC"
+  experiment: "EICC"
 
 implemented_observables:
   - observable_name: "G1F1CHARMRATIO"

--- a/nnpdf_data/nnpdf_data/commondata/EICC_NC_15GEV_EP/metadata.yaml
+++ b/nnpdf_data/nnpdf_data/commondata/EICC_NC_15GEV_EP/metadata.yaml
@@ -29,7 +29,7 @@ implemented_observables:
 
     # Plotting information
     plotting:
-      kinematics_override: dis_sqrt_scale
+      kinematics_override: identity
       dataset_label: "EICC 15GeV (g1c/F1c)"
       plot_x: x
       line_by: [Q2]

--- a/nnpdf_data/nnpdf_data/commondata/EICC_NC_22GEV_EP/metadata.yaml
+++ b/nnpdf_data/nnpdf_data/commondata/EICC_NC_22GEV_EP/metadata.yaml
@@ -29,7 +29,7 @@ implemented_observables:
 
     # Plotting information
     plotting:
-      kinematics_override: dis_sqrt_scale
+      kinematics_override: identity
       dataset_label: "EICC 22GeV (g1c/F1c)"
       plot_x: x
       line_by: [Q2]

--- a/nnpdf_data/nnpdf_data/commondata/EICC_NC_22GEV_EP/metadata.yaml
+++ b/nnpdf_data/nnpdf_data/commondata/EICC_NC_22GEV_EP/metadata.yaml
@@ -14,7 +14,7 @@ hepdata:
 
 nnpdf_metadata:
   nnpdf31_process: "DIS NC"
-  experiment: "EIC"
+  experiment: "EICC"
 
 implemented_observables:
   - observable_name: "G1F1CHARMRATIO"

--- a/nnpdf_data/nnpdf_data/commondata/EIC_NC_211GEV_EP/metadata.yaml
+++ b/nnpdf_data/nnpdf_data/commondata/EIC_NC_211GEV_EP/metadata.yaml
@@ -29,7 +29,7 @@ implemented_observables:
 
     # Plotting information
     plotting:
-      kinematics_override: dis_sqrt_scale
+      kinematics_override: identity
       dataset_label: "EIC 211GeV (g1c/F1c)"
       plot_x: x
       line_by: [Q2]

--- a/nnpdf_data/nnpdf_data/commondata/EIC_NC_43GEV_EP/metadata.yaml
+++ b/nnpdf_data/nnpdf_data/commondata/EIC_NC_43GEV_EP/metadata.yaml
@@ -29,7 +29,7 @@ implemented_observables:
 
     # Plotting information
     plotting:
-      kinematics_override: dis_sqrt_scale
+      kinematics_override: identity
       dataset_label: "EIC 43GeV (g1c/F1c)"
       plot_x: x
       line_by: [Q2]

--- a/nnpdf_data/nnpdf_data/commondata/EIC_NC_67GEV_EP/metadata.yaml
+++ b/nnpdf_data/nnpdf_data/commondata/EIC_NC_67GEV_EP/metadata.yaml
@@ -29,7 +29,7 @@ implemented_observables:
 
     # Plotting information
     plotting:
-      kinematics_override: dis_sqrt_scale
+      kinematics_override: identity
       dataset_label: "EIC 67GeV (g1c/F1c)"
       plot_x: x
       line_by: [Q2]


### PR DESCRIPTION
The EIC data was set with the old `kinematics_override` key which meant the value of Q was getting `sqrt'd`, now it looks ok:

![image](https://github.com/user-attachments/assets/dfb015a8-8596-4c6e-8e68-941e34f2f3f2)
