### PR TITLE
Update plottings for the collider LHCb datasets

### DIFF
--- a/nnpdf_data/nnpdf_data/commondata/LHCB_DY_7TEV_MUON/filter.py
+++ b/nnpdf_data/nnpdf_data/commondata/LHCB_DY_7TEV_MUON/filter.py
@@ -85,7 +85,7 @@ def get_kinematics(hepdata: dict, bin_index: list, boson: str = "Z") -> list:
         ymax = float(rapbins[bins]["high"])
         kin_value = {
             "y": {"min": ymin, "mid": 0.5 * (ymin + ymax), "max": ymax},
-            "M2": {"min": None, "mid": MAP_BOSON[boson] ** 2, "max": None},
+            "m_V2": {"min": None, "mid": MAP_BOSON[boson] ** 2, "max": None},
             "sqrts": {"min": None, "mid": SQRT_S, "max": None},
         }
         kinematics.append(kin_value)

--- a/nnpdf_data/nnpdf_data/commondata/LHCB_DY_7TEV_MUON/kinematics.yaml
+++ b/nnpdf_data/nnpdf_data/commondata/LHCB_DY_7TEV_MUON/kinematics.yaml
@@ -3,7 +3,7 @@ bins:
     min: 2.0
     mid: 2.0625
     max: 2.125
-  M2:
+  m_V2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -15,7 +15,7 @@ bins:
     min: 2.125
     mid: 2.1875
     max: 2.25
-  M2:
+  m_V2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -27,7 +27,7 @@ bins:
     min: 2.25
     mid: 2.3125
     max: 2.375
-  M2:
+  m_V2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -39,7 +39,7 @@ bins:
     min: 2.375
     mid: 2.4375
     max: 2.5
-  M2:
+  m_V2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -51,7 +51,7 @@ bins:
     min: 2.5
     mid: 2.5625
     max: 2.625
-  M2:
+  m_V2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -63,7 +63,7 @@ bins:
     min: 2.625
     mid: 2.6875
     max: 2.75
-  M2:
+  m_V2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -75,7 +75,7 @@ bins:
     min: 2.75
     mid: 2.8125
     max: 2.875
-  M2:
+  m_V2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -87,7 +87,7 @@ bins:
     min: 2.875
     mid: 2.9375
     max: 3.0
-  M2:
+  m_V2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -99,7 +99,7 @@ bins:
     min: 3.0
     mid: 3.0625
     max: 3.125
-  M2:
+  m_V2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -111,7 +111,7 @@ bins:
     min: 3.125
     mid: 3.1875
     max: 3.25
-  M2:
+  m_V2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -123,7 +123,7 @@ bins:
     min: 3.25
     mid: 3.3125
     max: 3.375
-  M2:
+  m_V2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -135,7 +135,7 @@ bins:
     min: 3.375
     mid: 3.4375
     max: 3.5
-  M2:
+  m_V2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -147,7 +147,7 @@ bins:
     min: 3.5
     mid: 3.5625
     max: 3.625
-  M2:
+  m_V2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -159,7 +159,7 @@ bins:
     min: 3.625
     mid: 3.6875
     max: 3.75
-  M2:
+  m_V2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -171,7 +171,7 @@ bins:
     min: 3.75
     mid: 3.8125
     max: 3.875
-  M2:
+  m_V2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -183,7 +183,7 @@ bins:
     min: 3.875
     mid: 3.9375
     max: 4.0
-  M2:
+  m_V2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -195,7 +195,7 @@ bins:
     min: 4.0
     mid: 4.125
     max: 4.25
-  M2:
+  m_V2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -207,7 +207,7 @@ bins:
     min: 2.0
     mid: 2.125
     max: 2.25
-  M2:
+  m_V2:
     min: null
     mid: 6.46383840e+03
     max: null
@@ -219,7 +219,7 @@ bins:
     min: 2.25
     mid: 2.375
     max: 2.5
-  M2:
+  m_V2:
     min: null
     mid: 6.46383840e+03
     max: null
@@ -231,7 +231,7 @@ bins:
     min: 2.5
     mid: 2.625
     max: 2.75
-  M2:
+  m_V2:
     min: null
     mid: 6.46383840e+03
     max: null
@@ -243,7 +243,7 @@ bins:
     min: 2.75
     mid: 2.875
     max: 3.0
-  M2:
+  m_V2:
     min: null
     mid: 6.46383840e+03
     max: null
@@ -255,7 +255,7 @@ bins:
     min: 3.0
     mid: 3.125
     max: 3.25
-  M2:
+  m_V2:
     min: null
     mid: 6.46383840e+03
     max: null
@@ -267,7 +267,7 @@ bins:
     min: 3.25
     mid: 3.375
     max: 3.5
-  M2:
+  m_V2:
     min: null
     mid: 6.46383840e+03
     max: null
@@ -279,7 +279,7 @@ bins:
     min: 3.5
     mid: 3.75
     max: 4.0
-  M2:
+  m_V2:
     min: null
     mid: 6.46383840e+03
     max: null
@@ -291,7 +291,7 @@ bins:
     min: 4.0
     mid: 4.25
     max: 4.5
-  M2:
+  m_V2:
     min: null
     mid: 6.46383840e+03
     max: null
@@ -303,7 +303,7 @@ bins:
     min: 2.0
     mid: 2.125
     max: 2.25
-  M2:
+  m_V2:
     min: null
     mid: 6.46383840e+03
     max: null
@@ -315,7 +315,7 @@ bins:
     min: 2.25
     mid: 2.375
     max: 2.5
-  M2:
+  m_V2:
     min: null
     mid: 6.46383840e+03
     max: null
@@ -327,7 +327,7 @@ bins:
     min: 2.5
     mid: 2.625
     max: 2.75
-  M2:
+  m_V2:
     min: null
     mid: 6.46383840e+03
     max: null
@@ -339,7 +339,7 @@ bins:
     min: 2.75
     mid: 2.875
     max: 3.0
-  M2:
+  m_V2:
     min: null
     mid: 6.46383840e+03
     max: null
@@ -351,7 +351,7 @@ bins:
     min: 3.0
     mid: 3.125
     max: 3.25
-  M2:
+  m_V2:
     min: null
     mid: 6.46383840e+03
     max: null
@@ -363,7 +363,7 @@ bins:
     min: 3.25
     mid: 3.375
     max: 3.5
-  M2:
+  m_V2:
     min: null
     mid: 6.46383840e+03
     max: null
@@ -375,7 +375,7 @@ bins:
     min: 3.5
     mid: 3.75
     max: 4.0
-  M2:
+  m_V2:
     min: null
     mid: 6.46383840e+03
     max: null
@@ -387,7 +387,7 @@ bins:
     min: 4.0
     mid: 4.25
     max: 4.5
-  M2:
+  m_V2:
     min: null
     mid: 6.46383840e+03
     max: null

--- a/nnpdf_data/nnpdf_data/commondata/LHCB_DY_7TEV_MUON/metadata.yaml
+++ b/nnpdf_data/nnpdf_data/commondata/LHCB_DY_7TEV_MUON/metadata.yaml
@@ -23,12 +23,12 @@ implemented_observables:
     description: "Inclusive cross-section for DY production (Z, W+/-) in bins of muon pseudorapidity"
     label: r"$d\sigma / d|y|$"
     units: "[fb]"
-  process_type: "EWK_RAP"
+  process_type: "DY_2L"
   tables: [1, 4]
   ndata: 33
   npoints: [17, 16]
   plotting:
-    kinematics_override: ewk_rap_sqrt_scale
+    kinematics_override: identity
     dataset_label: "LHCb $W,Z \\to \\mu$ 8 TeV"
     plot_x: y
     y_label: '$d\sigma/dy$ (fb)'
@@ -70,11 +70,11 @@ implemented_observables:
         "$W^-$",
         "$W^-$",
       ]
-  kinematic_coverage: [y, M2, sqrts]
+  kinematic_coverage: [y, m_V2, sqrts]
   kinematics:
     variables:
       y: {description: "Muon rapidity", label: "$y$", units: ""}
-      M2: {description: "W/Z boson Mass", label: "$M^2$", units: "$GeV^2$"}
+      m_V2: {description: "W/Z boson Mass", label: "$M^2$", units: "$GeV^2$"}
       sqrts: {description: "Center of Mass Energy", label: '$\sqrt{s}$', units: "$GeV$"}
     file: kinematics.yaml
   data_central: data.yaml

--- a/nnpdf_data/nnpdf_data/commondata/LHCB_DY_7TEV_MUON/metadata.yaml
+++ b/nnpdf_data/nnpdf_data/commondata/LHCB_DY_7TEV_MUON/metadata.yaml
@@ -23,7 +23,7 @@ implemented_observables:
     description: "Inclusive cross-section for DY production (Z, W+/-) in bins of muon pseudorapidity"
     label: r"$d\sigma / d|y|$"
     units: "[fb]"
-  process_type: "DY_VB_Y"
+  process_type: "DY_VB_ETA"
   tables: [1, 4]
   ndata: 33
   npoints: [17, 16]

--- a/nnpdf_data/nnpdf_data/commondata/LHCB_DY_7TEV_MUON/metadata.yaml
+++ b/nnpdf_data/nnpdf_data/commondata/LHCB_DY_7TEV_MUON/metadata.yaml
@@ -23,7 +23,7 @@ implemented_observables:
     description: "Inclusive cross-section for DY production (Z, W+/-) in bins of muon pseudorapidity"
     label: r"$d\sigma / d|y|$"
     units: "[fb]"
-  process_type: "DY_2L"
+  process_type: "DY_VB_Y"
   tables: [1, 4]
   ndata: 33
   npoints: [17, 16]

--- a/nnpdf_data/nnpdf_data/commondata/LHCB_DY_8TEV_MUON/filter.py
+++ b/nnpdf_data/nnpdf_data/commondata/LHCB_DY_8TEV_MUON/filter.py
@@ -85,7 +85,7 @@ def get_kinematics(hepdata: dict, bin_index: list, boson: str = "Z") -> list:
         ymax = float(rapbins[bins]["high"])
         kin_value = {
             "y": {"min": ymin, "mid": 0.5 * (ymin + ymax), "max": ymax},
-            "M2": {"min": None, "mid": MAP_BOSON[boson] ** 2, "max": None},
+            "m_V2": {"min": None, "mid": MAP_BOSON[boson] ** 2, "max": None},
             "sqrts": {"min": None, "mid": SQRT_S, "max": None},
         }
         kinematics.append(kin_value)

--- a/nnpdf_data/nnpdf_data/commondata/LHCB_DY_8TEV_MUON/kinematics.yaml
+++ b/nnpdf_data/nnpdf_data/commondata/LHCB_DY_8TEV_MUON/kinematics.yaml
@@ -3,7 +3,7 @@ bins:
     min: 2.0
     mid: 2.0625
     max: 2.125
-  M2:
+  m_V2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -15,7 +15,7 @@ bins:
     min: 2.125
     mid: 2.1875
     max: 2.25
-  M2:
+  m_V2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -27,7 +27,7 @@ bins:
     min: 2.25
     mid: 2.3125
     max: 2.375
-  M2:
+  m_V2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -39,7 +39,7 @@ bins:
     min: 2.375
     mid: 2.4375
     max: 2.5
-  M2:
+  m_V2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -51,7 +51,7 @@ bins:
     min: 2.5
     mid: 2.5625
     max: 2.625
-  M2:
+  m_V2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -63,7 +63,7 @@ bins:
     min: 2.625
     mid: 2.6875
     max: 2.75
-  M2:
+  m_V2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -75,7 +75,7 @@ bins:
     min: 2.75
     mid: 2.8125
     max: 2.875
-  M2:
+  m_V2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -87,7 +87,7 @@ bins:
     min: 2.875
     mid: 2.9375
     max: 3.0
-  M2:
+  m_V2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -99,7 +99,7 @@ bins:
     min: 3.0
     mid: 3.0625
     max: 3.125
-  M2:
+  m_V2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -111,7 +111,7 @@ bins:
     min: 3.125
     mid: 3.1875
     max: 3.25
-  M2:
+  m_V2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -123,7 +123,7 @@ bins:
     min: 3.25
     mid: 3.3125
     max: 3.375
-  M2:
+  m_V2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -135,7 +135,7 @@ bins:
     min: 3.375
     mid: 3.4375
     max: 3.5
-  M2:
+  m_V2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -147,7 +147,7 @@ bins:
     min: 3.5
     mid: 3.5625
     max: 3.625
-  M2:
+  m_V2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -159,7 +159,7 @@ bins:
     min: 3.625
     mid: 3.6875
     max: 3.75
-  M2:
+  m_V2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -171,7 +171,7 @@ bins:
     min: 3.75
     mid: 3.8125
     max: 3.875
-  M2:
+  m_V2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -183,7 +183,7 @@ bins:
     min: 3.875
     mid: 3.9375
     max: 4.0
-  M2:
+  m_V2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -195,7 +195,7 @@ bins:
     min: 4.0
     mid: 4.125
     max: 4.25
-  M2:
+  m_V2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -207,7 +207,7 @@ bins:
     min: 4.25
     mid: 4.375
     max: 4.5
-  M2:
+  m_V2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -219,7 +219,7 @@ bins:
     min: 2.0
     mid: 2.125
     max: 2.25
-  M2:
+  m_V2:
     min: null
     mid: 6.46383840e+03
     max: null
@@ -231,7 +231,7 @@ bins:
     min: 2.25
     mid: 2.375
     max: 2.5
-  M2:
+  m_V2:
     min: null
     mid: 6.46383840e+03
     max: null
@@ -243,7 +243,7 @@ bins:
     min: 2.5
     mid: 2.625
     max: 2.75
-  M2:
+  m_V2:
     min: null
     mid: 6.46383840e+03
     max: null
@@ -255,7 +255,7 @@ bins:
     min: 2.75
     mid: 2.875
     max: 3.0
-  M2:
+  m_V2:
     min: null
     mid: 6.46383840e+03
     max: null
@@ -267,7 +267,7 @@ bins:
     min: 3.0
     mid: 3.125
     max: 3.25
-  M2:
+  m_V2:
     min: null
     mid: 6.46383840e+03
     max: null
@@ -279,7 +279,7 @@ bins:
     min: 3.25
     mid: 3.375
     max: 3.5
-  M2:
+  m_V2:
     min: null
     mid: 6.46383840e+03
     max: null
@@ -291,7 +291,7 @@ bins:
     min: 3.5
     mid: 3.75
     max: 4.0
-  M2:
+  m_V2:
     min: null
     mid: 6.46383840e+03
     max: null
@@ -303,7 +303,7 @@ bins:
     min: 4.0
     mid: 4.25
     max: 4.5
-  M2:
+  m_V2:
     min: null
     mid: 6.46383840e+03
     max: null
@@ -315,7 +315,7 @@ bins:
     min: 2.0
     mid: 2.125
     max: 2.25
-  M2:
+  m_V2:
     min: null
     mid: 6.46383840e+03
     max: null
@@ -327,7 +327,7 @@ bins:
     min: 2.25
     mid: 2.375
     max: 2.5
-  M2:
+  m_V2:
     min: null
     mid: 6.46383840e+03
     max: null
@@ -339,7 +339,7 @@ bins:
     min: 2.5
     mid: 2.625
     max: 2.75
-  M2:
+  m_V2:
     min: null
     mid: 6.46383840e+03
     max: null
@@ -351,7 +351,7 @@ bins:
     min: 2.75
     mid: 2.875
     max: 3.0
-  M2:
+  m_V2:
     min: null
     mid: 6.46383840e+03
     max: null
@@ -363,7 +363,7 @@ bins:
     min: 3.0
     mid: 3.125
     max: 3.25
-  M2:
+  m_V2:
     min: null
     mid: 6.46383840e+03
     max: null
@@ -375,7 +375,7 @@ bins:
     min: 3.25
     mid: 3.375
     max: 3.5
-  M2:
+  m_V2:
     min: null
     mid: 6.46383840e+03
     max: null
@@ -387,7 +387,7 @@ bins:
     min: 3.5
     mid: 3.75
     max: 4.0
-  M2:
+  m_V2:
     min: null
     mid: 6.46383840e+03
     max: null
@@ -399,7 +399,7 @@ bins:
     min: 4.0
     mid: 4.25
     max: 4.5
-  M2:
+  m_V2:
     min: null
     mid: 6.46383840e+03
     max: null

--- a/nnpdf_data/nnpdf_data/commondata/LHCB_DY_8TEV_MUON/metadata.yaml
+++ b/nnpdf_data/nnpdf_data/commondata/LHCB_DY_8TEV_MUON/metadata.yaml
@@ -23,12 +23,12 @@ implemented_observables:
     description: "Inclusive cross-section for DY production (Z, W+/-) in bins of muon pseudorapidity at 8 TeV"
     label: r"$d\sigma / d|y|$"
     units: "[fb]"
-  process_type: "EWK_RAP"
+  process_type: "DY_2L"
   tables: [1, 2]
   ndata: 34
   npoints: [16, 18]
   plotting:
-    kinematics_override: ewk_rap_sqrt_scale
+    kinematics_override: identity
     dataset_label: "LHCb $W,Z \\to \\mu$ 8 TeV"
     plot_x: y
     y_label: '$d\sigma/dy$ (fb)'
@@ -71,11 +71,11 @@ implemented_observables:
         "$W^-$",
         "$W^-$",
       ]
-  kinematic_coverage: [y, M2, sqrts]
+  kinematic_coverage: [y, m_V2, sqrts]
   kinematics:
       variables:
         y: {description: "Muon rapidity", label: "$y$", units: ""}
-        M2: {description: "W/Z boson Mass", label: "$M^2$", units: "$GeV^2$"}
+        m_V2: {description: "W/Z boson Mass", label: "$M^2$", units: "$GeV^2$"}
         sqrts: {description: "Center of Mass Energy", label: '$\sqrt{s}$', units: "$GeV$"}
       file: kinematics.yaml
   data_central: data.yaml

--- a/nnpdf_data/nnpdf_data/commondata/LHCB_DY_8TEV_MUON/metadata.yaml
+++ b/nnpdf_data/nnpdf_data/commondata/LHCB_DY_8TEV_MUON/metadata.yaml
@@ -23,7 +23,7 @@ implemented_observables:
     description: "Inclusive cross-section for DY production (Z, W+/-) in bins of muon pseudorapidity at 8 TeV"
     label: r"$d\sigma / d|y|$"
     units: "[fb]"
-  process_type: "DY_VB_Y"
+  process_type: "DY_VB_ETA"
   tables: [1, 2]
   ndata: 34
   npoints: [16, 18]

--- a/nnpdf_data/nnpdf_data/commondata/LHCB_DY_8TEV_MUON/metadata.yaml
+++ b/nnpdf_data/nnpdf_data/commondata/LHCB_DY_8TEV_MUON/metadata.yaml
@@ -23,7 +23,7 @@ implemented_observables:
     description: "Inclusive cross-section for DY production (Z, W+/-) in bins of muon pseudorapidity at 8 TeV"
     label: r"$d\sigma / d|y|$"
     units: "[fb]"
-  process_type: "DY_2L"
+  process_type: "DY_VB_Y"
   tables: [1, 2]
   ndata: 34
   npoints: [16, 18]

--- a/nnpdf_data/nnpdf_data/commondata/LHCB_WPWM_7TEV_MUON/filter.py
+++ b/nnpdf_data/nnpdf_data/commondata/LHCB_WPWM_7TEV_MUON/filter.py
@@ -85,7 +85,7 @@ def get_kinematics(hepdata: dict, bin_index: list, boson: str = "Z") -> list:
         ymax = float(rapbins[bins]["high"])
         kin_value = {
             "y": {"min": ymin, "mid": 0.5 * (ymin + ymax), "max": ymax},
-            "M2": {"min": None, "mid": MAP_BOSON[boson] ** 2, "max": None},
+            "m_W2": {"min": None, "mid": MAP_BOSON[boson] ** 2, "max": None},
             "sqrts": {"min": None, "mid": SQRT_S, "max": None},
         }
         kinematics.append(kin_value)

--- a/nnpdf_data/nnpdf_data/commondata/LHCB_WPWM_7TEV_MUON/kinematics.yaml
+++ b/nnpdf_data/nnpdf_data/commondata/LHCB_WPWM_7TEV_MUON/kinematics.yaml
@@ -3,7 +3,7 @@ bins:
     min: 2.0
     mid: 2.125
     max: 2.25
-  M2:
+  m_W2:
     min: null
     mid: 6.46383840e+03
     max: null
@@ -15,7 +15,7 @@ bins:
     min: 2.25
     mid: 2.375
     max: 2.5
-  M2:
+  m_W2:
     min: null
     mid: 6.46383840e+03
     max: null
@@ -27,7 +27,7 @@ bins:
     min: 2.5
     mid: 2.625
     max: 2.75
-  M2:
+  m_W2:
     min: null
     mid: 6.46383840e+03
     max: null
@@ -39,7 +39,7 @@ bins:
     min: 2.75
     mid: 2.875
     max: 3.0
-  M2:
+  m_W2:
     min: null
     mid: 6.46383840e+03
     max: null
@@ -51,7 +51,7 @@ bins:
     min: 3.0
     mid: 3.125
     max: 3.25
-  M2:
+  m_W2:
     min: null
     mid: 6.46383840e+03
     max: null
@@ -63,7 +63,7 @@ bins:
     min: 3.25
     mid: 3.375
     max: 3.5
-  M2:
+  m_W2:
     min: null
     mid: 6.46383840e+03
     max: null
@@ -75,7 +75,7 @@ bins:
     min: 3.5
     mid: 3.75
     max: 4.0
-  M2:
+  m_W2:
     min: null
     mid: 6.46383840e+03
     max: null
@@ -87,7 +87,7 @@ bins:
     min: 4.0
     mid: 4.25
     max: 4.5
-  M2:
+  m_W2:
     min: null
     mid: 6.46383840e+03
     max: null
@@ -99,7 +99,7 @@ bins:
     min: 2.0
     mid: 2.125
     max: 2.25
-  M2:
+  m_W2:
     min: null
     mid: 6.46383840e+03
     max: null
@@ -111,7 +111,7 @@ bins:
     min: 2.25
     mid: 2.375
     max: 2.5
-  M2:
+  m_W2:
     min: null
     mid: 6.46383840e+03
     max: null
@@ -123,7 +123,7 @@ bins:
     min: 2.5
     mid: 2.625
     max: 2.75
-  M2:
+  m_W2:
     min: null
     mid: 6.46383840e+03
     max: null
@@ -135,7 +135,7 @@ bins:
     min: 2.75
     mid: 2.875
     max: 3.0
-  M2:
+  m_W2:
     min: null
     mid: 6.46383840e+03
     max: null
@@ -147,7 +147,7 @@ bins:
     min: 3.0
     mid: 3.125
     max: 3.25
-  M2:
+  m_W2:
     min: null
     mid: 6.46383840e+03
     max: null
@@ -159,7 +159,7 @@ bins:
     min: 3.25
     mid: 3.375
     max: 3.5
-  M2:
+  m_W2:
     min: null
     mid: 6.46383840e+03
     max: null
@@ -171,7 +171,7 @@ bins:
     min: 3.5
     mid: 3.75
     max: 4.0
-  M2:
+  m_W2:
     min: null
     mid: 6.46383840e+03
     max: null
@@ -183,7 +183,7 @@ bins:
     min: 4.0
     mid: 4.25
     max: 4.5
-  M2:
+  m_W2:
     min: null
     mid: 6.46383840e+03
     max: null

--- a/nnpdf_data/nnpdf_data/commondata/LHCB_WPWM_7TEV_MUON/metadata.yaml
+++ b/nnpdf_data/nnpdf_data/commondata/LHCB_WPWM_7TEV_MUON/metadata.yaml
@@ -23,7 +23,7 @@ implemented_observables:
     description: "Inclusive cross-section for W+ and W- boson production in bins of muon pseudorapidity"
     label: r"$d\sigma / d|y|$"
     units: "[fb]"
-  process_type: "DY_W_Y"
+  process_type: "DY_W_ETA"
   tables: [4]
   npoints: [16]
   ndata: 16

--- a/nnpdf_data/nnpdf_data/commondata/LHCB_WPWM_7TEV_MUON/metadata.yaml
+++ b/nnpdf_data/nnpdf_data/commondata/LHCB_WPWM_7TEV_MUON/metadata.yaml
@@ -23,7 +23,7 @@ implemented_observables:
     description: "Inclusive cross-section for W+ and W- boson production in bins of muon pseudorapidity"
     label: r"$d\sigma / d|y|$"
     units: "[fb]"
-  process_type: "DY_2L"
+  process_type: "DY_W_Y"
   tables: [4]
   npoints: [16]
   ndata: 16

--- a/nnpdf_data/nnpdf_data/commondata/LHCB_WPWM_7TEV_MUON/metadata.yaml
+++ b/nnpdf_data/nnpdf_data/commondata/LHCB_WPWM_7TEV_MUON/metadata.yaml
@@ -23,12 +23,12 @@ implemented_observables:
     description: "Inclusive cross-section for W+ and W- boson production in bins of muon pseudorapidity"
     label: r"$d\sigma / d|y|$"
     units: "[fb]"
-  process_type: "EWK_RAP"
+  process_type: "DY_2L"
   tables: [4]
   npoints: [16]
   ndata: 16
   plotting:
-    kinematics_override: ewk_rap_sqrt_scale
+    kinematics_override: identity
     dataset_label: "LHCb $W \\to \\mu$ 7 TeV"
     plot_x: y
     y_label: '$d\sigma/dy$ (fb)'
@@ -53,11 +53,11 @@ implemented_observables:
         "$W^-$",
         "$W^-$",
       ]
-  kinematic_coverage: [y, M2, sqrts]
+  kinematic_coverage: [y, m_W2, sqrts]
   kinematics:
     variables:
       y: {description: "Muon rapidity", label: "$y$", units: ""}
-      M2: {description: "W boson Mass", label: "$M^2$", units: "$GeV^2$"}
+      m_W2: {description: "W boson Mass", label: "$M^2$", units: "$GeV^2$"}
       sqrts: {description: "Center of Mass Energy", label: '$\sqrt{s}$', units: "$GeV$"}
     file: kinematics.yaml
   data_central: data.yaml

--- a/nnpdf_data/nnpdf_data/commondata/LHCB_WPWM_8TEV_MUON/filter.py
+++ b/nnpdf_data/nnpdf_data/commondata/LHCB_WPWM_8TEV_MUON/filter.py
@@ -85,7 +85,7 @@ def get_kinematics(hepdata: dict, bin_index: list, boson: str = "Z") -> list:
         ymax = float(rapbins[bins]["high"])
         kin_value = {
             "y": {"min": ymin, "mid": 0.5 * (ymin + ymax), "max": ymax},
-            "M2": {"min": None, "mid": MAP_BOSON[boson] ** 2, "max": None},
+            "m_W2": {"min": None, "mid": MAP_BOSON[boson] ** 2, "max": None},
             "sqrts": {"min": None, "mid": SQRT_S, "max": None},
         }
         kinematics.append(kin_value)

--- a/nnpdf_data/nnpdf_data/commondata/LHCB_WPWM_8TEV_MUON/kinematics.yaml
+++ b/nnpdf_data/nnpdf_data/commondata/LHCB_WPWM_8TEV_MUON/kinematics.yaml
@@ -3,7 +3,7 @@ bins:
     min: 2.0
     mid: 2.125
     max: 2.25
-  M2:
+  m_W2:
     min: null
     mid: 6.46383840e+03
     max: null
@@ -15,7 +15,7 @@ bins:
     min: 2.25
     mid: 2.375
     max: 2.5
-  M2:
+  m_W2:
     min: null
     mid: 6.46383840e+03
     max: null
@@ -27,7 +27,7 @@ bins:
     min: 2.5
     mid: 2.625
     max: 2.75
-  M2:
+  m_W2:
     min: null
     mid: 6.46383840e+03
     max: null
@@ -39,7 +39,7 @@ bins:
     min: 2.75
     mid: 2.875
     max: 3.0
-  M2:
+  m_W2:
     min: null
     mid: 6.46383840e+03
     max: null
@@ -51,7 +51,7 @@ bins:
     min: 3.0
     mid: 3.125
     max: 3.25
-  M2:
+  m_W2:
     min: null
     mid: 6.46383840e+03
     max: null
@@ -63,7 +63,7 @@ bins:
     min: 3.25
     mid: 3.375
     max: 3.5
-  M2:
+  m_W2:
     min: null
     mid: 6.46383840e+03
     max: null
@@ -75,7 +75,7 @@ bins:
     min: 3.5
     mid: 3.75
     max: 4.0
-  M2:
+  m_W2:
     min: null
     mid: 6.46383840e+03
     max: null
@@ -87,7 +87,7 @@ bins:
     min: 4.0
     mid: 4.25
     max: 4.5
-  M2:
+  m_W2:
     min: null
     mid: 6.46383840e+03
     max: null
@@ -99,7 +99,7 @@ bins:
     min: 2.0
     mid: 2.125
     max: 2.25
-  M2:
+  m_W2:
     min: null
     mid: 6.46383840e+03
     max: null
@@ -111,7 +111,7 @@ bins:
     min: 2.25
     mid: 2.375
     max: 2.5
-  M2:
+  m_W2:
     min: null
     mid: 6.46383840e+03
     max: null
@@ -123,7 +123,7 @@ bins:
     min: 2.5
     mid: 2.625
     max: 2.75
-  M2:
+  m_W2:
     min: null
     mid: 6.46383840e+03
     max: null
@@ -135,7 +135,7 @@ bins:
     min: 2.75
     mid: 2.875
     max: 3.0
-  M2:
+  m_W2:
     min: null
     mid: 6.46383840e+03
     max: null
@@ -147,7 +147,7 @@ bins:
     min: 3.0
     mid: 3.125
     max: 3.25
-  M2:
+  m_W2:
     min: null
     mid: 6.46383840e+03
     max: null
@@ -159,7 +159,7 @@ bins:
     min: 3.25
     mid: 3.375
     max: 3.5
-  M2:
+  m_W2:
     min: null
     mid: 6.46383840e+03
     max: null
@@ -171,7 +171,7 @@ bins:
     min: 3.5
     mid: 3.75
     max: 4.0
-  M2:
+  m_W2:
     min: null
     mid: 6.46383840e+03
     max: null
@@ -183,7 +183,7 @@ bins:
     min: 4.0
     mid: 4.25
     max: 4.5
-  M2:
+  m_W2:
     min: null
     mid: 6.46383840e+03
     max: null

--- a/nnpdf_data/nnpdf_data/commondata/LHCB_WPWM_8TEV_MUON/metadata.yaml
+++ b/nnpdf_data/nnpdf_data/commondata/LHCB_WPWM_8TEV_MUON/metadata.yaml
@@ -23,7 +23,7 @@ implemented_observables:
     description: "Inclusive cross-section for W+ and W- boson production in bins of muon pseudorapidity at 8 TeV"
     label: r"$d\sigma / d|y|$"
     units: "[fb]"
-  process_type: "DY_2L"
+  process_type: "DY_W_Y"
   tables: [1]
   npoints: [16]
   ndata: 16

--- a/nnpdf_data/nnpdf_data/commondata/LHCB_WPWM_8TEV_MUON/metadata.yaml
+++ b/nnpdf_data/nnpdf_data/commondata/LHCB_WPWM_8TEV_MUON/metadata.yaml
@@ -23,12 +23,12 @@ implemented_observables:
     description: "Inclusive cross-section for W+ and W- boson production in bins of muon pseudorapidity at 8 TeV"
     label: r"$d\sigma / d|y|$"
     units: "[fb]"
-  process_type: "EWK_RAP"
+  process_type: "DY_2L"
   tables: [1]
   npoints: [16]
   ndata: 16
   plotting:
-    kinematics_override: ewk_rap_sqrt_scale
+    kinematics_override: identity
     dataset_label: "LHCb $W \\to \\mu$ 8 TeV"
     plot_x: y
     y_label: '$d\sigma/dy$ (fb)'
@@ -53,11 +53,11 @@ implemented_observables:
         "$W^-$",
         "$W^-$",
       ]
-  kinematic_coverage: [y, M2, sqrts]
+  kinematic_coverage: [y, m_W2, sqrts]
   kinematics:
     variables:
       y: {description: "Muon rapidity", label: "$y$", units: ""}
-      M2: {description: "W boson Mass", label: "$M^2$", units: "$GeV^2$"}
+      m_W2: {description: "W boson Mass", label: "$M^2$", units: "$GeV^2$"}
       sqrts: {description: "Center of Mass Energy", label: '$\sqrt{s}$', units: "$GeV$"}
     file: kinematics.yaml
   data_central: data.yaml

--- a/nnpdf_data/nnpdf_data/commondata/LHCB_WPWM_8TEV_MUON/metadata.yaml
+++ b/nnpdf_data/nnpdf_data/commondata/LHCB_WPWM_8TEV_MUON/metadata.yaml
@@ -23,7 +23,7 @@ implemented_observables:
     description: "Inclusive cross-section for W+ and W- boson production in bins of muon pseudorapidity at 8 TeV"
     label: r"$d\sigma / d|y|$"
     units: "[fb]"
-  process_type: "DY_W_Y"
+  process_type: "DY_W_ETA"
   tables: [1]
   npoints: [16]
   ndata: 16

--- a/nnpdf_data/nnpdf_data/commondata/LHCB_Z0_13TEV/filter.py
+++ b/nnpdf_data/nnpdf_data/commondata/LHCB_Z0_13TEV/filter.py
@@ -83,7 +83,7 @@ def get_kinematics(hepdata: dict, bin_index: list) -> list:
         ymin, ymax = [float(i) for i in rapbins[idx]['value'].split("-")]
         kin_value = {
             "y": {"min": ymin, "mid": 0.5 * (ymin + ymax), "max": ymax},
-            "M2": {"min": None, "mid": MZ_VALUE**2, "max": None},
+            "m_Z2": {"min": None, "mid": MZ_VALUE**2, "max": None},
             "sqrts": {"min": None, "mid": SQRT_S, "max": None},
         }
         kinematics.append(kin_value)

--- a/nnpdf_data/nnpdf_data/commondata/LHCB_Z0_13TEV/kinematics_dielectron.yaml
+++ b/nnpdf_data/nnpdf_data/commondata/LHCB_Z0_13TEV/kinematics_dielectron.yaml
@@ -3,7 +3,7 @@ bins:
     min: 2.0
     mid: 2.0625
     max: 2.125
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -15,7 +15,7 @@ bins:
     min: 2.125
     mid: 2.1875
     max: 2.25
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -27,7 +27,7 @@ bins:
     min: 2.25
     mid: 2.3125
     max: 2.375
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -39,7 +39,7 @@ bins:
     min: 2.375
     mid: 2.4375
     max: 2.5
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -51,7 +51,7 @@ bins:
     min: 2.5
     mid: 2.5625
     max: 2.625
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -63,7 +63,7 @@ bins:
     min: 2.625
     mid: 2.6875
     max: 2.75
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -75,7 +75,7 @@ bins:
     min: 2.75
     mid: 2.8125
     max: 2.875
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -87,7 +87,7 @@ bins:
     min: 2.875
     mid: 2.9375
     max: 3.0
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -99,7 +99,7 @@ bins:
     min: 3.0
     mid: 3.0625
     max: 3.125
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -111,7 +111,7 @@ bins:
     min: 3.125
     mid: 3.1875
     max: 3.25
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -123,7 +123,7 @@ bins:
     min: 3.25
     mid: 3.3125
     max: 3.375
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -135,7 +135,7 @@ bins:
     min: 3.375
     mid: 3.4375
     max: 3.5
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -147,7 +147,7 @@ bins:
     min: 3.5
     mid: 3.5625
     max: 3.625
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -159,7 +159,7 @@ bins:
     min: 3.625
     mid: 3.6875
     max: 3.75
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -171,7 +171,7 @@ bins:
     min: 3.75
     mid: 3.8125
     max: 3.875
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -183,7 +183,7 @@ bins:
     min: 3.875
     mid: 3.9375
     max: 4.0
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -195,7 +195,7 @@ bins:
     min: 4.0
     mid: 4.125
     max: 4.25
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null

--- a/nnpdf_data/nnpdf_data/commondata/LHCB_Z0_13TEV/kinematics_dimuon.yaml
+++ b/nnpdf_data/nnpdf_data/commondata/LHCB_Z0_13TEV/kinematics_dimuon.yaml
@@ -3,7 +3,7 @@ bins:
     min: 2.0
     mid: 2.0625
     max: 2.125
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -15,7 +15,7 @@ bins:
     min: 2.125
     mid: 2.1875
     max: 2.25
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -27,7 +27,7 @@ bins:
     min: 2.25
     mid: 2.3125
     max: 2.375
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -39,7 +39,7 @@ bins:
     min: 2.375
     mid: 2.4375
     max: 2.5
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -51,7 +51,7 @@ bins:
     min: 2.5
     mid: 2.5625
     max: 2.625
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -63,7 +63,7 @@ bins:
     min: 2.625
     mid: 2.6875
     max: 2.75
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -75,7 +75,7 @@ bins:
     min: 2.75
     mid: 2.8125
     max: 2.875
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -87,7 +87,7 @@ bins:
     min: 2.875
     mid: 2.9375
     max: 3.0
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -99,7 +99,7 @@ bins:
     min: 3.0
     mid: 3.0625
     max: 3.125
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -111,7 +111,7 @@ bins:
     min: 3.125
     mid: 3.1875
     max: 3.25
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -123,7 +123,7 @@ bins:
     min: 3.25
     mid: 3.3125
     max: 3.375
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -135,7 +135,7 @@ bins:
     min: 3.375
     mid: 3.4375
     max: 3.5
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -147,7 +147,7 @@ bins:
     min: 3.5
     mid: 3.5625
     max: 3.625
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -159,7 +159,7 @@ bins:
     min: 3.625
     mid: 3.6875
     max: 3.75
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -171,7 +171,7 @@ bins:
     min: 3.75
     mid: 3.8125
     max: 3.875
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -183,7 +183,7 @@ bins:
     min: 3.875
     mid: 3.9375
     max: 4.0
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -195,7 +195,7 @@ bins:
     min: 4.0
     mid: 4.125
     max: 4.25
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -207,7 +207,7 @@ bins:
     min: 4.25
     mid: 4.375
     max: 4.5
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null

--- a/nnpdf_data/nnpdf_data/commondata/LHCB_Z0_13TEV/metadata.yaml
+++ b/nnpdf_data/nnpdf_data/commondata/LHCB_Z0_13TEV/metadata.yaml
@@ -28,15 +28,15 @@ implemented_observables:
   ndata: 17
   # Plotting information
   plotting:
-    kinematics_override: ewk_rap_sqrt_scale
+    kinematics_override: identity
     dataset_label: "LHCb $Z\\to ee$"
     plot_x: y
     y_label: '$d\sigma_{Z}/dy$ (fb)'
-  kinematic_coverage: [y, M2, sqrts]
+  kinematic_coverage: [y, m_Z2, sqrts]
   kinematics:
     variables:
       y: {description: "Z boson rapidity", label: "$y$", units: ""}
-      M2: {description: "Z boson Mass", label: "$M^2$", units: "$GeV^2$"}
+      m_Z2: {description: "Z boson Mass", label: "$M^2$", units: "$GeV^2$"}
       sqrts: {description: "Center of Mass Energy", label: '$\sqrt{s}$', units: "$GeV$"}
     file: kinematics_dielectron.yaml
   data_central: data_dielectron.yaml
@@ -63,11 +63,11 @@ implemented_observables:
     dataset_label: "LHCb $Z\\to µµ$"
     plot_x: y
     y_label: '$d\sigma_{Z}/dy$ (fb)'
-  kinematic_coverage: [y, M2, sqrts]
+  kinematic_coverage: [y, m_Z2, sqrts]
   kinematics:
     variables:
       y: {description: "Z boson rapidity", label: "$y$", units: ""}
-      M2: {description: "Z boson Mass", label: "$M^2$", units: "$GeV^2$"}
+      m_Z2: {description: "Z boson Mass", label: "$M^2$", units: "$GeV^2$"}
       sqrts: {description: "Center of Mass Energy", label: '$\sqrt{s}$', units: "$GeV$"}
     file: kinematics_dimuon.yaml
   data_central: data_dimuon.yaml

--- a/nnpdf_data/nnpdf_data/commondata/LHCB_Z0_13TEV/metadata.yaml
+++ b/nnpdf_data/nnpdf_data/commondata/LHCB_Z0_13TEV/metadata.yaml
@@ -22,7 +22,7 @@ implemented_observables:
     description: "Differential cross-section of Z-->ee as a function of Z-rapidity"
     label: r"$d\sigma / d|y|$"
     units: "[fb]"
-  process_type: "EWK_RAP"
+  process_type: "DY_Z_Y"
   tables: [5]
   npoints: [17]
   ndata: 17
@@ -53,7 +53,7 @@ implemented_observables:
     description: "Differential cross-section of Z-->µµ as a function of Z-rapidity"
     label: r"$d\sigma / d|y|$"
     units: "[fb]"
-  process_type: "EWK_RAP"
+  process_type: "DY_Z_Y"
   tables: [5]
   npoints: [18]
   ndata: 18

--- a/nnpdf_data/nnpdf_data/commondata/LHCB_Z0_7TEV_DIELECTRON/filter.py
+++ b/nnpdf_data/nnpdf_data/commondata/LHCB_Z0_7TEV_DIELECTRON/filter.py
@@ -70,7 +70,7 @@ def get_kinematics(hepdata: dict) -> list:
                 "mid": 0.5 * (bins["low"] + bins["high"]),
                 "max": bins["high"],
             },
-            "M2": {"min": None, "mid": MZ_VALUE**2, "max": None},
+            "m_Z2": {"min": None, "mid": MZ_VALUE**2, "max": None},
             "sqrts": {"min": None, "mid": SQRT_S, "max": None},
         }
         kinematics.append(kin_value)

--- a/nnpdf_data/nnpdf_data/commondata/LHCB_Z0_7TEV_DIELECTRON/kinematics.yaml
+++ b/nnpdf_data/nnpdf_data/commondata/LHCB_Z0_7TEV_DIELECTRON/kinematics.yaml
@@ -3,7 +3,7 @@ bins:
     min: 2.0
     mid: 2.125
     max: 2.25
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -15,7 +15,7 @@ bins:
     min: 2.25
     mid: 2.375
     max: 2.5
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -27,7 +27,7 @@ bins:
     min: 2.5
     mid: 2.625
     max: 2.75
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -39,7 +39,7 @@ bins:
     min: 2.75
     mid: 2.875
     max: 3.0
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -51,7 +51,7 @@ bins:
     min: 3.0
     mid: 3.125
     max: 3.25
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -63,7 +63,7 @@ bins:
     min: 3.25
     mid: 3.375
     max: 3.5
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -75,7 +75,7 @@ bins:
     min: 3.5
     mid: 3.625
     max: 3.75
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -87,7 +87,7 @@ bins:
     min: 3.75
     mid: 3.875
     max: 4.0
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -99,7 +99,7 @@ bins:
     min: 4.0
     mid: 4.125
     max: 4.25
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null

--- a/nnpdf_data/nnpdf_data/commondata/LHCB_Z0_7TEV_DIELECTRON/metadata.yaml
+++ b/nnpdf_data/nnpdf_data/commondata/LHCB_Z0_7TEV_DIELECTRON/metadata.yaml
@@ -28,15 +28,15 @@ implemented_observables:
   ndata: 9
   # Plotting information
   plotting:
-    kinematics_override: ewk_rap_sqrt_scale
+    kinematics_override: identity
     dataset_label: "LHCb $Z\\to ee$ 7 TeV"
     plot_x: y
     y_label: '$d\sigma_{Z/\gamma^{*}}/dy$ (fb)'
-  kinematic_coverage: [y, M2, sqrts]
+  kinematic_coverage: [y, m_Z2, sqrts]
   kinematics:
     variables:
       y: {description: "Z boson rapidity", label: "$y$", units: ""}
-      M2: {description: "Z boson Mass", label: "$M^2$", units: "$GeV^2$"}
+      m_Z2: {description: "Z boson Mass", label: "$M^2$", units: "$GeV^2$"}
       sqrts: {description: "Center of Mass Energy", label: '$\sqrt{s}$', units: "$GeV$"}
     file: kinematics.yaml
   data_central: data.yaml

--- a/nnpdf_data/nnpdf_data/commondata/LHCB_Z0_7TEV_DIELECTRON/metadata.yaml
+++ b/nnpdf_data/nnpdf_data/commondata/LHCB_Z0_7TEV_DIELECTRON/metadata.yaml
@@ -22,7 +22,7 @@ implemented_observables:
     description: "Differential cross-section of Z-->ee as a function of Z-rapidity"
     label: r"$d\sigma / d|y|$"
     units: "[fb]"
-  process_type: "EWK_RAP"
+  process_type: "DY_Z_Y"
   tables: [2]
   npoints: [9]
   ndata: 9

--- a/nnpdf_data/nnpdf_data/commondata/LHCB_Z0_7TEV_MUON/filter.py
+++ b/nnpdf_data/nnpdf_data/commondata/LHCB_Z0_7TEV_MUON/filter.py
@@ -85,7 +85,7 @@ def get_kinematics(hepdata: dict, bin_index: list, boson: str = "Z") -> list:
         ymax = float(rapbins[bins]["high"])
         kin_value = {
             "y": {"min": ymin, "mid": 0.5 * (ymin + ymax), "max": ymax},
-            "M2": {"min": None, "mid": MAP_BOSON[boson] ** 2, "max": None},
+            "m_Z2": {"min": None, "mid": MAP_BOSON[boson] ** 2, "max": None},
             "sqrts": {"min": None, "mid": SQRT_S, "max": None},
         }
         kinematics.append(kin_value)

--- a/nnpdf_data/nnpdf_data/commondata/LHCB_Z0_7TEV_MUON/kinematics.yaml
+++ b/nnpdf_data/nnpdf_data/commondata/LHCB_Z0_7TEV_MUON/kinematics.yaml
@@ -3,7 +3,7 @@ bins:
     min: 2.0
     mid: 2.0625
     max: 2.125
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -15,7 +15,7 @@ bins:
     min: 2.125
     mid: 2.1875
     max: 2.25
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -27,7 +27,7 @@ bins:
     min: 2.25
     mid: 2.3125
     max: 2.375
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -39,7 +39,7 @@ bins:
     min: 2.375
     mid: 2.4375
     max: 2.5
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -51,7 +51,7 @@ bins:
     min: 2.5
     mid: 2.5625
     max: 2.625
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -63,7 +63,7 @@ bins:
     min: 2.625
     mid: 2.6875
     max: 2.75
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -75,7 +75,7 @@ bins:
     min: 2.75
     mid: 2.8125
     max: 2.875
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -87,7 +87,7 @@ bins:
     min: 2.875
     mid: 2.9375
     max: 3.0
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -99,7 +99,7 @@ bins:
     min: 3.0
     mid: 3.0625
     max: 3.125
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -111,7 +111,7 @@ bins:
     min: 3.125
     mid: 3.1875
     max: 3.25
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -123,7 +123,7 @@ bins:
     min: 3.25
     mid: 3.3125
     max: 3.375
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -135,7 +135,7 @@ bins:
     min: 3.375
     mid: 3.4375
     max: 3.5
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -147,7 +147,7 @@ bins:
     min: 3.5
     mid: 3.5625
     max: 3.625
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -159,7 +159,7 @@ bins:
     min: 3.625
     mid: 3.6875
     max: 3.75
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -171,7 +171,7 @@ bins:
     min: 3.75
     mid: 3.8125
     max: 3.875
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -183,7 +183,7 @@ bins:
     min: 3.875
     mid: 3.9375
     max: 4.0
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -195,7 +195,7 @@ bins:
     min: 4.0
     mid: 4.125
     max: 4.25
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null

--- a/nnpdf_data/nnpdf_data/commondata/LHCB_Z0_7TEV_MUON/metadata.yaml
+++ b/nnpdf_data/nnpdf_data/commondata/LHCB_Z0_7TEV_MUON/metadata.yaml
@@ -28,15 +28,15 @@ implemented_observables:
   npoints: [17]
   ndata: 17
   plotting:
-    kinematics_override: ewk_rap_sqrt_scale
+    kinematics_override: identity
     dataset_label: "LHCb $Z \\to \\mu$ 7 TeV"
     plot_x: y
     y_label: '$d\sigma/dy$ (fb)'
-  kinematic_coverage: [y, M2, sqrts]
+  kinematic_coverage: [y, m_Z2, sqrts]
   kinematics:
     variables:
       y: {description: "Muon rapidity", label: "$y$", units: ""}
-      M2: {description: "Z boson Mass", label: "$M^2$", units: "$GeV^2$"}
+      m_Z2: {description: "Z boson Mass", label: "$M^2$", units: "$GeV^2$"}
       sqrts: {description: "Center of Mass Energy", label: '$\sqrt{s}$', units: "$GeV$"}
     file: kinematics.yaml
   data_central: data.yaml

--- a/nnpdf_data/nnpdf_data/commondata/LHCB_Z0_7TEV_MUON/metadata.yaml
+++ b/nnpdf_data/nnpdf_data/commondata/LHCB_Z0_7TEV_MUON/metadata.yaml
@@ -23,7 +23,7 @@ implemented_observables:
     description: "Inclusive cross-section for Z boson production in bins of rapidity"
     label: r"$d\sigma / d|y|$"
     units: "[fb]"
-  process_type: "EWK_RAP"
+  process_type: "DY_Z_Y"
   tables: [1]
   npoints: [17]
   ndata: 17

--- a/nnpdf_data/nnpdf_data/commondata/LHCB_Z0_8TEV_DIELECTRON/filter.py
+++ b/nnpdf_data/nnpdf_data/commondata/LHCB_Z0_8TEV_DIELECTRON/filter.py
@@ -75,7 +75,7 @@ def get_kinematics(hepdata: dict) -> list:
                 "mid": 0.5 * (bins["low"] + bins["high"]),
                 "max": bins["high"],
             },
-            "M2": {"min": None, "mid": MZ_VALUE**2, "max": None},
+            "m_Z2": {"min": None, "mid": MZ_VALUE**2, "max": None},
             "sqrts": {"min": None, "mid": SQRT_S, "max": None},
         }
         kinematics.append(kin_value)

--- a/nnpdf_data/nnpdf_data/commondata/LHCB_Z0_8TEV_DIELECTRON/kinematics.yaml
+++ b/nnpdf_data/nnpdf_data/commondata/LHCB_Z0_8TEV_DIELECTRON/kinematics.yaml
@@ -3,7 +3,7 @@ bins:
     min: 2.0
     mid: 2.0625
     max: 2.125
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -15,7 +15,7 @@ bins:
     min: 2.125
     mid: 2.1875
     max: 2.25
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -27,7 +27,7 @@ bins:
     min: 2.25
     mid: 2.3125
     max: 2.375
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -39,7 +39,7 @@ bins:
     min: 2.375
     mid: 2.4375
     max: 2.5
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -51,7 +51,7 @@ bins:
     min: 2.5
     mid: 2.5625
     max: 2.625
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -63,7 +63,7 @@ bins:
     min: 2.625
     mid: 2.6875
     max: 2.75
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -75,7 +75,7 @@ bins:
     min: 2.75
     mid: 2.8125
     max: 2.875
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -87,7 +87,7 @@ bins:
     min: 2.875
     mid: 2.9375
     max: 3.0
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -99,7 +99,7 @@ bins:
     min: 3.0
     mid: 3.0625
     max: 3.125
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -111,7 +111,7 @@ bins:
     min: 3.125
     mid: 3.1875
     max: 3.25
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -123,7 +123,7 @@ bins:
     min: 3.25
     mid: 3.3125
     max: 3.375
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -135,7 +135,7 @@ bins:
     min: 3.375
     mid: 3.4375
     max: 3.5
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -147,7 +147,7 @@ bins:
     min: 3.5
     mid: 3.5625
     max: 3.625
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -159,7 +159,7 @@ bins:
     min: 3.625
     mid: 3.6875
     max: 3.75
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -171,7 +171,7 @@ bins:
     min: 3.75
     mid: 3.8125
     max: 3.875
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -183,7 +183,7 @@ bins:
     min: 3.875
     mid: 3.9375
     max: 4.0
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -195,7 +195,7 @@ bins:
     min: 4.0
     mid: 4.125
     max: 4.25
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null

--- a/nnpdf_data/nnpdf_data/commondata/LHCB_Z0_8TEV_DIELECTRON/metadata.yaml
+++ b/nnpdf_data/nnpdf_data/commondata/LHCB_Z0_8TEV_DIELECTRON/metadata.yaml
@@ -22,7 +22,7 @@ implemented_observables:
     description: "Differential cross-section of Z-->ee as a function of Z-rapidity"
     label: r"$d\sigma / d|y|$"
     units: "[fb]"
-  process_type: "EWK_RAP"
+  process_type: "DY_Z_Y"
   tables: [2]
   npoints: [17]
   ndata: 17

--- a/nnpdf_data/nnpdf_data/commondata/LHCB_Z0_8TEV_DIELECTRON/metadata.yaml
+++ b/nnpdf_data/nnpdf_data/commondata/LHCB_Z0_8TEV_DIELECTRON/metadata.yaml
@@ -28,15 +28,15 @@ implemented_observables:
   ndata: 17
   # Plotting information
   plotting:
-    kinematics_override: ewk_rap_sqrt_scale
+    kinematics_override: identity
     dataset_label: "LHCb $Z\\to ee$ 8 TeV"
     plot_x: y
     y_label: '$d\sigma_{Z/\gamma^{*}}/dy$ (fb)'
-  kinematic_coverage: [y, M2, sqrts]
+  kinematic_coverage: [y, m_Z2, sqrts]
   kinematics:
     variables:
       y: {description: "Z boson rapidity", label: "$y$", units: ""}
-      M2: {description: "Z boson Mass", label: "$M^2$", units: "$GeV^2$"}
+      m_Z2: {description: "Z boson Mass", label: "$M^2$", units: "$GeV^2$"}
       sqrts: {description: "Center of Mass Energy", label: '$\sqrt{s}$', units: "$GeV$"}
     file: kinematics.yaml
   data_central: data.yaml

--- a/nnpdf_data/nnpdf_data/commondata/LHCB_Z0_8TEV_MUON/filter.py
+++ b/nnpdf_data/nnpdf_data/commondata/LHCB_Z0_8TEV_MUON/filter.py
@@ -85,7 +85,7 @@ def get_kinematics(hepdata: dict, bin_index: list, boson: str = "Z") -> list:
         ymax = float(rapbins[bins]["high"])
         kin_value = {
             "y": {"min": ymin, "mid": 0.5 * (ymin + ymax), "max": ymax},
-            "M2": {"min": None, "mid": MAP_BOSON[boson] ** 2, "max": None},
+            "m_Z2": {"min": None, "mid": MAP_BOSON[boson] ** 2, "max": None},
             "sqrts": {"min": None, "mid": SQRT_S, "max": None},
         }
         kinematics.append(kin_value)

--- a/nnpdf_data/nnpdf_data/commondata/LHCB_Z0_8TEV_MUON/kinematics.yaml
+++ b/nnpdf_data/nnpdf_data/commondata/LHCB_Z0_8TEV_MUON/kinematics.yaml
@@ -3,7 +3,7 @@ bins:
     min: 2.0
     mid: 2.0625
     max: 2.125
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -15,7 +15,7 @@ bins:
     min: 2.125
     mid: 2.1875
     max: 2.25
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -27,7 +27,7 @@ bins:
     min: 2.25
     mid: 2.3125
     max: 2.375
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -39,7 +39,7 @@ bins:
     min: 2.375
     mid: 2.4375
     max: 2.5
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -51,7 +51,7 @@ bins:
     min: 2.5
     mid: 2.5625
     max: 2.625
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -63,7 +63,7 @@ bins:
     min: 2.625
     mid: 2.6875
     max: 2.75
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -75,7 +75,7 @@ bins:
     min: 2.75
     mid: 2.8125
     max: 2.875
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -87,7 +87,7 @@ bins:
     min: 2.875
     mid: 2.9375
     max: 3.0
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -99,7 +99,7 @@ bins:
     min: 3.0
     mid: 3.0625
     max: 3.125
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -111,7 +111,7 @@ bins:
     min: 3.125
     mid: 3.1875
     max: 3.25
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -123,7 +123,7 @@ bins:
     min: 3.25
     mid: 3.3125
     max: 3.375
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -135,7 +135,7 @@ bins:
     min: 3.375
     mid: 3.4375
     max: 3.5
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -147,7 +147,7 @@ bins:
     min: 3.5
     mid: 3.5625
     max: 3.625
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -159,7 +159,7 @@ bins:
     min: 3.625
     mid: 3.6875
     max: 3.75
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -171,7 +171,7 @@ bins:
     min: 3.75
     mid: 3.8125
     max: 3.875
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -183,7 +183,7 @@ bins:
     min: 3.875
     mid: 3.9375
     max: 4.0
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -195,7 +195,7 @@ bins:
     min: 4.0
     mid: 4.125
     max: 4.25
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null
@@ -207,7 +207,7 @@ bins:
     min: 4.25
     mid: 4.375
     max: 4.5
-  M2:
+  m_Z2:
     min: null
     mid: 8.31517839e+03
     max: null

--- a/nnpdf_data/nnpdf_data/commondata/LHCB_Z0_8TEV_MUON/metadata.yaml
+++ b/nnpdf_data/nnpdf_data/commondata/LHCB_Z0_8TEV_MUON/metadata.yaml
@@ -28,7 +28,7 @@ implemented_observables:
   npoints: [18]
   ndata: 18
   plotting:
-    kinematics_override: ewk_rap_sqrt_scale
+    kinematics_override: identity
     dataset_label: "LHCb $Z \\to \\mu$ 8 TeV"
     plot_x: y
     y_label: '$d\sigma/dy$ (fb)'
@@ -55,11 +55,11 @@ implemented_observables:
         "$Z$",
         "$Z$",
       ]
-  kinematic_coverage: [y, M2, sqrts]
+  kinematic_coverage: [y, m_Z2, sqrts]
   kinematics:
     variables:
       y: {description: "Muon rapidity", label: "$y$", units: ""}
-      M2: {description: "Z boson Mass", label: "$M^2$", units: "$GeV^2$"}
+      m_Z2: {description: "Z boson Mass", label: "$M^2$", units: "$GeV^2$"}
       sqrts: {description: "Center of Mass Energy", label: '$\sqrt{s}$', units: "$GeV$"}
     file: kinematics.yaml
   data_central: data.yaml

--- a/nnpdf_data/nnpdf_data/commondata/LHCB_Z0_8TEV_MUON/metadata.yaml
+++ b/nnpdf_data/nnpdf_data/commondata/LHCB_Z0_8TEV_MUON/metadata.yaml
@@ -23,7 +23,7 @@ implemented_observables:
     description: "Inclusive cross-section for Z boson production in bins of muon pseudorapidity at 8 TeV"
     label: r"$d\sigma / d|y|$"
     units: "[fb]"
-  process_type: "EWK_RAP"
+  process_type: "DY_Z_Y"
   tables: [2]
   npoints: [18]
   ndata: 18

--- a/validphys2/src/validphys/process_options.py
+++ b/validphys2/src/validphys/process_options.py
@@ -423,10 +423,11 @@ PROCESSES = {
     "JET_POL": JET_POL,
     "DIJET_POL": DIJET_POL,
     "DY_Z_Y": dataclasses.replace(DY_2L, name="DY_Z_Y", description="DY Z -> ll rapidity"),
-    "DY_W_Y": dataclasses.replace(DY_2L, name="DY_W_Y", description="DY W -> ll rapidity"),
-    "DY_VB_Y": dataclasses.replace(DY_2L, name="DY_VB_Y", description="DY Z/W -> ll rapidity"),
     "DY_W_ETA": dataclasses.replace(
-        DY_2L, name="DY_W_ETA", description="DY W -> l nu (pseudo)rapidity"
+        DY_2L, name="DY_W_ETA", description="DY W -> l nu pseudorapidity"
+    ),
+    "DY_VB_ETA": dataclasses.replace(
+        DY_2L, name="DY_VB_ETA", description="DY Z/W -> ll pseudorapidity"
     ),
     "DY_NC_PT": dataclasses.replace(DY_PT, name="DY_NC_PT", description="DY Z (ll) + j"),
     "DY_NC_PTRAP": dataclasses.replace(DY_PT_RAP, name="DY_NC_PTRAP", description="DY Z (ll) + j"),

--- a/validphys2/src/validphys/process_options.py
+++ b/validphys2/src/validphys/process_options.py
@@ -32,6 +32,7 @@ class _Vars:
     abs_eta = "abs_eta"
     m_W2 = "m_W2"
     m_Z2 = "m_Z2"
+    m_V2 = "m_V2"
     abs_eta_1 = "abs_eta_1"
     abs_eta_2 = "abs_eta_2"
     eta_1 = "eta_1"
@@ -234,7 +235,7 @@ def _dyboson_xq2map(kin_info):
     Computes x and q2 mapping for pseudo rapidity observables
     originating from a W boson DY process.
     """
-    mass2 = kin_info.get_one_of(_Vars.m_W2, _Vars.m_Z2)
+    mass2 = kin_info.get_one_of(_Vars.m_W2, _Vars.m_Z2, _Vars.m_V2)
     eta = kin_info.get_one_of(_Vars.eta, _Vars.y)
     sqrts = kin_info[_Vars.sqrts]
 
@@ -369,7 +370,7 @@ HERAJET = _Process(
 DY_2L = _Process(
     "DY_2L",
     "DY W or Z -> 2 leptons ",
-    accepted_variables=(_Vars.y, _Vars.eta, _Vars.m_W2, _Vars.m_Z2, _Vars.sqrts),
+    accepted_variables=(_Vars.y, _Vars.eta, _Vars.m_W2, _Vars.m_Z2, _Vars.m_V2, _Vars.sqrts),
     xq2map_function=_dyboson_xq2map,
 )
 
@@ -384,7 +385,15 @@ DY_PT = _Process(
 DY_PT_RAP = _Process(
     "DY_PT",
     "DY W or Z (2 leptons) + j boson transverse momentum",
-    accepted_variables=(_Vars.pT, _Vars.m_W2, _Vars.m_Z2, _Vars.sqrts, _Vars.y, _Vars.eta, _Vars.m_ll2),
+    accepted_variables=(
+        _Vars.pT,
+        _Vars.m_W2,
+        _Vars.m_Z2,
+        _Vars.sqrts,
+        _Vars.y,
+        _Vars.eta,
+        _Vars.m_ll2,
+    ),
     xq2map_function=_dybosonptrap_xq2map,
 )
 

--- a/validphys2/src/validphys/process_options.py
+++ b/validphys2/src/validphys/process_options.py
@@ -422,7 +422,9 @@ PROCESSES = {
     "HERADIJET": dataclasses.replace(HERAJET, name="HERADIJET", description="DIS + jj production"),
     "JET_POL": JET_POL,
     "DIJET_POL": DIJET_POL,
-    "DY_Z_Y": dataclasses.replace(DY_2L, name="DY_Z_Y", description="DY Z -> ll (pseudo)rapidity"),
+    "DY_Z_Y": dataclasses.replace(DY_2L, name="DY_Z_Y", description="DY Z -> ll rapidity"),
+    "DY_W_Y": dataclasses.replace(DY_2L, name="DY_W_Y", description="DY W -> ll rapidity"),
+    "DY_VB_Y": dataclasses.replace(DY_2L, name="DY_VB_Y", description="DY Z/W -> ll rapidity"),
     "DY_W_ETA": dataclasses.replace(
         DY_2L, name="DY_W_ETA", description="DY W -> l nu (pseudo)rapidity"
     ),


### PR DESCRIPTION
This PR modifies the following:
- deprecate the use of `kinematic_override`
- replace the `process_type` from `EWK_RAP` to `DY_2L`

The data vs theory comparisons and kinematic plots are identical:
|   |  old plotting | new plotting  |
|---|---|---|
| data vs theory comparison  | [report](https://vp.nnpdf.science/HJlsNqz-QSqley8lNQJVig==)  | [report](https://vp.nnpdf.science/i46-oWMTSYOped7Lifsl9w==/)  |
|  kinematic plot | [report](https://vp.nnpdf.science/Xhg3mC3LReGU10CelaFBnw==)  |  [report](https://vp.nnpdf.science/3o6Owyd5Qaap9inoNkGiJg==/) |