### PR TITLE
add modsv key if xif not 1

### DIFF
--- a/nnpdf_data/nnpdf_data/theory.py
+++ b/nnpdf_data/nnpdf_data/theory.py
@@ -107,6 +107,17 @@ class TheoryCard:
                     f"Trying to use {self.ID} with {self.Qedref} != {self.Qref}. This is not supported!"
                 )
 
+        if self.XIF == 1 and self.ModSV is not None:
+            raise TheoryCardError(
+                f"Theory: {self.ID}, error: XIF is {self.XIF} while ModSV is {self.ModSV}. "
+                "If XIF is equal to 1.0, ModSV should not be defined."
+            )
+        elif self.XIF != 1 and self.ModSV is None:
+            raise TheoryCardError(
+                f"Theory: {self.ID}, error: XIF is {self.XIF} while ModSV is {self.ModSV}. "
+                "If XIF is different from 1.0, ModSV should be defined."
+            )
+
         if self.DAMP != 0 and "FONLL" in self.FNS:
             # Check the damp powers are being used
             if self.DAMPPOWERb is None:

--- a/nnpdf_data/nnpdf_data/theory.py
+++ b/nnpdf_data/nnpdf_data/theory.py
@@ -112,10 +112,10 @@ class TheoryCard:
                 f"Theory: {self.ID}, error: XIF is {self.XIF} while ModSV is {self.ModSV}. "
                 "If XIF is equal to 1.0, ModSV should not be defined."
             )
-        elif self.XIF != 1 and self.ModSV is None:
+        elif self.XIF != 1 and self.ModSV not in ["expanded", "exponentiated"]:
             raise TheoryCardError(
                 f"Theory: {self.ID}, error: XIF is {self.XIF} while ModSV is {self.ModSV}. "
-                "If XIF is different from 1.0, ModSV should be defined."
+                "If XIF is different from 1.0, ModSV should be either 'expanded' or 'exponentiated'."
             )
 
         if self.DAMP != 0 and "FONLL" in self.FNS:

--- a/nnpdf_data/nnpdf_data/theory_cards/1010.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/1010.yaml
@@ -1,7 +1,7 @@
 ID: 1010
 PTO: 3
 FNS: FONLL-E
-use_fhmruvv: True
+use_fhmruvv: true
 DAMP: 0
 IC: 1
 ModEv: TRN

--- a/nnpdf_data/nnpdf_data/theory_cards/1011.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/1011.yaml
@@ -1,7 +1,7 @@
 ID: 1011
 PTO: 3
 FNS: FONLL-E
-use_fhmruvv: True
+use_fhmruvv: true
 DAMP: 0
 IC: 1
 ModEv: TRN

--- a/nnpdf_data/nnpdf_data/theory_cards/1012.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/1012.yaml
@@ -1,7 +1,7 @@
 ID: 1012
 PTO: 3
 FNS: FONLL-E
-use_fhmruvv: True
+use_fhmruvv: true
 DAMP: 0
 IC: 1
 ModEv: TRN

--- a/nnpdf_data/nnpdf_data/theory_cards/1013.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/1013.yaml
@@ -1,7 +1,7 @@
 ID: 1013
 PTO: 3
 FNS: FONLL-E
-use_fhmruvv: True
+use_fhmruvv: true
 DAMP: 0
 IC: 1
 ModEv: TRN

--- a/nnpdf_data/nnpdf_data/theory_cards/1014.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/1014.yaml
@@ -1,7 +1,7 @@
 ID: 1014
 PTO: 3
 FNS: FONLL-E
-use_fhmruvv: True
+use_fhmruvv: true
 DAMP: 0
 IC: 1
 ModEv: TRN

--- a/nnpdf_data/nnpdf_data/theory_cards/1015.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/1015.yaml
@@ -1,7 +1,7 @@
 ID: 1015
 PTO: 3
 FNS: FONLL-E
-use_fhmruvv: True
+use_fhmruvv: true
 DAMP: 0
 IC: 1
 ModEv: TRN
@@ -48,3 +48,4 @@ Comments: NNPDF4.0 N3LO ad variation (0, 0, 0, 0, 0, 0, 0), FHMV splitting
 n3lo_ad_variation: [0, 0, 0, 0, 0, 0, 0]
 global_nx: 0
 EScaleVar: 1
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/1016.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/1016.yaml
@@ -1,7 +1,7 @@
 ID: 1016
 PTO: 3
 FNS: FONLL-E
-use_fhmruvv: True
+use_fhmruvv: true
 DAMP: 0
 IC: 1
 ModEv: TRN
@@ -48,3 +48,4 @@ Comments: NNPDF4.0 N3LO ad variation (0, 0, 0, 0, 0, 0, 0), FHMV splitting
 n3lo_ad_variation: [0, 0, 0, 0, 0, 0, 0]
 global_nx: 0
 EScaleVar: 1
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/1017.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/1017.yaml
@@ -1,7 +1,7 @@
 ID: 1017
 PTO: 3
 FNS: FONLL-E
-use_fhmruvv: True
+use_fhmruvv: true
 DAMP: 0
 IC: 1
 ModEv: TRN
@@ -48,3 +48,4 @@ Comments: NNPDF4.0 N3LO ad variation (0, 0, 0, 0, 0, 0, 0), FHMV splitting
 n3lo_ad_variation: [0, 0, 0, 0, 0, 0, 0]
 global_nx: 0
 EScaleVar: 1
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/1018.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/1018.yaml
@@ -1,7 +1,7 @@
 ID: 1018
 PTO: 3
 FNS: FONLL-E
-use_fhmruvv: True
+use_fhmruvv: true
 DAMP: 0
 IC: 1
 ModEv: TRN

--- a/nnpdf_data/nnpdf_data/theory_cards/1019.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/1019.yaml
@@ -1,7 +1,7 @@
 ID: 1019
 PTO: 3
 FNS: FONLL-E
-use_fhmruvv: True
+use_fhmruvv: true
 DAMP: 0
 IC: 1
 ModEv: TRN
@@ -48,3 +48,4 @@ Comments: NNPDF4.0 N3LO ad variation (0, 0, 0, 0, 0, 0, 0), FHMV splitting
 n3lo_ad_variation: [0, 0, 0, 0, 0, 0, 0]
 global_nx: 0
 EScaleVar: 1
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/1020.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/1020.yaml
@@ -1,7 +1,7 @@
 ID: 1020
 PTO: 3
 FNS: FONLL-E
-use_fhmruvv: True
+use_fhmruvv: true
 DAMP: 0
 IC: 1
 ModEv: TRN
@@ -48,3 +48,4 @@ Comments: NNPDF4.0 N3LO ad variation (0, 0, 0, 0, 0, 0, 0), FHMV splitting
 n3lo_ad_variation: [0, 0, 0, 0, 0, 0, 0]
 global_nx: 0
 EScaleVar: 1
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/1021.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/1021.yaml
@@ -1,7 +1,7 @@
 ID: 1021
 PTO: 3
 FNS: FONLL-E
-use_fhmruvv: True
+use_fhmruvv: true
 DAMP: 0
 IC: 1
 ModEv: TRN

--- a/nnpdf_data/nnpdf_data/theory_cards/1022.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/1022.yaml
@@ -1,7 +1,7 @@
 ID: 1022
 PTO: 3
 FNS: FONLL-E
-use_fhmruvv: True
+use_fhmruvv: true
 DAMP: 0
 IC: 1
 ModEv: TRN
@@ -48,3 +48,4 @@ Comments: NNPDF4.0 N3LO ad variation (0, 0, 0, 0, 0, 0, 0), FHMV splitting
 n3lo_ad_variation: [0, 0, 0, 0, 0, 0, 0]
 global_nx: 0
 EScaleVar: 1
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/1023.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/1023.yaml
@@ -1,7 +1,7 @@
 ID: 1023
 PTO: 3
 FNS: FONLL-E
-use_fhmruvv: True
+use_fhmruvv: true
 DAMP: 0
 IC: 1
 ModEv: TRN

--- a/nnpdf_data/nnpdf_data/theory_cards/1024.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/1024.yaml
@@ -1,7 +1,7 @@
 ID: 1024
 PTO: 3
 FNS: FONLL-E
-use_fhmruvv: True
+use_fhmruvv: true
 DAMP: 0
 IC: 1
 ModEv: TRN

--- a/nnpdf_data/nnpdf_data/theory_cards/1025.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/1025.yaml
@@ -1,7 +1,7 @@
 ID: 1025
 PTO: 3
 FNS: FONLL-E
-use_fhmruvv: True
+use_fhmruvv: true
 DAMP: 0
 IC: 1
 ModEv: TRN

--- a/nnpdf_data/nnpdf_data/theory_cards/1026.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/1026.yaml
@@ -1,7 +1,7 @@
 ID: 1026
 PTO: 3
 FNS: FONLL-E
-use_fhmruvv: True
+use_fhmruvv: true
 DAMP: 0
 IC: 1
 ModEv: TRN

--- a/nnpdf_data/nnpdf_data/theory_cards/156.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/156.yaml
@@ -46,3 +46,4 @@ MP: 0.938
 Comments: NNPDF3.1 NNLO FC xiF=xiR=0.5
 global_nx: 0
 EScaleVar: 1
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/157.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/157.yaml
@@ -46,3 +46,4 @@ MP: 0.938
 Comments: NNPDF3.1 NNLO FC xiF=xiR=2.0
 global_nx: 0
 EScaleVar: 1
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/158.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/158.yaml
@@ -46,3 +46,4 @@ MP: 0.938
 Comments: NNPDF3.1 NLO (FONLLA) FC xiF=xiR=0.5
 global_nx: 0
 EScaleVar: 1
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/159.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/159.yaml
@@ -46,3 +46,4 @@ MP: 0.938
 Comments: NNPDF3.1 NLO (FONNLA) FC xiF=xiR=2.0
 global_nx: 0
 EScaleVar: 1
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/164.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/164.yaml
@@ -46,3 +46,4 @@ MP: 0.938
 Comments: NNPDF3.1 NLO central, b thresholds 2*m, xiF=xiR=2
 global_nx: 0
 EScaleVar: 1
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/165.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/165.yaml
@@ -46,3 +46,4 @@ MP: 0.938
 Comments: NNPDF3.1 NLO central, b thresholds 2*m xiF=xiR=0.5
 global_nx: 0
 EScaleVar: 1
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/167.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/167.yaml
@@ -46,3 +46,4 @@ MP: 0.938
 Comments: NNPDF3.1 NNLO central, b thresholds 2*m, xiF=xiR=2
 global_nx: 0
 EScaleVar: 1
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/168.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/168.yaml
@@ -46,3 +46,4 @@ MP: 0.938
 Comments: NNPDF3.1 NNLO central, b thresholds 2*m xiF=xiR=0.5
 global_nx: 0
 EScaleVar: 1
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/171.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/171.yaml
@@ -46,3 +46,4 @@ MP: 0.938
 Comments: NNPDF3.1 NLO central, b thresholds 2*m, xiF=2.0, xiR=central
 global_nx: 0
 EScaleVar: 1
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/172.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/172.yaml
@@ -46,3 +46,4 @@ MP: 0.938
 Comments: NNPDF3.1 NLO central, b thresholds 2*m, xiF=0.5, xiR=central
 global_nx: 0
 EScaleVar: 1
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/173.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/173.yaml
@@ -46,3 +46,4 @@ MP: 0.938
 Comments: NNPDF3.1 NLO central, b thresholds 2*m, noEScaleVar, xiF=0.5, xiR=0.5
 global_nx: 0
 EScaleVar: 0
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/175.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/175.yaml
@@ -46,3 +46,4 @@ MP: 0.938
 Comments: NNPDF3.1 NLO central, b thresholds 2*m, noEScaleVar, xiF=2.0, xiR=0.5
 global_nx: 0
 EScaleVar: 0
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/176.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/176.yaml
@@ -46,3 +46,4 @@ MP: 0.938
 Comments: NNPDF3.1 NLO central, b thresholds 2*m, noEScaleVar, xiF=0.5, xiR=central
 global_nx: 0
 EScaleVar: 0
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/177.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/177.yaml
@@ -46,3 +46,4 @@ MP: 0.938
 Comments: NNPDF3.1 NLO central, b thresholds 2*m, noEScaleVar, xiF=2.0, xiR=central
 global_nx: 0
 EScaleVar: 0
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/178.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/178.yaml
@@ -46,3 +46,4 @@ MP: 0.938
 Comments: NNPDF3.1 NLO central, b thresholds 2*m, noEScaleVar, xiF=0.5, xiR=2.0
 global_nx: 0
 EScaleVar: 0
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/180.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/180.yaml
@@ -46,3 +46,4 @@ MP: 0.938
 Comments: NNPDF3.1 NLO central, b thresholds 2*m, noEScaleVar, xiF=2.0, xiR=2.0
 global_nx: 0
 EScaleVar: 0
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/182.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/182.yaml
@@ -46,3 +46,4 @@ MP: 0.938
 Comments: NNPDF3.1 NNLO central, b thresholds 2*m, noEScaleVar, xiF=0.5, xiR=0.5
 global_nx: 0
 EScaleVar: 0
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/184.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/184.yaml
@@ -46,3 +46,4 @@ MP: 0.938
 Comments: NNPDF3.1 NNLO central, b thresholds 2*m, noEScaleVar, xiF=2.0, xiR=0.5
 global_nx: 0
 EScaleVar: 0
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/185.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/185.yaml
@@ -46,3 +46,4 @@ MP: 0.938
 Comments: NNPDF3.1 NNLO central, b thresholds 2*m, noEScaleVar, xiF=0.5, xiR=central
 global_nx: 0
 EScaleVar: 0
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/186.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/186.yaml
@@ -46,3 +46,4 @@ MP: 0.938
 Comments: NNPDF3.1 NNLO central, b thresholds 2*m, noEScaleVar, xiF=2.0, xiR=central
 global_nx: 0
 EScaleVar: 0
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/187.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/187.yaml
@@ -46,3 +46,4 @@ MP: 0.938
 Comments: NNPDF3.1 NNLO central, b thresholds 2*m, noEScaleVar, xiF=0.5, xiR=2.0
 global_nx: 0
 EScaleVar: 0
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/189.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/189.yaml
@@ -46,3 +46,4 @@ MP: 0.938
 Comments: NNPDF3.1 NNLO central, b thresholds 2*m, noEScaleVar, xiF=2.0, xiR=2.0
 global_nx: 0
 EScaleVar: 0
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/40001003.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/40001003.yaml
@@ -1,5 +1,6 @@
 ID: 40_001_003
-Comments: NNPDF40 perturbative charm, NNLO QCD only, charm threshold displaced to 2xmc
+Comments: NNPDF40 perturbative charm, NNLO QCD only, charm threshold displaced to
+  2xmc
 PTO: 2
 FNS: FONLL-C
 DAMP: 1

--- a/nnpdf_data/nnpdf_data/theory_cards/40002000.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/40002000.yaml
@@ -12,7 +12,7 @@ CKM:
 - 0.999152
 DAMP: 0
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -21,7 +21,6 @@ MW: 80.398
 MZ: 91.1876
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65
@@ -44,5 +43,5 @@ mc: 1.51
 mt: 172.5
 nfref: 5
 nf0: 4
-n3lo_ad_variation: [0,0,0,0,0,0,0]
+n3lo_ad_variation: [0, 0, 0, 0, 0, 0, 0]
 n3lo_cf_variation: 0

--- a/nnpdf_data/nnpdf_data/theory_cards/40002001.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/40002001.yaml
@@ -12,7 +12,7 @@ CKM:
 - 0.999152
 DAMP: 0
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -21,7 +21,6 @@ MW: 80.398
 MZ: 91.1876
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65
@@ -44,5 +43,5 @@ mc: 1.51
 mt: 172.5
 nfref: 5
 nf0: 4
-n3lo_ad_variation: [0,0,0,0,0,0,0]
+n3lo_ad_variation: [0, 0, 0, 0, 0, 0, 0]
 n3lo_cf_variation: 0

--- a/nnpdf_data/nnpdf_data/theory_cards/40002002.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/40002002.yaml
@@ -12,7 +12,7 @@ CKM:
 - 0.999152
 DAMP: 0
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -21,7 +21,6 @@ MW: 80.398
 MZ: 91.1876
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65
@@ -44,5 +43,5 @@ mc: 1.51
 mt: 172.5
 nfref: 5
 nf0: 4
-n3lo_ad_variation: [0,0,0,0,0,0,0]
+n3lo_ad_variation: [0, 0, 0, 0, 0, 0, 0]
 n3lo_cf_variation: 0

--- a/nnpdf_data/nnpdf_data/theory_cards/40002003.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/40002003.yaml
@@ -12,7 +12,7 @@ CKM:
 - 0.999152
 DAMP: 0
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -21,7 +21,6 @@ MW: 80.398
 MZ: 91.1876
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65
@@ -44,5 +43,5 @@ mc: 1.51
 mt: 172.5
 nfref: 5
 nf0: 4
-n3lo_ad_variation: [0,0,0,0,0,0,0]
+n3lo_ad_variation: [0, 0, 0, 0, 0, 0, 0]
 n3lo_cf_variation: 0

--- a/nnpdf_data/nnpdf_data/theory_cards/40002004.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/40002004.yaml
@@ -12,7 +12,7 @@ CKM:
 - 0.999152
 DAMP: 0
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -21,7 +21,6 @@ MW: 80.398
 MZ: 91.1876
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65
@@ -44,5 +43,5 @@ mc: 1.51
 mt: 172.5
 nfref: 5
 nf0: 4
-n3lo_ad_variation: [0,0,0,0,0,0,0]
+n3lo_ad_variation: [0, 0, 0, 0, 0, 0, 0]
 n3lo_cf_variation: 0

--- a/nnpdf_data/nnpdf_data/theory_cards/40002006.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/40002006.yaml
@@ -12,7 +12,7 @@ CKM:
 - 0.999152
 DAMP: 0
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -21,7 +21,6 @@ MW: 80.398
 MZ: 91.1876
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65
@@ -44,5 +43,5 @@ mc: 1.51
 mt: 172.5
 nfref: 5
 nf0: 4
-n3lo_ad_variation: [0,0,0,0,0,0,0]
+n3lo_ad_variation: [0, 0, 0, 0, 0, 0, 0]
 n3lo_cf_variation: 0

--- a/nnpdf_data/nnpdf_data/theory_cards/40002007.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/40002007.yaml
@@ -12,7 +12,7 @@ CKM:
 - 0.999152
 DAMP: 0
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -21,7 +21,6 @@ MW: 80.398
 MZ: 91.1876
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65
@@ -44,5 +43,5 @@ mc: 1.51
 mt: 172.5
 nfref: 5
 nf0: 4
-n3lo_ad_variation: [0,0,0,0,0,0,0]
+n3lo_ad_variation: [0, 0, 0, 0, 0, 0, 0]
 n3lo_cf_variation: 0

--- a/nnpdf_data/nnpdf_data/theory_cards/40002008.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/40002008.yaml
@@ -12,7 +12,7 @@ CKM:
 - 0.999152
 DAMP: 0
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -21,7 +21,6 @@ MW: 80.398
 MZ: 91.1876
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65
@@ -44,5 +43,5 @@ mc: 1.51
 mt: 172.5
 nfref: 5
 nf0: 4
-n3lo_ad_variation: [0,0,0,0,0,0,0]
+n3lo_ad_variation: [0, 0, 0, 0, 0, 0, 0]
 n3lo_cf_variation: 0

--- a/nnpdf_data/nnpdf_data/theory_cards/40002009.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/40002009.yaml
@@ -12,7 +12,7 @@ CKM:
 - 0.999152
 DAMP: 0
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -21,7 +21,6 @@ MW: 80.398
 MZ: 91.1876
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65
@@ -44,5 +43,5 @@ mc: 1.51
 mt: 172.5
 nfref: 5
 nf0: 4
-n3lo_ad_variation: [0,0,0,0,0,0,0]
+n3lo_ad_variation: [0, 0, 0, 0, 0, 0, 0]
 n3lo_cf_variation: 0

--- a/nnpdf_data/nnpdf_data/theory_cards/40002010.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/40002010.yaml
@@ -12,7 +12,7 @@ CKM:
 - 0.999152
 DAMP: 0
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -21,7 +21,6 @@ MW: 80.398
 MZ: 91.1876
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65
@@ -44,5 +43,5 @@ mc: 1.51
 mt: 172.5
 nfref: 5
 nf0: 4
-n3lo_ad_variation: [0,0,0,0,0,0,0]
+n3lo_ad_variation: [0, 0, 0, 0, 0, 0, 0]
 n3lo_cf_variation: 0

--- a/nnpdf_data/nnpdf_data/theory_cards/40002011.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/40002011.yaml
@@ -12,7 +12,7 @@ CKM:
 - 0.999152
 DAMP: 0
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -21,7 +21,6 @@ MW: 80.398
 MZ: 91.1876
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65
@@ -44,5 +43,5 @@ mc: 1.51
 mt: 172.5
 nfref: 5
 nf0: 4
-n3lo_ad_variation: [0,0,0,0,0,0,0]
+n3lo_ad_variation: [0, 0, 0, 0, 0, 0, 0]
 n3lo_cf_variation: 0

--- a/nnpdf_data/nnpdf_data/theory_cards/40002012.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/40002012.yaml
@@ -12,7 +12,7 @@ CKM:
 - 0.999152
 DAMP: 0
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -21,7 +21,6 @@ MW: 80.398
 MZ: 91.1876
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65
@@ -44,5 +43,5 @@ mc: 1.51
 mt: 172.5
 nfref: 5
 nf0: 4
-n3lo_ad_variation: [0,0,0,0,0,0,0]
+n3lo_ad_variation: [0, 0, 0, 0, 0, 0, 0]
 n3lo_cf_variation: 0

--- a/nnpdf_data/nnpdf_data/theory_cards/40002013.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/40002013.yaml
@@ -12,7 +12,7 @@ CKM:
 - 0.999152
 DAMP: 0
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -21,7 +21,6 @@ MW: 80.398
 MZ: 91.1876
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65
@@ -44,5 +43,5 @@ mc: 1.51
 mt: 172.5
 nfref: 5
 nf0: 4
-n3lo_ad_variation: [0,0,0,0,0,0,0]
+n3lo_ad_variation: [0, 0, 0, 0, 0, 0, 0]
 n3lo_cf_variation: 0

--- a/nnpdf_data/nnpdf_data/theory_cards/40004000.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/40004000.yaml
@@ -1,7 +1,7 @@
 ID: 40_004_000
 PTO: 3
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 DAMP: 0
 IC: 1
 ModEv: EXA

--- a/nnpdf_data/nnpdf_data/theory_cards/40004001.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/40004001.yaml
@@ -1,7 +1,7 @@
 ID: 40_004_001
 PTO: 3
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 DAMP: 0
 IC: 1
 ModEv: EXA

--- a/nnpdf_data/nnpdf_data/theory_cards/40004002.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/40004002.yaml
@@ -1,7 +1,7 @@
 ID: 40_004_002
 PTO: 3
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 DAMP: 0
 IC: 1
 ModEv: EXA

--- a/nnpdf_data/nnpdf_data/theory_cards/40004003.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/40004003.yaml
@@ -1,7 +1,7 @@
 ID: 40_004_003
 PTO: 3
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 DAMP: 0
 IC: 1
 ModEv: EXA

--- a/nnpdf_data/nnpdf_data/theory_cards/40004004.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/40004004.yaml
@@ -1,7 +1,7 @@
 ID: 40_004_004
 PTO: 3
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 DAMP: 0
 IC: 1
 ModEv: EXA

--- a/nnpdf_data/nnpdf_data/theory_cards/40004005.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/40004005.yaml
@@ -1,7 +1,7 @@
 ID: 40_004_005
 PTO: 3
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 DAMP: 0
 IC: 1
 ModEv: EXA

--- a/nnpdf_data/nnpdf_data/theory_cards/40004006.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/40004006.yaml
@@ -1,7 +1,7 @@
 ID: 40_004_006
 PTO: 3
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 DAMP: 0
 IC: 1
 ModEv: EXA

--- a/nnpdf_data/nnpdf_data/theory_cards/40004007.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/40004007.yaml
@@ -1,7 +1,7 @@
 ID: 40_004_007
 PTO: 3
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 DAMP: 0
 IC: 1
 ModEv: EXA

--- a/nnpdf_data/nnpdf_data/theory_cards/40004008.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/40004008.yaml
@@ -1,7 +1,7 @@
 ID: 40_004_008
 PTO: 3
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 DAMP: 0
 IC: 1
 ModEv: EXA

--- a/nnpdf_data/nnpdf_data/theory_cards/40004009.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/40004009.yaml
@@ -1,7 +1,7 @@
 ID: 40_004_009
 PTO: 3
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 DAMP: 0
 IC: 1
 ModEv: EXA

--- a/nnpdf_data/nnpdf_data/theory_cards/40004010.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/40004010.yaml
@@ -1,7 +1,7 @@
 ID: 40_004_010
 PTO: 3
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 DAMP: 0
 IC: 1
 ModEv: EXA

--- a/nnpdf_data/nnpdf_data/theory_cards/40004011.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/40004011.yaml
@@ -1,7 +1,7 @@
 ID: 40_004_011
 PTO: 3
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 DAMP: 0
 IC: 1
 ModEv: EXA

--- a/nnpdf_data/nnpdf_data/theory_cards/40004012.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/40004012.yaml
@@ -1,7 +1,7 @@
 ID: 40_004_012
 PTO: 3
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 DAMP: 0
 IC: 1
 ModEv: EXA

--- a/nnpdf_data/nnpdf_data/theory_cards/401.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/401.yaml
@@ -46,3 +46,4 @@ MP: 0.938
 Comments: NNPDF4.0 NLO sv theory scheme B, (0.5, 0.5) point
 global_nx: 0
 EScaleVar: 1
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/402.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/402.yaml
@@ -46,3 +46,4 @@ MP: 0.938
 Comments: NNPDF4.0 NLO sv theory scheme B, (1.0, 0.5) point
 global_nx: 0
 EScaleVar: 1
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/403.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/403.yaml
@@ -46,3 +46,4 @@ MP: 0.938
 Comments: NNPDF4.0 NLO sv theory scheme B, (2.0, 0.5) point
 global_nx: 0
 EScaleVar: 1
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/407.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/407.yaml
@@ -46,3 +46,4 @@ MP: 0.938
 Comments: NNPDF4.0 NLO sv theory scheme B, (0.5, 2.0) point
 global_nx: 0
 EScaleVar: 1
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/408.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/408.yaml
@@ -46,3 +46,4 @@ MP: 0.938
 Comments: NNPDF4.0 NLO sv theory scheme B, (1.0, 2.0) point
 global_nx: 0
 EScaleVar: 1
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/409.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/409.yaml
@@ -46,3 +46,4 @@ MP: 0.938
 Comments: NNPDF4.0 NLO sv theory scheme B, (2.0, 2.0) point
 global_nx: 0
 EScaleVar: 1
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/410.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/410.yaml
@@ -46,3 +46,4 @@ MP: 0.938
 Comments: NNPDF4.0 NLO sv theory (scheme C), (0.5, 0.5) point
 global_nx: 0
 EScaleVar: 1
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/411.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/411.yaml
@@ -46,3 +46,4 @@ MP: 0.938
 Comments: NNPDF4.0 NLO sv theory (scheme C), (1.0, 0.5) point
 global_nx: 0
 EScaleVar: 1
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/41100000.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/41100000.yaml
@@ -22,7 +22,6 @@ MW: 80.398
 MZ: 91.1876
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: null
 NfFF: 4
 PTO: 2
 Q0: 1.0
@@ -44,4 +43,4 @@ mt: 172.5
 nfref: 5
 nf0: 3
 n3lo_cf_variation: 0
-n3lo_ad_variation: [0,0,0,0,0,0,0]
+n3lo_ad_variation: [0, 0, 0, 0, 0, 0, 0]

--- a/nnpdf_data/nnpdf_data/theory_cards/41100001.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/41100001.yaml
@@ -44,4 +44,4 @@ mt: 172.5
 nfref: 5
 nf0: 3
 n3lo_cf_variation: 0
-n3lo_ad_variation: [0,0,0,0,0,0,0]
+n3lo_ad_variation: [0, 0, 0, 0, 0, 0, 0]

--- a/nnpdf_data/nnpdf_data/theory_cards/41100002.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/41100002.yaml
@@ -44,4 +44,4 @@ mt: 172.5
 nfref: 5
 nf0: 3
 n3lo_cf_variation: 0
-n3lo_ad_variation: [0,0,0,0,0,0,0]
+n3lo_ad_variation: [0, 0, 0, 0, 0, 0, 0]

--- a/nnpdf_data/nnpdf_data/theory_cards/41100003.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/41100003.yaml
@@ -44,4 +44,4 @@ mt: 172.5
 nfref: 5
 nf0: 3
 n3lo_cf_variation: 0
-n3lo_ad_variation: [0,0,0,0,0,0,0]
+n3lo_ad_variation: [0, 0, 0, 0, 0, 0, 0]

--- a/nnpdf_data/nnpdf_data/theory_cards/41100004.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/41100004.yaml
@@ -22,7 +22,6 @@ MW: 80.398
 MZ: 91.1876
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: null
 NfFF: 4
 PTO: 2
 Q0: 1.0
@@ -44,4 +43,4 @@ mt: 172.5
 nfref: 5
 nf0: 3
 n3lo_cf_variation: 0
-n3lo_ad_variation: [0,0,0,0,0,0,0]
+n3lo_ad_variation: [0, 0, 0, 0, 0, 0, 0]

--- a/nnpdf_data/nnpdf_data/theory_cards/41100005.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/41100005.yaml
@@ -22,7 +22,6 @@ MW: 80.398
 MZ: 91.1876
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: null
 NfFF: 4
 PTO: 2
 Q0: 1.0
@@ -44,4 +43,4 @@ mt: 172.5
 nfref: 5
 nf0: 3
 n3lo_cf_variation: 0
-n3lo_ad_variation: [0,0,0,0,0,0,0]
+n3lo_ad_variation: [0, 0, 0, 0, 0, 0, 0]

--- a/nnpdf_data/nnpdf_data/theory_cards/41100006.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/41100006.yaml
@@ -44,4 +44,4 @@ mt: 172.5
 nfref: 5
 nf0: 3
 n3lo_cf_variation: 0
-n3lo_ad_variation: [0,0,0,0,0,0,0]
+n3lo_ad_variation: [0, 0, 0, 0, 0, 0, 0]

--- a/nnpdf_data/nnpdf_data/theory_cards/41100007.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/41100007.yaml
@@ -44,4 +44,4 @@ mt: 172.5
 nfref: 5
 nf0: 3
 n3lo_cf_variation: 0
-n3lo_ad_variation: [0,0,0,0,0,0,0]
+n3lo_ad_variation: [0, 0, 0, 0, 0, 0, 0]

--- a/nnpdf_data/nnpdf_data/theory_cards/41100008.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/41100008.yaml
@@ -44,4 +44,4 @@ mt: 172.5
 nfref: 5
 nf0: 3
 n3lo_cf_variation: 0
-n3lo_ad_variation: [0,0,0,0,0,0,0]
+n3lo_ad_variation: [0, 0, 0, 0, 0, 0, 0]

--- a/nnpdf_data/nnpdf_data/theory_cards/41100010.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/41100010.yaml
@@ -22,7 +22,6 @@ MW: 80.398
 MZ: 91.1876
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: null
 NfFF: 4
 PTO: 1
 Q0: 1.0
@@ -44,4 +43,4 @@ mt: 172.5
 nfref: 5
 nf0: 3
 n3lo_cf_variation: 0
-n3lo_ad_variation: [0,0,0,0,0,0,0]
+n3lo_ad_variation: [0, 0, 0, 0, 0, 0, 0]

--- a/nnpdf_data/nnpdf_data/theory_cards/41100011.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/41100011.yaml
@@ -44,4 +44,4 @@ mt: 172.5
 nfref: 5
 nf0: 3
 n3lo_cf_variation: 0
-n3lo_ad_variation: [0,0,0,0,0,0,0]
+n3lo_ad_variation: [0, 0, 0, 0, 0, 0, 0]

--- a/nnpdf_data/nnpdf_data/theory_cards/41100012.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/41100012.yaml
@@ -44,4 +44,4 @@ mt: 172.5
 nfref: 5
 nf0: 3
 n3lo_cf_variation: 0
-n3lo_ad_variation: [0,0,0,0,0,0,0]
+n3lo_ad_variation: [0, 0, 0, 0, 0, 0, 0]

--- a/nnpdf_data/nnpdf_data/theory_cards/41100013.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/41100013.yaml
@@ -44,4 +44,4 @@ mt: 172.5
 nfref: 5
 nf0: 3
 n3lo_cf_variation: 0
-n3lo_ad_variation: [0,0,0,0,0,0,0]
+n3lo_ad_variation: [0, 0, 0, 0, 0, 0, 0]

--- a/nnpdf_data/nnpdf_data/theory_cards/41100014.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/41100014.yaml
@@ -22,7 +22,6 @@ MW: 80.398
 MZ: 91.1876
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: null
 NfFF: 4
 PTO: 1
 Q0: 1.0
@@ -44,4 +43,4 @@ mt: 172.5
 nfref: 5
 nf0: 3
 n3lo_cf_variation: 0
-n3lo_ad_variation: [0,0,0,0,0,0,0]
+n3lo_ad_variation: [0, 0, 0, 0, 0, 0, 0]

--- a/nnpdf_data/nnpdf_data/theory_cards/41100015.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/41100015.yaml
@@ -22,7 +22,6 @@ MW: 80.398
 MZ: 91.1876
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: null
 NfFF: 4
 PTO: 1
 Q0: 1.0
@@ -44,4 +43,4 @@ mt: 172.5
 nfref: 5
 nf0: 3
 n3lo_cf_variation: 0
-n3lo_ad_variation: [0,0,0,0,0,0,0]
+n3lo_ad_variation: [0, 0, 0, 0, 0, 0, 0]

--- a/nnpdf_data/nnpdf_data/theory_cards/41100016.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/41100016.yaml
@@ -44,4 +44,4 @@ mt: 172.5
 nfref: 5
 nf0: 3
 n3lo_cf_variation: 0
-n3lo_ad_variation: [0,0,0,0,0,0,0]
+n3lo_ad_variation: [0, 0, 0, 0, 0, 0, 0]

--- a/nnpdf_data/nnpdf_data/theory_cards/41100017.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/41100017.yaml
@@ -44,4 +44,4 @@ mt: 172.5
 nfref: 5
 nf0: 3
 n3lo_cf_variation: 0
-n3lo_ad_variation: [0,0,0,0,0,0,0]
+n3lo_ad_variation: [0, 0, 0, 0, 0, 0, 0]

--- a/nnpdf_data/nnpdf_data/theory_cards/41100018.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/41100018.yaml
@@ -44,4 +44,4 @@ mt: 172.5
 nfref: 5
 nf0: 3
 n3lo_cf_variation: 0
-n3lo_ad_variation: [0,0,0,0,0,0,0]
+n3lo_ad_variation: [0, 0, 0, 0, 0, 0, 0]

--- a/nnpdf_data/nnpdf_data/theory_cards/41100020.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/41100020.yaml
@@ -22,7 +22,6 @@ MW: 80.398
 MZ: 91.1876
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: null
 NfFF: 4
 PTO: 0
 Q0: 1.0
@@ -44,4 +43,4 @@ mt: 172.5
 nfref: 5
 nf0: 3
 n3lo_cf_variation: 0
-n3lo_ad_variation: [0,0,0,0,0,0,0]
+n3lo_ad_variation: [0, 0, 0, 0, 0, 0, 0]

--- a/nnpdf_data/nnpdf_data/theory_cards/41100021.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/41100021.yaml
@@ -44,4 +44,4 @@ mt: 172.5
 nfref: 5
 nf0: 3
 n3lo_cf_variation: 0
-n3lo_ad_variation: [0,0,0,0,0,0,0]
+n3lo_ad_variation: [0, 0, 0, 0, 0, 0, 0]

--- a/nnpdf_data/nnpdf_data/theory_cards/41100022.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/41100022.yaml
@@ -44,4 +44,4 @@ mt: 172.5
 nfref: 5
 nf0: 3
 n3lo_cf_variation: 0
-n3lo_ad_variation: [0,0,0,0,0,0,0]
+n3lo_ad_variation: [0, 0, 0, 0, 0, 0, 0]

--- a/nnpdf_data/nnpdf_data/theory_cards/41100023.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/41100023.yaml
@@ -44,4 +44,4 @@ mt: 172.5
 nfref: 5
 nf0: 3
 n3lo_cf_variation: 0
-n3lo_ad_variation: [0,0,0,0,0,0,0]
+n3lo_ad_variation: [0, 0, 0, 0, 0, 0, 0]

--- a/nnpdf_data/nnpdf_data/theory_cards/41100024.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/41100024.yaml
@@ -22,7 +22,6 @@ MW: 80.398
 MZ: 91.1876
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: null
 NfFF: 4
 PTO: 0
 Q0: 1.0
@@ -44,4 +43,4 @@ mt: 172.5
 nfref: 5
 nf0: 3
 n3lo_cf_variation: 0
-n3lo_ad_variation: [0,0,0,0,0,0,0]
+n3lo_ad_variation: [0, 0, 0, 0, 0, 0, 0]

--- a/nnpdf_data/nnpdf_data/theory_cards/41100025.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/41100025.yaml
@@ -22,7 +22,6 @@ MW: 80.398
 MZ: 91.1876
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: null
 NfFF: 4
 PTO: 0
 Q0: 1.0
@@ -44,4 +43,4 @@ mt: 172.5
 nfref: 5
 nf0: 3
 n3lo_cf_variation: 0
-n3lo_ad_variation: [0,0,0,0,0,0,0]
+n3lo_ad_variation: [0, 0, 0, 0, 0, 0, 0]

--- a/nnpdf_data/nnpdf_data/theory_cards/41100026.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/41100026.yaml
@@ -44,4 +44,4 @@ mt: 172.5
 nfref: 5
 nf0: 3
 n3lo_cf_variation: 0
-n3lo_ad_variation: [0,0,0,0,0,0,0]
+n3lo_ad_variation: [0, 0, 0, 0, 0, 0, 0]

--- a/nnpdf_data/nnpdf_data/theory_cards/41100027.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/41100027.yaml
@@ -44,4 +44,4 @@ mt: 172.5
 nfref: 5
 nf0: 3
 n3lo_cf_variation: 0
-n3lo_ad_variation: [0,0,0,0,0,0,0]
+n3lo_ad_variation: [0, 0, 0, 0, 0, 0, 0]

--- a/nnpdf_data/nnpdf_data/theory_cards/41100028.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/41100028.yaml
@@ -44,4 +44,4 @@ mt: 172.5
 nfref: 5
 nf0: 3
 n3lo_cf_variation: 0
-n3lo_ad_variation: [0,0,0,0,0,0,0]
+n3lo_ad_variation: [0, 0, 0, 0, 0, 0, 0]

--- a/nnpdf_data/nnpdf_data/theory_cards/41100054.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/41100054.yaml
@@ -1,4 +1,5 @@
-Comments: Polarised NNPDF2.0 NNLO alphas=0.118 with nFONLL, XIF=1.0 XIR=0.5 only for JETS and DIJETS
+Comments: Polarised NNPDF2.0 NNLO alphas=0.118 with nFONLL, XIF=1.0 XIR=0.5 only for
+  JETS and DIJETS
 ID: 41_100_054
 XIF: 1.0
 XIR: 0.5
@@ -22,7 +23,6 @@ MW: 80.398
 MZ: 91.1876
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: null
 NfFF: 4
 PTO: 2
 Q0: 1.0
@@ -44,4 +44,4 @@ mt: 172.5
 nfref: 5
 nf0: 3
 n3lo_cf_variation: 0
-n3lo_ad_variation: [0,0,0,0,0,0,0]
+n3lo_ad_variation: [0, 0, 0, 0, 0, 0, 0]

--- a/nnpdf_data/nnpdf_data/theory_cards/41100055.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/41100055.yaml
@@ -1,4 +1,5 @@
-Comments: Polarised NNPDF2.0 NNLO alphas=0.118 with nFONLL, XIF=1.0 XIR=2.0 only for JETS and DIJETS
+Comments: Polarised NNPDF2.0 NNLO alphas=0.118 with nFONLL, XIF=1.0 XIR=2.0 only for
+  JETS and DIJETS
 ID: 41_100_055
 XIF: 1.0
 XIR: 2.0
@@ -22,7 +23,6 @@ MW: 80.398
 MZ: 91.1876
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: null
 NfFF: 4
 PTO: 2
 Q0: 1.0
@@ -44,4 +44,4 @@ mt: 172.5
 nfref: 5
 nf0: 3
 n3lo_cf_variation: 0
-n3lo_ad_variation: [0,0,0,0,0,0,0]
+n3lo_ad_variation: [0, 0, 0, 0, 0, 0, 0]

--- a/nnpdf_data/nnpdf_data/theory_cards/412.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/412.yaml
@@ -46,3 +46,4 @@ MP: 0.938
 Comments: NNPDF4.0 NLO sv theory (scheme C), (2.0, 0.5) point
 global_nx: 0
 EScaleVar: 1
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/416.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/416.yaml
@@ -46,3 +46,4 @@ MP: 0.938
 Comments: NNPDF4.0 NLO sv theory (scheme C), (0.5, 2.0) point
 global_nx: 0
 EScaleVar: 1
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/417.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/417.yaml
@@ -46,3 +46,4 @@ MP: 0.938
 Comments: NNPDF4.0 NLO sv theory (scheme C), (1.0, 2.0) point
 global_nx: 0
 EScaleVar: 1
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/418.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/418.yaml
@@ -46,3 +46,4 @@ MP: 0.938
 Comments: NNPDF4.0 NLO sv theory (scheme C), (2.0, 2.0) point
 global_nx: 0
 EScaleVar: 1
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/420.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/420.yaml
@@ -46,3 +46,4 @@ MP: 0.938
 Comments: NNPDF4.0 NNLO sv theory scheme B, (0.5, 0.5) point
 global_nx: 0
 EScaleVar: 1
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/421.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/421.yaml
@@ -46,3 +46,4 @@ MP: 0.938
 Comments: NNPDF4.0 NNLO sv theory scheme B, (1.0, 0.5) point
 global_nx: 0
 EScaleVar: 1
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/422.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/422.yaml
@@ -46,3 +46,4 @@ MP: 0.938
 Comments: NNPDF4.0 NNLO sv theory scheme B, (2.0, 0.5) point
 global_nx: 0
 EScaleVar: 1
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/426.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/426.yaml
@@ -46,3 +46,4 @@ MP: 0.938
 Comments: NNPDF4.0 NNLO sv theory scheme B, (0.5, 2.0) point
 global_nx: 0
 EScaleVar: 1
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/427.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/427.yaml
@@ -46,3 +46,4 @@ MP: 0.938
 Comments: NNPDF4.0 NNLO sv theory scheme B, (1.0, 2.0) point
 global_nx: 0
 EScaleVar: 1
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/428.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/428.yaml
@@ -46,3 +46,4 @@ MP: 0.938
 Comments: NNPDF4.0 NNLO sv theory scheme B, (2.0, 2.0) point
 global_nx: 0
 EScaleVar: 1
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/430.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/430.yaml
@@ -46,3 +46,4 @@ MP: 0.938
 Comments: NNPDF4.0 NNLO sv theory (scheme C), (0.5, 0.5) point
 global_nx: 0
 EScaleVar: 1
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/431.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/431.yaml
@@ -46,3 +46,4 @@ MP: 0.938
 Comments: NNPDF4.0 NNLO sv theory (scheme C), (1.0, 0.5) point
 global_nx: 0
 EScaleVar: 1
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/432.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/432.yaml
@@ -46,3 +46,4 @@ MP: 0.938
 Comments: NNPDF4.0 NNLO sv theory (scheme C), (2.0, 0.5) point
 global_nx: 0
 EScaleVar: 1
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/436.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/436.yaml
@@ -46,3 +46,4 @@ MP: 0.938
 Comments: NNPDF4.0 NNLO sv theory (scheme C), (0.5, 2.0) point
 global_nx: 0
 EScaleVar: 1
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/437.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/437.yaml
@@ -46,3 +46,4 @@ MP: 0.938
 Comments: NNPDF4.0 NNLO sv theory (scheme C), (1.0, 2.0) point
 global_nx: 0
 EScaleVar: 1
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/438.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/438.yaml
@@ -46,3 +46,4 @@ MP: 0.938
 Comments: NNPDF4.0 NNLO sv theory (scheme C), (2.0, 2.0) point
 global_nx: 0
 EScaleVar: 1
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/601.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/601.yaml
@@ -46,3 +46,4 @@ MP: 0.938
 Comments: 600 with SV
 global_nx: 0
 EScaleVar: 1
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/602.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/602.yaml
@@ -46,3 +46,4 @@ MP: 0.938
 Comments: 600 with SV
 global_nx: 0
 EScaleVar: 1
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/603.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/603.yaml
@@ -46,3 +46,4 @@ MP: 0.938
 Comments: 600 with SV
 global_nx: 0
 EScaleVar: 1
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/607.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/607.yaml
@@ -46,3 +46,4 @@ MP: 0.938
 Comments: 600 with SV
 global_nx: 0
 EScaleVar: 1
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/608.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/608.yaml
@@ -46,3 +46,4 @@ MP: 0.938
 Comments: 600 with SV
 global_nx: 0
 EScaleVar: 1
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/609.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/609.yaml
@@ -46,3 +46,4 @@ MP: 0.938
 Comments: 600 with SV
 global_nx: 0
 EScaleVar: 1
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/66.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/66.yaml
@@ -46,3 +46,4 @@ MP: 0.938
 Comments: NNPDF3.1 NLO FC xiF=xiR=0.5
 global_nx: 0
 EScaleVar: 1
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/67.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/67.yaml
@@ -46,3 +46,4 @@ MP: 0.938
 Comments: NNPDF3.1 NLO FC xiF=xiR=2.0
 global_nx: 0
 EScaleVar: 1
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/704.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/704.yaml
@@ -46,3 +46,4 @@ MP: 0.938
 Comments: NNLO nFONLL theory with (XIR, XIF) = (0.5, 0.5)
 global_nx: 0
 EScaleVar: 1
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/705.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/705.yaml
@@ -46,3 +46,4 @@ MP: 0.938
 Comments: NNLO nFONLL theory with (XIR, XIF) = (1.0, 0.5)
 global_nx: 0
 EScaleVar: 1
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/706.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/706.yaml
@@ -46,3 +46,4 @@ MP: 0.938
 Comments: NNLO nFONLL theory with (XIR, XIF) = (2.0, 0.5)
 global_nx: 0
 EScaleVar: 1
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/710.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/710.yaml
@@ -46,3 +46,4 @@ MP: 0.938
 Comments: NNLO nFONLL theory with (XIR, XIF) = (0.5, 2.0)
 global_nx: 0
 EScaleVar: 1
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/711.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/711.yaml
@@ -46,3 +46,4 @@ MP: 0.938
 Comments: NNLO nFONLL theory with (XIR, XIF) = (1.0, 2.0)
 global_nx: 0
 EScaleVar: 1
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/712.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/712.yaml
@@ -46,3 +46,4 @@ MP: 0.938
 Comments: NNLO nFONLL theory with (XIR, XIF) = (2.0, 2.0)
 global_nx: 0
 EScaleVar: 1
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/713.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/713.yaml
@@ -46,3 +46,4 @@ MP: 0.938
 Comments: NLO sv theory with xir,xif = (0.5,0.5)
 global_nx: 0
 EScaleVar: 1
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/714.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/714.yaml
@@ -46,3 +46,4 @@ MP: 0.938
 Comments: NLO sv theory with xir,xif = (1.0,0.5)
 global_nx: 0
 EScaleVar: 1
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/715.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/715.yaml
@@ -46,3 +46,4 @@ MP: 0.938
 Comments: NLO sv theory with xir,xif = (2.0,0.5)
 global_nx: 0
 EScaleVar: 1
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/719.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/719.yaml
@@ -46,3 +46,4 @@ MP: 0.938
 Comments: NLO sv theory with xir,xif = (0.5,2.0)
 global_nx: 0
 EScaleVar: 1
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/720.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/720.yaml
@@ -46,3 +46,4 @@ MP: 0.938
 Comments: NLO sv theory with xir,xif = (1.0,2.0)
 global_nx: 0
 EScaleVar: 1
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/721.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/721.yaml
@@ -46,3 +46,4 @@ MP: 0.938
 Comments: NLO sv theory with xir,xif = (2.0,2.0)
 global_nx: 0
 EScaleVar: 1
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/722.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/722.yaml
@@ -1,5 +1,6 @@
 ID: 722
-Comments: NNPDF4.0 N3LO alphas=0.118 with new pipeline, no N3LO ad variation, XIF=1.0, XIR=1.0
+Comments: NNPDF4.0 N3LO alphas=0.118 with new pipeline, no N3LO ad variation, XIF=1.0,
+  XIR=1.0
 CKM:
 - 0.97428
 - 0.2253
@@ -12,7 +13,7 @@ CKM:
 - 0.999152
 DAMP: 0
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -21,7 +22,6 @@ MW: 80.398
 MZ: 91.1876
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65
@@ -44,5 +44,5 @@ mc: 1.51
 mt: 172.5
 nfref: 5
 nf0: 4
-n3lo_ad_variation: [0,0,0,0,0,0,0]
+n3lo_ad_variation: [0, 0, 0, 0, 0, 0, 0]
 n3lo_cf_variation: 0

--- a/nnpdf_data/nnpdf_data/theory_cards/723.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/723.yaml
@@ -12,7 +12,7 @@ Comments: NNPDF4.0 N3LO alphas=0.118, N3LO ad variation [1, 0, 0, 0, 0, 0, 0]
 DAMP: 0
 EScaleVar: 1
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -23,7 +23,6 @@ MZ: 91.1876
 MaxNfAs: 5
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65

--- a/nnpdf_data/nnpdf_data/theory_cards/724.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/724.yaml
@@ -12,7 +12,7 @@ Comments: NNPDF4.0 N3LO alphas=0.118, N3LO ad variation [2, 0, 0, 0, 0, 0, 0]
 DAMP: 0
 EScaleVar: 1
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -23,7 +23,6 @@ MZ: 91.1876
 MaxNfAs: 5
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65

--- a/nnpdf_data/nnpdf_data/theory_cards/725.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/725.yaml
@@ -12,7 +12,7 @@ Comments: NNPDF4.0 N3LO alphas=0.118, N3LO ad variation [3, 0, 0, 0, 0, 0, 0]
 DAMP: 0
 EScaleVar: 1
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -23,7 +23,6 @@ MZ: 91.1876
 MaxNfAs: 5
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65

--- a/nnpdf_data/nnpdf_data/theory_cards/726.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/726.yaml
@@ -12,7 +12,7 @@ Comments: NNPDF4.0 N3LO alphas=0.118, N3LO ad variation [4, 0, 0, 0, 0, 0, 0]
 DAMP: 0
 EScaleVar: 1
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -23,7 +23,6 @@ MZ: 91.1876
 MaxNfAs: 5
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65

--- a/nnpdf_data/nnpdf_data/theory_cards/727.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/727.yaml
@@ -12,7 +12,7 @@ Comments: NNPDF4.0 N3LO alphas=0.118, N3LO ad variation [5, 0, 0, 0, 0, 0, 0]
 DAMP: 0
 EScaleVar: 1
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -23,7 +23,6 @@ MZ: 91.1876
 MaxNfAs: 5
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65

--- a/nnpdf_data/nnpdf_data/theory_cards/728.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/728.yaml
@@ -12,7 +12,7 @@ Comments: NNPDF4.0 N3LO alphas=0.118, N3LO ad variation [6, 0, 0, 0, 0, 0, 0]
 DAMP: 0
 EScaleVar: 1
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -23,7 +23,6 @@ MZ: 91.1876
 MaxNfAs: 5
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65

--- a/nnpdf_data/nnpdf_data/theory_cards/729.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/729.yaml
@@ -12,7 +12,7 @@ Comments: NNPDF4.0 N3LO alphas=0.118, N3LO ad variation [7, 0, 0, 0, 0, 0, 0]
 DAMP: 0
 EScaleVar: 1
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -23,7 +23,6 @@ MZ: 91.1876
 MaxNfAs: 5
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65

--- a/nnpdf_data/nnpdf_data/theory_cards/730.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/730.yaml
@@ -12,7 +12,7 @@ Comments: NNPDF4.0 N3LO alphas=0.118, N3LO ad variation [8, 0, 0, 0, 0, 0, 0]
 DAMP: 0
 EScaleVar: 1
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -23,7 +23,6 @@ MZ: 91.1876
 MaxNfAs: 5
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65

--- a/nnpdf_data/nnpdf_data/theory_cards/731.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/731.yaml
@@ -12,7 +12,7 @@ Comments: NNPDF4.0 N3LO alphas=0.118, N3LO ad variation [9, 0, 0, 0, 0, 0, 0]
 DAMP: 0
 EScaleVar: 1
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -23,7 +23,6 @@ MZ: 91.1876
 MaxNfAs: 5
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65

--- a/nnpdf_data/nnpdf_data/theory_cards/732.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/732.yaml
@@ -12,7 +12,7 @@ Comments: NNPDF4.0 N3LO alphas=0.118, N3LO ad variation [10, 0, 0, 0, 0, 0, 0]
 DAMP: 0
 EScaleVar: 1
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -23,7 +23,6 @@ MZ: 91.1876
 MaxNfAs: 5
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65

--- a/nnpdf_data/nnpdf_data/theory_cards/733.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/733.yaml
@@ -12,7 +12,7 @@ Comments: NNPDF4.0 N3LO alphas=0.118, N3LO ad variation [11, 0, 0, 0, 0, 0, 0]
 DAMP: 0
 EScaleVar: 1
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -23,7 +23,6 @@ MZ: 91.1876
 MaxNfAs: 5
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65

--- a/nnpdf_data/nnpdf_data/theory_cards/734.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/734.yaml
@@ -12,7 +12,7 @@ Comments: NNPDF4.0 N3LO alphas=0.118, N3LO ad variation [12, 0, 0, 0, 0, 0, 0]
 DAMP: 0
 EScaleVar: 1
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -23,7 +23,6 @@ MZ: 91.1876
 MaxNfAs: 5
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65

--- a/nnpdf_data/nnpdf_data/theory_cards/735.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/735.yaml
@@ -12,7 +12,7 @@ Comments: NNPDF4.0 N3LO alphas=0.118, N3LO ad variation [13, 0, 0, 0, 0, 0, 0]
 DAMP: 0
 EScaleVar: 1
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -23,7 +23,6 @@ MZ: 91.1876
 MaxNfAs: 5
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65

--- a/nnpdf_data/nnpdf_data/theory_cards/736.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/736.yaml
@@ -12,7 +12,7 @@ Comments: NNPDF4.0 N3LO alphas=0.118, N3LO ad variation [14, 0, 0, 0, 0, 0, 0]
 DAMP: 0
 EScaleVar: 1
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -23,7 +23,6 @@ MZ: 91.1876
 MaxNfAs: 5
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65

--- a/nnpdf_data/nnpdf_data/theory_cards/737.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/737.yaml
@@ -12,7 +12,7 @@ Comments: NNPDF4.0 N3LO alphas=0.118, N3LO ad variation [15, 0, 0, 0, 0, 0, 0]
 DAMP: 0
 EScaleVar: 1
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -23,7 +23,6 @@ MZ: 91.1876
 MaxNfAs: 5
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65

--- a/nnpdf_data/nnpdf_data/theory_cards/738.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/738.yaml
@@ -12,7 +12,7 @@ Comments: NNPDF4.0 N3LO alphas=0.118, N3LO ad variation [16, 0, 0, 0, 0, 0, 0]
 DAMP: 0
 EScaleVar: 1
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -23,7 +23,6 @@ MZ: 91.1876
 MaxNfAs: 5
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65

--- a/nnpdf_data/nnpdf_data/theory_cards/739.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/739.yaml
@@ -12,7 +12,7 @@ Comments: NNPDF4.0 N3LO alphas=0.118, N3LO ad variation [17, 0, 0, 0, 0, 0, 0]
 DAMP: 0
 EScaleVar: 1
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -23,7 +23,6 @@ MZ: 91.1876
 MaxNfAs: 5
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65

--- a/nnpdf_data/nnpdf_data/theory_cards/740.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/740.yaml
@@ -12,7 +12,7 @@ Comments: NNPDF4.0 N3LO alphas=0.118, N3LO ad variation [18, 0, 0, 0, 0, 0, 0]
 DAMP: 0
 EScaleVar: 1
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -23,7 +23,6 @@ MZ: 91.1876
 MaxNfAs: 5
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65

--- a/nnpdf_data/nnpdf_data/theory_cards/741.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/741.yaml
@@ -12,7 +12,7 @@ Comments: NNPDF4.0 N3LO alphas=0.118, N3LO ad variation [19, 0, 0, 0, 0, 0, 0]
 DAMP: 0
 EScaleVar: 1
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -23,7 +23,6 @@ MZ: 91.1876
 MaxNfAs: 5
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65

--- a/nnpdf_data/nnpdf_data/theory_cards/742.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/742.yaml
@@ -12,7 +12,7 @@ Comments: NNPDF4.0 N3LO alphas=0.118, N3LO ad variation [0, 1, 0, 0, 0, 0, 0]
 DAMP: 0
 EScaleVar: 1
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -23,7 +23,6 @@ MZ: 91.1876
 MaxNfAs: 5
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65

--- a/nnpdf_data/nnpdf_data/theory_cards/743.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/743.yaml
@@ -12,7 +12,7 @@ Comments: NNPDF4.0 N3LO alphas=0.118, N3LO ad variation [0, 2, 0, 0, 0, 0, 0]
 DAMP: 0
 EScaleVar: 1
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -23,7 +23,6 @@ MZ: 91.1876
 MaxNfAs: 5
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65

--- a/nnpdf_data/nnpdf_data/theory_cards/744.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/744.yaml
@@ -12,7 +12,7 @@ Comments: NNPDF4.0 N3LO alphas=0.118, N3LO ad variation [0, 3, 0, 0, 0, 0, 0]
 DAMP: 0
 EScaleVar: 1
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -23,7 +23,6 @@ MZ: 91.1876
 MaxNfAs: 5
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65

--- a/nnpdf_data/nnpdf_data/theory_cards/745.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/745.yaml
@@ -12,7 +12,7 @@ Comments: NNPDF4.0 N3LO alphas=0.118, N3LO ad variation [0, 4, 0, 0, 0, 0, 0]
 DAMP: 0
 EScaleVar: 1
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -23,7 +23,6 @@ MZ: 91.1876
 MaxNfAs: 5
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65

--- a/nnpdf_data/nnpdf_data/theory_cards/746.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/746.yaml
@@ -12,7 +12,7 @@ Comments: NNPDF4.0 N3LO alphas=0.118, N3LO ad variation [0, 5, 0, 0, 0, 0, 0]
 DAMP: 0
 EScaleVar: 1
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -23,7 +23,6 @@ MZ: 91.1876
 MaxNfAs: 5
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65

--- a/nnpdf_data/nnpdf_data/theory_cards/747.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/747.yaml
@@ -12,7 +12,7 @@ Comments: NNPDF4.0 N3LO alphas=0.118, N3LO ad variation [0, 6, 0, 0, 0, 0, 0]
 DAMP: 0
 EScaleVar: 1
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -23,7 +23,6 @@ MZ: 91.1876
 MaxNfAs: 5
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65

--- a/nnpdf_data/nnpdf_data/theory_cards/748.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/748.yaml
@@ -12,7 +12,7 @@ Comments: NNPDF4.0 N3LO alphas=0.118, N3LO ad variation [0, 7, 0, 0, 0, 0, 0]
 DAMP: 0
 EScaleVar: 1
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -23,7 +23,6 @@ MZ: 91.1876
 MaxNfAs: 5
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65

--- a/nnpdf_data/nnpdf_data/theory_cards/749.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/749.yaml
@@ -12,7 +12,7 @@ Comments: NNPDF4.0 N3LO alphas=0.118, N3LO ad variation [0, 8, 0, 0, 0, 0, 0]
 DAMP: 0
 EScaleVar: 1
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -23,7 +23,6 @@ MZ: 91.1876
 MaxNfAs: 5
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65

--- a/nnpdf_data/nnpdf_data/theory_cards/750.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/750.yaml
@@ -12,7 +12,7 @@ Comments: NNPDF4.0 N3LO alphas=0.118, N3LO ad variation [0, 9, 0, 0, 0, 0, 0]
 DAMP: 0
 EScaleVar: 1
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -23,7 +23,6 @@ MZ: 91.1876
 MaxNfAs: 5
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65

--- a/nnpdf_data/nnpdf_data/theory_cards/751.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/751.yaml
@@ -12,7 +12,7 @@ Comments: NNPDF4.0 N3LO alphas=0.118, N3LO ad variation [0, 10, 0, 0, 0, 0, 0]
 DAMP: 0
 EScaleVar: 1
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -23,7 +23,6 @@ MZ: 91.1876
 MaxNfAs: 5
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65

--- a/nnpdf_data/nnpdf_data/theory_cards/752.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/752.yaml
@@ -12,7 +12,7 @@ Comments: NNPDF4.0 N3LO alphas=0.118, N3LO ad variation [0, 11, 0, 0, 0, 0, 0]
 DAMP: 0
 EScaleVar: 1
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -23,7 +23,6 @@ MZ: 91.1876
 MaxNfAs: 5
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65

--- a/nnpdf_data/nnpdf_data/theory_cards/753.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/753.yaml
@@ -12,7 +12,7 @@ Comments: NNPDF4.0 N3LO alphas=0.118, N3LO ad variation [0, 12, 0, 0, 0, 0, 0]
 DAMP: 0
 EScaleVar: 1
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -23,7 +23,6 @@ MZ: 91.1876
 MaxNfAs: 5
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65

--- a/nnpdf_data/nnpdf_data/theory_cards/754.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/754.yaml
@@ -12,7 +12,7 @@ Comments: NNPDF4.0 N3LO alphas=0.118, N3LO ad variation [0, 13, 0, 0, 0, 0, 0]
 DAMP: 0
 EScaleVar: 1
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -23,7 +23,6 @@ MZ: 91.1876
 MaxNfAs: 5
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65

--- a/nnpdf_data/nnpdf_data/theory_cards/755.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/755.yaml
@@ -12,7 +12,7 @@ Comments: NNPDF4.0 N3LO alphas=0.118, N3LO ad variation [0, 14, 0, 0, 0, 0, 0]
 DAMP: 0
 EScaleVar: 1
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -23,7 +23,6 @@ MZ: 91.1876
 MaxNfAs: 5
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65

--- a/nnpdf_data/nnpdf_data/theory_cards/756.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/756.yaml
@@ -12,7 +12,7 @@ Comments: NNPDF4.0 N3LO alphas=0.118, N3LO ad variation [0, 15, 0, 0, 0, 0, 0]
 DAMP: 0
 EScaleVar: 1
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -23,7 +23,6 @@ MZ: 91.1876
 MaxNfAs: 5
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65

--- a/nnpdf_data/nnpdf_data/theory_cards/757.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/757.yaml
@@ -12,7 +12,7 @@ Comments: NNPDF4.0 N3LO alphas=0.118, N3LO ad variation [0, 16, 0, 0, 0, 0, 0]
 DAMP: 0
 EScaleVar: 1
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -23,7 +23,6 @@ MZ: 91.1876
 MaxNfAs: 5
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65

--- a/nnpdf_data/nnpdf_data/theory_cards/758.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/758.yaml
@@ -12,7 +12,7 @@ Comments: NNPDF4.0 N3LO alphas=0.118, N3LO ad variation [0, 17, 0, 0, 0, 0, 0]
 DAMP: 0
 EScaleVar: 1
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -23,7 +23,6 @@ MZ: 91.1876
 MaxNfAs: 5
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65

--- a/nnpdf_data/nnpdf_data/theory_cards/759.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/759.yaml
@@ -12,7 +12,7 @@ Comments: NNPDF4.0 N3LO alphas=0.118, N3LO ad variation [0, 18, 0, 0, 0, 0, 0]
 DAMP: 0
 EScaleVar: 1
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -23,7 +23,6 @@ MZ: 91.1876
 MaxNfAs: 5
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65

--- a/nnpdf_data/nnpdf_data/theory_cards/760.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/760.yaml
@@ -12,7 +12,7 @@ Comments: NNPDF4.0 N3LO alphas=0.118, N3LO ad variation [0, 19, 0, 0, 0, 0, 0]
 DAMP: 0
 EScaleVar: 1
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -23,7 +23,6 @@ MZ: 91.1876
 MaxNfAs: 5
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65

--- a/nnpdf_data/nnpdf_data/theory_cards/761.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/761.yaml
@@ -12,7 +12,7 @@ Comments: NNPDF4.0 N3LO alphas=0.118, N3LO ad variation [0, 20, 0, 0, 0, 0, 0]
 DAMP: 0
 EScaleVar: 1
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -23,7 +23,6 @@ MZ: 91.1876
 MaxNfAs: 5
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65

--- a/nnpdf_data/nnpdf_data/theory_cards/762.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/762.yaml
@@ -12,7 +12,7 @@ Comments: NNPDF4.0 N3LO alphas=0.118, N3LO ad variation [0, 21, 0, 0, 0, 0, 0]
 DAMP: 0
 EScaleVar: 1
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -23,7 +23,6 @@ MZ: 91.1876
 MaxNfAs: 5
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65

--- a/nnpdf_data/nnpdf_data/theory_cards/763.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/763.yaml
@@ -12,7 +12,7 @@ Comments: NNPDF4.0 N3LO alphas=0.118, N3LO ad variation [0, 0, 1, 0, 0, 0, 0]
 DAMP: 0
 EScaleVar: 1
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -23,7 +23,6 @@ MZ: 91.1876
 MaxNfAs: 5
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65

--- a/nnpdf_data/nnpdf_data/theory_cards/764.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/764.yaml
@@ -12,7 +12,7 @@ Comments: NNPDF4.0 N3LO alphas=0.118, N3LO ad variation [0, 0, 2, 0, 0, 0, 0]
 DAMP: 0
 EScaleVar: 1
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -23,7 +23,6 @@ MZ: 91.1876
 MaxNfAs: 5
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65

--- a/nnpdf_data/nnpdf_data/theory_cards/765.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/765.yaml
@@ -12,7 +12,7 @@ Comments: NNPDF4.0 N3LO alphas=0.118, N3LO ad variation [0, 0, 3, 0, 0, 0, 0]
 DAMP: 0
 EScaleVar: 1
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -23,7 +23,6 @@ MZ: 91.1876
 MaxNfAs: 5
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65

--- a/nnpdf_data/nnpdf_data/theory_cards/766.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/766.yaml
@@ -12,7 +12,7 @@ Comments: NNPDF4.0 N3LO alphas=0.118, N3LO ad variation [0, 0, 4, 0, 0, 0, 0]
 DAMP: 0
 EScaleVar: 1
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -23,7 +23,6 @@ MZ: 91.1876
 MaxNfAs: 5
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65

--- a/nnpdf_data/nnpdf_data/theory_cards/767.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/767.yaml
@@ -12,7 +12,7 @@ Comments: NNPDF4.0 N3LO alphas=0.118, N3LO ad variation [0, 0, 5, 0, 0, 0, 0]
 DAMP: 0
 EScaleVar: 1
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -23,7 +23,6 @@ MZ: 91.1876
 MaxNfAs: 5
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65

--- a/nnpdf_data/nnpdf_data/theory_cards/768.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/768.yaml
@@ -12,7 +12,7 @@ Comments: NNPDF4.0 N3LO alphas=0.118, N3LO ad variation [0, 0, 6, 0, 0, 0, 0]
 DAMP: 0
 EScaleVar: 1
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -23,7 +23,6 @@ MZ: 91.1876
 MaxNfAs: 5
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65

--- a/nnpdf_data/nnpdf_data/theory_cards/769.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/769.yaml
@@ -12,7 +12,7 @@ Comments: NNPDF4.0 N3LO alphas=0.118, N3LO ad variation [0, 0, 7, 0, 0, 0, 0]
 DAMP: 0
 EScaleVar: 1
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -23,7 +23,6 @@ MZ: 91.1876
 MaxNfAs: 5
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65

--- a/nnpdf_data/nnpdf_data/theory_cards/770.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/770.yaml
@@ -12,7 +12,7 @@ Comments: NNPDF4.0 N3LO alphas=0.118, N3LO ad variation [0, 0, 8, 0, 0, 0, 0]
 DAMP: 0
 EScaleVar: 1
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -23,7 +23,6 @@ MZ: 91.1876
 MaxNfAs: 5
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65

--- a/nnpdf_data/nnpdf_data/theory_cards/771.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/771.yaml
@@ -12,7 +12,7 @@ Comments: NNPDF4.0 N3LO alphas=0.118, N3LO ad variation [0, 0, 9, 0, 0, 0, 0]
 DAMP: 0
 EScaleVar: 1
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -23,7 +23,6 @@ MZ: 91.1876
 MaxNfAs: 5
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65

--- a/nnpdf_data/nnpdf_data/theory_cards/772.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/772.yaml
@@ -12,7 +12,7 @@ Comments: NNPDF4.0 N3LO alphas=0.118, N3LO ad variation [0, 0, 10, 0, 0, 0, 0]
 DAMP: 0
 EScaleVar: 1
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -23,7 +23,6 @@ MZ: 91.1876
 MaxNfAs: 5
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65

--- a/nnpdf_data/nnpdf_data/theory_cards/773.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/773.yaml
@@ -12,7 +12,7 @@ Comments: NNPDF4.0 N3LO alphas=0.118, N3LO ad variation [0, 0, 11, 0, 0, 0, 0]
 DAMP: 0
 EScaleVar: 1
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -23,7 +23,6 @@ MZ: 91.1876
 MaxNfAs: 5
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65

--- a/nnpdf_data/nnpdf_data/theory_cards/774.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/774.yaml
@@ -12,7 +12,7 @@ Comments: NNPDF4.0 N3LO alphas=0.118, N3LO ad variation [0, 0, 12, 0, 0, 0, 0]
 DAMP: 0
 EScaleVar: 1
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -23,7 +23,6 @@ MZ: 91.1876
 MaxNfAs: 5
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65

--- a/nnpdf_data/nnpdf_data/theory_cards/775.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/775.yaml
@@ -12,7 +12,7 @@ Comments: NNPDF4.0 N3LO alphas=0.118, N3LO ad variation [0, 0, 13, 0, 0, 0, 0]
 DAMP: 0
 EScaleVar: 1
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -23,7 +23,6 @@ MZ: 91.1876
 MaxNfAs: 5
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65

--- a/nnpdf_data/nnpdf_data/theory_cards/776.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/776.yaml
@@ -12,7 +12,7 @@ Comments: NNPDF4.0 N3LO alphas=0.118, N3LO ad variation [0, 0, 14, 0, 0, 0, 0]
 DAMP: 0
 EScaleVar: 1
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -23,7 +23,6 @@ MZ: 91.1876
 MaxNfAs: 5
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65

--- a/nnpdf_data/nnpdf_data/theory_cards/777.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/777.yaml
@@ -12,7 +12,7 @@ Comments: NNPDF4.0 N3LO alphas=0.118, N3LO ad variation [0, 0, 15, 0, 0, 0, 0]
 DAMP: 0
 EScaleVar: 1
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -23,7 +23,6 @@ MZ: 91.1876
 MaxNfAs: 5
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65

--- a/nnpdf_data/nnpdf_data/theory_cards/778.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/778.yaml
@@ -12,7 +12,7 @@ Comments: NNPDF4.0 N3LO alphas=0.118, N3LO ad variation [0, 0, 0, 1, 0, 0, 0]
 DAMP: 0
 EScaleVar: 1
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -23,7 +23,6 @@ MZ: 91.1876
 MaxNfAs: 5
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65

--- a/nnpdf_data/nnpdf_data/theory_cards/779.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/779.yaml
@@ -12,7 +12,7 @@ Comments: NNPDF4.0 N3LO alphas=0.118, N3LO ad variation [0, 0, 0, 2, 0, 0, 0]
 DAMP: 0
 EScaleVar: 1
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -23,7 +23,6 @@ MZ: 91.1876
 MaxNfAs: 5
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65

--- a/nnpdf_data/nnpdf_data/theory_cards/780.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/780.yaml
@@ -12,7 +12,7 @@ Comments: NNPDF4.0 N3LO alphas=0.118, N3LO ad variation [0, 0, 0, 3, 0, 0, 0]
 DAMP: 0
 EScaleVar: 1
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -23,7 +23,6 @@ MZ: 91.1876
 MaxNfAs: 5
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65

--- a/nnpdf_data/nnpdf_data/theory_cards/781.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/781.yaml
@@ -12,7 +12,7 @@ Comments: NNPDF4.0 N3LO alphas=0.118, N3LO ad variation [0, 0, 0, 4, 0, 0, 0]
 DAMP: 0
 EScaleVar: 1
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -23,7 +23,6 @@ MZ: 91.1876
 MaxNfAs: 5
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65

--- a/nnpdf_data/nnpdf_data/theory_cards/782.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/782.yaml
@@ -12,7 +12,7 @@ Comments: NNPDF4.0 N3LO alphas=0.118, N3LO ad variation [0, 0, 0, 5, 0, 0, 0]
 DAMP: 0
 EScaleVar: 1
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -23,7 +23,6 @@ MZ: 91.1876
 MaxNfAs: 5
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65

--- a/nnpdf_data/nnpdf_data/theory_cards/783.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/783.yaml
@@ -12,7 +12,7 @@ Comments: NNPDF4.0 N3LO alphas=0.118, N3LO ad variation [0, 0, 0, 6, 0, 0, 0]
 DAMP: 0
 EScaleVar: 1
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 GF: 1.1663787e-05
 HQ: POLE
 IC: 1
@@ -23,7 +23,6 @@ MZ: 91.1876
 MaxNfAs: 5
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: None
 NfFF: 4
 PTO: 3
 Q0: 1.65

--- a/nnpdf_data/nnpdf_data/theory_cards/784.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/784.yaml
@@ -1,7 +1,7 @@
 ID: 784
 PTO: 3
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 DAMP: 0
 IC: 1
 ModEv: TRN
@@ -47,3 +47,4 @@ MP: 0.938
 Comments: NNPDF4.0 N3LO ad variation (0, 0, 0, 0)
 global_nx: 0
 EScaleVar: 1
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/785.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/785.yaml
@@ -1,7 +1,7 @@
 ID: 785
 PTO: 3
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 DAMP: 0
 IC: 1
 ModEv: TRN
@@ -47,3 +47,4 @@ MP: 0.938
 Comments: NNPDF4.0 N3LO ad variation (0, 0, 0, 0)
 global_nx: 0
 EScaleVar: 1
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/786.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/786.yaml
@@ -1,7 +1,7 @@
 ID: 786
 PTO: 3
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 DAMP: 0
 IC: 1
 ModEv: TRN
@@ -47,3 +47,4 @@ MP: 0.938
 Comments: NNPDF4.0 N3LO ad variation (0, 0, 0, 0)
 global_nx: 0
 EScaleVar: 1
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/787.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/787.yaml
@@ -1,7 +1,7 @@
 ID: 787
 PTO: 3
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 DAMP: 0
 IC: 1
 ModEv: TRN

--- a/nnpdf_data/nnpdf_data/theory_cards/788.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/788.yaml
@@ -1,7 +1,7 @@
 ID: 788
 PTO: 3
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 DAMP: 0
 IC: 1
 ModEv: TRN
@@ -47,3 +47,4 @@ MP: 0.938
 Comments: NNPDF4.0 N3LO ad variation (0, 0, 0, 0)
 global_nx: 0
 EScaleVar: 1
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/789.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/789.yaml
@@ -1,7 +1,7 @@
 ID: 789
 PTO: 3
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 DAMP: 0
 IC: 1
 ModEv: TRN
@@ -47,3 +47,4 @@ MP: 0.938
 Comments: NNPDF4.0 N3LO ad variation (0, 0, 0, 0)
 global_nx: 0
 EScaleVar: 1
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/790.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/790.yaml
@@ -1,7 +1,7 @@
 ID: 790
 PTO: 3
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 DAMP: 0
 IC: 1
 ModEv: TRN

--- a/nnpdf_data/nnpdf_data/theory_cards/791.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/791.yaml
@@ -1,7 +1,7 @@
 ID: 791
 PTO: 3
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 DAMP: 0
 IC: 1
 ModEv: TRN
@@ -47,3 +47,4 @@ MP: 0.938
 Comments: NNPDF4.0 N3LO ad variation (0, 0, 0, 0)
 global_nx: 0
 EScaleVar: 1
+ModSV: expanded

--- a/nnpdf_data/nnpdf_data/theory_cards/792.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/792.yaml
@@ -1,7 +1,7 @@
 ID: 792
 PTO: 3
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 DAMP: 0
 IC: 1
 ModEv: TRN

--- a/nnpdf_data/nnpdf_data/theory_cards/793.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/793.yaml
@@ -1,7 +1,7 @@
 ID: 793
 PTO: 3
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 DAMP: 0
 IC: 1
 ModEv: TRN

--- a/nnpdf_data/nnpdf_data/theory_cards/794.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/794.yaml
@@ -1,7 +1,7 @@
 ID: 794
 PTO: 3
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 DAMP: 0
 IC: 1
 ModEv: TRN

--- a/nnpdf_data/nnpdf_data/theory_cards/795.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/795.yaml
@@ -1,7 +1,7 @@
 ID: 795
 PTO: 3
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 DAMP: 0
 IC: 1
 ModEv: TRN

--- a/nnpdf_data/nnpdf_data/theory_cards/796.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/796.yaml
@@ -1,7 +1,7 @@
 ID: 796
 PTO: 3
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 DAMP: 0
 IC: 1
 ModEv: TRN

--- a/nnpdf_data/nnpdf_data/theory_cards/797.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/797.yaml
@@ -1,7 +1,7 @@
 ID: 797
 PTO: 3
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 DAMP: 0
 IC: 1
 ModEv: TRN

--- a/nnpdf_data/nnpdf_data/theory_cards/801.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/801.yaml
@@ -1,7 +1,7 @@
 ID: 801
 PTO: 3
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 DAMP: 0
 IC: 1
 ModEv: TRN

--- a/nnpdf_data/nnpdf_data/theory_cards/802.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/802.yaml
@@ -1,7 +1,7 @@
 ID: 802
 PTO: 3
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 DAMP: 0
 IC: 1
 ModEv: TRN

--- a/nnpdf_data/nnpdf_data/theory_cards/822.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/822.yaml
@@ -22,7 +22,6 @@ MZ: 91.1876
 MaxNfAs: 5
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: null
 NfFF: 4
 PTO: 2
 Q0: 1.0

--- a/nnpdf_data/nnpdf_data/theory_cards/823.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/823.yaml
@@ -22,7 +22,6 @@ MZ: 91.1876
 MaxNfAs: 5
 MaxNfPdf: 5
 ModEv: TRN
-ModSV: null
 NfFF: 4
 PTO: 1
 Q0: 1.0

--- a/nnpdf_data/nnpdf_data/theory_cards/824.yaml
+++ b/nnpdf_data/nnpdf_data/theory_cards/824.yaml
@@ -1,7 +1,7 @@
 ID: 824
 PTO: 3
 FNS: FONLL-E
-use_fhmruvv: False
+use_fhmruvv: false
 DAMP: 0
 IC: 1
 ModEv: EXA


### PR DESCRIPTION
This adds the `ModSV: expanded` key in case `XIF` is not equal to 1 as discussed in the telegram channel. 

Please check if for the polarized the update is also correct or if it should only be applied to a subset of the theories.

I used the script below (apologies about the stylistic changes, they're coming from ruamel)

```python
import os
from ruamel.yaml import YAML
from nnpdf_data import theory_cards as theory_cards_folder

yaml = YAML()
yaml.preserve_quotes = True

for filename in os.listdir(theory_cards_folder):
    if filename.endswith(".yaml") or filename.endswith(".yml"):
        filepath = os.path.join(theory_cards_folder, filename)

        with open(filepath, 'r') as file:
            data = yaml.load(file)

        if data.get("XIF") != 1:
            data["ModSV"] = "expanded"

        if data.get("XIF") == 1:
            data.pop("ModSV", None)

        with open(filepath, 'w') as file:
            yaml.dump(data, file)
```