### PR TITLE
Unify the way theories are getting read

### DIFF
--- a/nnpdf_data/nnpdf_data/theory.py
+++ b/nnpdf_data/nnpdf_data/theory.py
@@ -158,13 +158,3 @@ class TheoryCard:
 
     def asdict(self):
         return dataclasses.asdict(self)
-
-
-@lru_cache
-def parse_theory_card(theory_card):
-    """Read the theory card using validobj parsing
-    Returns the theory as a dictionary
-    """
-    if theory_card.exists():
-        return parse_yaml_inp(theory_card, TheoryCard)
-    raise TheoryNotFoundInDatabase(f"Theory card {theory_card} not found")


### PR DESCRIPTION
Thanks to @jacoterh's PR  #2213 I realized the tests to the theories were not being applied correctly because `fetch_all` sort of bypassed "`fetch_one`".
This just ensures that theories are always loaded through the same functions.