### PR TITLE
implementation of CMS_WCHARM_7TEV in the new format

### DIFF
--- a/nnpdf_data/nnpdf_data/commondata/CMS_WCHARM_7TEV/metadata.yaml
+++ b/nnpdf_data/nnpdf_data/commondata/CMS_WCHARM_7TEV/metadata.yaml
@@ -1,17 +1,21 @@
 setname: CMS_WCHARM_7TEV
-version: 1
-version_comment: Port of old commondata
+
 nnpdf_metadata:
   nnpdf31_process: DY CC
   experiment: CMS
+
 arXiv:
   url: https://arxiv.org/abs/1310.1138
   journal: JHEP 02 (2014) 013
 iNSPIRE:
-  url: ''
+  url: https://inspirehep.net/literature/1256938
 hepdata:
-  url: ''
-  version: -1
+  url: https://www.hepdata.net/record/ins1256938
+  version: 1
+
+version: 2
+version_comment: Implementation in the new format
+
 implemented_observables:
 - observable_name: WPWM-RATIO
   observable:
@@ -62,6 +66,7 @@ implemented_observables:
       - uncertainties_WPWM-RATIO_sys_10.yaml
   data_central: data_legacy_WPWM-RATIO.yaml
   ported_from: CMSWCHARMRAT
+
 - observable_name: WPWM-TOT
   observable:
     description: Jet Rapidity Distribution


### PR DESCRIPTION
Comments
========
This dataset delivers two different observables:
- Total x-sec
- Ratio of x-secs

The variant `sys_10` accounts for the 3pt prescription and thus it should be deprecated in the new format.

$(x,Q^2)$-map and data-theory comparison
=================================
Legacy: [[default](https://vp.nnpdf.science/ODh8VYk-QTKhFHrp6o-9MA==)]