### PR TITLE
n3fit prepro initialisation

### DIFF
--- a/n3fit/src/n3fit/backends/keras_backend/MetaLayer.py
+++ b/n3fit/src/n3fit/backends/keras_backend/MetaLayer.py
@@ -8,7 +8,7 @@
     For instance: np_to_tensor is just a call to K.constant
 """
 
-from keras.initializers import Constant, RandomUniform, glorot_normal, glorot_uniform
+from keras.initializers import Constant, RandomUniform, glorot_normal, glorot_uniform, RandomNormal
 from keras.layers import Layer
 
 # Define in this dictionary new initializers as well as the arguments they accept (with default values if needed be)
@@ -16,6 +16,7 @@ initializers = {
     "random_uniform": (RandomUniform, {"minval": -0.5, "maxval": 0.5}),
     "glorot_uniform": (glorot_uniform, {}),
     "glorot_normal": (glorot_normal, {}),
+    "random_normal": (RandomNormal, {"mean": 0.0, "stddev": 0.05}),
 }
 
 

--- a/n3fit/src/n3fit/layers/preprocessing.py
+++ b/n3fit/src/n3fit/layers/preprocessing.py
@@ -76,15 +76,15 @@ class Preprocessing(MetaLayer):
             single_replica_initializer = MetaLayer.init_constant(0.0)
             trainable = False
         else:
-            minval, maxval = dictionary[kind]
+            prepro_kwargs = dictionary[kind]
             trainable = dictionary.get("trainable", True)
             # Seeds will be set in the wrapper MultiInitializer
-            single_replica_initializer = MetaLayer.select_initializer(
-                "random_uniform", minval=minval, maxval=maxval
-            )
+            single_replica_initializer = MetaLayer.select_initializer(**prepro_kwargs)
             # If we are training, constrain the weights to be within the limits
-            if trainable:
-                constraint = constraints.MinMaxWeight(minval, maxval)
+            if trainable and prepro_kwargs["ini_name"] == "random_uniform":
+                constraint = constraints.MinMaxWeight(
+                    prepro_kwargs["minval"], prepro_kwargs["maxval"]
+                )
 
         initializer = MultiInitializer(single_replica_initializer, self._replica_seeds, base_seed=0)
         # increment seeds for the next coefficient


### PR DESCRIPTION
This pull request introduces changes to the `n3fit` package for better initializer handling.The most important changes include adding a new initializer and modifying the weight generation logic

Initializers update:

* [`n3fit/src/n3fit/backends/keras_backend/MetaLayer.py`](diffhunk://#diff-b1e9997427e416cda90e812413c31a8c9c0748eafea0276fc297c9a1e0f6e04eL11-R19): Added `RandomNormal` to the list of available initializers. (`[n3fit/src/n3fit/backends/keras_backend/MetaLayer.pyL11-R19](diffhunk://#diff-b1e9997427e416cda90e812413c31a8c9c0748eafea0276fc297c9a1e0f6e04eL11-R19)`)

Weight generation logic improvement:

* [`n3fit/src/n3fit/layers/preprocessing.py`](diffhunk://#diff-29a4fb3f4aba49242bccaf2c84b6c891a276e329b2ef1d7b8c20575ce83e0f88L79-R87): Updated the `generate_weight` method to use a dictionary for initializer parameters and apply constraints only if the initializer is `random_uniform`. (`[n3fit/src/n3fit/layers/preprocessing.pyL79-R87](diffhunk://#diff-29a4fb3f4aba49242bccaf2c84b6c891a276e329b2ef1d7b8c20575ce83e0f88L79-R87)`)


## Note
Based on the introduced changes the `flav_info` dict in the runcard would change to something like:

```
flav_info: [
    {
        "fl": "sng",
        "trainable": False,
        "smallx": {ini_name: "random_normal", mean: 1, stddev: 0.001}, #minval=1.099, maxval=1.109}, #[1.099, 1.109],
        "largex": {ini_name: "random_uniform", minval: 2.197, maxval: 2.397}, #[2.197, 2.397],
    },

....
```

This would however allow for the use of different initialisations 


