### PR TITLE
Recover the special type and cuts for heavy quark dis

### DIFF
--- a/nnpdf_data/nnpdf_data/commondata/HERA_NC_318GEV_EAVG/metadata.yaml
+++ b/nnpdf_data/nnpdf_data/commondata/HERA_NC_318GEV_EAVG/metadata.yaml
@@ -18,7 +18,7 @@ implemented_observables:
     description: Deep Inelastic Scattering
     label: HERA comb. $\sigma_{b\bar b}^{\rm red}$
     units: ''
-  process_type: DIS_NC
+  process_type: DIS_NC_BOTTOM
   tables: []
   npoints: []
   ndata: 27
@@ -74,7 +74,7 @@ implemented_observables:
     description: Deep Inelastic Scattering
     label: HERA comb. $\sigma_{c\bar c}^{\rm red}$
     units: ''
-  process_type: DIS_NC
+  process_type: DIS_NC_CHARM
   tables: []
   npoints: []
   ndata: 52

--- a/validphys2/src/validphys/cuts/filters.yaml
+++ b/validphys2/src/validphys/cuts/filters.yaml
@@ -398,7 +398,7 @@
   rule: "Q2 > q2min and w2 > w2min"
 
 
-- process_type: DIS_NCP_CH
+- process_type: DIS_NC_CHARM
   reason: |
     Heavy quark corrections are large in the FONLL-A calculation, and
     points at small-x and small Q2 need to be removed.
@@ -411,7 +411,7 @@
     Q2 > Q2cut1_f2c and
     (Q2 > Q2cut2_f2c or x > xcut_f2c)
 
-- process_type: DIS_NCP_CH
+- process_type: DIS_NC_CHARM
   reason: |
     Missing higher order corrections to Delta F_IC, the piece that needs
     to be added to the FONLL-C calculation in the case of fitted charm.
@@ -419,7 +419,7 @@
   IC: True
   rule: "Q2 > 8"
 
-- process_type: DIS_NCP_CH
+- process_type: DIS_NC_CHARM
   reason: |
     Missing higher order corrections to Delta F_IC, the piece that needs
     to be added to the FONLL-E calculation in the case of fitted charm.

--- a/validphys2/src/validphys/process_options.py
+++ b/validphys2/src/validphys/process_options.py
@@ -490,6 +490,8 @@ PROCESSES = {
     "DIS_CC": dataclasses.replace(DIS, name="DIS_CC"),
     "DIS_NCE": dataclasses.replace(DIS, name="DIS_NCE"),
     "DIS_POL": dataclasses.replace(DIS, name="DIS_POL"),
+    "DIS_NC_CHARM": dataclasses.replace(DIS, name="DIS_NC_CHARM"),
+    "DIS_NC_BOTTOM": dataclasses.replace(DIS, name="DIS_NC_BOTTOM"),
     "JET": JET,
     "DIJET": DIJET,
     "SHP_ASY": SHP,


### PR DESCRIPTION
In #2175 all processes where changed to DIS_NC/CC losing the heavy quark information, and so the internal cuts for charm were not applied.

This might fix the problem you are seeing @RoyStegeman 