### PR TITLE
split ATLAS_1JET_8TEV_R06 into legacy_theory and legacy_data

### DIFF
--- a/nnpdf_data/nnpdf_data/commondata/ATLAS_1JET_8TEV_R06/metadata.yaml
+++ b/nnpdf_data/nnpdf_data/commondata/ATLAS_1JET_8TEV_R06/metadata.yaml
@@ -67,12 +67,12 @@ implemented_observables:
       data_uncertainties:
       - uncertainties_decorrelated.yaml
     legacy_decorrelated:
-      theory:
+      theory: &id004
         conversion_factor: 1.0
         operation: 'NULL'
         FK_tables:
         - - ATLAS_1JET_8TEV_R06
-      data_uncertainties:
+      data_uncertainties:  &id003
       - uncertainties_legacy_PTY.yaml
     legacy:
       theory: &id002
@@ -86,6 +86,10 @@ implemented_observables:
       data_uncertainties: *id001
     legacy_theory:
       theory: *id002
+    legacy_decorrelated_data:
+      data_uncertainties: *id003
+    legacy_decorrelated_theory:
+      theory: *id004
   theory:
     FK_tables:
     - - ATLAS_1JET_8TEV_R06_PTY_BIN1


### PR DESCRIPTION
~This is needed for #2262.~ Which can be done once tomorrow morning all the missing DY and ATLAS datasets are merged.

This PR is no longer needed since one can do `variant: [legacy_theory, decorrelated]`, the runcard below can be used for fit 2.  

```
#
# Configuration file for n3fit
#
######################################################################################
description: NNLO baseline fit, NNPDF4.0 dataset, compare to NNPDF40_nnlo_as_01180_qcd

######################################################################################
dataset_inputs:
- {dataset: NMC_NC_NOTFIXED_EM-F2, frac: 0.75, variant: legacy_dw}
- {dataset: NMC_NC_NOTFIXED_P_EM-SIGMARED, frac: 0.75, variant: legacy}
- {dataset: SLAC_NC_NOTFIXED_P_EM-F2, frac: 0.75, variant: legacy_dw}
- {dataset: SLAC_NC_NOTFIXED_D_EM-F2, frac: 0.75, variant: legacy_dw}
- {dataset: BCDMS_NC_NOTFIXED_P_EM-F2, frac: 0.75, variant: legacy_dw}
- {dataset: BCDMS_NC_NOTFIXED_D_EM-F2, frac: 0.75, variant: legacy_dw}
- {dataset: CHORUS_CC_NOTFIXED_PB_NU-SIGMARED, frac: 0.75, variant: legacy_dw}
- {dataset: CHORUS_CC_NOTFIXED_PB_NB-SIGMARED, frac: 0.75, variant: legacy_dw}
- {dataset: NUTEV_CC_NOTFIXED_FE_NU-SIGMARED, cfac: [MAS], frac: 0.75, variant: legacy_dw}
- {dataset: NUTEV_CC_NOTFIXED_FE_NB-SIGMARED, cfac: [MAS], frac: 0.75, variant: legacy_dw}
- {dataset: HERA_NC_318GEV_EM-SIGMARED, frac: 0.75}
- {dataset: HERA_NC_225GEV_EP-SIGMARED, frac: 0.75}
- {dataset: HERA_NC_251GEV_EP-SIGMARED, frac: 0.75}
- {dataset: HERA_NC_300GEV_EP-SIGMARED, frac: 0.75}
- {dataset: HERA_NC_318GEV_EP-SIGMARED, frac: 0.75}
- {dataset: HERA_CC_318GEV_EM-SIGMARED, frac: 0.75}
- {dataset: HERA_CC_318GEV_EP-SIGMARED, frac: 0.75}
- {dataset: HERA_NC_318GEV_EAVG_CHARM-SIGMARED, frac: 0.75}
- {dataset: HERA_NC_318GEV_EAVG_BOTTOM-SIGMARED, frac: 0.75}
- {dataset: DYE866_Z0_800GEV_DW_RATIO_PDXSECRATIO, frac: 0.75}
- {dataset: DYE866_Z0_800GEV_PXSEC, frac: 0.75}
- {dataset: DYE605_Z0_38P8GEV_DW_PXSEC, frac: 0.75}
- {dataset: DYE906_Z0_120GEV_DW_PDXSECRATIO, frac: 0.75, cfac: [ACC]}
- {dataset: CDF_Z0_1P96TEV_ZRAP, frac: 0.75}
- {dataset: D0_Z0_1P96TEV_ZRAP, frac: 0.75}
- {dataset: D0_WPWM_1P96TEV_ASY, frac: 0.75}
- {dataset: ATLAS_WPWM_7TEV_36PB_ETA, frac: 0.75}
- {dataset: ATLAS_Z0_7TEV_36PB_ETA, frac: 0.75}
- {dataset: ATLAS_Z0_7TEV_49FB_HIMASS, frac: 0.75}
- {dataset: ATLAS_Z0_7TEV_LOMASS_M, frac: 0.75}
- {dataset: ATLAS_WPWM_7TEV_46FB_CC-ETA, frac: 0.75}
- {dataset: ATLAS_Z0_7TEV_46FB_CC-Y, frac: 0.75}
- {dataset: ATLAS_Z0_7TEV_46FB_CF-Y, frac: 0.75}
- {dataset: ATLAS_Z0_8TEV_HIMASS_M-Y, frac: 0.75}
- {dataset: ATLAS_Z0_8TEV_LOWMASS_M-Y, frac: 0.75}
- {dataset: ATLAS_Z0_13TEV_TOT, frac: 0.75, cfac: [NRM]}
- {dataset: ATLAS_WPWM_13TEV_TOT, frac: 0.75, cfac: [NRM]}
- {dataset: ATLAS_WJ_8TEV_WP-PT, frac: 0.75}
- {dataset: ATLAS_WJ_8TEV_WM-PT, frac: 0.75}
- {dataset: ATLAS_Z0J_8TEV_PT-M, frac: 0.75, variant: sys_10}
- {dataset: ATLAS_Z0J_8TEV_PT-Y, frac: 0.75, variant: sys_10}
- {dataset: ATLAS_TTBAR_7TEV_TOT_X-SEC, frac: 0.75, variant: legacy_theory}
- {dataset: ATLAS_TTBAR_8TEV_TOT_X-SEC, frac: 0.75, variant: legacy_theory}
- {dataset: ATLAS_TTBAR_13TEV_TOT_X-SEC, frac: 0.75, variant: legacy_theory}
- {dataset: ATLAS_TTBAR_8TEV_LJ_DIF_YT-NORM, frac: 0.75, variant: legacy_theory}
- {dataset: ATLAS_TTBAR_8TEV_LJ_DIF_YTTBAR-NORM, frac: 0.75, variant: legacy_theory}
- {dataset: ATLAS_TTBAR_8TEV_2L_DIF_YTTBAR-NORM, frac: 0.75}
- {dataset: ATLAS_1JET_8TEV_R06_PTY, frac: 0.75, variant: [legacy_theory, decorrelated]}
- {dataset: ATLAS_2JET_7TEV_R06_M12Y, frac: 0.75}
- {dataset: ATLAS_PH_13TEV_XSEC, frac: 0.75, cfac: [EWK]}
- {dataset: ATLAS_SINGLETOP_7TEV_TCHANNEL-XSEC, frac: 0.75}
- {dataset: ATLAS_SINGLETOP_13TEV_TCHANNEL-XSEC, frac: 0.75}
- {dataset: ATLAS_SINGLETOP_7TEV_T-Y-NORM, frac: 0.75}
- {dataset: ATLAS_SINGLETOP_7TEV_TBAR-Y-NORM, frac: 0.75}
- {dataset: ATLAS_SINGLETOP_8TEV_T-RAP-NORM, frac: 0.75}
- {dataset: ATLAS_SINGLETOP_8TEV_TBAR-RAP-NORM, frac: 0.75}
- {dataset: CMS_WPWM_7TEV_ELECTRON_ASY, frac: 0.75}
- {dataset: CMS_WPWM_7TEV_MUON_ASY, frac: 0.75}
- {dataset: CMS_Z0_7TEV_DIMUON_2D, frac: 0.75}
- {dataset: CMS_WPWM_8TEV_MUON_Y, frac: 0.75}
- {dataset: CMS_Z0J_8TEV_PT-Y, frac: 0.75, cfac: [NRM], variant: sys_10}
- {dataset: CMS_2JET_7TEV_M12Y, frac: 0.75}
- {dataset: CMS_1JET_8TEV_PTY, frac: 0.75, variant: legacy_theory}
- {dataset: CMS_TTBAR_7TEV_TOT_X-SEC, frac: 0.75, variant: legacy_theory}
- {dataset: CMS_TTBAR_8TEV_TOT_X-SEC, frac: 0.75, variant: legacy_theory}
- {dataset: CMS_TTBAR_13TEV_TOT_X-SEC, frac: 0.75, variant: legacy_theory}
- {dataset: CMS_TTBAR_8TEV_LJ_DIF_YTTBAR-NORM, frac: 0.75}
- {dataset: CMS_TTBAR_5TEV_TOT_X-SEC, frac: 0.75}
- {dataset: CMS_TTBAR_8TEV_2L_DIF_MTTBAR-YT-NORM, frac: 0.75, variant: legacy_theory}
- {dataset: CMS_TTBAR_13TEV_2L_DIF_YT, frac: 0.75}
- {dataset: CMS_TTBAR_13TEV_LJ_2016_DIF_YTTBAR, frac: 0.75}
- {dataset: CMS_SINGLETOP_7TEV_TCHANNEL-XSEC, frac: 0.75}
- {dataset: CMS_SINGLETOP_8TEV_TCHANNEL-XSEC, frac: 0.75}
- {dataset: CMS_SINGLETOP_13TEV_TCHANNEL-XSEC, frac: 0.75}
- {dataset: LHCB_Z0_7TEV_DIELECTRON_Y, frac: 0.75}
- {dataset: LHCB_Z0_8TEV_DIELECTRON_Y, frac: 0.75}
- {dataset: LHCB_WPWM_7TEV_MUON_Y, frac: 0.75, cfac: [NRM]}
- {dataset: LHCB_Z0_7TEV_MUON_Y, frac: 0.75, cfac: [NRM]}
- {dataset: LHCB_WPWM_8TEV_MUON_Y, frac: 0.75, cfac: [NRM]}
- {dataset: LHCB_Z0_8TEV_MUON_Y, frac: 0.75, cfac: [NRM]}
- {dataset: LHCB_Z0_13TEV_DIMUON-Y, frac: 0.75}
- {dataset: LHCB_Z0_13TEV_DIELECTRON-Y, frac: 0.75}

################################################################################
datacuts:
  t0pdfset: 240701-02-rs-nnpdf40-baseline
  q2min: 3.49
  w2min: 12.5

################################################################################
# NNLO QCD TRN evolution
theory:
  theoryid: 40_000_000

# For fits <= 4.0 multiplicative and additive uncertainties were sampled separately
# and thus the flag `separate_multiplicative` needs to be set to True
# sampling:
#   separate_multiplicative: True

################################################################################
trvlseed: 591866982
nnseed: 945709987
mcseed: 519562661
genrep: true

################################################################################
parameters: # This defines the parameter dictionary that is passed to the Model Trainer
  nodes_per_layer: [25, 20, 8]
  activation_per_layer: [tanh, tanh, linear]
  initializer: glorot_normal
  optimizer:
    clipnorm: 6.073e-6
    learning_rate: 2.621e-3
    optimizer_name: Nadam
  epochs: 17000
  positivity:
    initial: 184.8
    multiplier:
  integrability:
    initial: 10
    multiplier:
  stopping_patience: 0.1
  layer_type: dense
  dropout: 0.0
  threshold_chi2: 3.5

fitting:
  fitbasis: EVOL
  savepseudodata: True
  basis:
  - {fl: sng, trainable: false, smallx: [1.089, 1.119], largex: [1.475, 3.119]}
  - {fl: g, trainable: false, smallx: [0.7504, 1.098], largex: [2.814, 5.669]}
  - {fl: v, trainable: false, smallx: [0.479, 0.7384], largex: [1.549, 3.532]}
  - {fl: v3, trainable: false, smallx: [0.1073, 0.4397], largex: [1.733, 3.458]}
  - {fl: v8, trainable: false, smallx: [0.5507, 0.7837], largex: [1.516, 3.356]}
  - {fl: t3, trainable: false, smallx: [-0.4506, 0.9305], largex: [1.745, 3.424]}
  - {fl: t8, trainable: false, smallx: [0.5877, 0.8687], largex: [1.522, 3.515]}
  - {fl: t15, trainable: false, smallx: [1.089, 1.141], largex: [1.492, 3.222]}

################################################################################
positivity:
  posdatasets:
  # Positivity Lagrange Multiplier
  - {dataset: NNPDF_POS_2P24GEV_F2U, maxlambda: 1e6}
  - {dataset: NNPDF_POS_2P24GEV_F2D, maxlambda: 1e6}
  - {dataset: NNPDF_POS_2P24GEV_F2S, maxlambda: 1e6}
  - {dataset: NNPDF_POS_2P24GEV_FLL, maxlambda: 1e6}
  - {dataset: NNPDF_POS_2P24GEV_DYU, maxlambda: 1e10}
  - {dataset: NNPDF_POS_2P24GEV_DYD, maxlambda: 1e10}
  - {dataset: NNPDF_POS_2P24GEV_DYS, maxlambda: 1e10}
  - {dataset: NNPDF_POS_2P24GEV_F2C, maxlambda: 1e6}
  # Positivity of MSbar PDFs
  - {dataset: NNPDF_POS_2P24GEV_XUQ, maxlambda: 1e6}
  - {dataset: NNPDF_POS_2P24GEV_XUB, maxlambda: 1e6}
  - {dataset: NNPDF_POS_2P24GEV_XDQ, maxlambda: 1e6}
  - {dataset: NNPDF_POS_2P24GEV_XDB, maxlambda: 1e6}
  - {dataset: NNPDF_POS_2P24GEV_XSQ, maxlambda: 1e6}
  - {dataset: NNPDF_POS_2P24GEV_XSB, maxlambda: 1e6}
  - {dataset: NNPDF_POS_2P24GEV_XGL, maxlambda: 1e6}

added_filter_rules:
  - dataset: NNPDF_POS_2P24GEV_FLL
    rule: "x > 5.0e-7"
  - dataset: NNPDF_POS_2P24GEV_F2C
    rule: "x < 0.74"
  - dataset: NNPDF_POS_2P24GEV_XGL
    rule: "x > 0.1"
  - dataset: NNPDF_POS_2P24GEV_XUQ
    rule: "x > 0.1"
  - dataset: NNPDF_POS_2P24GEV_XUB
    rule: "x > 0.1"
  - dataset: NNPDF_POS_2P24GEV_XDQ
    rule: "x > 0.1"
  - dataset: NNPDF_POS_2P24GEV_XDB
    rule: "x > 0.1"
  - dataset: NNPDF_POS_2P24GEV_XSQ
    rule: "x > 0.1"
  - dataset: NNPDF_POS_2P24GEV_XSB
    rule: "x > 0.1"

integrability:
  integdatasets:
  - {dataset: NNPDF_INTEG_3GEV_XT8, maxlambda: 1e2}
  - {dataset: NNPDF_INTEG_3GEV_XT3, maxlambda: 1e2}

################################################################################
debug: false
maxcores: 8
```