### PR TITLE
Modify the VP api so it can take its own objects.

### DIFF
--- a/validphys2/src/validphys/config.py
+++ b/validphys2/src/validphys/config.py
@@ -7,6 +7,7 @@ import inspect
 import logging
 import numbers
 import pathlib
+from typing import Union
 
 import pandas as pd
 
@@ -17,6 +18,7 @@ from reportengine.environment import Environment, EnvironmentError_
 from reportengine.helputils import get_parser_type
 from reportengine.namespaces import NSList
 from validphys.core import (
+    PDF,
     CutsPolicy,
     DataGroupSpec,
     DataSetInput,
@@ -147,10 +149,15 @@ class CoreConfig(configparser.Config):
 
     @element_of("pdfs")
     @_id_with_label
-    def parse_pdf(self, name: str, unpolarized_bc=None):
+    def parse_pdf(self, name: Union[str, PDF], unpolarized_bc=None):
         """A PDF set installed in LHAPDF.
         If an unpolarized boundary condition it defined, it will be registered as part of the PDF.
+
+        If ``name`` is already an instance of a vp PDF object, return it unchanged.
         """
+        # This allows passing pdf objects to the validphys API
+        if isinstance(name, PDF):
+            return name
         pdf = self._check_pdf_usable(name)
         if unpolarized_bc is not None:
             pdf.register_boundary(unpolarized_bc=unpolarized_bc)

--- a/validphys2/src/validphys/config.py
+++ b/validphys2/src/validphys/config.py
@@ -7,7 +7,6 @@ import inspect
 import logging
 import numbers
 import pathlib
-from typing import Union
 
 import pandas as pd
 
@@ -149,13 +148,14 @@ class CoreConfig(configparser.Config):
 
     @element_of("pdfs")
     @_id_with_label
-    def parse_pdf(self, name: Union[str, PDF], unpolarized_bc=None):
+    def parse_pdf(self, name, unpolarized_bc=None):
         """A PDF set installed in LHAPDF.
         If an unpolarized boundary condition it defined, it will be registered as part of the PDF.
 
         If ``name`` is already an instance of a vp PDF object, return it unchanged.
         """
-        # This allows passing pdf objects to the validphys API
+        # NB: for reportengine to check the inputs, name should have type: Union[str, PDF]
+        # to be changed when support for older versions of python is dropped
         if isinstance(name, PDF):
             return name
         pdf = self._check_pdf_usable(name)


### PR DESCRIPTION
Right now the validphys api is limited to strings for PDFs. This small change allows to take either already loaded PDFs or other objects (such as the PDFs coming directly from n3fit).

Note: while `from __future__ import annotations` would allow using `Union[str, PDF]` in python 3.9, this in practice changes PDF to "PDF" (which was the old way) and this is not allowed/understood by reportengine. So for now the type annotation for the pdf name must be removed for `parse_pdf` to allow both strings and classes.