### PR TITLE
install reportengine with pip

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,8 +68,7 @@ numpy = "*"
 "ruamel.yaml" = "*"
 validobj = "*"
 prompt_toolkit = "*"
-# Reportengine needs to be installed from git
-reportengine = { git = "https://github.com/NNPDF/reportengine" }
+reportengine = "*"
 # Fit
 psutil = "*"
 tensorflow = "*"


### PR DESCRIPTION
This pull request includes a change to the `pyproject.toml` file. The change updates the `reportengine` dependency to use a version from the package index instead of installing it from the git repository.

Dependency update:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L71-R71): Changed `reportengine` dependency to use a version from the package index by replacing the git installation with a wildcard version.