### PR TITLE
sample thcovmat only for L2 data, not L1

### DIFF
--- a/validphys2/src/validphys/config.py
+++ b/validphys2/src/validphys/config.py
@@ -772,7 +772,7 @@ class CoreConfig(configparser.Config):
             if sep_mult:
                 return covmats.dataset_inputs_total_covmat_separate
             else:
-                return covmats.dataset_inputs_total_covmat
+                return covmats.dataset_inputs_t0_total_covmat
         else:
             if sep_mult:
                 return covmats.dataset_inputs_exp_covmat_separate

--- a/validphys2/src/validphys/config.py
+++ b/validphys2/src/validphys/config.py
@@ -1742,13 +1742,13 @@ class CoreConfig(configparser.Config):
             return validphys.filters.filter_real_data
         else:
             if theorycovmatconfig is not None and theorycovmatconfig.get(
-                "use_thcovmat_in_sampling"
+                "use_thcovmat_in_fakedata_sampling"
             ):
                 # NOTE: By the time we run theory covmat closure tests,
                 # hopefully the generation of pseudodata will be done in python.
                 raise ConfigError(
-                    "Generating closure test data which samples from the theory "
-                    "covariance matrix has not been implemented yet."
+                    "Generating L1 closure test data which samples from the "
+                    "theory covariance matrix has not been implemented yet."
                 )
             return validphys.filters.filter_closure_data_by_experiment
 

--- a/validphys2/src/validphys/eff_exponents.py
+++ b/validphys2/src/validphys/eff_exponents.py
@@ -606,10 +606,10 @@ def iterated_runcard_yaml(fit, update_runcard_description_yaml):
             fitting_data[seed] = random.randrange(0, maxint)
 
     # Next "closuretest" section of runcard
-    if "closuretest" in filtermap:
-        closuretest_data = filtermap["closuretest"]
-        if "filterseed" in closuretest_data:
-            closuretest_data["filterseed"] = random.randrange(0, maxint)
+    # if "closuretest" in filtermap:
+    #     closuretest_data = filtermap["closuretest"]
+    #     if "filterseed" in closuretest_data:
+    #         closuretest_data["filterseed"] = random.randrange(0, maxint)
 
     if "fiatlux" in filtermap:
         filtermap['fiatlux']['luxset'] = fit.name


### PR DESCRIPTION
To do a closure test of alphas determinations with the TCM we want to sample the theory covmat in the generation of L2 data, but not in the generation of L1 data. So there should be a separate key to activate sampling in the latter rather than using `use_thcovmat_in_sampling` to decide wether the covmat should be used both at L1 and L2. 

Having said that, there are plans to also include MHOUs in a closure test which would complicate things since then we want to use the MHOU covmat in the L1 sampling but not the alphas covmat. Not sure how this can be done somewhat elegantly... 