### PR TITLE
Make pymongo optional

### DIFF
--- a/.github/workflows/fitbot.yml
+++ b/.github/workflows/fitbot.yml
@@ -32,10 +32,10 @@ jobs:
         show-channel-urls: true
         auto-update-conda: true
         activate-environment: nnpdfenv
-    - name: Install lhapdf, pandoc and mongodb
+    - name: Install lhapdf and pandoc
       shell: bash -l {0}
       run: |
-        conda install lhapdf pandoc mongodb
+        conda install lhapdf pandoc
     - name: Install nnpdf with pip
       shell: bash -l {0}
       run: |

--- a/.github/workflows/python_installation.yml
+++ b/.github/workflows/python_installation.yml
@@ -33,7 +33,7 @@ jobs:
         conda config --set solver libmamba
         conda config --append channels conda-forge
         conda config --set show_channel_urls true
-        conda install lhapdf pandoc mongodb
+        conda install lhapdf pandoc
     - name: Install nnpdf with testing and qed extras
       shell: bash -l {0}
       run: |

--- a/n3fit/src/n3fit/hyper_optimization/hyper_scan.py
+++ b/n3fit/src/n3fit/hyper_optimization/hyper_scan.py
@@ -12,6 +12,7 @@ another hyperoptimization library, assuming that it also takes just
 you can do so by simply modifying the wrappers to point somewhere else
 (and, of course the function in the fitting action that calls the minimization).
 """
+
 import copy
 import logging
 import os
@@ -22,7 +23,13 @@ import numpy as np
 
 from n3fit.backends import MetaLayer, MetaModel
 from n3fit.hyper_optimization.filetrials import FileTrials
-from n3fit.hyper_optimization.mongofiletrials import MongodRunner, MongoFileTrials
+
+try:
+    from n3fit.hyper_optimization.mongofiletrials import MongodRunner, MongoFileTrials
+
+    _has_pymongo = True
+except ModuleNotFoundError:
+    _has_pymongo = False
 
 log = logging.getLogger(__name__)
 
@@ -241,6 +248,15 @@ class HyperScanner:
 
         # adding extra options for parallel execution
         parallel_config = sampling_dict.get("parallel")
+        if parallel_config is None:
+            self.parallel_hyperopt = False
+        elif _has_pymongo:
+            self.parallel_hyperopt = True
+        else:
+            raise ModuleNotFoundError(
+                "Could not import pymongo modules, please install with `.[parallelhyperopt]`"
+            )
+
         self.parallel_hyperopt = True if parallel_config else False
 
         # setting up MondoDB options

--- a/n3fit/src/n3fit/tests/test_hyperopt.py
+++ b/n3fit/src/n3fit/tests/test_hyperopt.py
@@ -1,5 +1,5 @@
 """
-    Test hyperoptimization features
+Test hyperoptimization features
 """
 
 import json
@@ -177,6 +177,7 @@ def test_restart_from_pickle(tmp_path):
     # Note that it doesn't check the final loss of the second trial
 
 
+@pytest.mark.skipif(shutil.which("mongod") is None, reason="mongodb not available")
 @pytest.mark.linux
 def test_parallel_hyperopt(tmp_path):
     """Ensure that the parallel implementation of hyperopt with MongoDB works as expected."""
@@ -259,6 +260,7 @@ def get_tar_size(filetar):
     return size
 
 
+@pytest.mark.skipif(shutil.which("mongod") is None, reason="mongodb not available")
 def test_restart_from_tar(tmp_path):
     """Ensure that our parallel hyperopt restart works as expected."""
     # Prepare the run

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,8 +78,6 @@ joblib = "*"
 # Hyperopt
 hyperopt = "*"
 seaborn = "*"
-# Hyperopt parallel
-pymongo = "<4"
 # LHAPDF installation for debugging purposes
 # a3b2bbc3ced97675ac3a71df45f55ba = "*"
 # Optional dependencies
@@ -99,6 +97,8 @@ pdfflow = {version = "^1.2.1", optional = true}
 lhapdf-management = {version = "^0.5", optional = true}
 # torch
 torch = {version = "*", optional = true}
+# parallel hyperopt
+pymongo = {version = "<4", optional = true}
 
 # Optional dependencies
 [tool.poetry.extras]
@@ -107,6 +107,7 @@ docs = ["sphinxcontrib", "sphinx-rtd-theme", "sphinx", "tabulate"]
 qed = ["fiatlux"]
 nolha = ["pdfflow", "lhapdf-management"]
 torch = ["torch"]
+parallelhyperopt = ["pymongo"]
 
 [tool.poetry-dynamic-versioning]
 enable = true

--- a/validphys2/src/validphys/loader.py
+++ b/validphys2/src/validphys/loader.py
@@ -909,6 +909,12 @@ def download_and_extract(url, local_path, target_name=None):
             dest_path = pathlib.Path(folder_dest.name)
             try:
                 res_tar.extractall(path=dest_path, filter="data")
+            except TypeError as e:
+                if sys.version_info > (3, 9, 16):
+                    # Filter was added in 3.9.17, and raises TypeError before then
+                    # mac's default is still in 3.9.6, so fallback to the unsafe behaviour
+                    raise e
+                res_tar.extractall(path=dest_path)
             except tarfile.LinkOutsideDestinationError as e:
                 if sys.version_info > (3, 11):
                     raise e


### PR DESCRIPTION
So that we don't need to have `pymongo` (or `mongodb`) installed just to run a fit or the tests. Having to have a very specific version is becoming a pain. 