### PR TITLE
remove conda_build_config.yaml

### DIFF
--- a/conda-recipe/conda_build_config.yaml
+++ b/conda-recipe/conda_build_config.yaml
@@ -1,7 +1,0 @@
-#For some reason the resolver decides to use an old version of numpy
-#without this
-numpy:
-    - 1.26
-
-pin_run_as_build:
-    lhapdf: x.x.x


### PR DESCRIPTION
I'm not exactly sure why conda_build_config.yaml was used to pin the version number of numpy, since it provides a way to pin version numbers and thereby create different variants, see https://docs.conda.io/projects/conda-build/en/stable/resources/variants.html. But I don't see the reason to keep this around anymore. 