### PR TITLE
Remove conda upload from the test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,24 +41,3 @@ jobs:
       shell: bash -l {0}
       run: |
         conda build -q conda-recipe --package-format=1
-    - name: Upload noarch conda package to NNPDF server
-      if: ${{ (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')) && startsWith(matrix.os, 'ubuntu') }}
-      shell: bash -l {0}
-      run: |
-        KEY=$( mktemp )
-        echo "$NNPDF_SSH_KEY" | base64 --decode > "$KEY"
-        scp -i "$KEY" -o StrictHostKeyChecking=no\
-          $CONDA_PREFIX/conda-bld/noarch/*.tar.bz2 \
-          dummy@packages.nnpdf.science:~/packages/conda/noarch
-    - name: Build and upload sphinx documentation to NNPDF server
-      if: startsWith(matrix.os, 'ubuntu') && github.ref == 'refs/heads/master'
-      shell: bash -l {0}
-      run: |
-        KEY=$( mktemp )
-        echo "$NNPDF_SSH_KEY" | base64 --decode > "$KEY"
-        conda install nnpdf --yes
-        cd doc/sphinx
-        make html
-        scp -r -i "$KEY" -o StrictHostKeyChecking=no\
-          build/html/* \
-          dummy@packages.nnpdf.science:~/sphinx-docs/


### PR DESCRIPTION
In a separate PR I'll add a `deploy` action that will upload the packages and documentation when the code is tagged.