### PR TITLE
Update docs, citations

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,3 +41,15 @@ jobs:
       shell: bash -l {0}
       run: |
         conda build -q conda-recipe --package-format=1
+    - name: Build and upload sphinx documentation to NNPDF server
+      if: startsWith(matrix.os, 'ubuntu') && github.ref == 'refs/heads/master'
+      shell: bash -l {0}
+      run: |
+        KEY=$( mktemp )
+        echo "$NNPDF_SSH_KEY" | base64 --decode > "$KEY"
+        conda install nnpdf --yes
+        cd doc/sphinx
+        make html
+        scp -r -i "$KEY" -o StrictHostKeyChecking=no\
+          build/html/* \
+          dummy@packages.nnpdf.science:~/sphinx-docs/

--- a/doc/sphinx/source/contributing/dev_install.rst
+++ b/doc/sphinx/source/contributing/dev_install.rst
@@ -12,7 +12,7 @@ While we recommend that you install ``nnpdf`` in the most comfortable way for yo
 installing some of the dependencies such as LHAPDF might be challenging.
 Below we describe how to prepare a development environment using conda.
 
-1. Setup a conda environment with a recent python version supported by NNPDF (see `here <https://github.com/NNPDF/nnpdf/blob/master/pyproject.toml>`_).
+1. Setup a conda environment with a recent python version supported by NNPDF (for 4.0.10, this corresponds to ``python>=3.9.2,<3.13``).
 
 .. code::
 

--- a/doc/sphinx/source/get-started/cite.rst
+++ b/doc/sphinx/source/get-started/cite.rst
@@ -4,17 +4,12 @@ References
 ==========
 If you use this code please consider citing at least the following papers:
 
-* NNPDF4.0 :cite:p:`nnpdf40`
 * NNPDF4.0 code paper :cite:p:`nnpdf40code`
-* Reportengine :cite:p:`zahari_kassabov_2019_2571601`
-* All papers that are relevant for the QCD NNLO and EW NLO K-factors
-  that are released with this version of the code. In particular:
+* Backend for the automatic reports, ``reportengine`` :cite:p:`zahari_kassabov_2019_2571601`
+* Theory pipeline, :cite:p:`Barontini:2023vmr`
+* Evolution code, ``EKO``, :cite:p:`Candido:2022tld`
+* Grid interpolation, ``PineAPPL`` :cite:p:`Carrazza:2020gss`
 
-  * Z pT  :cite:p:`Boughezal:2017nla`, :cite:p:`Boughezal:2015ded`,
-    :cite:p:`Gavin:2010az`, :cite:p:`Boughezal:2016isb`, :cite:p:`Boughezal:2015dva`, :cite:p:`Boughezal:2015eha`, :cite:p:`Gaunt:2015pea`, :cite:p:`Denner:2011vu`
-  * Inclusive jets and dijets :cite:p:`AbdulKhalek:2020jut`, :cite:p:`Currie:2017eqf`, :cite:p:`Currie:2016bfm`
-  * Top pair productions :cite:p:`Czakon:2016olj`,
-    :cite:p:`Czakon:2017dip`, :cite:p:`Czakon:2013goa`
-  * Single top  :cite:p:`Nocera:2019wyk`, :cite:p:`Berger:2016oht`, :cite:p:`Berger:2017zof`
-  * Direct photon :cite:p:`Campbell:2018wfu`, :cite:p:`Campbell:2016lzl`
-  * NNLO massive correction to CC DIS :cite:p:`Gao:2017kkx`
+* All papers that are relevant for the QCD NNLO and EW NLO K-factors
+  that are made available with this code can be found in the references for
+  NNPDF4.0 :cite:p:`nnpdf40`

--- a/doc/sphinx/source/get-started/installation.rst
+++ b/doc/sphinx/source/get-started/installation.rst
@@ -47,13 +47,12 @@ While the fitting code is currently not available, it can be installed directly 
 
   python -m venv environment_nnpdf
   . environment_nnpdf/bin/activate
-  python -m pip install git+https://github.com/NNPDF/nnpdf.git@4.0.9
+  python -m pip install git+https://github.com/NNPDF/nnpdf.git@4.0.10
 
 
 .. warning::
 
-   When you install using pip, non-python codes such as LHAPDF and pandoc won't be installed automatically and neeed to be manually installed in the environment.
-
+   When you install using pip, non-python codes such as LHAPDF and pandoc won't be installed automatically and neeed to be manually installed in the environment. If using python 3.9, make sure it is newer than ``3.9.2`` (see issue `here <https://github.com/NNPDF/reportengine/pull/69>`_)
 
 .. _bootstrap-installation:
 

--- a/doc/sphinx/source/get-started/installation.rst
+++ b/doc/sphinx/source/get-started/installation.rst
@@ -6,9 +6,7 @@ either a Linux-based operating system or macOS.
 The code can be installed either with :ref:`conda <condainstall>` or with :ref:`pip <pip>`,
 the former offering a "batteries included" approach where non-python software
 such as LHAPDF and pandoc will be installed automatically.
-
-If you don't have a recent version of conda installed, please use the
-following :ref:`bootstrap-installation`
+We also made available an automatic installation of conda, see :ref:`bootstrap-installation`
 to install conda as well as set up relevant channels.
 
 If you plan to contribute to the development of NNPDF, please see :ref:`Source`.

--- a/doc/sphinx/source/index.rst
+++ b/doc/sphinx/source/index.rst
@@ -20,7 +20,7 @@ The NNPDF code
 The scientific output of the collaboration is freely available to the
 public through the arXiv, journal repositories, and software
 repositories. Along with this online documentation, we release the
-`NNPDF code <https://github.com/NNPDF/nnpdf>`_. 
+`NNPDF code <https://github.com/NNPDF/nnpdf>`_.
 The code is made available as an open-source package together with user-friendly examples and an extensive documentation presented here.
 
 The code can be used to produce the ingredients needed for PDF fits, to run the fits themselves, and to analyse the results. This is the first framework used to produce a global PDF fit made publicly  available, enabling for detailed external validation and reproducibility of the NNPDF4.0 analysis. Moreover, the code enables the user to explore a number of phenomenological applications, such as the assessment of the impact of new experimental data on PDFs, the effect of changes in theory settings on the resulting PDFs and a fast quantitative comparison between theoretical predictions and experimental data over a broad range of observables.
@@ -145,6 +145,7 @@ Contents
    :maxdepth: 2
 
    get-started/index
+   tutorials/index
    n3fit/index
    vp/index
    data/index
@@ -155,7 +156,6 @@ Contents
    ci/index
    serverconf/index
    external-code/index
-   tutorials/index
 
 Bibliography
 ============

--- a/doc/sphinx/source/references.bib
+++ b/doc/sphinx/source/references.bib
@@ -156,7 +156,7 @@
 
 @misc{zahari_kassabov_2019_2571601,
   author       = {Zahari Kassabov},
-  title        = {{Reportengine: A framework for declarative data 
+  title        = {{Reportengine: A framework for declarative data
                    analysis}},
   month        = feb,
   year         = 2019,
@@ -686,4 +686,44 @@ archivePrefix = {arXiv},
     number = "24",
     pages = "242002",
     year = "2016"
+}
+
+@article{Candido:2022tld,
+    author = "Candido, Alessandro and Hekhorn, Felix and Magni, Giacomo",
+    title = "{EKO: evolution kernel operators}",
+    eprint = "2202.02338",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ph",
+    reportNumber = "TIF-UNIMI-2022-2, Nikhef-2022-003",
+    doi = "10.1140/epjc/s10052-022-10878-w",
+    journal = "Eur. Phys. J. C",
+    volume = "82",
+    number = "10",
+    pages = "976",
+    year = "2022"
+}
+@article{Carrazza:2020gss,
+    author = "Carrazza, S. and Nocera, E. R. and Schwan, C. and Zaro, M.",
+    title = "{PineAPPL: combining EW and QCD corrections for fast evaluation of LHC processes}",
+    eprint = "2008.12789",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ph",
+    doi = "10.1007/JHEP12(2020)108",
+    journal = "JHEP",
+    volume = "12",
+    pages = "108",
+    year = "2020"
+}
+@article{Barontini:2023vmr,
+    author = "Barontini, Andrea and Candido, Alessandro and Cruz-Martinez, Juan M. and Hekhorn, Felix and Schwan, Christopher",
+    title = "{Pineline: Industrialization of high-energy theory predictions}",
+    eprint = "2302.12124",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ph",
+    reportNumber = "TIF-UNIMI-2023-4, CERN-TH-2023-021",
+    doi = "10.1016/j.cpc.2023.109061",
+    journal = "Comput. Phys. Commun.",
+    volume = "297",
+    pages = "109061",
+    year = "2024"
 }

--- a/doc/sphinx/source/releases.rst
+++ b/doc/sphinx/source/releases.rst
@@ -20,9 +20,12 @@ developments and to mark versions used to produce main results. The
 significant releases since the code was made public are:
 
 `Version 4.0.10 <https://github.com/NNPDF/nnpdf/releases/tag/4.0.10>`_
-    Last release fully compatible with the 4.0 era runcards.
-    The new commondata and theory formats have been fully adopted.
+    Last release of the 4.0 era. Runcards for 4.0 work in this release will work
+    but are no longer used the old tools, commondata or theories.
+    The new commondata and theory pipeline has been fully adopted.
     EKO is now the only evolution code supported. C++ and cmake have been removed.
+    Closure tests done with old version (pre-4.0) of the code can be converted to the new version
+    but won't work out of the box.
 `Version 4.0.9 <https://github.com/NNPDF/nnpdf/releases/tag/4.0.9>`_
     Release for 4.0 `N3LO <https://arxiv.org/abs/2402.18635>`_;
     last release fully backwards-compatible with 4.0 pipeline. 4.0 runcards will still work but

--- a/doc/sphinx/source/releases.rst
+++ b/doc/sphinx/source/releases.rst
@@ -19,11 +19,15 @@ The code is tagged to contextualize the versioning, mark significant
 developments and to mark versions used to produce main results. The
 significant releases since the code was made public are:
 
+`Version 4.0.10 <https://github.com/NNPDF/nnpdf/releases/tag/4.0.10>`_
+    Last release fully compatible with the 4.0 era runcards.
+    The new commondata and theory formats have been fully adopted.
+    EKO is now the only evolution code supported. C++ and cmake have been removed.
 `Version 4.0.9 <https://github.com/NNPDF/nnpdf/releases/tag/4.0.9>`_
     Release for 4.0 `N3LO <https://arxiv.org/abs/2402.18635>`_;
     last release fully backwards-compatible with 4.0 pipeline. 4.0 runcards will still work but
     external tools, and data and theory not used in the 4.0 family of fits will no longer be
-    guaranteed to work from 4.0.10 onwards Last release compatible with the old commondata format
+    guaranteed to work from 4.0.10 onwards. Last release compatible with the old commondata format
     and that accepts apfel as evolution code.
 `Version 4.0.8 <https://github.com/NNPDF/nnpdf/releases/tag/4.0.8>`_
     Release for the `QED <https://arxiv.org/abs/2401.08749>`_ and `MHOU <https://arxiv.org/abs/2401.10319>`_ papers.

--- a/doc/sphinx/source/releases.rst
+++ b/doc/sphinx/source/releases.rst
@@ -26,6 +26,7 @@ significant releases since the code was made public are:
     EKO is now the only evolution code supported. C++ and cmake have been removed.
     Closure tests done with old version (pre-4.0) of the code can be converted to the new version
     but won't work out of the box.
+    Further releases of the ``4.0.X`` series will be only bugfixes upon 4.0.10.
 `Version 4.0.9 <https://github.com/NNPDF/nnpdf/releases/tag/4.0.9>`_
     Release for 4.0 `N3LO <https://arxiv.org/abs/2402.18635>`_;
     last release fully backwards-compatible with 4.0 pipeline. 4.0 runcards will still work but

--- a/doc/sphinx/source/releases.rst
+++ b/doc/sphinx/source/releases.rst
@@ -20,8 +20,7 @@ developments and to mark versions used to produce main results. The
 significant releases since the code was made public are:
 
 `Version 4.0.10 <https://github.com/NNPDF/nnpdf/releases/tag/4.0.10>`_
-    Last release of the 4.0 era. Runcards for 4.0 work in this release will work
-    but are no longer used the old tools, commondata or theories.
+    Last release of the 4.0 era. Runcards for 4.0 will still run using new tools, data and theory.
     The new commondata and theory pipeline has been fully adopted.
     EKO is now the only evolution code supported. C++ and cmake have been removed.
     Closure tests done with old version (pre-4.0) of the code can be converted to the new version

--- a/doc/sphinx/source/tutorials/index.rst
+++ b/doc/sphinx/source/tutorials/index.rst
@@ -43,7 +43,6 @@ Special PDF sets
 .. toctree ::
    :maxdepth: 1
 
-   ./reproduce
    ./bundle-pdfs.rst
    ./mc2hessian.rst
    ./hessian2mc.rst


### PR DESCRIPTION
I've also recovered the autodeploy for the documentation since we are still updating it.

The references look like this now

<img width="856" alt="Screenshot 2025-03-07 at 14 19 56" src="https://github.com/user-attachments/assets/74061729-d092-459c-838b-145114b96d2f" />

I've also moved the tutorials to the top, since I think it is the first thing people actually look at.