### PR TITLE
Add faketheoryid

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
         args: ['--config=./pyproject.toml']
 
 -   repo: https://github.com/pycqa/isort
-    rev: '6.0.0'
+    rev: '6.0.1'
     hooks:
     -   id: isort
         args: ['--settings-path=./pyproject.toml']

--- a/doc/sphinx/source/references.bib
+++ b/doc/sphinx/source/references.bib
@@ -633,7 +633,7 @@ archivePrefix = {arXiv},
  primaryClass = {hep-ph}
 }
 
-@article{NNPDF:2021uiq,
+@article{nnpdf40code,
     author = "Ball, Richard D. and others",
     collaboration = "NNPDF",
     title = "{An open-source machine learning framework for global analyses of parton distributions}",

--- a/doc/sphinx/source/references.bib
+++ b/doc/sphinx/source/references.bib
@@ -633,14 +633,19 @@ archivePrefix = {arXiv},
  primaryClass = {hep-ph}
 }
 
-@article{nnpdf40code,
+@article{NNPDF:2021uiq,
     author = "Ball, Richard D. and others",
+    collaboration = "NNPDF",
     title = "{An open-source machine learning framework for global analyses of parton distributions}",
     eprint = "2109.02671",
     archivePrefix = "arXiv",
     primaryClass = "hep-ph",
     reportNumber = "Edinburgh 2021/13, Nikhef-2021-020, TIF-UNIMI-2021-12",
-    month = "9",
+    doi = "10.1140/epjc/s10052-021-09747-9",
+    journal = "Eur. Phys. J. C",
+    volume = "81",
+    number = "10",
+    pages = "958",
     year = "2021"
 }
 

--- a/doc/sphinx/source/references.bib
+++ b/doc/sphinx/source/references.bib
@@ -1,14 +1,17 @@
 @article{NNPDF:2024nan,
     author = "Ball, Richard D. and others",
     collaboration = "NNPDF",
-    title = "{The Path to N$^3$LO Parton Distributions}",
+    title = "{The path to $\hbox {N}^3\hbox {LO}$ parton distributions}",
     eprint = "2402.18635",
     archivePrefix = "arXiv",
     primaryClass = "hep-ph",
-    reportNumber = "Nikhef-2023-020, TIF-UNIMI-2023-23, Edinburgh 2023/29",
-    month = "2",
-    year = "2024",
-    journal = ""
+    reportNumber = "Nikhef-2023-020, TIF-UNIMI-2023-23, Edinburgh 2023/29, CERN-TH-2024-033",
+    doi = "10.1140/epjc/s10052-024-12891-7",
+    journal = "Eur. Phys. J. C",
+    volume = "84",
+    number = "7",
+    pages = "659",
+    year = "2024"
 }
 
 @article{NNPDF:2024dpb,
@@ -19,23 +22,29 @@
     archivePrefix = "arXiv",
     primaryClass = "hep-ph",
     reportNumber = "TIF-UNIMI-2023-22, Edinburgh 2023/34, CERN-TH-2024-009",
-    month = "1",
-    year = "2024",
-    journal = ""
+    doi = "10.1140/epjc/s10052-024-12772-z",
+    journal = "Eur. Phys. J. C",
+    volume = "84",
+    number = "5",
+    pages = "517",
+    year = "2024"
 }
 
 @article{NNPDF:2023tyk,
     author = "Ball, Richard D. and Candido, Alessandro and Cruz-Martinez, Juan and Forte, Stefano and Giani, Tommaso and Hekhorn, Felix and Magni, Giacomo and Nocera, Emanuele R. and Rojo, Juan and Stegeman, Roy",
     collaboration = "NNPDF",
-    title = "{The intrinsic charm quark valence distribution of the proton}",
+    title = "{Intrinsic charm quark valence distribution of the proton}",
     eprint = "2311.00743",
     archivePrefix = "arXiv",
     primaryClass = "hep-ph",
     reportNumber = "Edinburgh 2023/22, TIF-UNIMI-2023-28, Nikhef 2023-012,
   CERN-TH-2023-196",
-    month = "11",
-    year = "2023",
-    journal = ""
+    doi = "10.1103/PhysRevD.109.L091501",
+    journal = "Phys. Rev. D",
+    volume = "109",
+    number = "9",
+    pages = "L091501",
+    year = "2024"
 }
 
 @article{NNPDF:2024djq,
@@ -46,11 +55,13 @@
     archivePrefix = "arXiv",
     primaryClass = "hep-ph",
     reportNumber = "TIF-UNIMI-2023-17, Edinburgh 2023/19, CERN-TH-2023-159",
-    month = "1",
-    year = "2024",
-    journal = ""
+    doi = "10.1140/epjc/s10052-024-12731-8",
+    journal = "Eur. Phys. J. C",
+    volume = "84",
+    number = "5",
+    pages = "540",
+    year = "2024"
 }
-
 
 @article{Ball:2022qks,
     author = "Ball, Richard D. and Candido, Alessandro and Cruz-Martinez, Juan and Forte, Stefano and Giani, Tommaso and Hekhorn, Felix and Kudashkin, Kirill and Magni, Giacomo and Rojo, Juan",
@@ -74,7 +85,11 @@
     eprint = "2207.00690",
     archivePrefix = "arXiv",
     primaryClass = "hep-ph",
-    month = "7",
+    doi = "10.1140/epjc/s10052-022-10932-7",
+    journal = "Eur. Phys. J. C",
+    volume = "82",
+    number = "10",
+    pages = "956",
     year = "2022"
 }
 
@@ -210,7 +225,7 @@
     year = "2021"
 }
 
-@article{Forte:2020yip,
+@misc{Forte:2020yip,
     author = "Forte, Stefano and Carrazza, Stefano",
     title = "{Parton distribution functions}",
     eprint = "2008.12305",
@@ -551,7 +566,7 @@
     primaryClass = "hep-ph",
     reportNumber = "CAVENDISH-HEP-17-08, TTK-17-10",
     month = "4",
-    year = "2017"
+    year = "2017",
 }
 
 @article{Czakon:2013goa,
@@ -620,17 +635,19 @@ Through $O(\alpha^4_S)$}",
 
 %%%%% NNPDF4.0
 @article{nnpdf40,
-       author = {{Ball}, Richard D. and {Carrazza}, Stefano and {Cruz-Martinez}, Juan and {Del Debbio}, Luigi and {Forte}, Stefano and {Giani}, Tommaso and {Iranipour}, Shayan and {Kassabov}, Zahari and {Latorre}, Jose I. and {Nocera}, Emanuele R. and {Pearson}, Rosalyn L. and {Rojo}, Juan and {Stegeman}, Roy and {Schwan}, Christopher and {Ubiali}, Maria and {Voisey}, Cameron and {Wilson}, Michael},
-        title = "{The Path to Proton Structure at One-Percent Accuracy}",
-      journal = {arXiv e-prints},
-     keywords = {High Energy Physics - Phenomenology, High Energy Physics - Experiment},
-         year = 2021,
-        month = sep,
-          eid = {arXiv:2109.02653},
-        pages = {arXiv:2109.02653},
-archivePrefix = {arXiv},
-       eprint = {2109.02653},
- primaryClass = {hep-ph}
+    author = "Ball, Richard D. and others",
+    collaboration = "NNPDF",
+    title = "{The path to proton structure at 1\% accuracy}",
+    eprint = "2109.02653",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ph",
+    reportNumber = "Edinburgh 2021/12, Nikhef-2021-013, TIF-UNIMI-2021-11",
+    doi = "10.1140/epjc/s10052-022-10328-7",
+    journal = "Eur. Phys. J. C",
+    volume = "82",
+    number = "5",
+    pages = "428",
+    year = "2022"
 }
 
 @article{nnpdf40code,

--- a/doc/sphinx/source/tutorials/closuretest.rst
+++ b/doc/sphinx/source/tutorials/closuretest.rst
@@ -59,13 +59,16 @@ Before you've made any changes, a typical ``closuretest`` section will be as fol
     filterseed  : 0   # Random seed to be used in filtering data partitions
     fakedata    : False
     fakepdf     : MMHT2014nnlo68cl
+    faketheoryid: 41_000_000
     fakenoise   : False
 
-Setting ``fakedata`` to ``True`` will cause closure test pseudodata to be generated
-and subsequently fitted. The PDf which the pseudodata will be generated from
-is specified by the ``fakepdf`` key. It is strongly advised to set the ``fakepdf``
-and ``t0pdfset``, found under ``datacuts`` to be the same PDF, unless specifically
-testing the impact of the t0 procedure.
+Setting ``fakedata`` to ``True`` will cause closure test pseudodata to be
+generated and subsequently fitted. The PDF which the pseudodata will be
+generated from is specified by the ``fakepdf`` key and the theory is specified
+by the ``faketheoryid`` key. It is strongly advised to set the ``fakepdf`` and
+``t0pdfset`` found under ``datacuts`` to be the same PDF, as well as setting
+``t0theoryid`` found under ``theory`` and ``faketheoryid`` to be the same
+theoryid, unless specifically testing the impact of the t0 procedure.
 
 The ``fakenoise`` key specifies whether or not the level 1 shift η will be
 add to the pseudodata during the filtering step, this is require for
@@ -79,6 +82,7 @@ An example of a typical level 1 or level 2 ``closuretest`` specification is give
     filterseed  : 0   # Random seed to be used in filtering data partitions
     fakedata    : True
     fakepdf     : MMHT2014nnlo68cl
+    faketheoryid: 41_000_000
     fakenoise   : True
 
 Note that it is *critical* that two closure tests which are to be compared have
@@ -89,13 +93,18 @@ example a `report <https://vp.nnpdf.science/mbcTUd6-TQmQFvaGd37bkg==/>`_
 comparing two level 2 closure tests with identical settings apart from
 ``filterseed``.
 
-There are still some relevant settings to the closure test. For the above example
-we would choose that the t0 set was the same as the underlying law:
+There are still some relevant settings to the closure test. For the above
+example we would choose that the t0 pdf and the t0 theoryid are the same as the
+underlying law:
 
 .. code:: yaml
 
   datacuts:
     t0pdfset     : MMHT2014nnlo68cl # PDF set to generate t0 covmat
+    ...
+
+  theory:
+    t0theoryid   : 41_000_000 # theoryID to generate t0 covmat
     ...
 
 Finally we need to specify whether or not MC replicas will be generated in the

--- a/doc/sphinx/source/tutorials/run-fit.rst
+++ b/doc/sphinx/source/tutorials/run-fit.rst
@@ -145,7 +145,10 @@ After obtaining the fit you can proceed with the fit upload and analysis by:
 
 1.  *For members of NNPDF*, it is possible to upload the results to the nnpdf server using ``vp-upload runcard_folder`` then install the fitted set with ``vp-get fit fit_name``. Otherwise, copy or link to the results to the ``share/NNPDF/results/`` folder (usually under ``~/.local/share`` or ``${CONDA_PREFIX}/share/``.
 
-2.  Analysing the results with ``validphys``, see the :ref:`vp-guide <vp-index>`.
+2.  It is recommended to iterate a fit to achieve a higher degree of convergence/stability in the fit.
+    To read more about this, see :ref:`How to run an iterated fit <run-iterated-fit>`.
+
+3.  Analysing the results with ``validphys``, see the :ref:`vp-guide <vp-index>`.
     Consider using the ``vp-comparefits`` tool.
 
 
@@ -169,12 +172,6 @@ In order to change the backend, the environment variable ``KERAS_BACKENDD`` need
 
 The best results are obtained with ``tensorflow[and-cuda]`` installed from pip
 and running ``n3fit`` in GPU, see :ref:`parallel-label`.
-
-Iterate the fit
-~~~~~~~~~~~~~~~
-
-It may be desirable to iterate a fit to achieve a higher degree of convergence/stability in the fit.
-To read more about this, see :ref:`How to run an iterated fit <run-iterated-fit>`.
 
 QED fit
 ~~~~~~~

--- a/n3fit/runcards/examples/Basic_runcard_closure_test.yml
+++ b/n3fit/runcards/examples/Basic_runcard_closure_test.yml
@@ -21,7 +21,7 @@ datacuts:
 
 ############################################################
 theory:
-  theoryid: 717       # database id
+  theoryid: 708       # database id
 
 separate_multiplicative: True
 parameters: # This defines the parameter dictionary that is passed to the Model Trainer

--- a/n3fit/runcards/examples/Basic_runcard_closure_test.yml
+++ b/n3fit/runcards/examples/Basic_runcard_closure_test.yml
@@ -21,7 +21,7 @@ datacuts:
 
 ############################################################
 theory:
-  theoryid: 708       # database id
+  theoryid: 717       # database id
 
 separate_multiplicative: True
 parameters: # This defines the parameter dictionary that is passed to the Model Trainer

--- a/n3fit/runcards/examples/Basic_runcard_closure_test.yml
+++ b/n3fit/runcards/examples/Basic_runcard_closure_test.yml
@@ -83,5 +83,6 @@ maxcores: 8
 closuretest:
   filterseed: 3345348918 # Random seed to be used in filtering data partitions
   fakedata: true     # true = to use FAKEPDF to generate pseudo-data
-  fakepdf: NNPDF40_nnlo_as_01180      # Theory input for pseudo-data
+  fakepdf: NNPDF40_nnlo_as_01180      # PDF input for pseudo-data
   fakenoise: true    # true = to add random fluctuations to pseudo-data
+  faketheoryid: 708  # theory input for pseudo-data

--- a/n3fit/src/n3fit/scripts/vp_setupfit.py
+++ b/n3fit/src/n3fit/scripts/vp_setupfit.py
@@ -37,7 +37,10 @@ from ruamel.yaml import error
 from reportengine import colors
 from validphys.app import App
 from validphys.config import Config, ConfigError, Environment, EnvironmentError_
+from validphys.loader import FallbackLoader
 from validphys.utils import yaml_safe
+
+l = FallbackLoader()
 
 SETUPFIT_FIXED_CONFIG = dict(
     actions_=[
@@ -146,7 +149,12 @@ class SetupFitConfig(Config):
             # Use faketheoryid to create the L0 data to be stored into the filter folder
             # (L1 data is stored if fakedata is True)
             if 'faketheoryid' in closuredict:
-                file_content['theory']['theoryid'] = closuredict['faketheoryid']
+                # make sure theory key exists in SETUPFIT_FIXED_CONFIG
+                SETUPFIT_FIXED_CONFIG.setdefault('theory', {})
+                # overwrite theoryid with the faketheoryid
+                SETUPFIT_FIXED_CONFIG['theory']['theoryid'] = closuredict['faketheoryid']
+                # download theoryid since it will be used in the fit
+                l.check_theoryID(file_content['theory']['theoryid'])
             filter_action = 'datacuts::closuretest::theory::fitting filter'
             check_n3fit_action = 'datacuts::theory::closuretest::fitting n3fit_checks_action'
         else:

--- a/n3fit/src/n3fit/scripts/vp_setupfit.py
+++ b/n3fit/src/n3fit/scripts/vp_setupfit.py
@@ -141,6 +141,10 @@ class SetupFitConfig(Config):
             )
 
         if file_content.get('closuretest') is not None:
+            # Use faketheoryid to create the L0 data to be stored into the filter folder
+            # (L1 data is stored if fakedata is True)
+            if 'faketheoryid' in file_content['theory']:
+                file_content['theory']['theoryid'] = file_content['theory']['faketheoryid']
             filter_action = 'datacuts::closuretest::theory::fitting filter'
             check_n3fit_action = 'datacuts::theory::closuretest::fitting n3fit_checks_action'
         else:

--- a/n3fit/src/n3fit/scripts/vp_setupfit.py
+++ b/n3fit/src/n3fit/scripts/vp_setupfit.py
@@ -37,10 +37,10 @@ from ruamel.yaml import error
 from reportengine import colors
 from validphys.app import App
 from validphys.config import Config, ConfigError, Environment, EnvironmentError_
-from validphys.loader import FallbackLoader
+from validphys.loader import Loader, TheoryNotFound
 from validphys.utils import yaml_safe
 
-l = FallbackLoader()
+l = Loader()
 
 SETUPFIT_FIXED_CONFIG = dict(
     actions_=[
@@ -154,7 +154,10 @@ class SetupFitConfig(Config):
                 # overwrite theoryid with the faketheoryid
                 SETUPFIT_FIXED_CONFIG['theory']['theoryid'] = closuredict['faketheoryid']
                 # download theoryid since it will be used in the fit
-                l.check_theoryID(file_content['theory']['theoryid'])
+                try:
+                    l.check_theoryID(file_content['theory']['theoryid'])
+                except TheoryNotFound as e:
+                    log.warning(e)
             filter_action = 'datacuts::closuretest::theory::fitting filter'
             check_n3fit_action = 'datacuts::theory::closuretest::fitting n3fit_checks_action'
         else:

--- a/n3fit/src/n3fit/scripts/vp_setupfit.py
+++ b/n3fit/src/n3fit/scripts/vp_setupfit.py
@@ -141,11 +141,12 @@ class SetupFitConfig(Config):
                 f"Expecting input runcard to be a mapping, " f"not '{type(file_content)}'."
             )
 
-        if file_content.get('closuretest') is not None:
+        closuredict = file_content.get('closuretest')
+        if closuredict is not None:
             # Use faketheoryid to create the L0 data to be stored into the filter folder
             # (L1 data is stored if fakedata is True)
-            if 'faketheoryid' in file_content['theory']:
-                file_content['theory']['theoryid'] = file_content['theory']['faketheoryid']
+            if 'faketheoryid' in closuredict:
+                file_content['theory']['theoryid'] = closuredict['faketheoryid']
             filter_action = 'datacuts::closuretest::theory::fitting filter'
             check_n3fit_action = 'datacuts::theory::closuretest::fitting n3fit_checks_action'
         else:
@@ -168,7 +169,6 @@ class SetupFitConfig(Config):
             SETUPFIT_FIXED_CONFIG['actions_'].append(
                 'datacuts::theory::theorycovmatconfig nnfit_theory_covmat'
             )
-
 
         # Check fiatlux configuration
         fiatlux = file_content.get('fiatlux')


### PR DESCRIPTION
For closure testing the CRM we need a `faketheoryid` that defines which theory to use during the generation of the L0 data. 

Another possible solution (that [Andrea chose at the time](https://github.com/NNPDF/nnpdf/tree/closure_with_same_level1), but was never merged) is to introduce a `data_level0` which replaces the usual `data` that is given as input to the relevant closure test actions (since the fktables are part of the data class object). Since `faketheoryid` is only needed in vp-setupfit I think this solution is a bit simpler/cleaner.

The second commit intends to make `SetupFitConfig` more readable but doesn't change any functionality.  

I didn't touch the closuretstmetric section or the th covmat section since those will be changed in the ongoing incosistent closure test study and the effort to update the docs. I also realised the roles of t0pdfset and theoryid in the n3fit runcard are not documented. 