### PR TITLE
Prepare a coverage report in the CI

### DIFF
--- a/.github/workflows/all_tests_nnpdf.yml
+++ b/.github/workflows/all_tests_nnpdf.yml
@@ -119,4 +119,4 @@ jobs:
     - name: Merge and show
       run: |
         coverage combine reports/**/.coverage
-        coverage report
+        coverage report -i

--- a/.github/workflows/all_tests_nnpdf.yml
+++ b/.github/workflows/all_tests_nnpdf.yml
@@ -30,7 +30,15 @@ jobs:
       - name: Test n3fit and validphys
         shell: bash -l {0}
         run: |
-          pytest --mpl --pyargs validphys n3fit --mpl-default-tolerance 18
+          pytest --cov=${PWD} --cov-config=pyproject.toml --mpl --pyargs validphys n3fit --mpl-default-tolerance 18
+      - name: Keep coverage file
+        if: startsWith(matrix.python-version, '3.12')
+        uses: actions/upload-artifact@v4
+        with:
+          include-hidden-files: true
+          name: coverage-package-${{ matrix.os }}
+          path: .coverage
+
 
   regression_tests:
     runs-on: ubuntu-latest
@@ -40,7 +48,13 @@ jobs:
       - name: Run regression tests
         shell: bash -l {0}
         run: |
-          pytest extra_tests/regression_checks.py
+          pytest --cov=${PWD} --cov-config=pyproject.toml extra_tests/regression_checks.py
+      - name: Keep coverage file
+        uses: actions/upload-artifact@v4
+        with:
+          include-hidden-files: true
+          name: coverage-regression
+          path: .coverage
 
   conda_tests:
     strategy:
@@ -87,3 +101,22 @@ jobs:
       run: |
         cd n3fit/runcards/examples
         n3fit Basic_runcard.yml 4
+
+  full_coverage:
+    needs: [run_package_tests, regression_tests]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: ./.github/actions/install_conda_pip
+      with:
+        nnpdf-extras: ""
+    - name: Install coverage
+      run: pip install coverage
+    - name: Download reports
+      uses: actions/download-artifact@v4
+      with:
+        path: reports
+    - name: Merge and show
+      run: |
+        coverage combine reports/**/.coverage
+        coverage report

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,7 @@ seaborn = "*"
 # tests
 pytest = {version = "*", optional = true}
 pytest-mpl = {version = "*", optional = true}
+pytest-cov = {version = ">=6", optional = true}
 hypothesis = {version = "*", optional = true}
 # docs
 sphinxcontrib-bibtex = {version = "*", optional = true}
@@ -102,7 +103,7 @@ pymongo = {version = "<4", optional = true}
 
 # Optional dependencies
 [tool.poetry.extras]
-tests = ["pytest", "pytest-mpl", "hypothesis"]
+tests = ["pytest", "pytest-mpl", "hypothesis", "pytest-cov"]
 docs = ["sphinxcontrib-bibtex", "sphinx-rtd-theme", "sphinx", "tabulate"]
 qed = ["fiatlux"]
 nolha = ["pdfflow", "lhapdf-management"]
@@ -148,3 +149,10 @@ force_sort_within_sections = true
 
 [tool.pytest.ini_options]
 addopts = "--disable-warnings"
+
+[tool.coverage.run]
+omit = [
+    "deprecated_functions.py",
+    "*/nnpdf_data/commondata/*",
+    "*/nnpdf_data/filter_utils/*",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,6 +157,7 @@ omit = [
     "deprecated_functions.py",
     "*/nnpdf_data/commondata/*",
     "*/nnpdf_data/filter_utils/*",
+    "*test_*.py"
 ]
 [tool.coverage.paths]
 cipaths = [ # In order to combine files from both the ubuntu and macos runners

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,7 +152,15 @@ addopts = "--disable-warnings"
 
 [tool.coverage.run]
 omit = [
+    "*/local*",
+    "*/rule*",
     "deprecated_functions.py",
     "*/nnpdf_data/commondata/*",
     "*/nnpdf_data/filter_utils/*",
+]
+[tool.coverage.paths]
+cipaths = [ # In order to combine files from both the ubuntu and macos runners
+    "./", # CI working directory
+    "/Users/runner/work/nnpdf/nnpdf",
+    "/home/runner/work/nnpdf/nnpdf"
 ]


### PR DESCRIPTION
This closes #29 :)

At the moment the coverage report is not uploaded and not enforced just shown in the CI.

We have currently [69%](https://github.com/NNPDF/nnpdf/actions/runs/13808494769/job/38627865533?pr=2299#step:6:237) coverage (nice! since it is "organic"!) 

I'm not sure whether some tests started by subprocesses are counted correctly (apparently is is quite difficult to do so, but pytest-cov includes some tricks). 