### PR TITLE
Add an option to drop filter rules for a given dataset

### DIFF
--- a/doc/sphinx/source/vp/filters.rst
+++ b/doc/sphinx/source/vp/filters.rst
@@ -307,6 +307,33 @@ append a list of filter rules to the rules obtained by the mechanisms described 
 The value of ``added_filter_rules`` should be a list of rules with the same format as ``filter_rules``.
 
 
+.. _drop_filter_rules::
+
+Dropping filter rules for selected datasets
+-------------------------------------------
+
+Sometimes it might be necessary to drop the filter rules for a dataset while keeping all other rules intact.
+This is possible with the ``drop_filter_rules`` key, which will drop all dataset-scoped rules applying to a given dataset.
+Since ``drop_filter_rules`` is applied before ``added_filter_rules`` it can be utilized to reset the rules for a given dataset
+while keeping all other internal rules.
+
+.. code:: yaml
+
+    use_cuts: "internal"
+    pdf: "NNPDF40_nnlo_as_01180"
+
+    dataset_inputs:
+      - { dataset: ATLAS_Z0J_8TEV_PT-Y }
+      - { dataset: ATLAS_Z0J_8TEV_PT-M }
+
+    theoryid: 40_000_000
+
+    drop_internal_rules:
+      - ATLAS_Z0J_8TEV_PT-Y
+
+    actions_:
+      - groups_chi2_table
+
 
 Examples
 --------
@@ -345,13 +372,13 @@ less than NNLO (i.e LO or NLO). I check what the process type of
 
 .. code:: ipython
 
-   In [1]: from validphys.loader import Loader                                                                                                                                   
+   In [1]: from validphys.loader import Loader
 
-   In [2]: l = Loader()                                                                                                                                                          
+   In [2]: l = Loader()
 
-   In [3]: cd = l.check_commondata("CMSDY2D12")                                                                                                                                  
+   In [3]: cd = l.check_commondata("CMSDY2D12")
 
-   In [4]: cd.process_type                                                                                                                                                       
+   In [4]: cd.process_type
    Out[4]: 'EWK_RAP'
 
 Then cross check this against ``NNPDF.CommonData.kinLabels`` to see that

--- a/n3fit/src/n3fit/io/writer.py
+++ b/n3fit/src/n3fit/io/writer.py
@@ -1,8 +1,8 @@
 """
-    Module containing functions dedicated to the write down of the output of n3fit
+Module containing functions dedicated to the write down of the output of n3fit
 
-    The goal is to generate the same folder/file structure as the old nnfit code
-    so previously active scripts can still work.
+The goal is to generate the same folder/file structure as the old nnfit code
+so previously active scripts can still work.
 """
 
 import json
@@ -398,13 +398,15 @@ def version():
     try:
         import keras
 
-        versions["keras"] = f"{keras.__version__} backend={keras.backend()}"
+        backend = keras.backend.backend()
 
-        if keras.backend.backend() == "tensorflow":
+        versions["keras"] = f"{keras.__version__} {backend=}"
+
+        if backend == "tensorflow":
             import tensorflow as tf
 
             versions["tensorflow"] = tf.__version__
-        elif keras.backend.backend() == "torch":
+        elif backend == "torch":
             import torch
 
             versions["torch"] == torch.__version__

--- a/validphys2/src/validphys/tests/conftest.py
+++ b/validphys2/src/validphys/tests/conftest.py
@@ -16,6 +16,8 @@ import pytest
 settings.register_profile("extratime", deadline=1500)
 settings.load_profile("extratime")
 
+lhapdf.setVerbosity(0)
+
 
 # Fortunately py.test works much like reportengine and providers are
 # connected by argument names.

--- a/validphys2/src/validphys/tests/test_filter_rules.py
+++ b/validphys2/src/validphys/tests/test_filter_rules.py
@@ -101,7 +101,7 @@ def test_good_rules():
     l = Loader()
     rules = [mkrule(inp) for inp in good_rules]
     dsnames = ['ATLAS_1JET_8TEV_R06_PTY', 'NMC_NC_NOTFIXED_EM-F2']
-    variants = ["legacy","legacy_dw"]
+    variants = ["legacy", "legacy_dw"]
     for dsname, v in zip(dsnames, variants):
         ds = l.check_dataset(
             dsname, cuts='internal', rules=tuple(rules), theoryid=THEORYID, variant=v
@@ -137,3 +137,42 @@ def test_added_rules():
     assert np.isnan(tb["empty data"].iloc[1, 1])
     assert tb["empty data"]["ndata"].iloc[0] == 0
     assert np.all(tb[1:]["fewer data"] != tb[1:]["Original"])
+
+
+def test_drop_internal_rules(data_internal_cuts_config, test_dataset="CMS_Z0J_8TEV_PT-Y"):
+    """Check that the key drop_internal_rules work as expected:
+    - Drops all cuts for a given dataset
+    - It is applied before added_filter_rules
+    """
+    assert test_dataset in [
+        i["dataset"] for i in data_internal_cuts_config["dataset_inputs"]
+    ], "If you updated the test DATA, please update this test as well"
+
+    def test_fun(**config):
+        """Use some internal validphy function which will for sure use cuts and separate
+        the results for the test dataset.
+        """
+        # Get data and predictions separated by dataset (drop grouping)
+        ret = API.group_result_central_table_no_table(**config).droplevel(0)
+        # Now separate the test dataset from the rest
+        df_test = ret.loc[test_dataset]
+        df_rest = ret.drop(index=test_dataset)
+        return df_test, df_rest
+
+    # Use internal cuts
+    def_test, def_all = test_fun(**data_internal_cuts_config)
+
+    # Drop all rules for the test dataset only
+    drop_test, drop_all = test_fun(**data_internal_cuts_config, drop_internal_rules=[test_dataset])
+
+    assert len(drop_test) > len(def_test), "Cuts have not been dropped!"
+    assert len(drop_all) == len(def_all), "Drop cuts have affected other datasets!"
+
+    # Add a new rule for this dataset while dropping all previous rules
+    new_rule = {"dataset": test_dataset, "rule": "pT >= 80"}
+    add_test, add_all = test_fun(
+        **data_internal_cuts_config,
+        added_filter_rules=[new_rule],
+        drop_internal_rules=[test_dataset]
+    )
+    assert len(new_rule) < len(drop_test), "New rule has not been added after dropping the cuts!"


### PR DESCRIPTION
At the moment we can only either drop all cuts (adding new `filter_rules`) or append cuts (with `added_filter_rules`).

This PR adds `drop_internal_rules: [dataset list]` to drop all rules for a given dataset while keeping the rest of internal rules.

<details>

<summary> Example script </summary>

```python
#!/usr/bin/env python

from validphys.api import API
from lhapdf import setVerbosity

setVerbosity(0)

ds = "ATLAS_Z0J_8TEV_PT-Y"

kwargs = {
        "dataset_input": {"dataset": ds},
        "theoryid": 40_000_000,
        "use_cuts": "internal",
        "pdf": "NNPDF40_nnlo_as_01180"
}

# Use internal cuts
chi2 = API.abs_chi2_data(**kwargs)
print(f"{chi2.central_result} for {chi2.ndata} points: {chi2.central_result/chi2.ndata}")

# Filter rules drop all cuts
new_rule = {"dataset": ds, "rule": "pT >= 40"}
chi2 = API.abs_chi2_data(**kwargs, filter_rules = [new_rule])
print(f"{chi2.central_result} for {chi2.ndata} points: {chi2.central_result/chi2.ndata}")

# Added filter rules
new_rule = {"dataset": ds, "rule": "pT >= 40"}
chi2 = API.abs_chi2_data(**kwargs, added_filter_rules = [new_rule])
print(f"{chi2.central_result} for {chi2.ndata} points: {chi2.central_result/chi2.ndata}")

# Drop and add filter rules
new_rule = {"dataset": ds, "rule": "pT >= 40"}
chi2 = API.abs_chi2_data(**kwargs, added_filter_rules = [new_rule], drop_internal_rules = [ds])
print(f"{chi2.central_result} for {chi2.ndata} points: {chi2.central_result/chi2.ndata}")

# Dropping for a different dataset has no effect 
chi2 = API.abs_chi2_data(**kwargs, added_filter_rules = [new_rule], drop_internal_rules = ["ATLAS_Z0J_8TEV_PT-M"])
print(f"{chi2.central_result} for {chi2.ndata} points: {chi2.central_result/chi2.ndata}")
```

</details>