### PR TITLE
Make parallel_models=true the default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,9 @@ compile_commands.json
 CTestTestfile.cmake
 build
 
+## Theory docs
+doc/sphinx/source/theories_central.csv
+
 ### JupyterNotebook ###
 .ipynb_checkpoints
 */.ipynb_checkpoints/*

--- a/doc/sphinx/source/n3fit/hyperopt.rst
+++ b/doc/sphinx/source/n3fit/hyperopt.rst
@@ -344,9 +344,6 @@ hyperopt configuration dictionary).
             - HERA_NC_251GEV_EP-SIGMARED
           - datasets:
 
-        parallel_models: true
-        same_trvl_per_replica: true
-
 We can run this hyperparameter scan for 10 parallel replicas for 20 trials with:
 
 .. code-block:: bash

--- a/doc/sphinx/source/n3fit/runcard_detailed.rst
+++ b/doc/sphinx/source/n3fit/runcard_detailed.rst
@@ -340,23 +340,14 @@ as well as a detailed analysis of the amount of time that TensorFlow spent on ea
 Running fits in parallel
 ------------------------
 
-It is possible to run fits in parallel with ``n3fit`` by setting the ``parallel_models``
-flag in the runcard to ``true`` when running a range of replicas.
+When running more than one replicas, they will run in parallel by default.
+It is possible to run the fits sequentially as well
+by setting the ``parallel_models`` flag in the runcard to ``false`` when running a range of replicas.
 Running in parallel can be quite hard on memory and it is only advantageous when
 fitting on a GPU, where one can find a speed up equal to the number of models run
 in parallel (each model being a different replica).
 Running in parallel models produces the exact same pseudodata as the sequential runs.
 Note that numerical differences might be generated during the training
-
-In other words, in order to run several replicas in parallel in a machine
-(be it a big CPU or, most likely, a GPU)
-it is necessary to modify the ``n3fit`` runcard by adding the following
-top-level option:
-
-.. code-block:: yaml
-
-  parallel_models: true
-
 
 Once this is done, the user can run ``n3fit`` with a
 replica range to be parallelized (in this case from replica 1 to replica 4).

--- a/n3fit/src/n3fit/checks.py
+++ b/n3fit/src/n3fit/checks.py
@@ -432,7 +432,9 @@ def check_consistent_parallel(parameters, parallel_models):
     if not parallel_models:
         return
     if parameters.get("layer_type") not in ("dense"):
-        raise CheckError("Parallelization has only been tested with layer_type=='dense'")
+        raise CheckError(
+            "Parallelization has only been tested with layer_type=='dense', set `parallel_models: false`"
+        )
 
 
 @make_argcheck

--- a/n3fit/src/n3fit/checks.py
+++ b/n3fit/src/n3fit/checks.py
@@ -436,16 +436,6 @@ def check_consistent_parallel(parameters, parallel_models):
 
 
 @make_argcheck
-def can_run_multiple_replicas(replicas, parallel_models):
-    """Warns the user if trying to run just one replica in parallel"""
-    if not parallel_models:
-        return
-    if len(replicas) == 1:
-        log.warning("parallel_models is set to true for only one replica")
-        return
-
-
-@make_argcheck
 def check_deprecated_options(fitting):
     """Checks whether the runcard is using deprecated options"""
     options_outside = ["trvlseed", "nnseed", "mcseed", "save", "load", "genrep", "parameters"]
@@ -460,6 +450,7 @@ def check_deprecated_options(fitting):
     for option in nnfit_options:
         if option in fitting:
             log.warning("'fitting::%s' is an nnfit-only key, it will be ignored", option)
+
 
 @make_argcheck
 def check_multireplica_qed(replicas, fiatlux):

--- a/n3fit/src/n3fit/n3fit_checks_provider.py
+++ b/n3fit/src/n3fit/n3fit_checks_provider.py
@@ -27,7 +27,7 @@ def n3fit_checks_action(
     hyperopt=None,
     kfold=None,
     tensorboard=None,
-    parallel_models=False,
+    parallel_models=True,
     double_precision=False,
 ):
     return

--- a/n3fit/src/n3fit/performfit.py
+++ b/n3fit/src/n3fit/performfit.py
@@ -1,5 +1,5 @@
 """
-    Fit action controller
+Fit action controller
 """
 
 # Backend-independent imports
@@ -13,7 +13,6 @@ log = logging.getLogger(__name__)
 
 # Action to be called by validphys
 # All information defining the NN should come here in the "parameters" dict
-@n3fit.checks.can_run_multiple_replicas
 @n3fit.checks.check_multireplica_qed
 @n3fit.checks.check_polarized_configs
 def performfit(
@@ -42,7 +41,7 @@ def performfit(
     debug=False,
     maxcores=None,
     double_precision=False,
-    parallel_models=False,
+    parallel_models=True,
 ):
     """
     This action will (upon having read a validcard) process a full PDF fit

--- a/n3fit/src/n3fit/tests/regressions/noval-quickcard.yml
+++ b/n3fit/src/n3fit/tests/regressions/noval-quickcard.yml
@@ -72,3 +72,4 @@ closuretest:
 
 ############################################################
 debug: false
+parallel_models: false

--- a/n3fit/src/n3fit/tests/regressions/pc-quickcard.yml
+++ b/n3fit/src/n3fit/tests/regressions/pc-quickcard.yml
@@ -66,3 +66,4 @@ closuretest:
 
 ############################################################
 debug: false
+parallel_models: false


### PR DESCRIPTION
The only reason it wasn't at this point was that the pseudodata was not written down. This is not a concern anymore.