### PR TITLE
Multiarchitecture models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -355,6 +355,7 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+doc/sphinx/source/theories_central.csv
 
 # PyBuilder
 target/

--- a/n3fit/src/n3fit/backends/keras_backend/MetaModel.py
+++ b/n3fit/src/n3fit/backends/keras_backend/MetaModel.py
@@ -1,8 +1,8 @@
 """
-    MetaModel class
+MetaModel class
 
-    Extension of the backend Model class containing some wrappers in order to absorb other
-    backend-dependent calls.
+Extension of the backend Model class containing some wrappers in order to absorb other
+backend-dependent calls.
 """
 
 from pathlib import Path
@@ -408,7 +408,7 @@ class MetaModel(Model):
             raise ValueError("Trying to generate single replica models with no generator set.")
         replicas = []
         for i_replica in range(self.num_replicas):
-            replica = self.single_replica_generator()
+            replica = self.single_replica_generator(i_replica)
             replica.set_replica_weights(self.get_replica_weights(i_replica))
             replicas.append(replica)
 

--- a/n3fit/src/n3fit/hyper_optimization/penalties.py
+++ b/n3fit/src/n3fit/hyper_optimization/penalties.py
@@ -49,11 +49,12 @@ def saturation(pdf_model=None, n=100, min_x=1e-6, max_x=1e-4, flavors=None, **_k
     Example
     -------
     >>> from n3fit.hyper_optimization.penalties import saturation
-    >>> from n3fit.model_gen import generate_pdf_model
+    >>> from n3fit.model_gen import generate_pdf_model, ReplicaSettings
     >>> fake_fl = [{'fl' : i, 'largex' : [0,1], 'smallx': [1,2]} for i in ['u', 'ubar', 'd', 'dbar', 'c', 'g', 's', 'sbar']]
-    >>> pdf_model = generate_pdf_model(nodes=[8], activations=['linear'], seed_list=[0], flav_info=fake_fl, fitbasis="FLAVOUR")
-    >>> saturation(pdf_model, 5), float)
-    array([0.0038])
+    >>> rp = [ReplicaSettings(nodes = [8], activations=["linear"], seed=0)]
+    >>> pdf_model = generate_pdf_model(rp, flav_info=fake_fl, fitbasis="FLAVOUR")
+    >>> saturation(pdf_model, 5)
+    array([0.00014878])
 
     """
     if flavors is None:
@@ -129,9 +130,10 @@ def integrability(pdf_model=None, **_kwargs):
     Example
     -------
     >>> from n3fit.hyper_optimization.penalties import integrability
-    >>> from n3fit.model_gen import generate_pdf_model
+    >>> from n3fit.model_gen import generate_pdf_model, ReplicaSettings
     >>> fake_fl = [{'fl' : i, 'largex' : [0,1], 'smallx': [1,2]} for i in ['u', 'ubar', 'd', 'dbar', 'c', 'g', 's', 'sbar']]
-    >>> pdf_model = generate_pdf_model(nodes=[8], activations=['linear'], seed_list=[0], flav_info=fake_fl, fitbasis="FLAVOUR")
+    >>> rp = [ReplicaSettings(nodes = [8], activations=["linear"], seed=0)]
+    >>> pdf_model = generate_pdf_model(rp, flav_info=fake_fl, fitbasis="FLAVOUR")
     >>> integrability(pdf_model)
     5.184705528587072e+21
 

--- a/n3fit/src/n3fit/hyper_optimization/penalties.py
+++ b/n3fit/src/n3fit/hyper_optimization/penalties.py
@@ -18,6 +18,7 @@ And return a float to be added to the hyperscan loss.
 New penalties can be added directly in this module.
 The name in the runcard must match the name used in this module.
 """
+
 import numpy as np
 
 from n3fit.vpinterface import N3PDF, integrability_numbers
@@ -48,11 +49,11 @@ def saturation(pdf_model=None, n=100, min_x=1e-6, max_x=1e-4, flavors=None, **_k
     Example
     -------
     >>> from n3fit.hyper_optimization.penalties import saturation
-    >>> from n3fit.model_gen import pdfNN_layer_generator
+    >>> from n3fit.model_gen import generate_pdf_model
     >>> fake_fl = [{'fl' : i, 'largex' : [0,1], 'smallx': [1,2]} for i in ['u', 'ubar', 'd', 'dbar', 'c', 'g', 's', 'sbar']]
-    >>> pdf_model = pdfNN_layer_generator(nodes=[8], activations=['linear'], seed=0, flav_info=fake_fl, fitbasis="FLAVOUR")
-    >>> isinstance(saturation(pdf_model, 5), float)
-    True
+    >>> pdf_model = generate_pdf_model(nodes=[8], activations=['linear'], seed_list=[0], flav_info=fake_fl, fitbasis="FLAVOUR")
+    >>> saturation(pdf_model, 5), float)
+    array([0.0038])
 
     """
     if flavors is None:
@@ -128,11 +129,11 @@ def integrability(pdf_model=None, **_kwargs):
     Example
     -------
     >>> from n3fit.hyper_optimization.penalties import integrability
-    >>> from n3fit.model_gen import pdfNN_layer_generator
+    >>> from n3fit.model_gen import generate_pdf_model
     >>> fake_fl = [{'fl' : i, 'largex' : [0,1], 'smallx': [1,2]} for i in ['u', 'ubar', 'd', 'dbar', 'c', 'g', 's', 'sbar']]
-    >>> pdf_model = pdfNN_layer_generator(nodes=[8], activations=['linear'], seed=0, flav_info=fake_fl, fitbasis="FLAVOUR")
-    >>> isinstance(integrability(pdf_model), float)
-    True
+    >>> pdf_model = generate_pdf_model(nodes=[8], activations=['linear'], seed_list=[0], flav_info=fake_fl, fitbasis="FLAVOUR")
+    >>> integrability(pdf_model)
+    5.184705528587072e+21
 
     """
     pdf_instance = N3PDF(pdf_model.split_replicas())

--- a/n3fit/src/n3fit/hyper_optimization/rewards.py
+++ b/n3fit/src/n3fit/hyper_optimization/rewards.py
@@ -213,7 +213,7 @@ class HyperLoss:
         >>> ds = Loader().check_dataset("NMC_NC_NOTFIXED_P_EM-SIGMARED", variant="legacy", theoryid=399, cuts="internal")
         >>> experimental_data = [Loader().check_experiment("My DataGroupSpec", [ds])]
         >>> fake_fl = [{'fl' : i, 'largex' : [0,1], 'smallx': [1,2]} for i in ['u', 'ubar', 'd', 'dbar', 'c', 'g', 's', 'sbar']]
-        >>> pdf_model = generate_pdf_model(nodes=[8], activations=['linear'], seed=0, num_replicas=2, flav_info=fake_fl, fitbasis="FLAVOUR")
+        >>> pdf_model = generate_pdf_model(nodes=[8], activations=['linear'], seed=[0,2], flav_info=fake_fl, fitbasis="FLAVOUR")
         >>> pdf = N3PDF(pdf_model.split_replicas())
         >>> loss = hyper.compute_loss(penalties, experimental_loss, pdf, experimental_data)
         """

--- a/n3fit/src/n3fit/model_gen.py
+++ b/n3fit/src/n3fit/model_gen.py
@@ -375,7 +375,7 @@ class ReplicaSettings:
             )
         if self.regularizer_args and self.regularizer is None:
             raise ValueError(
-                "Regularizer arguments have been provided but not regularizer is selected"
+                "Regularizer arguments have been provided but no regularizer is selected"
             )
 
 
@@ -674,7 +674,7 @@ def _pdfNN_layer_generator(
         list_of_nn_pdfs.append(rep_pdf(x_input))
 
     # Stack all replicas together as one single object
-    nn_pdfs = Lambda(lambda nns: op.stack(nns, axis=1), name=f"stack_replicas")(list_of_nn_pdfs)
+    nn_pdfs = Lambda(lambda nns: op.stack(nns, axis=1), name="stack_replicas")(list_of_nn_pdfs)
     nn_replicas = MetaModel({'NN_input': x_input}, nn_pdfs, name=NN_LAYER_ALL_REPLICAS)
 
     ## Preprocessing factors:
@@ -787,7 +787,7 @@ def _pdfNN_layer_generator(
     if not replica_axis:
         PDFs = Lambda(lambda pdfs: pdfs[:, 0], name="remove_replica_axis")(PDFs)
 
-    return MetaModel(model_input, PDFs, name=f"PDFs", scaler=scaler)
+    return MetaModel(model_input, PDFs, name="PDFs", scaler=scaler)
 
 
 # TODO: is there a way of keeping sincronized the input of this function and ReplicaSettings

--- a/n3fit/src/n3fit/model_trainer.py
+++ b/n3fit/src/n3fit/model_trainer.py
@@ -705,7 +705,7 @@ class ModelTrainer:
             layer_type=layer_type,
             flav_info=self.flavinfo,
             fitbasis=self.fitbasis,
-            seed=seed,
+            seed_list=seed,
             initializer_name=initializer,
             dropout=dropout,
             regularizer=regularizer,

--- a/n3fit/src/n3fit/model_trainer.py
+++ b/n3fit/src/n3fit/model_trainer.py
@@ -712,7 +712,6 @@ class ModelTrainer:
             regularizer_args=regularizer_args,
             impose_sumrule=self.impose_sumrule,
             scaler=self._scaler,
-            num_replicas=len(self.replicas),
             photons=photons,
         )
         return pdf_model

--- a/n3fit/src/n3fit/tests/test_hyperopt.py
+++ b/n3fit/src/n3fit/tests/test_hyperopt.py
@@ -14,7 +14,7 @@ from numpy.testing import assert_approx_equal
 import pytest
 
 from n3fit.hyper_optimization.rewards import HyperLoss
-from n3fit.model_gen import generate_pdf_model
+from n3fit.model_gen import ReplicaSettings, generate_pdf_model
 from n3fit.vpinterface import N3PDF
 from validphys.loader import Loader
 from validphys.tests.conftest import THEORYID
@@ -26,9 +26,8 @@ def generate_pdf(seeds):
         {"fl": i, "largex": [0, 1], "smallx": [1, 2]}
         for i in ["u", "ubar", "d", "dbar", "c", "g", "s", "sbar"]
     ]
-    pdf_model = generate_pdf_model(
-        nodes=[8], activations=["linear"], seed_list=seeds, flav_info=fake_fl, fitbasis="FLAVOUR"
-    )
+    rp = [ReplicaSettings(nodes=[8], activations=["linear"], seed=seed) for seed in seeds]
+    pdf_model = generate_pdf_model(rp, flav_info=fake_fl, fitbasis="FLAVOUR")
     return pdf_model
 
 

--- a/n3fit/src/n3fit/tests/test_hyperopt.py
+++ b/n3fit/src/n3fit/tests/test_hyperopt.py
@@ -20,19 +20,14 @@ from validphys.loader import Loader
 from validphys.tests.conftest import THEORYID
 
 
-def generate_pdf(seed, num_replicas):
+def generate_pdf(seeds):
     """Generate generic pdf model."""
     fake_fl = [
         {"fl": i, "largex": [0, 1], "smallx": [1, 2]}
         for i in ["u", "ubar", "d", "dbar", "c", "g", "s", "sbar"]
     ]
     pdf_model = generate_pdf_model(
-        nodes=[8],
-        activations=["linear"],
-        seed_list=seed,
-        num_replicas=num_replicas,
-        flav_info=fake_fl,
-        fitbasis="FLAVOUR",
+        nodes=[8], activations=["linear"], seed_list=seeds, flav_info=fake_fl, fitbasis="FLAVOUR"
     )
     return pdf_model
 
@@ -63,7 +58,7 @@ def test_compute_per_fold_loss(loss_type, replica_statistic, expected_per_fold_l
     This example assumes a 2 replica calculation with 3 added penalties.
     """
     # generate 2 replica pdf model
-    pdf_model = generate_pdf(seed=[1, 2], num_replicas=2)
+    pdf_model = generate_pdf(seeds=[1, 2])
     # add 3 penalties for a 2 replica model
     penalties = {
         'saturation': np.array([0.0, 0.0]),

--- a/n3fit/src/n3fit/tests/test_hyperopt.py
+++ b/n3fit/src/n3fit/tests/test_hyperopt.py
@@ -29,7 +29,7 @@ def generate_pdf(seed, num_replicas):
     pdf_model = generate_pdf_model(
         nodes=[8],
         activations=["linear"],
-        seed=seed,
+        seed_list=seed,
         num_replicas=num_replicas,
         flav_info=fake_fl,
         fitbasis="FLAVOUR",

--- a/n3fit/src/n3fit/tests/test_layers.py
+++ b/n3fit/src/n3fit/tests/test_layers.py
@@ -1,6 +1,6 @@
 """
-    Tests for the layers of n3fit
-    This module checks that the layers do what they would do with numpy
+Tests for the layers of n3fit
+This module checks that the layers do what they would do with numpy
 """
 
 import dataclasses
@@ -139,7 +139,7 @@ def test_DIS_basis():
         reference = np.zeros(FLAVS, dtype=bool)
         for i in comb:
             reference[i] = True
-        assert np.alltrue(result == reference)
+        np.testing.assert_allclose(result, reference)
 
 
 def test_DY_basis():
@@ -153,7 +153,7 @@ def test_DY_basis():
         reference = np.zeros((FLAVS, FLAVS))
         for i, j in comb:
             reference[i, j] = True
-        assert np.alltrue(result == reference)
+        np.testing.assert_allclose(result, reference)
 
 
 def test_DIS():
@@ -232,7 +232,7 @@ def test_rotation_flavour():
     pdf = op.numpy_to_tensor(pdf)
     rotmat = layers.FlavourToEvolution(flav_info, "FLAVOUR")
     res_layer = rotmat(pdf)
-    assert np.alltrue(res_np == res_layer)
+    np.testing.assert_allclose(res_np, res_layer)
 
 
 def test_rotation_evol():
@@ -257,7 +257,7 @@ def test_rotation_evol():
     pdf = op.numpy_to_tensor(pdf)
     rotmat = layers.FlavourToEvolution(flav_info, "EVOL")
     res_layer = rotmat(pdf)
-    assert np.alltrue(res_np == res_layer)
+    np.testing.assert_allclose(res_np, res_layer)
 
 
 def test_mask():

--- a/n3fit/src/n3fit/tests/test_modelgen.py
+++ b/n3fit/src/n3fit/tests/test_modelgen.py
@@ -6,31 +6,40 @@ It checks that both the number of layers and the shape
 of the weights of the layers are what is expected
 """
 
-from n3fit.backends import NN_PREFIX
+from n3fit.backends import NN_PREFIX, Input
 from n3fit.model_gen import _generate_nn
 
 INSIZE = 16
 OUT_SIZES = (4, 3)
-BASIS_SIZE = 3
+BASIS_SIZE = OUT_SIZES[-1]
 
-COMMON_ARGS = {
-    "nodes_in": INSIZE,
-    "nodes": OUT_SIZES,
-    "activations": ["sigmoid", "tanh"],
-    "initializer_name": "glorot_uniform",
-    "replica_seeds": [0],
-    "dropout": 0.0,
-    "regularizer": None,
-    "regularizer_args": {},
-    "last_layer_nodes": BASIS_SIZE,
-}
+
+def _common_generation(architecture, dropout=0.0):
+    """Generate a NN with shared configuration with only
+    some free parameters"""
+    config = {
+        "architecture": architecture,
+        "nodes": OUT_SIZES,
+        "activations": ["sigmoid", "tanh"],
+        "initializer": "glorot_uniform",
+        "seed": 27,
+        "dropout_rate": dropout,
+        "regularizer": None,
+        "regularizer_args": {},
+    }
+    xin = Input(shape=(None, INSIZE), batch_size=1)
+    return _generate_nn(xin, **config)
 
 
 def test_generate_dense_network():
-    nn = _generate_nn("dense", **COMMON_ARGS)
+    nn_w_dropout = _common_generation("dense", dropout=0.4)
+    nn = _common_generation("dense")
 
     # The number of layers should be input layer + len(OUT_SIZES)
     assert len(nn.layers) == len(OUT_SIZES) + 1
+    # And one more with dropout
+    assert len(nn_w_dropout.layers) == len(OUT_SIZES) + 2
+
     # Check that the number of parameters is as expected
     expected_sizes = [(INSIZE, OUT_SIZES[0]), (OUT_SIZES[0]), (*OUT_SIZES,), (OUT_SIZES[1])]
     for weight, esize in zip(nn.weights, expected_sizes):
@@ -38,7 +47,7 @@ def test_generate_dense_network():
 
 
 def test_generate_dense_per_flavour_network():
-    nn = _generate_nn("dense_per_flavour", **COMMON_ARGS).get_layer(f"{NN_PREFIX}_0")
+    nn = _common_generation("dense_per_flavour")
 
     # The number of layers should be input + BASIS_SIZE*len(OUT_SIZES) + concatenate
     assert len(nn.layers) == BASIS_SIZE * len(OUT_SIZES) + 2

--- a/n3fit/src/n3fit/tests/test_modelgen.py
+++ b/n3fit/src/n3fit/tests/test_modelgen.py
@@ -1,13 +1,13 @@
 """
-    Test for the model generation
+Test for the model generation
 
-    These tests check that the generated NN are as expected
-    It checks that both the number of layers and the shape
-    of the weights of the layers are what is expected
+These tests check that the generated NN are as expected
+It checks that both the number of layers and the shape
+of the weights of the layers are what is expected
 """
 
 from n3fit.backends import NN_PREFIX
-from n3fit.model_gen import generate_nn
+from n3fit.model_gen import _generate_nn
 
 INSIZE = 16
 OUT_SIZES = (4, 3)
@@ -27,7 +27,7 @@ COMMON_ARGS = {
 
 
 def test_generate_dense_network():
-    nn = generate_nn("dense", **COMMON_ARGS)
+    nn = _generate_nn("dense", **COMMON_ARGS)
 
     # The number of layers should be input layer + len(OUT_SIZES)
     assert len(nn.layers) == len(OUT_SIZES) + 1
@@ -38,7 +38,7 @@ def test_generate_dense_network():
 
 
 def test_generate_dense_per_flavour_network():
-    nn = generate_nn("dense_per_flavour", **COMMON_ARGS).get_layer(f"{NN_PREFIX}_0")
+    nn = _generate_nn("dense_per_flavour", **COMMON_ARGS).get_layer(f"{NN_PREFIX}_0")
 
     # The number of layers should be input + BASIS_SIZE*len(OUT_SIZES) + concatenate
     assert len(nn.layers) == BASIS_SIZE * len(OUT_SIZES) + 2

--- a/n3fit/src/n3fit/tests/test_modelgen.py
+++ b/n3fit/src/n3fit/tests/test_modelgen.py
@@ -11,7 +11,7 @@ from dataclasses import asdict
 import pytest
 
 from n3fit.backends import Input
-from n3fit.model_gen import _generate_nn, _ReplicaSettings
+from n3fit.model_gen import ReplicaSettings, _generate_nn
 from nnpdf_data.utils import parse_input
 
 INSIZE = 16
@@ -83,15 +83,15 @@ def test_replica_settings():
         "dropout_rate": 0.4,
     }
 
-    rsettings = parse_input(config, _ReplicaSettings)
+    rsettings = parse_input(config, ReplicaSettings)
 
     with pytest.raises(ValueError):
         ctmp = {**config, "regularizer_args": {"some": 4}}
-        _ReplicaSettings(**ctmp)
+        ReplicaSettings(**ctmp)
 
     with pytest.raises(ValueError):
         ctmp = {**config, "nodes": [2]}
-        _ReplicaSettings(**ctmp)
+        ReplicaSettings(**ctmp)
 
     x = Input(shape=(None, 2))
     nn = _generate_nn(x, 0, **asdict(rsettings))

--- a/n3fit/src/n3fit/tests/test_modelgen.py
+++ b/n3fit/src/n3fit/tests/test_modelgen.py
@@ -6,11 +6,16 @@ It checks that both the number of layers and the shape
 of the weights of the layers are what is expected
 """
 
-from n3fit.backends import NN_PREFIX, Input
-from n3fit.model_gen import _generate_nn
+from dataclasses import asdict
+
+import pytest
+
+from n3fit.backends import Input
+from n3fit.model_gen import _generate_nn, _ReplicaSettings
+from nnpdf_data.utils import parse_input
 
 INSIZE = 16
-OUT_SIZES = (4, 3)
+OUT_SIZES = (4, 7, 3)
 BASIS_SIZE = OUT_SIZES[-1]
 
 
@@ -20,7 +25,7 @@ def _common_generation(architecture, dropout=0.0):
     config = {
         "architecture": architecture,
         "nodes": OUT_SIZES,
-        "activations": ["sigmoid", "tanh"],
+        "activations": ["sigmoid", "sigmoid", "tanh"],
         "initializer": "glorot_uniform",
         "seed": 27,
         "dropout_rate": dropout,
@@ -41,7 +46,11 @@ def test_generate_dense_network():
     assert len(nn_w_dropout.layers) == len(OUT_SIZES) + 2
 
     # Check that the number of parameters is as expected
-    expected_sizes = [(INSIZE, OUT_SIZES[0]), (OUT_SIZES[0]), (*OUT_SIZES,), (OUT_SIZES[1])]
+    expected_sizes = [(INSIZE, OUT_SIZES[0])]
+    for i, oz in enumerate(OUT_SIZES[:-1]):
+        expected_sizes.append((oz,))
+        expected_sizes.append((oz, OUT_SIZES[i + 1]))
+    expected_sizes.append((OUT_SIZES[-1],))
     for weight, esize in zip(nn.weights, expected_sizes):
         assert weight.shape == esize
 
@@ -54,6 +63,37 @@ def test_generate_dense_per_flavour_network():
     # The shape for this network of denses for flavours will depend on the basis_size
     expected_sizes = []
     expected_sizes += BASIS_SIZE * [(INSIZE, OUT_SIZES[0]), (OUT_SIZES[0],)]
-    expected_sizes += BASIS_SIZE * [(OUT_SIZES[0], 1), (1,)]
+    for i, oz in enumerate(OUT_SIZES[1:-1]):
+        expected_sizes += BASIS_SIZE * [(OUT_SIZES[i], oz), (oz,)]
+    expected_sizes += BASIS_SIZE * [(oz, 1), (1,)]
+
     for weight, esize in zip(nn.weights, expected_sizes):
         assert weight.shape == esize
+
+
+def test_replica_settings():
+    """Checks that the _ReplicaSettings object works as expected and
+    that it matches the input of _generate_nn"""
+    config = {
+        "seed": 8,
+        "nodes": [4, 10],
+        "activations": ["linear"] * 2,
+        "architecture": "dense",
+        "initializer": "glorot_uniform",
+        "dropout_rate": 0.4,
+    }
+
+    rsettings = parse_input(config, _ReplicaSettings)
+
+    with pytest.raises(ValueError):
+        ctmp = {**config, "regularizer_args": {"some": 4}}
+        _ReplicaSettings(**ctmp)
+
+    with pytest.raises(ValueError):
+        ctmp = {**config, "nodes": [2]}
+        _ReplicaSettings(**ctmp)
+
+    x = Input(shape=(None, 2))
+    nn = _generate_nn(x, 0, **asdict(rsettings))
+
+    nn.layers == (1 + len(rsettings.nodes) + 1 * rsettings.dropout_rate)

--- a/n3fit/src/n3fit/tests/test_multireplica.py
+++ b/n3fit/src/n3fit/tests/test_multireplica.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from n3fit.model_gen import generate_pdf_model
+from n3fit.model_gen import ReplicaSettings, generate_pdf_model
 
 
 def test_replica_split():
@@ -11,13 +11,8 @@ def test_replica_split():
         {"fl": i, "largex": [0.5, 1.5], "smallx": [1.5, 2.5]}
         for i in ["u", "ubar", "d", "dbar", "c", "g", "s", "sbar"]
     ]
-    pdf_model = generate_pdf_model(
-        nodes=[8],
-        activations=["linear"],
-        seed_list=[34] * num_replicas,
-        flav_info=fake_fl,
-        fitbasis="FLAVOUR",
-    )
+    rps = num_replicas * [ReplicaSettings(nodes=[8], activations=["linear"], seed=34)]
+    pdf_model = generate_pdf_model(rps, flav_info=fake_fl, fitbasis="FLAVOUR")
     rng = np.random.default_rng(seed=34)
     eps = 1e-9
     pdf_input = np.maximum(rng.random((1, 5, 1)), eps)

--- a/n3fit/src/n3fit/tests/test_multireplica.py
+++ b/n3fit/src/n3fit/tests/test_multireplica.py
@@ -2,21 +2,22 @@ import numpy as np
 
 from n3fit.model_gen import ReplicaSettings, generate_pdf_model
 
+EPS = 1e-9
+FAKE_FL = [
+    {"fl": i, "largex": [0.5, 1.5], "smallx": [1.5, 2.5]}
+    for i in ["u", "ubar", "d", "dbar", "c", "g", "s", "sbar"]
+]
+
 
 def test_replica_split():
     """Check that multi replica pdf and concatenated single output pdfs agree"""
     num_replicas = 3
     replica_axis = 1
-    fake_fl = [
-        {"fl": i, "largex": [0.5, 1.5], "smallx": [1.5, 2.5]}
-        for i in ["u", "ubar", "d", "dbar", "c", "g", "s", "sbar"]
-    ]
     rps = num_replicas * [ReplicaSettings(nodes=[8], activations=["linear"], seed=34)]
-    pdf_model = generate_pdf_model(rps, flav_info=fake_fl, fitbasis="FLAVOUR")
+    pdf_model = generate_pdf_model(rps, flav_info=FAKE_FL, fitbasis="FLAVOUR")
     rng = np.random.default_rng(seed=34)
-    eps = 1e-9
-    pdf_input = np.maximum(rng.random((1, 5, 1)), eps)
-    int_input = np.maximum(rng.random((1, 2_000, 1)), eps)
+    pdf_input = np.maximum(rng.random((1, 5, 1)), EPS)
+    int_input = np.maximum(rng.random((1, 2_000, 1)), EPS)
 
     fake_input = {
         'pdf_input': np.sort(pdf_input, axis=1),
@@ -30,3 +31,44 @@ def test_replica_split():
     output_split_stacked = np.stack(output_split, axis=replica_axis)
 
     np.testing.assert_allclose(output_full, output_split_stacked, rtol=1e-5)
+
+
+def test_multimodel(seed=42, xlen=5):
+    """Check that we can run different models, with different settings,
+    in one go.
+
+    This tests runs 3 replicas with 1, 2, and 3 layers respectively.
+    """
+    nodes = [20, 10, 8]
+    activations = ["tanh", "sigmoid", "linear"]
+    init_array = ["glorot_normal", "glorot_uniform", "random_uniform"]
+
+    rps = []
+    for i, initialization in enumerate(init_array):
+        idx = i + 1
+        rps.append(
+            ReplicaSettings(
+                nodes=nodes[-idx:],
+                activations=activations[-idx:],
+                seed=seed + idx,
+                initializer=initialization,
+            )
+        )
+
+    rng = np.random.default_rng(seed=seed)
+    pdf_input = np.maximum(rng.random((1, xlen, 1)), EPS)
+    int_input = np.maximum(rng.random((1, 2000, 1)), EPS)
+    fake_input = {
+        'pdf_input': np.sort(pdf_input, axis=1),
+        'xgrid_integration': np.sort(int_input, axis=1),
+    }
+
+    pdf_model = generate_pdf_model(rps, flav_info=FAKE_FL, fitbasis="FLAVOUR")
+    output_full = pdf_model(fake_input)
+    # Check that the output size is what we expect
+    np.testing.assert_array_equal(output_full.shape, (1, len(rps), xlen, 14))
+    # And now check that the split model has the right layers
+    single_replicas = pdf_model.split_replicas()
+
+    for i, model in enumerate(single_replicas):
+        len(model.get_layer("all_NNs").weights) == 2 * (i + 1)

--- a/n3fit/src/n3fit/tests/test_multireplica.py
+++ b/n3fit/src/n3fit/tests/test_multireplica.py
@@ -17,7 +17,6 @@ def test_replica_split():
         seed_list=[34] * num_replicas,
         flav_info=fake_fl,
         fitbasis="FLAVOUR",
-        num_replicas=num_replicas,
     )
     rng = np.random.default_rng(seed=34)
     eps = 1e-9

--- a/n3fit/src/n3fit/tests/test_multireplica.py
+++ b/n3fit/src/n3fit/tests/test_multireplica.py
@@ -14,7 +14,7 @@ def test_replica_split():
     pdf_model = generate_pdf_model(
         nodes=[8],
         activations=["linear"],
-        seed=34,
+        seed_list=[34] * num_replicas,
         flav_info=fake_fl,
         fitbasis="FLAVOUR",
         num_replicas=num_replicas,

--- a/n3fit/src/n3fit/tests/test_penalties.py
+++ b/n3fit/src/n3fit/tests/test_penalties.py
@@ -1,6 +1,7 @@
 """
-    Test the penalties for n3fit hyperopt
+Test the penalties for n3fit hyperopt
 """
+
 from types import SimpleNamespace
 
 from n3fit.hyper_optimization.penalties import integrability, patience, saturation
@@ -14,7 +15,7 @@ def test_saturation():
         for i in ["u", "ubar", "d", "dbar", "c", "g", "s", "sbar"]
     ]
     pdf_model = generate_pdf_model(
-        nodes=[8], activations=["linear"], seed=0, flav_info=fake_fl, fitbasis="FLAVOUR"
+        nodes=[8], activations=["linear"], seed_list=[0], flav_info=fake_fl, fitbasis="FLAVOUR"
     )
     assert isinstance(saturation(pdf_model, 5)[0], float)
 
@@ -35,6 +36,6 @@ def test_integrability_numbers():
         for i in ["u", "ubar", "d", "dbar", "c", "g", "s", "sbar"]
     ]
     pdf_model = generate_pdf_model(
-        nodes=[8], activations=["linear"], seed=0, flav_info=fake_fl, fitbasis="FLAVOUR"
+        nodes=[8], activations=["linear"], seed_list=[0], flav_info=fake_fl, fitbasis="FLAVOUR"
     )
     assert isinstance(integrability(pdf_model), float)

--- a/n3fit/src/n3fit/tests/test_penalties.py
+++ b/n3fit/src/n3fit/tests/test_penalties.py
@@ -5,7 +5,7 @@ Test the penalties for n3fit hyperopt
 from types import SimpleNamespace
 
 from n3fit.hyper_optimization.penalties import integrability, patience, saturation
-from n3fit.model_gen import generate_pdf_model
+from n3fit.model_gen import ReplicaSettings, generate_pdf_model
 
 
 def test_saturation():
@@ -14,9 +14,8 @@ def test_saturation():
         {"fl": i, "largex": [0, 1], "smallx": [1, 2]}
         for i in ["u", "ubar", "d", "dbar", "c", "g", "s", "sbar"]
     ]
-    pdf_model = generate_pdf_model(
-        nodes=[8], activations=["linear"], seed_list=[0], flav_info=fake_fl, fitbasis="FLAVOUR"
-    )
+    rps = [ReplicaSettings(nodes=[8], activations=["linear"], seed=0)]
+    pdf_model = generate_pdf_model(rps, flav_info=fake_fl, fitbasis="FLAVOUR")
     assert isinstance(saturation(pdf_model, 5)[0], float)
 
 
@@ -35,7 +34,6 @@ def test_integrability_numbers():
         {"fl": i, "largex": [0, 1], "smallx": [1, 2]}
         for i in ["u", "ubar", "d", "dbar", "c", "g", "s", "sbar"]
     ]
-    pdf_model = generate_pdf_model(
-        nodes=[8], activations=["linear"], seed_list=[0], flav_info=fake_fl, fitbasis="FLAVOUR"
-    )
+    rps = [ReplicaSettings(nodes=[8], activations=["linear"], seed=0)]
+    pdf_model = generate_pdf_model(rps, flav_info=fake_fl, fitbasis="FLAVOUR")
     assert isinstance(integrability(pdf_model), float)

--- a/n3fit/src/n3fit/tests/test_preprocessing.py
+++ b/n3fit/src/n3fit/tests/test_preprocessing.py
@@ -102,8 +102,8 @@ def test_constraint():
     # Check that now everything satisfies the constraint again
     for w in prepro.weights:
         if w.trainable:
-            assert np.alltrue(w.constraint.min_value <= w.numpy())
-            assert np.alltrue(w.numpy() <= w.constraint.max_value)
+            np.testing.assert_array_less(w.constraint.min_value, w.numpy())
+            np.testing.assert_array_less(w.numpy(), w.constraint.max_value)
 
     # Check that other replicas were not affected
     for wa, wb in zip(weights_after[1:], weights_before[1:]):

--- a/n3fit/src/n3fit/tests/test_preprocessing.py
+++ b/n3fit/src/n3fit/tests/test_preprocessing.py
@@ -102,8 +102,8 @@ def test_constraint():
     # Check that now everything satisfies the constraint again
     for w in prepro.weights:
         if w.trainable:
-            np.testing.assert_array_less(w.constraint.min_value, w.numpy())
-            np.testing.assert_array_less(w.numpy(), w.constraint.max_value)
+            assert np.all(w.constraint.min_value <= w.numpy())
+            assert np.all(w.numpy() <= w.constraint.max_value)
 
     # Check that other replicas were not affected
     for wa, wb in zip(weights_after[1:], weights_before[1:]):

--- a/n3fit/src/n3fit/tests/test_vpinterface.py
+++ b/n3fit/src/n3fit/tests/test_vpinterface.py
@@ -22,9 +22,8 @@ def generate_n3pdf(layers=1, members=1, name="n3fit"):
     pdf_model = generate_pdf_model(
         nodes=nodes,
         activations=activations,
-        seed_list=[np.random.randint(100)] * members,
+        seed_list=np.random.randint(100, size=members),
         flav_info=fake_fl,
-        num_replicas=members,
         fitbasis="FLAVOUR",
     ).split_replicas()
     return N3PDF(pdf_model, name=name)

--- a/n3fit/src/n3fit/tests/test_vpinterface.py
+++ b/n3fit/src/n3fit/tests/test_vpinterface.py
@@ -6,7 +6,7 @@ from hypothesis import example, given, settings
 from hypothesis.strategies import integers
 import numpy as np
 
-from n3fit.model_gen import generate_pdf_model
+from n3fit.model_gen import ReplicaSettings, generate_pdf_model
 from n3fit.vpinterface import N3PDF, compute_arclength, integrability_numbers
 from validphys.pdfgrids import distance_grids, xplotting_grid
 
@@ -19,13 +19,9 @@ def generate_n3pdf(layers=1, members=1, name="n3fit"):
     ]
     nodes = list(np.random.randint(1, 10, size=layers)) + [8]
     activations = ["tanh"] * layers + ["linear"]
-    pdf_model = generate_pdf_model(
-        nodes=nodes,
-        activations=activations,
-        seed_list=np.random.randint(100, size=members),
-        flav_info=fake_fl,
-        fitbasis="FLAVOUR",
-    ).split_replicas()
+    seeds = np.random.randint(100, size=members)
+    rps = [ReplicaSettings(nodes=nodes, activations=activations, seed=seed) for seed in seeds]
+    pdf_model = generate_pdf_model(rps, flav_info=fake_fl, fitbasis="FLAVOUR").split_replicas()
     return N3PDF(pdf_model, name=name)
 
 

--- a/n3fit/src/n3fit/tests/test_vpinterface.py
+++ b/n3fit/src/n3fit/tests/test_vpinterface.py
@@ -1,5 +1,5 @@
 """
-    Test the n3fit-validphys interface
+Test the n3fit-validphys interface
 """
 
 from hypothesis import example, given, settings
@@ -22,7 +22,7 @@ def generate_n3pdf(layers=1, members=1, name="n3fit"):
     pdf_model = generate_pdf_model(
         nodes=nodes,
         activations=activations,
-        seed=np.random.randint(100),
+        seed_list=[np.random.randint(100)] * members,
         flav_info=fake_fl,
         num_replicas=members,
         fitbasis="FLAVOUR",

--- a/n3fit/src/n3fit/vpinterface.py
+++ b/n3fit/src/n3fit/vpinterface.py
@@ -6,16 +6,16 @@ Example
 
 >>> import numpy as np
 >>> from n3fit.vpinterface import N3PDF
->>> from n3fit.model_gen import pdfNN_layer_generator
+>>> from n3fit.model_gen import generate_pdf_model
 >>> from validphys.pdfgrids import xplotting_grid
->>> fake_fl = [{'fl' : i, 'largex' : [0,1], 'smallx': [1,2]} for i in ['u', 'ubar', 'd', 'dbar', 'c', 'cbar', 's', 'sbar']]
+>>> fake_fl = [{'fl' : i, 'largex' : [0,1], 'smallx': [1,2]} for i in ['u', 'ubar', 'd', 'dbar', 'c', 's', 'sbar', 'g']]
 >>> fake_x = np.linspace(1e-3,0.8,3)
->>> pdf_model = pdfNN_layer_generator(nodes=[8], activations=['linear'], seed=0, flav_info=fake_fl)
->>> n3pdf = N3PDF(pdf_model)
+>>> pdf_model = generate_pdf_model(nodes=[8], activations=['linear'], seed_list=np.arange(4), flav_info=fake_fl, fitbasis='FLAVOUR')
+>>> n3pdf = N3PDF(pdf_model.split_replicas())
 >>> res = xplotting_grid(n3pdf, 1.6, fake_x)
 >>> res.grid_values.error_members().shape
-(1, 8, 3)
-
+(4, 8, 3)
+# (nreplicas, flavours, x-grid)
 
 """
 
@@ -376,7 +376,7 @@ def compute_phi(n3pdf, experimental_data):
     >>> from n3fit.model_gen import generate_pdf_model
     >>> from validphys.loader import Loader
     >>> fake_fl = [{'fl' : i, 'largex' : [0,1], 'smallx': [1,2]} for i in ['u', 'ubar', 'd', 'dbar', 'c', 'g', 's', 'sbar']]
-    >>> pdf_model = generate_pdf_model(nodes=[8], activations=['linear'], seed=0, num_replicas=2, flav_info=fake_fl, fitbasis="FLAVOUR")
+    >>> pdf_model = generate_pdf_model(nodes=[8], activations=['linear'], seed=[0,1], flav_info=fake_fl, fitbasis="FLAVOUR")
     >>> n3pdf = N3PDF(pdf_model.split_replicas())
     >>> ds = Loader().check_dataset("NMC_NC_NOTFIXED_P_EM-SIGMARED", theoryid=399, cuts="internal")
     >>> data_group_spec = Loader().check_experiment("My DataGroupSpec", [ds])

--- a/n3fit/src/n3fit/vpinterface.py
+++ b/n3fit/src/n3fit/vpinterface.py
@@ -6,11 +6,12 @@ Example
 
 >>> import numpy as np
 >>> from n3fit.vpinterface import N3PDF
->>> from n3fit.model_gen import generate_pdf_model
+>>> from n3fit.model_gen import generate_pdf_model, ReplicaSettings
 >>> from validphys.pdfgrids import xplotting_grid
 >>> fake_fl = [{'fl' : i, 'largex' : [0,1], 'smallx': [1,2]} for i in ['u', 'ubar', 'd', 'dbar', 'c', 's', 'sbar', 'g']]
 >>> fake_x = np.linspace(1e-3,0.8,3)
->>> pdf_model = generate_pdf_model(nodes=[8], activations=['linear'], seed_list=np.arange(4), flav_info=fake_fl, fitbasis='FLAVOUR')
+>>> rps = [ReplicaSettings(nodes=[8], activations=["linear"], seed=4)]*4
+>>> pdf_model = generate_pdf_model(rps, flav_info=fake_fl, fitbasis='FLAVOUR')
 >>> n3pdf = N3PDF(pdf_model.split_replicas())
 >>> res = xplotting_grid(n3pdf, 1.6, fake_x)
 >>> res.grid_values.error_members().shape
@@ -373,12 +374,13 @@ def compute_phi(n3pdf, experimental_data):
     Example
     -------
     >>> from n3fit.vpinterface import N3PDF, compute_phi
-    >>> from n3fit.model_gen import generate_pdf_model
+    >>> from n3fit.model_gen import generate_pdf_model, ReplicaSettings
     >>> from validphys.loader import Loader
     >>> fake_fl = [{'fl' : i, 'largex' : [0,1], 'smallx': [1,2]} for i in ['u', 'ubar', 'd', 'dbar', 'c', 'g', 's', 'sbar']]
-    >>> pdf_model = generate_pdf_model(nodes=[8], activations=['linear'], seed=[0,1], flav_info=fake_fl, fitbasis="FLAVOUR")
+    >>> rps = [ReplicaSettings(nodes=[8], activations=["linear"], seed=i) for i in [0,1]]
+    >>> pdf_model = generate_pdf_model(rps, flav_info=fake_fl, fitbasis="FLAVOUR")
     >>> n3pdf = N3PDF(pdf_model.split_replicas())
-    >>> ds = Loader().check_dataset("NMC_NC_NOTFIXED_P_EM-SIGMARED", theoryid=399, cuts="internal")
+    >>> ds = Loader().check_dataset("NMC_NC_NOTFIXED_P_EM-SIGMARED", theoryid=40_000_000, cuts="internal", variant="legacy")
     >>> data_group_spec = Loader().check_experiment("My DataGroupSpec", [ds])
     >>> phi = compute_phi(n3pdf, [data_group_spec])
     """


### PR DESCRIPTION
This PR will implement the multiarchitecture parlallel training. The way I'm planning to do it is by first refactoring everything that happens below `generate_pdf_model`, which is the only function that gets called from the outside, without changing anything from the interface (other than perhaps making it more strict on the input). 

The refactoring in this case means separating very clearly the options that can be modified in a per-replica basis and the options that must be generic to the entire model (e.g., the number of layer of each replica can be different, but the output shape must be the same).

I will try my best to do things such that it also prepares the future implementation of FF and nuclear PDFs.

After that I will add a very minimal and proof-of-concept sampling upon which we will build the one for 4.1

I wanted to open the draft early so that people can pitch in, in case you have some idea already about how to structure this. @RoyStegeman @Radonirinaunimi @tgiani 