### PR TITLE
Modify the theory metadata for ATLAS_Z0J_8TEV_PT-M

### DIFF
--- a/nnpdf_data/nnpdf_data/commondata/ATLAS_Z0J_8TEV/metadata.yaml
+++ b/nnpdf_data/nnpdf_data/commondata/ATLAS_Z0J_8TEV/metadata.yaml
@@ -129,6 +129,9 @@ implemented_observables:
     sys_10:
       data_uncertainties:
       - uncertainties_sys_10_PT-M.yaml
+    legacy_data:
+      data_uncertainties:
+      - uncertainties_legacy_PT-M.yaml
     legacy:
       theory: *legtheo
       data_uncertainties:

--- a/nnpdf_data/nnpdf_data/commondata/ATLAS_Z0J_8TEV/metadata.yaml
+++ b/nnpdf_data/nnpdf_data/commondata/ATLAS_Z0J_8TEV/metadata.yaml
@@ -104,24 +104,36 @@ implemented_observables:
   data_central: data_PT-M.yaml
   theory:
     conversion_factor: 1.0
-    shifts:
-      ATLASZPT8TEVMDIST-ATLASZPT8TEV-MLLBIN4_ptZ: 10
-      ATLASZPT8TEVMDIST-ATLASZPT8TEV-MLLBIN6_ptZ: 10
     operation: 'null'
     FK_tables:
-    - - ATLASZPT8TEVMDIST-ATLASZPT8TEV-MLLBIN1_ptZ
-      - ATLASZPT8TEVMDIST-ATLASZPT8TEV-MLLBIN2_ptZ
-      - ATLASZPT8TEVMDIST-ATLASZPT8TEV-MLLBIN3_ptZ
-      - ATLASZPT8TEVMDIST-ATLASZPT8TEV-MLLBIN4_ptZ
-      - ATLASZPT8TEVMDIST-ATLASZPT8TEV-MLLBIN6_ptZ
+      - - ATLAS_Z0J_8TEV_PT.pT_mll_12_20
+        - ATLAS_Z0J_8TEV_PT.pT_mll_20_30
+        - ATLAS_Z0J_8TEV_PT.pT_mll_30_46
+        - ATLAS_Z0J_8TEV_PT.pT_mll_46_66
+        - ATLAS_Z0J_8TEV_PT.pT_mll_116_150
   data_uncertainties: [uncertainties_PT-M.yaml]
   variants:
+    legacy_theory:
+      theory: &legtheo
+        conversion_factor: 1.0
+        shifts:
+          ATLASZPT8TEVMDIST-ATLASZPT8TEV-MLLBIN4_ptZ: 10
+          ATLASZPT8TEVMDIST-ATLASZPT8TEV-MLLBIN6_ptZ: 10
+        operation: 'null'
+        FK_tables:
+        - - ATLASZPT8TEVMDIST-ATLASZPT8TEV-MLLBIN1_ptZ
+          - ATLASZPT8TEVMDIST-ATLASZPT8TEV-MLLBIN2_ptZ
+          - ATLASZPT8TEVMDIST-ATLASZPT8TEV-MLLBIN3_ptZ
+          - ATLASZPT8TEVMDIST-ATLASZPT8TEV-MLLBIN4_ptZ
+          - ATLASZPT8TEVMDIST-ATLASZPT8TEV-MLLBIN6_ptZ
     sys_10:
       data_uncertainties:
       - uncertainties_sys_10_PT-M.yaml
     legacy:
+      theory: *legtheo
       data_uncertainties:
       - uncertainties_legacy_PT-M.yaml
     legacy_10:
+      theory: *legtheo
       data_uncertainties:
       - uncertainties_legacy_sys_10_PT-M.yaml

--- a/validphys2/src/validphys/tests/test_datafiles.py
+++ b/validphys2/src/validphys/tests/test_datafiles.py
@@ -104,7 +104,7 @@ def test_all_datasets(dataset_name, data_internal_cuts_new_theory_config):
         # First check that if legacy_theory exists by itself, it is because legacy_data also exists
         if "legacy_data" not in main_cd.metadata.variants:
             raise KeyError(
-                f"Variant 'legadcy_data' must exist whenever 'legacy_theory' does, it doesn't for {dataset_name}"
+                f"Variant 'legacy_data' must exist whenever 'legacy_theory' does, it doesn't for {dataset_name}"
             )
 
         # Check that legacy_theory + legacy_data == legacy


### PR DESCRIPTION
Move the old theory to a `legacy_theory` (that will be automatically used in legacy mode). The reason for this change is that the old grids were missing the bins for pt < 30 GeV (which were cut away so it doesn't matter) while the data includes these points.
The new grids match the data so the shifts are no longer needed.

With the last commit in https://github.com/NNPDF/theories_slim/pull/58 and this branch you should be able to run your notebook @achiefa, please let me know whether this is the case