### PR TITLE
Misc validphys speed ups

### DIFF
--- a/validphys2/src/validphys/convolution.py
+++ b/validphys2/src/validphys/convolution.py
@@ -373,6 +373,13 @@ def _gv_hadron_predictions(loaded_fk, gv1func, gv2func=None):
     # possible x1-x2 combinations (f1, f2, x1, x2)
     luminosity = np.einsum("ijk, ijl->ijkl", expanded_gv1, expanded_gv2)
 
+    if not loaded_fk.legacy:
+        lx = len(xgrid)
+        lc = len(fl1)
+        fktab = sigma.values.reshape(-1, lx, lx, lc)
+        ret = np.einsum("rcab, nabc->nr", luminosity, fktab)
+        return pd.DataFrame(ret, index=loaded_fk.data_index)
+
     def appl(df):
         # x1 and x2 are encoded as the first and second index levels.
         xx1 = df.index.get_level_values(1)
@@ -380,6 +387,12 @@ def _gv_hadron_predictions(loaded_fk, gv1func, gv2func=None):
         # take the active combinations from the luminosity tensor
         partial_lumi = luminosity[..., xx1, xx2]
         return pd.Series(np.einsum("ijk,kj->i", partial_lumi, df.values))
+
+    # The gv1/gv2 grids are arrays of shape (replicas, flavours<14>, xarray)
+    # the expanded gv1/gv2 instead are shaped according to the channels (which will match)
+    # therefore the luminosity is an array of shape (replicas, channels, x1, x2)
+    # this needs to be matched with the fktable which for the old interface were not ordered
+    # and so the full dataframe needs to be used instead to keep track of the index
 
     return sigma.groupby(level=0).apply(appl)
 
@@ -396,6 +409,12 @@ def _gv_dis_predictions(loaded_fk, gvfunc):
     # TODO: Ideally we would return before computing the grid
     if sigma.empty:
         return pd.DataFrame(columns=range(gv.shape[0]))
+
+    if not loaded_fk.legacy:
+        lx = len(xgrid)
+        fktab = sigma.values.reshape(-1, lx, len(fm))
+        ret = np.einsum("rfa, naf->nr", gv, fktab)
+        return pd.DataFrame(ret, index=loaded_fk.data_index)
 
     def appl(df):
         # x is encoded as the first index level.

--- a/validphys2/src/validphys/convolution.py
+++ b/validphys2/src/validphys/convolution.py
@@ -43,8 +43,8 @@ import operator
 import numpy as np
 import pandas as pd
 
-from validphys.pdfbases import evolution
 import validphys
+from validphys.pdfbases import evolution
 
 FK_FLAVOURS = evolution.to_known_elements(
     [
@@ -176,6 +176,7 @@ def _predictions(dataset, pdf, fkfunc):
     return opfunc(*all_predictions)
 
 
+@functools.cache
 def predictions(dataset, pdf):
     """ "Compute theory predictions for a given PDF and dataset. Information
     regading the dataset, on cuts, CFactors and combinations of FKTables is
@@ -227,6 +228,7 @@ def predictions(dataset, pdf):
     return _predictions(dataset, pdf, fk_predictions)
 
 
+@functools.cache
 def central_predictions(
     dataset: validphys.core.DataSetSpec, pdf: validphys.core.PDF
 ) -> pd.DataFrame:

--- a/validphys2/src/validphys/convolution.py
+++ b/validphys2/src/validphys/convolution.py
@@ -373,28 +373,28 @@ def _gv_hadron_predictions(loaded_fk, gv1func, gv2func=None):
     # possible x1-x2 combinations (f1, f2, x1, x2)
     luminosity = np.einsum("ijk, ijl->ijkl", expanded_gv1, expanded_gv2)
 
-    if not loaded_fk.legacy:
-        lx = len(xgrid)
-        lc = len(fl1)
-        fktab = sigma.values.reshape(-1, lx, lx, lc)
-        ret = np.einsum("rcab, nabc->nr", luminosity, fktab)
-        return pd.DataFrame(ret, index=loaded_fk.data_index)
+    if loaded_fk.legacy:
+        # Old FkTables are singled out since they are not always sorted in x1/x2 so matching the
+        # FkTable with the PDF grids (gv1/gv2) is done by means of dataframes, which is slow.
+        # The gv1/gv2 grids are arrays of shape (replicas, flavours<14>, xarray)
+        # the expanded gv1/gv2 instead are shaped according to the channels (which will match)
+        # therefore the luminosity is an array of shape (replicas, channels, x1, x2)
+        def appl(df):
+            # x1 and x2 are encoded as the first and second index levels.
+            xx1 = df.index.get_level_values(1)
+            xx2 = df.index.get_level_values(2)
+            # take the active combinations from the luminosity tensor
+            partial_lumi = luminosity[..., xx1, xx2]
+            return pd.Series(np.einsum("ijk,kj->i", partial_lumi, df.values))
 
-    def appl(df):
-        # x1 and x2 are encoded as the first and second index levels.
-        xx1 = df.index.get_level_values(1)
-        xx2 = df.index.get_level_values(2)
-        # take the active combinations from the luminosity tensor
-        partial_lumi = luminosity[..., xx1, xx2]
-        return pd.Series(np.einsum("ijk,kj->i", partial_lumi, df.values))
+        return sigma.groupby(level=0).apply(appl)
 
-    # The gv1/gv2 grids are arrays of shape (replicas, flavours<14>, xarray)
-    # the expanded gv1/gv2 instead are shaped according to the channels (which will match)
-    # therefore the luminosity is an array of shape (replicas, channels, x1, x2)
-    # this needs to be matched with the fktable which for the old interface were not ordered
-    # and so the full dataframe needs to be used instead to keep track of the index
-
-    return sigma.groupby(level=0).apply(appl)
+    # Pineappl FkTables are sorted and can be treated as numpy arrays
+    lx = len(xgrid)
+    lc = len(fl1)
+    fktab = sigma.values.reshape(-1, lx, lx, lc)
+    ret = np.einsum("rcab, nabc->nr", luminosity, fktab)
+    return pd.DataFrame(ret, index=loaded_fk.data_index)
 
 
 def _gv_dis_predictions(loaded_fk, gvfunc):
@@ -410,18 +410,20 @@ def _gv_dis_predictions(loaded_fk, gvfunc):
     if sigma.empty:
         return pd.DataFrame(columns=range(gv.shape[0]))
 
-    if not loaded_fk.legacy:
-        lx = len(xgrid)
-        fktab = sigma.values.reshape(-1, lx, len(fm))
-        ret = np.einsum("rfa, naf->nr", gv, fktab)
-        return pd.DataFrame(ret, index=loaded_fk.data_index)
+    if loaded_fk.legacy:
+        # Old FkTable are not necessarily sorted in x and need to be treated as dataframes
+        # See comment in `_gv_hadron_predictions` for more details
+        def appl(df):
+            # x is encoded as the first index level.
+            xind = df.index.get_level_values(1)
+            return pd.Series(np.einsum("ijk,kj->i", gv[:, :, xind], df.values))
 
-    def appl(df):
-        # x is encoded as the first index level.
-        xind = df.index.get_level_values(1)
-        return pd.Series(np.einsum("ijk,kj->i", gv[:, :, xind], df.values))
+        return sigma.groupby(level=0).apply(appl)
 
-    return sigma.groupby(level=0).apply(appl)
+    lx = len(xgrid)
+    fktab = sigma.values.reshape(-1, lx, len(fm))
+    ret = np.einsum("rfa, naf->nr", gv, fktab)
+    return pd.DataFrame(ret, index=loaded_fk.data_index)
 
 
 def hadron_predictions(loaded_fk, pdf):

--- a/validphys2/src/validphys/covmats.py
+++ b/validphys2/src/validphys/covmats.py
@@ -125,7 +125,7 @@ def covmat_from_systematics(
 
 def dataset_inputs_covmat_from_systematics(
     dataset_inputs_loaded_cd_with_cuts,
-    data_input,
+    data_input=None,
     use_weights_in_covmat=True,
     norm_threshold=None,
     _list_of_central_values=None,
@@ -186,9 +186,15 @@ def dataset_inputs_covmat_from_systematics(
     special_corrs = []
     block_diags = []
     weights = []
+
     if _list_of_central_values is None:
         # want to just pass None to systematic_errors method
         _list_of_central_values = [None] * len(dataset_inputs_loaded_cd_with_cuts)
+
+    if data_input is None:
+        if use_weights_in_covmat:
+            raise ValueError("if use_weights_in_covmat=True, ``data_input`` cannot be empty")
+        data_input = [None] * len(dataset_inputs_loaded_cd_with_cuts)
 
     for cd, dsinp, central_values in zip(
         dataset_inputs_loaded_cd_with_cuts, data_input, _list_of_central_values
@@ -199,7 +205,8 @@ def dataset_inputs_covmat_from_systematics(
         else:
             sys_errors = cd.systematic_errors(central_values)
         stat_errors = cd.stat_errors.to_numpy()
-        weights.append(np.full_like(stat_errors, dsinp.weight))
+        if use_weights_in_covmat and dsinp is not None:
+            weights.append(np.full_like(stat_errors, dsinp.weight))
         # separate out the special uncertainties which can be correlated across
         # datasets
         is_intra_dataset_error = sys_errors.columns.isin(INTRA_DATASET_SYS_NAME)

--- a/validphys2/src/validphys/fkparser.py
+++ b/validphys2/src/validphys/fkparser.py
@@ -18,7 +18,7 @@ CFactors applied.
     res = load_fktable(fk)
 """
 
-# TODO: this module is deprecated and support for older theories will be removed
+# TODO: this module is deprecated and support for older theories is not guaranteed
 
 import dataclasses
 import functools

--- a/validphys2/src/validphys/fkparser.py
+++ b/validphys2/src/validphys/fkparser.py
@@ -18,6 +18,8 @@ CFactors applied.
     res = load_fktable(fk)
 """
 
+# TODO: this module is deprecated and support for older theories will be removed
+
 import dataclasses
 import functools
 import io
@@ -313,9 +315,17 @@ def parse_fktable(f):
             hadronic = res['GridInfo'].hadronic
             ndata = res['GridInfo'].ndata
             xgrid = res.pop('xGrid')
+            data_idx = sigma.index.get_level_values("data").unique().to_series()
 
             return FKTableData(
-                sigma=sigma, ndata=ndata, Q0=Q0, metadata=res, hadronic=hadronic, xgrid=xgrid
+                sigma=sigma,
+                ndata=ndata,
+                Q0=Q0,
+                metadata=res,
+                hadronic=hadronic,
+                xgrid=xgrid,
+                data_index=data_idx,
+                legacy=True,
             )
         elif header_name in _KNOWN_SEGMENTS:
             parser = _KNOWN_SEGMENTS[header_name]

--- a/validphys2/src/validphys/pineparser.py
+++ b/validphys2/src/validphys/pineparser.py
@@ -203,6 +203,7 @@ def pineappl_reader(fkspec):
 
     partial_fktables = []
     ndata = 0
+    full_data_index = []
     for fkname, p in zip(fknames, pines):
         # Start by reading possible cfactors if cfactor is not empty
         cfprod = 1.0
@@ -247,6 +248,7 @@ def pineappl_reader(fkspec):
         partial_fktables.append(pd.DataFrame(df_fktable, columns=lumi_columns, index=idx))
 
         ndata += n
+        full_data_index.append(data_idx)
 
     # Finallly concatenate all fktables, sort by flavours and fill any holes
     sigma = pd.concat(partial_fktables, sort=True, copy=False).fillna(0.0)
@@ -265,8 +267,14 @@ def pineappl_reader(fkspec):
             ndata = 1
 
         if ndata == 1:
-            # There's no doubt
-            protected = divisor == name
+            # When the number of points is 1 and the fktable is a divisor, protect it from cuts
+            if divisor == name:
+                protected = True
+                full_data_index = [[0]]
+
+    # Keeping the data index as a series is exploited to speed up certain operations (e.g. hadronic conv)
+    fid = np.concatenate(full_data_index)
+    data_index = pd.Series(fid, index=fid, name="data")
 
     return FKTableData(
         sigma=sigma,
@@ -277,4 +285,5 @@ def pineappl_reader(fkspec):
         hadronic=hadronic,
         xgrid=xgrid,
         protected=protected,
+        data_index=data_index,
     )

--- a/validphys2/src/validphys/pineparser.py
+++ b/validphys2/src/validphys/pineparser.py
@@ -272,7 +272,8 @@ def pineappl_reader(fkspec):
                 protected = True
                 full_data_index = [[0]]
 
-    # Keeping the data index as a series is exploited to speed up certain operations (e.g. hadronic conv)
+    # Keeping the data index as a series is exploited to speed up convolutions
+    # see e.g., convolution.py::_gv_hadron_predictions
     fid = np.concatenate(full_data_index)
     data_index = pd.Series(fid, index=fid, name="data")
 


### PR DESCRIPTION
Trying to speed up a few things I noticed the convolutions spent a good fraction of the time just moving things around inside the dataframe.

Now, this is necessary because the old fktables didn't follow any particular order... when loading fktables with pineappl instead this is not the case. Among other things because all fktables get casted to the same array: https://github.com/NNPDF/nnpdf/blob/bcfe00b07cc7e70063751c18daf725a7b4add30b/validphys2/src/validphys/pineparser.py#L226 
with these changes a full vp-comparefit goes from 40 min to about 20 in my computer.

Note: I have not bothered to port this speed up to old fktables. In principle it could be done just the same by ordering them sensibly after they are loaded.

Note 2: we load the pineappl fktables into an intermediate dataframe that with these changes is no longer necessary, but that's trickier to remove since the fktable is assumed to be a dataframe at various points.