### PR TITLE
Separate the ekos into its own folder

### DIFF
--- a/validphys2/src/validphys/loader.py
+++ b/validphys2/src/validphys/loader.py
@@ -186,7 +186,13 @@ def _get_nnpdf_profile(profile_path=None):
         ) from e
 
     # Now read all paths and define them as relative to nnpdf_share (unless given as absolute)
-    for var in ["results_path", "theories_path", "validphys_cache_path", "hyperscan_path"]:
+    for var in [
+        "results_path",
+        "theories_path",
+        "validphys_cache_path",
+        "hyperscan_path",
+        "ekos_path",
+    ]:
         # if there are any problems setting or getting these variable erroring out is more than justified
         absolute_var = nnpdf_share / pathlib.Path(profile_dict[var]).expanduser()
         profile_dict[var] = absolute_var.absolute().as_posix()
@@ -249,6 +255,7 @@ class LoaderBase:
         datapath = pathlib.Path(profile["data_path"])
         theories_path = pathlib.Path(profile["theories_path"])
         resultspath = pathlib.Path(profile["results_path"])
+        ekos_path = pathlib.Path(profile["ekos_path"])
 
         if not datapath.exists():
             raise LoaderError(f"The data path {datapath} does not exist.")
@@ -260,6 +267,7 @@ class LoaderBase:
         # And save them up
         self.datapath = datapath
         self._theories_path = theories_path
+        self._ekos_path = ekos_path
         self.resultspath = resultspath
         self._extremely_old_fits = set()
         self.nnprofile = profile
@@ -466,9 +474,8 @@ In order to upgrade it you need to use the script `vp-rebuild-data` with a versi
 
     @functools.lru_cache
     def check_eko(self, theoryID):
-        """Check the eko (and the parent theory) both exists and returns the path to it"""
-        theory = self.check_theoryID(theoryID)
-        eko_path = theory.path / "eko.tar"
+        """Check the eko exists and return the path to it"""
+        eko_path = self._ekos_path / f"eko_{int(theoryID)}.tar"
         if not eko_path.exists():
             raise EkoNotFound(f"Could not find eko {eko_path} in theory: {theoryID}")
         return eko_path
@@ -1286,8 +1293,7 @@ class RemoteLoader(LoaderBase):
         if thid not in remote:
             raise EkoNotFound(f"EKO for TheoryID {thid} is not available in the remote server")
         # Check that we have the theory we need
-        theory = self.check_theoryID(thid)
-        target_path = theory.path / "eko.tar"
+        target_path = self._ekos_path / f"eko_{int(thid)}.tar"
         download_file(remote[thid], target_path, delete_on_failure=True)
 
     def download_vp_output_file(self, filename, **kwargs):

--- a/validphys2/src/validphys/nnprofile_default.yaml
+++ b/validphys2/src/validphys/nnprofile_default.yaml
@@ -29,6 +29,7 @@ results_path: results
 theories_path: theories
 hyperscan_path: hyperscan
 validphys_cache_path: vp-cache
+ekos_path: ekos
 
 # Starting from nnpdf > 4.0.7 the data is bundled together with the vp installation
 # data_path: <be careful when filling in the data path with custom values>


### PR DESCRIPTION
At the moment ekos are downloaded as `eko.tar` into the theory folder. As a result sometimes they end up in the server mingled with the theory.

This commit separates them so that you have, in the share directory, a `theories` folder and an `ekos` folder. They will be downloaded now as `eko_<theoryid>.tar` which is the same name they have in the remote server, making the match also easier. You can also remove the theories (if you want to download the fktables again) without having to remove the eko.