### PR TITLE
Separate covmat so that the inversion can be hashed

### DIFF
--- a/validphys2/src/validphys/config.py
+++ b/validphys2/src/validphys/config.py
@@ -911,9 +911,9 @@ class CoreConfig(configparser.Config):
         from validphys import n3fit_data
 
         if diagonal_basis:
-            return n3fit_data._diagonal_masks
+            return n3fit_data.diagonal_masks
         else:
-            return n3fit_data._standard_masks
+            return n3fit_data.standard_masks
 
     @configparser.explicit_node
     def produce_covariance_matrix(self, use_pdferr: bool = False):

--- a/validphys2/src/validphys/n3fit_data.py
+++ b/validphys2/src/validphys/n3fit_data.py
@@ -22,6 +22,14 @@ from validphys.n3fit_data_utils import validphys_group_extractor
 log = logging.getLogger(__name__)
 
 
+class Hashrray(TupleComp):
+    """Wrapper class to hash a numpy array so it can be cached."""
+
+    def __init__(self, array):
+        self.array = array
+        super().__init__(hash(self.array.tobytes()))
+
+
 def _per_replica(f):
     """Decorator to be used on top of reportengine's decorators.
     It replaces the preparation step of the decorator with a custom function,
@@ -153,7 +161,7 @@ class _Masks(TupleComp):
         super().__init__(group_name, seed)
 
 
-def _diagonal_masks(
+def diagonal_masks(
     data, replica_trvlseed, dataset_inputs_fitting_covmat, diagonal_frac=1.0, threshold_eigvals=0
 ):
 
@@ -187,7 +195,7 @@ def _diagonal_masks(
     )
 
 
-def _standard_masks(data, replica_trvlseed):
+def standard_masks(data, replica_trvlseed):
     """Generate the boolean masks used to split data into training and
     validation points. Returns a list of 1-D boolean arrays, one for each
     dataset. Each array has length equal to N_data, the datapoints which
@@ -203,6 +211,7 @@ def _standard_masks(data, replica_trvlseed):
 
     trmask_partial = []
     vlmask_partial = []
+    nomasking = True
     for dataset in data.datasets:
         # TODO: python commondata will not require this rubbish.
         # all data if cuts are None
@@ -214,6 +223,8 @@ def _standard_masks(data, replica_trvlseed):
             continue
 
         frac = dataset.frac
+        # nomasking turns to False as soon as one frac is not equal to 1
+        nomasking &= frac == 1.0
         # We do this so that a given dataset will always have the same number of points masked
         trmax = int(ndata * frac)
         if trmax == 0:
@@ -224,6 +235,9 @@ def _standard_masks(data, replica_trvlseed):
         vl_mask = ~tr_mask
         trmask_partial.append(tr_mask)
         vlmask_partial.append(vl_mask)
+    # if we are not masking, remove the seed from the object
+    if nomasking:
+        replica_trvlseed = None
     return _Masks(str(data), replica_trvlseed, trmask_partial, vlmask_partial)
 
 
@@ -304,65 +318,24 @@ def fittable_datasets_masked(data):
     return validphys_group_extractor(data.datasets)
 
 
-def fitting_data_dict(
-    data,
-    make_replica,
-    dataset_inputs_loaded_cd_with_cuts,
-    dataset_inputs_fitting_covmat,
-    masks,
-    kfold_masks,
-    fittable_datasets_masked,
-    diagonal_basis=False,
-):
+def _hashed_dataset_inputs_fitting_covmat(dataset_inputs_fitting_covmat) -> Hashrray:
+    """Wrap the covmat into a Hashrray for caches to work"""
+    return Hashrray(dataset_inputs_fitting_covmat)
+
+
+@functools.lru_cache
+def _inv_covmat_prepared(masks, _hashed_dataset_inputs_fitting_covmat, diagonal_basis=False):
+    """Returns the inverse covmats for training, validation and totalm
+    attending to the right masks and whether it is diagonal or not.
+
+    Since the masks and number of datapoints need to be treated for 1-point datasets
+    it also returns the right ndata and masks for training and validation:
+
+    inv_total, inv_training, inv_validation, ndata_tr, ndata_vl, mask_tr, mask_vl, diagonal_rotation
     """
-    Provider which takes  the information from validphys ``data``.
-
-    Returns
-    -------
-    all_dict_out: dict
-        Containing all the information of the experiment/dataset
-        for training, validation and experimental With the following keys:
-
-        'datasets'
-            list of dictionaries for each of the datasets contained in ``data``
-        'name'
-            name of the ``data`` - typically experiment/group name
-        'expdata_true'
-            non-replica data
-        'covmat'
-            full covmat
-        'invcovmat_true'
-            inverse of the covmat (non-replica)
-        'trmask'
-            mask for the training data
-        'invcovmat'
-            inverse of the covmat for the training data
-        'ndata'
-            number of datapoints for the training data
-        'expdata'
-            experimental data (replica'd) for training
-        'vlmask'
-            (same as above for validation)
-        'invcovmat_vl'
-            (same as above for validation)
-        'ndata_vl'
-            (same as above for validation)
-        'expdata_vl'
-            (same as above for validation)
-        'positivity'
-            bool - is this a positivity set?
-        'count_chi2'
-            should this be counted towards the chi2
-    """
-    # TODO: Plug in the python data loading when available. Including but not
-    # limited to: central values, ndata, replica generation, covmat construction
-    expdata_true = np.concatenate([d.central_values for d in dataset_inputs_loaded_cd_with_cuts])
-    expdata = make_replica
-
-    covmat = dataset_inputs_fitting_covmat  # t0 covmat, or theory covmat or whatever was decided by the runcard
-    # TODO: use cholesky decomposition to get the inverse of the covariance matrix
-    inv_true = np.linalg.inv(covmat)
-    fittable_datasets = fittable_datasets_masked
+    covmat = _hashed_dataset_inputs_fitting_covmat.array
+    inv_total = np.linalg.inv(covmat)
+    diagonal_rotation = None
 
     if diagonal_basis:
         log.info("working in diagonal basis.")
@@ -372,7 +345,6 @@ def fitting_data_dict(
 
         # rotate the experimental data to the diagonal basis of the cormat and obtain training/validation masks
         diagonal_rotation = masks.diagonal_rotation
-        expdata = diagonal_rotation @ expdata
         tr_mask = masks.tr_masks[0]
         vl_mask = masks.vl_masks[0]
 
@@ -455,6 +427,80 @@ def fitting_data_dict(
         ndata_tr -= len(data_zero_tr)
         ndata_vl -= len(data_zero_vl)
 
+    return (
+        inv_total,
+        invcovmat_tr,
+        invcovmat_vl,
+        ndata_tr,
+        ndata_vl,
+        tr_mask,
+        vl_mask,
+        diagonal_rotation,
+    )
+
+
+def fitting_data_dict(
+    data,
+    make_replica,
+    dataset_inputs_loaded_cd_with_cuts,
+    dataset_inputs_fitting_covmat,
+    _inv_covmat_prepared,
+    kfold_masks,
+    fittable_datasets_masked,
+):
+    """
+    Provider which takes  the information from validphys ``data``.
+
+    Returns
+    -------
+    all_dict_out: dict
+        Containing all the information of the experiment/dataset
+        for training, validation and experimental With the following keys:
+
+        'datasets'
+            list of dictionaries for each of the datasets contained in ``data``
+        'name'
+            name of the ``data`` - typically experiment/group name
+        'expdata_true'
+            non-replica data
+        'covmat'
+            full covmat
+        'invcovmat_true'
+            inverse of the covmat (non-replica)
+        'trmask'
+            mask for the training data
+        'invcovmat'
+            inverse of the covmat for the training data
+        'ndata'
+            number of datapoints for the training data
+        'expdata'
+            experimental data (replica'd) for training
+        'vlmask'
+            (same as above for validation)
+        'invcovmat_vl'
+            (same as above for validation)
+        'ndata_vl'
+            (same as above for validation)
+        'expdata_vl'
+            (same as above for validation)
+        'positivity'
+            bool - is this a positivity set?
+        'count_chi2'
+            should this be counted towards the chi2
+    """
+    # TODO: Plug in the python data loading when available. Including but not
+    # limited to: central values, ndata, replica generation, covmat construction
+    expdata_true = np.concatenate([d.central_values for d in dataset_inputs_loaded_cd_with_cuts])
+    expdata = make_replica
+    fittable_datasets = fittable_datasets_masked
+
+    inv_true, invcovmat_tr, invcovmat_vl, ndata_tr, ndata_vl, tr_mask, vl_mask, diag_rot = (
+        _inv_covmat_prepared
+    )
+
+    if diag_rot is not None:
+        expdata = diag_rot @ expdata
+
     expdata_tr = expdata[tr_mask].reshape(1, -1)
     expdata_vl = expdata[vl_mask].reshape(1, -1)
 
@@ -477,7 +523,7 @@ def fitting_data_dict(
         "name": str(data),
         "expdata_true": expdata_true.reshape(1, -1),
         "invcovmat_true": inv_true,
-        "covmat": covmat,
+        "covmat": dataset_inputs_fitting_covmat,
         "trmask": tr_mask,
         "invcovmat": invcovmat_tr,
         "ndata": ndata_tr,
@@ -489,7 +535,7 @@ def fitting_data_dict(
         "positivity": False,
         "count_chi2": True,
         "folds": folds,
-        "data_transformation": diagonal_rotation if diagonal_basis else None,
+        "data_transformation": diag_rot,
     }
     return dict_out
 

--- a/validphys2/src/validphys/n3fit_data.py
+++ b/validphys2/src/validphys/n3fit_data.py
@@ -325,7 +325,7 @@ def _hashed_dataset_inputs_fitting_covmat(dataset_inputs_fitting_covmat) -> Hash
 
 @functools.lru_cache
 def _inv_covmat_prepared(masks, _hashed_dataset_inputs_fitting_covmat, diagonal_basis=False):
-    """Returns the inverse covmats for training, validation and totalm
+    """Returns the inverse covmats for training, validation and total
     attending to the right masks and whether it is diagonal or not.
 
     Since the masks and number of datapoints need to be treated for 1-point datasets


### PR DESCRIPTION
This is necessary for https://github.com/NNPDF/nnpdf/issues/2332

I've basically moved the covmat inversion out of the generic function and added a "Hashed array" class. The advantage (right now) is that you can do a very large number of replicas in a GPU with a single covariance matrix (if the trvl faction is set to 1.0).

There are probably more pieces that can be taken out but that's left for #2332