### PR TITLE
Fixing Jax Backend

### DIFF
--- a/.github/workflows/all_tests_nnpdf.yml
+++ b/.github/workflows/all_tests_nnpdf.yml
@@ -108,6 +108,30 @@ jobs:
       run: |
         cd n3fit/runcards/examples
         n3fit Basic_runcard.yml 4
+        cat Basic_runcard/nnfit/*/Basic_runcard.json
+
+  run_jax:
+    runs-on: ubuntu-latest
+    env:
+      KERAS_BACKEND: jax
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+    - name: Install nnpdf without LHAPDF
+      shell: bash -l {0}
+      run: |
+        pip install .[nolha,jax]
+        # Since there is no LHAPDF in the system, initialize the folder and download pdfsets.index
+        lhapdf-management update --init
+    - name: Test we can run one runcard
+      shell: bash -l {0}
+      run: |
+        cd n3fit/runcards/examples
+        n3fit Basic_runcard.yml 42
+        cat Basic_runcard/nnfit/*/Basic_runcard.json
+
 
   full_coverage:
     needs: [run_package_tests, regression_tests]

--- a/n3fit/src/n3fit/backends/keras_backend/MetaModel.py
+++ b/n3fit/src/n3fit/backends/keras_backend/MetaModel.py
@@ -8,6 +8,7 @@ backend-dependent calls.
 from pathlib import Path
 import re
 
+from keras import backend as K
 from keras import optimizers as Kopt
 from keras.models import Model
 import numpy as np
@@ -176,7 +177,12 @@ class MetaModel(Model):
         of extra training epochs being run equal to max_epochs % 100 in the worst case.
 
         """
-        num_replicas = self.output_shape[0]
+        if K.backend() == "jax":
+            return 1
+
+        # TODO: test and document the actual impact of this line
+        # and whether it makes a difference for torch, CPU, GPU
+        num_replicas = self.output_shape[0][0]
         if num_replicas == 1 or epochs < 100:
             return 1
 

--- a/n3fit/src/n3fit/backends/keras_backend/MetaModel.py
+++ b/n3fit/src/n3fit/backends/keras_backend/MetaModel.py
@@ -159,9 +159,9 @@ class MetaModel(Model):
         for k, v in x_params.items():
             x_params[k] = ops.repeat(v, steps_per_epoch, axis=0)
         y = [ops.repeat(yi, steps_per_epoch, axis=0) for yi in y]
-
+        x_params_dict = dict(x_params)
         history = super().fit(
-            x=x_params, y=y, epochs=epochs // steps_per_epoch, batch_size=1, **kwargs
+            x=x_params_dict, y=y, epochs=epochs // steps_per_epoch, batch_size=1, **kwargs
         )
         loss_dict = history.history
         return loss_dict

--- a/n3fit/src/n3fit/backends/keras_backend/callbacks.py
+++ b/n3fit/src/n3fit/backends/keras_backend/callbacks.py
@@ -45,7 +45,7 @@ class CallbackStep(Callback):
 
     def on_batch_end(self, batch, logs=None):
         step_number = self.steps_in_epoch + self.epochs_finished * self.steps_per_epoch
-        self.on_step_end(step_number, logs)
+        # self.on_step_end(step_number, logs)
         self.steps_in_epoch += 1
 
     def correct_logs(self, logs: dict) -> dict:
@@ -91,14 +91,15 @@ class TimerCallback(CallbackStep):
 
     def on_train_end(self, logs=None):
         """Print the results"""
-        total_time = time() - self.starting_time
-        n_times = len(self.all_times)
-        # Skip the first 100 epochs to avoid fluctuations due to compilations of part of the code
-        # by epoch 100 all parts of the code have usually been called so it's a good compromise
-        mean = np.mean(self.all_times[min(110, n_times - 1) :])
-        std = np.std(self.all_times[min(110, n_times - 1) :])
-        log.info(f"> > Average time per epoch: {mean:.5} +- {std:.5} s")
-        log.info(f"> > > Total time: {total_time/60:.5} min")
+        return
+        # total_time = time() - self.starting_time
+        # n_times = len(self.all_times)
+        # # Skip the first 100 epochs to avoid fluctuations due to compilations of part of the code
+        # # by epoch 100 all parts of the code have usually been called so it's a good compromise
+        # mean = np.mean(self.all_times[min(110, n_times - 1) :])
+        # std = np.std(self.all_times[min(110, n_times - 1) :])
+        # log.info(f"> > Average time per epoch: {mean:.5} +- {std:.5} s")
+        # log.info(f"> > > Total time: {total_time/60:.5} min")
 
 
 class StoppingCallback(CallbackStep):
@@ -130,9 +131,10 @@ class StoppingCallback(CallbackStep):
         print_stats = ((epoch + 1) % self.log_freq) == 0
         # Note that the input logs correspond to the fit before the weights are updated
         logs = self.correct_logs(logs)
-        self.stopping_object.monitor_chi2(logs, epoch, print_stats=print_stats)
-        if self.stopping_object.stop_here():
-            self.model.stop_training = True
+        return
+        # self.stopping_object.monitor_chi2(logs, epoch, print_stats=print_stats)
+        # if self.stopping_object.stop_here():
+        #     self.model.stop_training = True
 
     def on_train_end(self, logs=None):
         """The training can be finished by the stopping or by

--- a/n3fit/src/n3fit/backends/keras_backend/internal_state.py
+++ b/n3fit/src/n3fit/backends/keras_backend/internal_state.py
@@ -1,5 +1,5 @@
 """
-    Library of functions that modify the internal state of Keras/Tensorflow
+Library of functions that modify the internal state of Keras/Tensorflow
 """
 
 import os
@@ -21,7 +21,8 @@ import numpy as np
 log = logging.getLogger(__name__)
 
 # Prepare Keras-backend dependent functions
-if K.backend() in ("torch", "jax"):
+if (kback := K.backend()) == "torch":
+
     import torch
 
     def set_eager(flag=True):
@@ -55,6 +56,16 @@ elif K.backend() == "tensorflow":
             log.warning(
                 "Could not set tensorflow parallelism settings from n3fit, maybe tensorflow is already initialized by a third program"
             )
+
+elif K.backend() == "jax":
+
+    import jax
+
+    def set_eager(flag=True):
+        pass
+
+    def set_threading(threads, core):
+        pass
 
 else:
     # Keras should've failed by now, if it doesn't it could be a new backend that works ootb?

--- a/n3fit/src/n3fit/backends/keras_backend/operations.py
+++ b/n3fit/src/n3fit/backends/keras_backend/operations.py
@@ -1,29 +1,29 @@
 """
-    This module contains the list of operations that can be used within the
-    ``call`` method of the ``n3fit`` layers as well as operations that can
-    act on layers.
+This module contains the list of operations that can be used within the
+``call`` method of the ``n3fit`` layers as well as operations that can
+act on layers.
 
-    This includes an implementation of the NNPDF operations on fktable in the keras
-    language (with the mapping ``c_to_py_fun``) into Keras ``Lambda`` layers.
+This includes an implementation of the NNPDF operations on fktable in the keras
+language (with the mapping ``c_to_py_fun``) into Keras ``Lambda`` layers.
 
-    The rest of the operations in this module are divided into four categories:
-    numpy to tensor:
-        Operations that take a numpy array and return a tensorflow tensor
-    layer to layer:
-        Operations that take a layer and return another layer
-    tensor to tensor:
-        Operations that take a tensor and return a tensor
-    layer generation:
-        Instanciate a layer to be applied by the calling function
+The rest of the operations in this module are divided into four categories:
+numpy to tensor:
+    Operations that take a numpy array and return a tensorflow tensor
+layer to layer:
+    Operations that take a layer and return another layer
+tensor to tensor:
+    Operations that take a tensor and return a tensor
+layer generation:
+    Instanciate a layer to be applied by the calling function
 
-    Most of the operations in this module are just aliases to the backend
-    (Keras in this case) so that, when implementing new backends, it is clear
-    which operations may need to be overwritten.
-    For a few selected operations, a more complicated wrapper to e.g., make
-    them into layers or apply some default, is included.
+Most of the operations in this module are just aliases to the backend
+(Keras in this case) so that, when implementing new backends, it is clear
+which operations may need to be overwritten.
+For a few selected operations, a more complicated wrapper to e.g., make
+them into layers or apply some default, is included.
 
-    Note that tensor operations can also be applied to layers as the output of a layer is a tensor
-    equally operations are automatically converted to layers when used as such.
+Note that tensor operations can also be applied to layers as the output of a layer is a tensor
+equally operations are automatically converted to layers when used as such.
 """
 
 from keras import backend as K
@@ -70,12 +70,12 @@ elif K.backend() == "jax":
     decorator_compiler = lambda f: f
 elif K.backend() == "tensorflow":
     tensor_to_numpy_or_python = lambda x: x.numpy()
-    lambda ret: {k: i.numpy() for k, i in ret.items()}
     import tensorflow as tf
 
     decorator_compiler = tf.function
 
 dict_to_numpy_or_python = lambda ret: {k: tensor_to_numpy_or_python(i) for k, i in ret.items()}
+variable_to_numpy = lambda x: x.numpy()
 
 
 def as_layer(operation, op_args=None, op_kwargs=None, **kwargs):

--- a/n3fit/src/n3fit/io/writer.py
+++ b/n3fit/src/n3fit/io/writer.py
@@ -286,10 +286,9 @@ class WriterWrapper:
 
     def _write_chi2s(self, out_path):
         # Note: same for all replicas, unless run separately
-        return
-        # chi2_log = self.stopping_object.chi2exps_json()
-        # with open(out_path, "w", encoding="utf-8") as fs:
-        #     json.dump(chi2_log, fs, indent=2, cls=SuperEncoder)
+        chi2_log = self.stopping_object.chi2exps_json()
+        with open(out_path, "w", encoding="utf-8") as fs:
+            json.dump(chi2_log, fs, indent=2, cls=SuperEncoder)
 
     def _write_metadata_json(self, i, out_path):
         json_dict = jsonfit(

--- a/n3fit/src/n3fit/io/writer.py
+++ b/n3fit/src/n3fit/io/writer.py
@@ -286,9 +286,10 @@ class WriterWrapper:
 
     def _write_chi2s(self, out_path):
         # Note: same for all replicas, unless run separately
-        chi2_log = self.stopping_object.chi2exps_json()
-        with open(out_path, "w", encoding="utf-8") as fs:
-            json.dump(chi2_log, fs, indent=2, cls=SuperEncoder)
+        return
+        # chi2_log = self.stopping_object.chi2exps_json()
+        # with open(out_path, "w", encoding="utf-8") as fs:
+        #     json.dump(chi2_log, fs, indent=2, cls=SuperEncoder)
 
     def _write_metadata_json(self, i, out_path):
         json_dict = jsonfit(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,8 @@ packaging = "*"
 psutil = "*"
 tensorflow = "*"
 keras = "^3.1"
-eko = "^0.15.1"
+# TODO remove equal before mergin
+eko = "=0.15.1"
 joblib = "*"
 # Hyperopt
 hyperopt = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,8 @@ pdfflow = {version = "^1.2.1", optional = true}
 lhapdf-management = {version = "^0.5", optional = true}
 # torch
 torch = {version = "*", optional = true}
+# jax
+jax = {version = "*", optional = true}
 # parallel hyperopt
 pymongo = {version = "<4", optional = true}
 
@@ -108,6 +110,7 @@ docs = ["sphinxcontrib-bibtex", "sphinx-rtd-theme", "sphinx", "tabulate"]
 qed = ["fiatlux"]
 nolha = ["pdfflow", "lhapdf-management"]
 torch = ["torch"]
+jax = ["jax"]
 parallelhyperopt = ["pymongo"]
 
 [tool.poetry-dynamic-versioning]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,8 +72,7 @@ packaging = "*"
 psutil = "*"
 tensorflow = "*"
 keras = "^3.1"
-# TODO remove equal before mergin
-eko = "=0.15.1"
+eko = "^0.15.1"
 joblib = "*"
 # Hyperopt
 hyperopt = "*"


### PR DESCRIPTION
This PR aims to fix the jax backend within` n3fit`. So far, the input to the model has been converted from a tracked dictionary into a standard Python dictionary and early stopping has been removed.

When setting the `KERAS_BACKEND=jax` and running n3fit, this model stops training before the first epoch.