### PR TITLE
Remove spurious lhapdf imports

### DIFF
--- a/.github/workflows/all_tests_nnpdf.yml
+++ b/.github/workflows/all_tests_nnpdf.yml
@@ -109,6 +109,13 @@ jobs:
         cd n3fit/runcards/examples
         n3fit Basic_runcard.yml 4
         cat Basic_runcard/nnfit/*/Basic_runcard.json
+    - name: Test we can still run postfit
+      shell: bash -l {0}
+      run: |
+        output=$(vp-get fit NNPDF40_nnlo_like_CI_testing_250616)
+        fit_path=$(echo $output | grep -o  "PosixPath('.*')" | cut -d"'" -f2)
+        mv ${fit_path} .
+        postfit 50 NNPDF40_nnlo_like_CI_testing_250616
 
   run_jax:
     runs-on: ubuntu-latest
@@ -131,7 +138,6 @@ jobs:
         cd n3fit/runcards/examples
         n3fit Basic_runcard.yml 42
         cat Basic_runcard/nnfit/*/Basic_runcard.json
-
 
   full_coverage:
     needs: [run_package_tests, regression_tests]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,7 @@ tabulate = {version = "*", optional = true}
 fiatlux = {version = "*", optional = true}
 # without lhapdf
 pdfflow = {version = "^1.2.1", optional = true}
-lhapdf-management = {version = "^0.5", optional = true}
+lhapdf-management = {version = "^0.6", optional = true}
 # torch
 torch = {version = "*", optional = true}
 # jax

--- a/validphys2/src/validphys/hessian2mc.py
+++ b/validphys2/src/validphys/hessian2mc.py
@@ -6,14 +6,14 @@ like MSHT20 and CT18 to Monte Carlo sets.
 The functions implemented here follow equations (4.3) of the paper arXiv:2203.05506
 """
 
-import pathlib
-import lhapdf
-import os
 import logging
+import os
+
 import numpy as np
 
-from validphys.lhio import load_all_replicas, rep_matrix, write_replica
 from validphys.checks import check_pdf_is_hessian
+from validphys.lhaindex import get_lha_datapath
+from validphys.lhio import load_all_replicas, rep_matrix, write_replica
 
 log = logging.getLogger(__name__)
 
@@ -108,7 +108,7 @@ def write_hessian_to_mc_watt_thorne(pdf, mc_pdf_name, num_members, watt_thorne_r
     """
     hessian_set = pdf
 
-    lhapdf_path = pathlib.Path(lhapdf.paths()[-1])
+    lhapdf_path = get_lha_datapath()
 
     # path to hessian lhapdf set
     hessian_pdf_path = lhapdf_path / str(hessian_set)

--- a/validphys2/src/validphys/lhaindex.py
+++ b/validphys2/src/validphys/lhaindex.py
@@ -150,3 +150,8 @@ def get_index_path(folder=None):
         folder = get_lha_datapath()
     index_file = os.path.join(folder, 'pdfsets.index')
     return index_file
+
+
+def paths_prepend(new_path):
+    """Prepend a path to the LHAPDF list of paths so that it takes precedence."""
+    lhapdf.pathsPrepend(new_path.as_posix())

--- a/validphys2/src/validphys/scripts/postfit.py
+++ b/validphys2/src/validphys/scripts/postfit.py
@@ -22,12 +22,12 @@ import re
 import shutil
 import sys
 
-import lhapdf
-
 from reportengine import colors
 from validphys import fitdata, fitveto, lhio
 from validphys.core import PDF
 from validphys.fitveto import INTEG_THRESHOLD, NSIGMA_DISCARD_ARCLENGTH, NSIGMA_DISCARD_CHI2
+from validphys.lhaindex import paths_prepend
+from validphys.lhapdf_compatibility import make_pdf
 from validphys.loader import Loader
 from validphys.utils import tempfile_cleaner
 
@@ -218,13 +218,13 @@ def _postfit(
         log.info("Beginning construction of replica 0")
         # It's important that this is prepended, so that any existing instance of
         # `fitname` is not read from some other path
-        lhapdf.pathsPrepend(str(postfit_path))
+        paths_prepend(postfit_path)
         generatingPDF = PDF(fitname)
         lhio.generate_replica0(generatingPDF)
 
         # Test replica 0
         try:
-            lhapdf.mkPDF(fitname, 0)
+            make_pdf(fitname, 0)
         except RuntimeError as e:
             raise PostfitError("CRITICAL ERROR: Failure in reading replica zero") from e
 

--- a/validphys2/src/validphys/scripts/vp_pdfrename.py
+++ b/validphys2/src/validphys/scripts/vp_pdfrename.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python
 """
-    vp-pdfrename - command line tool to rename LHAPDFs
+vp-pdfrename - command line tool to rename LHAPDFs
 
-    To obtain the PDF from an fit, simply run
-    vp-pdfrename <path-to-fit> <PDF name>. Optional flags allow for the
-    resulting pdf to be placed in the LHAPDF directory, as well as modifying
-    various fields of the info file. In addition, it is possible to compress
-    the resulting PDF also using tar archiving.
+To obtain the PDF from an fit, simply run
+vp-pdfrename <path-to-fit> <PDF name>. Optional flags allow for the
+resulting pdf to be placed in the LHAPDF directory, as well as modifying
+various fields of the info file. In addition, it is possible to compress
+the resulting PDF also using tar archiving.
 """
 
 import argparse
@@ -18,9 +18,8 @@ import sys
 import tarfile
 import tempfile
 
-import lhapdf
-
 from reportengine import colors
+from validphys.lhaindex import get_lha_datapath
 from validphys.renametools import rename_pdf
 from validphys.utils import yaml_rt
 
@@ -118,7 +117,7 @@ def main():
     log.addHandler(colors.ColorHandler())
 
     if args.lhapdf_path:
-        dest_path = pathlib.Path(lhapdf.paths()[-1]) / pdf_name
+        dest_path = get_lha_datapath() / pdf_name
     else:
         dest_path = source_path.with_name(pdf_name)
 

--- a/validphys2/src/validphys/tests/conftest.py
+++ b/validphys2/src/validphys/tests/conftest.py
@@ -9,14 +9,18 @@ import pathlib
 import sys
 
 from hypothesis import settings
-import lhapdf
 import pytest
 
 # Adding this here to change the time of deadline from default (200ms) to 1500ms
 settings.register_profile("extratime", deadline=1500)
 settings.load_profile("extratime")
 
-lhapdf.setVerbosity(0)
+try:
+    import lhapdf
+
+    lhapdf.setVerbosity(0)
+except ModuleNotFoundError:
+    pass
 
 
 # Fortunately py.test works much like reportengine and providers are

--- a/validphys2/src/validphys/tests/test_hessian2mc.py
+++ b/validphys2/src/validphys/tests/test_hessian2mc.py
@@ -1,8 +1,10 @@
+import pathlib
+from unittest import mock
+
 import numpy as np
 import pandas as pd
-from unittest import mock
-from validphys.hessian2mc import write_mc_watt_thorne_replicas, write_hessian_to_mc_watt_thorne
-import pathlib
+
+from validphys.hessian2mc import write_hessian_to_mc_watt_thorne, write_mc_watt_thorne_replicas
 
 
 @mock.patch("validphys.hessian2mc.write_replica")
@@ -40,7 +42,7 @@ def test_write_mc_watt_thorne_replicas(mock_log_info, mock_write_replica):
 @mock.patch("validphys.hessian2mc.rep_matrix")
 @mock.patch("validphys.hessian2mc.write_new_lhapdf_info_file_from_previous_pdf")
 @mock.patch("validphys.hessian2mc.os.makedirs")
-@mock.patch("validphys.hessian2mc.lhapdf.paths")
+@mock.patch("validphys.hessian2mc.get_lha_datapath")
 def test_write_hessian_to_mc_watt_thorne(
     mock_lhapdf_paths,
     mock_makedirs,
@@ -56,7 +58,7 @@ def test_write_hessian_to_mc_watt_thorne(
 
     mock_load_all_replicas.return_value = (None, None)
 
-    mock_lhapdf_paths.return_value = [pathlib.Path("/path/to/lhapdf")]
+    mock_lhapdf_paths.return_value = pathlib.Path("/path/to/lhapdf")
 
     mock_rep_matrix.return_value = np.random.randn(5, 7)  # Mocked replica matrix
 


### PR DESCRIPTION
This PR finalizes hiding the `lhapdf` imports under the `lhapdf_compatibiltiy` module, which at the moment was still imported explicitly in various places meaning one could not cleanly use a different backend.

Among other things, this means that now every management or fitting task can be performed without LHAPDF: `n3fit`, `postfit`, `vp-get *`, etc.
And management tasks even without `pdfflow` (or eventually `neopdf`).

In principle reports could also be done without LHAPDF, but `pdfflow` takes way too much memory for many members and `neopdf` is not implemented yet.