### PR TITLE
don't allow ruamel to introdue linebreaks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: 'v5.0.0'
+    rev: 'v6.0.0'
     hooks:
     -   id: check-merge-conflict
     -   id: check-toml

--- a/validphys2/src/validphys/utils.py
+++ b/validphys2/src/validphys/utils.py
@@ -8,6 +8,7 @@ from ruamel.yaml import YAML
 
 yaml_safe = YAML(typ='safe')
 yaml_rt = YAML(typ='rt')
+yaml_rt.width = 2**31  # to prevent ruamel.yaml introducing linebreaks
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
The linebreaks were annoying me - makes it more difficult to compare two runcards 