### PR TITLE
Add first NNPDF4.1 example runcard

### DIFF
--- a/n3fit/runcards/example-nnpdf41.yml
+++ b/n3fit/runcards/example-nnpdf41.yml
@@ -1,0 +1,188 @@
+#
+# Configuration file for n3fit
+#
+######################################################################################
+description: Starting runcard for the NNPDF4.1 series of fits. Work In Progress
+
+######################################################################################
+dataset_inputs:
+- {dataset: NMC_NC_NOTFIXED_EM-F2, frac: 0.75, variant: legacy_dw}
+- {dataset: NMC_NC_NOTFIXED_P_EM-SIGMARED, frac: 0.75, variant: legacy}
+- {dataset: SLAC_NC_NOTFIXED_P_EM-F2, frac: 0.75, variant: legacy_dw}
+- {dataset: SLAC_NC_NOTFIXED_D_EM-F2, frac: 0.75, variant: legacy_dw}
+- {dataset: BCDMS_NC_NOTFIXED_P_EM-F2, frac: 0.75, variant: legacy_dw}
+- {dataset: BCDMS_NC_NOTFIXED_D_EM-F2, frac: 0.75, variant: legacy_dw}
+- {dataset: CHORUS_CC_NOTFIXED_PB_NU-SIGMARED, frac: 0.75, variant: legacy_dw}
+- {dataset: CHORUS_CC_NOTFIXED_PB_NB-SIGMARED, frac: 0.75, variant: legacy_dw}
+- {dataset: NUTEV_CC_NOTFIXED_FE_NU-SIGMARED, cfac: [MAS], frac: 0.75, variant: legacy_dw}
+- {dataset: NUTEV_CC_NOTFIXED_FE_NB-SIGMARED, cfac: [MAS], frac: 0.75, variant: legacy_dw}
+- {dataset: HERA_NC_318GEV_EM-SIGMARED, frac: 0.75}
+- {dataset: HERA_NC_225GEV_EP-SIGMARED, frac: 0.75}
+- {dataset: HERA_NC_251GEV_EP-SIGMARED, frac: 0.75}
+- {dataset: HERA_NC_300GEV_EP-SIGMARED, frac: 0.75}
+- {dataset: HERA_NC_318GEV_EP-SIGMARED, frac: 0.75}
+- {dataset: HERA_CC_318GEV_EM-SIGMARED, frac: 0.75}
+- {dataset: HERA_CC_318GEV_EP-SIGMARED, frac: 0.75}
+- {dataset: HERA_NC_318GEV_EAVG_CHARM-SIGMARED, frac: 0.75}
+- {dataset: HERA_NC_318GEV_EAVG_BOTTOM-SIGMARED, frac: 0.75}
+- {dataset: DYE866_Z0_800GEV_DW_RATIO_PDXSECRATIO, frac: 0.75}
+- {dataset: DYE866_Z0_800GEV_PXSEC, frac: 0.75}
+- {dataset: DYE605_Z0_38P8GEV_DW_PXSEC, frac: 0.75}
+# - {dataset: DYE906_Z0_120GEV_DW_PDXSECRATIO, frac: 0.75}
+- {dataset: CDF_Z0_1P96TEV_ZRAP, frac: 0.75}
+- {dataset: D0_Z0_1P96TEV_ZRAP, frac: 0.75}
+- {dataset: D0_WPWM_1P96TEV_ASY, frac: 0.75}
+- {dataset: ATLAS_WPWM_7TEV_36PB_ETA, frac: 0.75}
+- {dataset: ATLAS_Z0_7TEV_36PB_ETA, frac: 0.75}
+- {dataset: ATLAS_Z0_7TEV_49FB_HIMASS, frac: 0.75}
+- {dataset: ATLAS_Z0_7TEV_LOMASS_M, frac: 0.75}
+- {dataset: ATLAS_WPWM_7TEV_46FB_CC-ETA, frac: 0.75}
+- {dataset: ATLAS_Z0_7TEV_46FB_CC-Y, frac: 0.75}
+- {dataset: ATLAS_Z0_7TEV_46FB_CF-Y, frac: 0.75}
+- {dataset: ATLAS_Z0_8TEV_HIMASS_M-Y, frac: 0.75}
+# - {dataset: ATLAS_Z0_8TEV_LOWMASS_M-Y, frac: 0.75, variant: legacy}
+- {dataset: ATLAS_Z0_13TEV_TOT, frac: 0.75, cfac: [NRM]}
+- {dataset: ATLAS_WPWM_13TEV_TOT, frac: 0.75, cfac: [NRM]}
+- {dataset: ATLAS_WJ_8TEV_WP-PT, frac: 0.75}
+- {dataset: ATLAS_WJ_8TEV_WM-PT, frac: 0.75}
+- {dataset: ATLAS_Z0J_8TEV_PT-M, frac: 0.75}
+- {dataset: ATLAS_Z0J_8TEV_PT-Y, frac: 0.75}
+- {dataset: ATLAS_TTBAR_7TEV_TOT_X-SEC, frac: 0.75}
+- {dataset: ATLAS_TTBAR_8TEV_TOT_X-SEC, frac: 0.75}
+- {dataset: ATLAS_TTBAR_13TEV_TOT_X-SEC, frac: 0.75}
+- {dataset: ATLAS_TTBAR_8TEV_LJ_DIF_YT-NORM, frac: 0.75}
+- {dataset: ATLAS_TTBAR_8TEV_LJ_DIF_YTTBAR-NORM, frac: 0.75}
+- {dataset: ATLAS_TTBAR_8TEV_2L_DIF_YTTBAR-NORM, frac: 0.75}
+- {dataset: ATLAS_1JET_8TEV_R06_PTY, frac: 0.75, variant: legacy_data}
+- {dataset: ATLAS_2JET_7TEV_R06_M12Y, frac: 0.75}
+- {dataset: ATLAS_PH_13TEV_XSEC, frac: 0.75, cfac: [EWK]}
+- {dataset: ATLAS_SINGLETOP_7TEV_TCHANNEL-XSEC, frac: 0.75}
+- {dataset: ATLAS_SINGLETOP_13TEV_TCHANNEL-XSEC, frac: 0.75}
+- {dataset: ATLAS_SINGLETOP_7TEV_T-Y-NORM, frac: 0.75}
+- {dataset: ATLAS_SINGLETOP_7TEV_TBAR-Y-NORM, frac: 0.75}
+- {dataset: ATLAS_SINGLETOP_8TEV_T-RAP-NORM, frac: 0.75}
+- {dataset: ATLAS_SINGLETOP_8TEV_TBAR-RAP-NORM, frac: 0.75}
+- {dataset: CMS_WPWM_7TEV_ELECTRON_ASY, frac: 0.75}
+- {dataset: CMS_WPWM_7TEV_MUON_ASY, frac: 0.75}
+- {dataset: CMS_Z0_7TEV_DIMUON_2D, frac: 0.75}
+- {dataset: CMS_WPWM_8TEV_MUON_Y, frac: 0.75}
+- {dataset: CMS_Z0J_8TEV_PT-Y, frac: 0.75, cfac: [NRM]}
+- {dataset: CMS_2JET_7TEV_M12-Y, frac: 0.75}
+- {dataset: CMS_1JET_8TEV_PTY, frac: 0.75, variant: legacy_data}
+- {dataset: CMS_TTBAR_7TEV_TOT_X-SEC, frac: 0.75}
+- {dataset: CMS_TTBAR_8TEV_TOT_X-SEC, frac: 0.75}
+- {dataset: CMS_TTBAR_13TEV_TOT_X-SEC, frac: 0.75}
+- {dataset: CMS_TTBAR_8TEV_LJ_DIF_YTTBAR-NORM, frac: 0.75}
+- {dataset: CMS_TTBAR_5TEV_TOT_X-SEC, frac: 0.75}
+- {dataset: CMS_TTBAR_8TEV_2L_DIF_MTTBAR-YT-NORM, frac: 0.75}
+- {dataset: CMS_TTBAR_13TEV_2L_DIF_YT, frac: 0.75}
+- {dataset: CMS_TTBAR_13TEV_LJ_DIF_YT, frac: 0.75}
+- {dataset: CMS_SINGLETOP_7TEV_TCHANNEL-XSEC, frac: 0.75}
+- {dataset: CMS_SINGLETOP_8TEV_TCHANNEL-XSEC, frac: 0.75}
+- {dataset: CMS_SINGLETOP_13TEV_TCHANNEL-XSEC, frac: 0.75}
+- {dataset: LHCB_Z0_7TEV_DIELECTRON_Y, frac: 0.75}
+- {dataset: LHCB_Z0_8TEV_DIELECTRON_Y, frac: 0.75}
+- {dataset: LHCB_WPWM_7TEV_MUON_Y, frac: 0.75, cfac: [NRM]}
+- {dataset: LHCB_Z0_7TEV_MUON_Y, frac: 0.75, cfac: [NRM]}
+- {dataset: LHCB_WPWM_8TEV_MUON_Y, frac: 0.75, cfac: [NRM]}
+- {dataset: LHCB_Z0_8TEV_MUON_Y, frac: 0.75, cfac: [NRM]}
+- {dataset: LHCB_Z0_13TEV_DIMUON-Y, frac: 0.75}
+- {dataset: LHCB_Z0_13TEV_DIELECTRON-Y, frac: 0.75}
+
+
+################################################################################
+datacuts:
+  t0pdfset: 250917-jcm-001
+  q2min: 3.49
+  w2min: 12.5
+theory:
+  theoryid: 41_000_000
+
+trvlseed: 1953065998
+nnseed: 1589400026
+mcseed: 2135943670
+genrep: true
+parameters: # This defines the parameter dictionary that is passed to the Model Trainer
+  nodes_per_layer: [70, 50, 25, 20, 9]
+  activation_per_layer: [tanh, tanh, tanh, tanh, linear]
+  initializer: glorot_normal
+  optimizer:
+    clipnorm: 6.073e-6
+    learning_rate: 2.621e-3
+    optimizer_name: Nadam
+  epochs: 27000
+  positivity:
+    initial: 184.8
+    multiplier:
+  integrability:
+    initial: 10
+    multiplier:
+  stopping_patience: 0.1
+  layer_type: dense
+  dropout: 0.0
+  threshold_chi2: 3.5
+  interpolation_points: 5
+fitting:
+  fitbasis: CCBAR_ASYMM  # EVOL (7), EVOLQED (8), etc.
+  savepseudodata: true
+  basis:
+  - {fl: sng, trainable: false, smallx: [1.103, 1.12], largex: [1.461, 3.778]}
+  - {fl: g, trainable: false, smallx: [0.8737, 1.088], largex: [2.204, 4.431]}
+  - {fl: v, trainable: false, smallx: [0.5051, 0.6847], largex: [1.526, 2.557]}
+  - {fl: v3, trainable: false, smallx: [0.1932, 0.4309], largex: [1.73, 2.559]}
+  - {fl: v8, trainable: false, smallx: [0.5645, 0.7228], largex: [1.566, 2.662]}
+  - {fl: t3, trainable: false, smallx: [-0.4244, 1.0], largex: [1.75, 2.939]}
+  - {fl: t8, trainable: false, smallx: [0.6677, 0.9282], largex: [1.55, 3.504]}
+  - {fl: t15, trainable: false, smallx: [1.087, 1.136], largex: [1.503, 3.379]}
+  - {fl: v15, trainable: false, smallx: [0.4713, 0.7641], largex: [1.464, 3.851]}
+
+################################################################################
+positivity:
+  posdatasets:
+  # Positivity Lagrange Multiplier
+  - {dataset: NNPDF_POS_2P24GEV_F2U, maxlambda: 1e6}
+  - {dataset: NNPDF_POS_2P24GEV_F2D, maxlambda: 1e6}
+  - {dataset: NNPDF_POS_2P24GEV_F2S, maxlambda: 1e6}
+  - {dataset: NNPDF_POS_2P24GEV_FLL, maxlambda: 1e6}
+  - {dataset: NNPDF_POS_2P24GEV_DYU, maxlambda: 1e10}
+  - {dataset: NNPDF_POS_2P24GEV_DYD, maxlambda: 1e10}
+  - {dataset: NNPDF_POS_2P24GEV_DYS, maxlambda: 1e10}
+  - {dataset: NNPDF_POS_2P24GEV_F2C-CCE-17PTS, maxlambda: 1e6}
+  - {dataset: NNPDF_POS_2P24GEV_F2C-CCP-17PTS, maxlambda: 1e6}
+  # Positivity of MSbar PDFs
+  - {dataset: NNPDF_POS_2P24GEV_XUQ, maxlambda: 1e6}
+  - {dataset: NNPDF_POS_2P24GEV_XUB, maxlambda: 1e6}
+  - {dataset: NNPDF_POS_2P24GEV_XDQ, maxlambda: 1e6}
+  - {dataset: NNPDF_POS_2P24GEV_XDB, maxlambda: 1e6}
+  - {dataset: NNPDF_POS_2P24GEV_XSQ, maxlambda: 1e6}
+  - {dataset: NNPDF_POS_2P24GEV_XSB, maxlambda: 1e6}
+  - {dataset: NNPDF_POS_2P24GEV_XGL, maxlambda: 1e6}
+
+added_filter_rules:
+- dataset: NNPDF_POS_2P24GEV_FLL
+  rule: x > 5.0e-7
+- dataset: NNPDF_POS_2P24GEV_F2C
+  rule: x < 0.74
+- dataset: NNPDF_POS_2P24GEV_XGL
+  rule: x > 0.1
+- dataset: NNPDF_POS_2P24GEV_XUQ
+  rule: x > 0.1
+- dataset: NNPDF_POS_2P24GEV_XUB
+  rule: x > 0.1
+- dataset: NNPDF_POS_2P24GEV_XDQ
+  rule: x > 0.1
+- dataset: NNPDF_POS_2P24GEV_XDB
+  rule: x > 0.1
+- dataset: NNPDF_POS_2P24GEV_XSQ
+  rule: x > 0.1
+- dataset: NNPDF_POS_2P24GEV_XSB
+  rule: x > 0.1
+
+integrability:
+  integdatasets:
+  - {dataset: NNPDF_INTEG_3GEV_XT8, maxlambda: 1e2}
+  - {dataset: NNPDF_INTEG_3GEV_XT3, maxlambda: 1e2}
+
+################################################################################
+debug: false
+maxcores: 16

--- a/n3fit/runcards/example-nnpdf41.yml
+++ b/n3fit/runcards/example-nnpdf41.yml
@@ -147,8 +147,8 @@ positivity:
   - {dataset: NNPDF_POS_2P24GEV_DYU, maxlambda: 1e10}
   - {dataset: NNPDF_POS_2P24GEV_DYD, maxlambda: 1e10}
   - {dataset: NNPDF_POS_2P24GEV_DYS, maxlambda: 1e10}
-  - {dataset: NNPDF_POS_2P24GEV_F2C-CCE-17PTS, maxlambda: 1e6}
-  - {dataset: NNPDF_POS_2P24GEV_F2C-CCP-17PTS, maxlambda: 1e6}
+  - {dataset: NNPDF_POS_2P24GEV_F2C-CCE, maxlambda: 1e6}
+  - {dataset: NNPDF_POS_2P24GEV_F2C-CCP, maxlambda: 1e6}
   # Positivity of MSbar PDFs
   - {dataset: NNPDF_POS_2P24GEV_XUQ, maxlambda: 1e6}
   - {dataset: NNPDF_POS_2P24GEV_XUB, maxlambda: 1e6}
@@ -161,7 +161,9 @@ positivity:
 added_filter_rules:
 - dataset: NNPDF_POS_2P24GEV_FLL
   rule: x > 5.0e-7
-- dataset: NNPDF_POS_2P24GEV_F2C
+- dataset: NNPDF_POS_2P24GEV_F2C-CCE
+  rule: x < 0.74
+- dataset: NNPDF_POS_2P24GEV_F2C-CCP
   rule: x < 0.74
 - dataset: NNPDF_POS_2P24GEV_XGL
   rule: x > 0.1

--- a/nnpdf_data/nnpdf_data/commondata/NNPDF_POS_2P24GEV/metadata.yaml
+++ b/nnpdf_data/nnpdf_data/commondata/NNPDF_POS_2P24GEV/metadata.yaml
@@ -916,3 +916,63 @@ implemented_observables:
     - - NNPDF_POS_ANTI_UP
     - - NNPDF_POS_ANTI_DUP
   data_uncertainties: []
+- observable_name: F2C-CCP
+  observable:
+    description: Deep Inelastic Scattering
+    label: 'positivity dataset: CC DIS $\bar{c}$ structure function $F_2^{W^+,c}$'
+    units: ''
+  process_type: POS_DIS
+  tables: []
+  npoints: []
+  ndata: 20
+  plotting:
+    dataset_label: 'positivity dataset: CC DIS $\bar{c}$ structure function $F_2^{W^+,c}$'
+    plot_x: x
+  kinematic_coverage:
+  - x
+  - Q2
+  kinematics:
+    variables:
+      x:
+        description: Bjorken x
+        label: x
+        units: ''
+      Q2:
+        description: Factorization Scale
+        label: Q2
+        units: ''
+    file: kinematics_F2C.yaml
+  theory:
+    FK_tables:
+    - - NNPDF_POS_F2C_CCP_40
+  data_uncertainties: []
+- observable_name: F2C-CCE
+  observable:
+    description: Deep Inelastic Scattering
+    label: 'positivity dataset: DIS $c$ structure function $F_2^{W^-,c}$'
+    units: ''
+  process_type: POS_DIS
+  tables: []
+  npoints: []
+  ndata: 20
+  plotting:
+    dataset_label: 'positivity dataset: DIS $c$ structure function $F_2^{W^-,c}$'
+    plot_x: x
+  kinematic_coverage:
+  - x
+  - Q2
+  kinematics:
+    variables:
+      x:
+        description: Bjorken x
+        label: x
+        units: ''
+      Q2:
+        description: Factorization Scale
+        label: Q2
+        units: ''
+    file: kinematics_F2C.yaml
+  theory:
+    FK_tables:
+    - - NNPDF_POS_F2C_CCE_40
+  data_uncertainties: []

--- a/validphys2/src/validphys/loader.py
+++ b/validphys2/src/validphys/loader.py
@@ -1168,7 +1168,7 @@ class RemoteLoader(LoaderBase):
             raise PDFNotFound("PDF '%s' is neither an uploaded fit nor an " "LHAPDF set." % name)
 
     def download_theoryID(self, thid):
-        thid = str(thid)
+        thid = str(int(thid))
         remote = self.remote_theories
         if thid not in remote:
             raise TheoryNotFound("Theory %s not available." % thid)

--- a/validphys2/src/validphys/nnprofile_default.yaml
+++ b/validphys2/src/validphys/nnprofile_default.yaml
@@ -37,7 +37,6 @@ ekos_path: ekos
 # Remote resource locations
 fit_urls:
     - 'https://data.nnpdf.science/fits/'
-    - 'https://nnpdf.web.cern.ch/nnpdf/fits/'
 
 fit_index: 'fitdata.json'
 
@@ -47,12 +46,14 @@ hyperscan_urls:
 hyperscan_index: 'hyperscandata.json'
 
 theory_urls:
+    - 'https://nnpdf.nikhef.nl/nnpdf/theories/'
     - 'https://nnpdf.web.cern.ch/nnpdf/tables/'
     - 'https://nnpdf.web.cern.ch/nnpdf/tables_box/'
 
 theory_index: 'theorydata.json'
 
 eko_urls:
+    - 'https://nnpdf.nikhef.nl/nnpdf/ekos/'
     - 'https://nnpdf.web.cern.ch/nnpdf/ekos/'
     - 'https://nnpdf.web.cern.ch/nnpdf/ekos_box/'
 


### PR DESCRIPTION
This is the (work-in-progress) first version of the NNPDF runcard.

This PR also makes nikhef the most important theory server (and eventually the CERN ones will be removed).

There's already a fit done with this runcard: `250925-jcm-001` and a report comparing to a previous 4.0 https://vp.nnpdf.science/7zylCbEbSnyYile2AgytSA==



Missing items:
--------------
- [x] Uncomment singletop and photon data (I ran the fit before @evagroenendijk updated the theory)
- [x] What do we do with `CMS_TTBAR_13TEV_LJ_2016_DIF_YT` @enocera? This has been superseded by which one? Do we want to start with the old one?
- [x] Valence Charm -> in order to fit also V15 I want to wait to have the two missing positivity fktables which are missing right now.

To Check:
----------

There's a few dataset for which I've left `legacy` the legacy version. @enocera please comment on them:

- [x] Old FTDIS -> these are truly legacy, I think we decided we didn't want/have any new version anyway
- [x] `DYE906_Z0_120GEV_DW_PDXSECRATIO` <--- Do we want to jump immediately to the new version that @achiefa computed? Do we remove it for now and make it part of the data appraisal as it were a new dataset?
- [x] `ATLAS_TTBAR_8TEV_LJ_DIF_YT-NORM` and `ATLAS_TTBAR_8TEV_LJ_DIF_YTTBAR-NORM` in a first test the chi2 was notably worse with these. Do we want to "suck it up" or do we want to do further checks?
- [x] `ATLAS_Z0_8TEV_LOWMASS_M-Y` -> our good friend, do we want to remove it completely?
- [ ] `ATLAS_1JET_8TEV_R06_PTY` and `CMS_1JET_8TEV_PTY` -> jets be jets, I'm not sure what variant of the data to use