### PR TITLE
Add positivity data along W^2=10 GeV^2 line

### DIFF
--- a/nnpdf_data/nnpdf_data/commondata/NNPDF_POS_100GEV/kinematics_XGL.yaml
+++ b/nnpdf_data/nnpdf_data/commondata/NNPDF_POS_100GEV/kinematics_XGL.yaml
@@ -117,6 +117,14 @@ bins:
     max: null
   Q2:
     min: null
+    mid: 39.69
+    max: null
+- x:
+    min: null
+    mid: 0.5
+    max: null
+  Q2:
+    min: null
     mid: 10000.0
     max: null
 - x:
@@ -129,11 +137,27 @@ bins:
     max: null
 - x:
     min: null
+    mid: 0.6
+    max: null
+  Q2:
+    min: null
+    mid: 62.41
+    max: null
+- x:
+    min: null
     mid: 0.66
     max: null
   Q2:
     min: null
     mid: 10000.0
+    max: null
+- x:
+    min: null
+    mid: 0.7
+    max: null
+  Q2:
+    min: null
+    mid: 110.25
     max: null
 - x:
     min: null
@@ -145,11 +169,27 @@ bins:
     max: null
 - x:
     min: null
+    mid: 0.8
+    max: null
+  Q2:
+    min: null
+    mid: 249.64
+    max: null
+- x:
+    min: null
     mid: 0.82
     max: null
   Q2:
     min: null
     mid: 10000.0
+    max: null
+- x:
+    min: null
+    mid: 0.9
+    max: null
+  Q2:
+    min: null
+    mid: 998.56
     max: null
 - x:
     min: null

--- a/nnpdf_data/nnpdf_data/commondata/NNPDF_POS_100GEV/metadata.yaml
+++ b/nnpdf_data/nnpdf_data/commondata/NNPDF_POS_100GEV/metadata.yaml
@@ -276,7 +276,7 @@ implemented_observables:
   process_type: POS_XPDF
   tables: []
   npoints: []
-  ndata: 20
+  ndata: 25
   plotting:
     dataset_label: 'positivity dataset: $xg$ PDF $Q^2=10000$ GeV$^2$'
     plot_x: x
@@ -295,8 +295,8 @@ implemented_observables:
         units: ''
     file: kinematics_XGL.yaml
   theory:
-    conversion_factor: 1.0
     operation: 'null'
+    conversion_factor: 1.0
     FK_tables:
-    - - NNPDF_POS_GLUON_Q2_10000
+    - - NNPDF_POS_GLUON_Q2_VARIABLE
   data_uncertainties: []


### PR DESCRIPTION
This PR is to update positivity dataset for gluon, I added new datapoints along the W^2=10 GeV^2 line in `kinematic_XGL.yaml` and updated `metadata.yaml`. The baseline fit runcard does not need to be changed, since the dataset name is the same. @scarlehoff let me know if you have any question