### PR TITLE
Fix for ruamel update

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ matplotlib = "^3.9"
 pineappl = "^1.0.0"
 pandas = "*"
 numpy = "*"
-"ruamel.yaml" = "*"
+"ruamel.yaml" = {version = ">=0.19.1", extras=["oldlibyaml"]}
 validobj = "*"
 prompt_toolkit = "*"
 reportengine = ">=0.32"


### PR DESCRIPTION
`ruamel.yaml` has updated to version 0.19, changes a few things internally, but most importantly there's a change of library that makes it incompatible with some LHAPDF info files.

I don't know whether the reason is they are badly formatted or a bug in ruamel, before investigating that I've just modified the dependences to install the old parser which should be ok for now. 

This is the reason for the recent errors in the CI e.g.,. https://github.com/NNPDF/nnpdf/actions/runs/20849541813/job/59901073339?pr=2393#step:4:443