### PR TITLE
Correct sign in front of shifts

### DIFF
--- a/validphys2/src/validphys/dataplots.py
+++ b/validphys2/src/validphys/dataplots.py
@@ -304,7 +304,7 @@ def _plot_fancy_impl(
         err = np.full(ndata, np.nan)
         # Shift the theory when with_shift option is True
         if i==1 and with_shift:
-            cv[mask] = result.central_value + shifts
+            cv[mask] = result.central_value - shifts
         else:
             cv[mask] = result.central_value           
         # Retain only the uncorrelated part of the error if shifting the data


### PR DESCRIPTION
This PR corrects a bug in the application of the shifts due to correlated systematic uncertainties. The sign is now consistent with Eq. (7) of hep-ph/0201195. We are actually shifting the theory, not the data.
cc @achiefa #2361 https://github.com/NNPDF/theories_slim/pull/74