### PR TITLE
Update the process type of the 3D CMS 13 TeV

### DIFF
--- a/nnpdf_data/nnpdf_data/process_options.py
+++ b/nnpdf_data/nnpdf_data/process_options.py
@@ -362,7 +362,7 @@ DIJET = _Process(
 )
 
 DIJET_3D = _Process(
-    "DIJET",
+    "DIJET_3D",
     "DiJets production",
     accepted_variables=(_Vars.ystar, _Vars.m_jj, _Vars.sqrts, _Vars.ydiff, _Vars.ymax, _Vars.yb),
     xq2map_function=_dijets_xq2map,


### PR DESCRIPTION
Just a small change in the process options. This is needed for the power correction analysis since I need to tell apart DIJET and DIJET_3D. 