### PR TITLE
Fix bug

### DIFF
--- a/n3fit/src/n3fit/vpinterface.py
+++ b/n3fit/src/n3fit/vpinterface.py
@@ -151,7 +151,7 @@ class N3LHAPDFSet(LHAPDFSet):
         if flavours != "n3fit":
             # Ensure that the result has its flavour in the basis-defined order
             ii = self.basis._to_indexes(flavours)
-            result[:, :, ii] = result
+            result = result[:, :, np.argsort(ii)]
         return result
 
     def grid_values(self, flavours, xarr, qmat=None):


### PR DESCRIPTION
When we ensure that the network outputs are in the same order of the basis adopted, we used a in-place reordering (aliasing). The behaviour of this reordering depends on how numpy creates the buffer for the alias, and thus is machine-dependent. This should fix the problem.