### PR TITLE
Treat only the single name "stat" in a special way

### DIFF
--- a/nnpdf_data/nnpdf_data/commondataparser.py
+++ b/nnpdf_data/nnpdf_data/commondataparser.py
@@ -903,7 +903,10 @@ def _check_if_statistical(col):
     Returns true if and only if the column name stats with "stat",
     its treatment is additive and it is not correlated (type == UNCORR)
     """
-    return col[0].lower().startswith("stat") and col[1] == "ADD" and col[2] == "UNCORR"
+    if col[0].lower() == "stat":
+        assert col[1] == "ADD" and col[2] == "UNCORR"
+        return True
+    return False
 
 
 def load_commondata(metadata):


### PR DESCRIPTION
For historical reason everything that started with "stat" was treated in a special way (i.e., regardless of what was written, it was treated as uncorrelated and additive).

This broke the recent jet data, so we instead made a explicit check... but I made the mistake of checking all lowercase... the herajet data contain two statistical uncertainties: stat and StatMC which now breaks a different part of validphys (while before the second one was not being considered in account of being uppercase).

Given  #2458 and the answer to #2459, this PR just makes it so only `stat` is special. Also, if it is not both additive and uncorrelated it will fail.