### PR TITLE
covmat-by-reference-bug

### DIFF
--- a/.github/actions/install_conda_pip/action.yml
+++ b/.github/actions/install_conda_pip/action.yml
@@ -39,7 +39,7 @@ runs:
     - name: Install host requirements
       shell: bash -l {0}
       run: |
-        conda install lhapdf pandoc
+        conda install lhapdf pandoc pip
     - name: Install package with test extras
       shell: bash -l {0}
       run: |

--- a/.github/actions/prepare_environment/action.yml
+++ b/.github/actions/prepare_environment/action.yml
@@ -28,7 +28,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: conda-incubator/setup-miniconda@v3
+    - uses: conda-incubator/setup-miniconda@v4
       with:
         python-version: ${{ inputs.python-version }}
         use-mamba: true

--- a/.github/workflows/all_tests_nnpdf.yml
+++ b/.github/workflows/all_tests_nnpdf.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Build recipe
         shell: bash -l {0}
         run: |
-          conda -n base install conda-build --yes
+          conda install -n base conda-build --yes
           conda build -q conda-recipe --package-format=1
       - name: Keep conda package as artifact
         if: ${{ !cancelled() }}

--- a/.github/workflows/all_tests_nnpdf.yml
+++ b/.github/workflows/all_tests_nnpdf.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Build recipe
         shell: bash -l {0}
         run: |
-          conda install conda-build --yes
+          conda -n base install conda-build --yes
           conda build -q conda-recipe --package-format=1
       - name: Keep conda package as artifact
         if: ${{ !cancelled() }}

--- a/nnpdf_data/nnpdf_data/filter_utils/utils.py
+++ b/nnpdf_data/nnpdf_data/filter_utils/utils.py
@@ -284,13 +284,12 @@ def concat_matrices(rows, columns, list_of_matrices):
         the final, fully concatenated matrix row by row.
 
     """
-    for i in range(len(list_of_matrices)):
-        list_of_matrices[i] = np.array(list_of_matrices[i])
+    matrices = [np.array(matrix) for matrix in list_of_matrices]
     col_list = []
     for i in range(rows):
         row_list = []
         for j in range(columns):
-            row_list.append(list_of_matrices[j + i * columns])
+            row_list.append(matrices[j + i * columns])
         col_list.append(np.concatenate(tuple(row_list), axis=1))
     final_mat = np.concatenate(tuple(col_list), axis=0)
     final_mat_list = []
@@ -438,6 +437,7 @@ def check_xq2_degenearcy(Q2, x):
             unique kinematics are: {unique_pairs.shape[1]}, original size: {size}"""
         ) from exc
 
+
 def uncert_skip_variant(source_file, skip_file, uncert_file, uncert_name, remove_source=True):
     r"""
     Create two new uncertainty files, one where the specified uncertainty
@@ -469,7 +469,9 @@ def uncert_skip_variant(source_file, skip_file, uncert_file, uncert_name, remove
     content_uncert = {}
 
     if 'definitions' in content and uncert_name in content['definitions']:
-        content_uncert['definitions'] = {uncert_name: copy.deepcopy(content['definitions'][uncert_name])}
+        content_uncert['definitions'] = {
+            uncert_name: copy.deepcopy(content['definitions'][uncert_name])
+        }
         content_uncert['bins'] = {}
         bins = []
         for i in range(len(content['bins'])):

--- a/nnpdf_data/nnpdf_data/filter_utils/utils.py
+++ b/nnpdf_data/nnpdf_data/filter_utils/utils.py
@@ -284,12 +284,13 @@ def concat_matrices(rows, columns, list_of_matrices):
         the final, fully concatenated matrix row by row.
 
     """
-    matrices = [np.array(matrix) for matrix in list_of_matrices]
+    for i in range(len(list_of_matrices)):
+        list_of_matrices[i] = np.array(list_of_matrices[i])
     col_list = []
     for i in range(rows):
         row_list = []
         for j in range(columns):
-            row_list.append(matrices[j + i * columns])
+            row_list.append(list_of_matrices[j + i * columns])
         col_list.append(np.concatenate(tuple(row_list), axis=1))
     final_mat = np.concatenate(tuple(col_list), axis=0)
     final_mat_list = []

--- a/validphys2/src/validphys/covmats.py
+++ b/validphys2/src/validphys/covmats.py
@@ -413,9 +413,7 @@ def dataset_inputs_t0_total_covmat_separate(
     In this case the t0 prescription is used for the experimental covmat and the multiplicative
     errors are separated. Moreover, the theory covmat is added to experimental covmat.
     """
-    covmat = dataset_inputs_t0_exp_covmat_separate
-    covmat += loaded_theory_covmat
-    return covmat
+    return dataset_inputs_t0_exp_covmat_separate + loaded_theory_covmat
 
 
 def dataset_inputs_t0_exp_covmat_separate(
@@ -448,9 +446,7 @@ def dataset_inputs_total_covmat_separate(dataset_inputs_exp_covmat_separate, loa
     In this case the t0 prescription is not used for the experimental covmat and the multiplicative
     errors are separated. Moreover, the theory covmat is added to experimental covmat.
     """
-    covmat = dataset_inputs_exp_covmat_separate
-    covmat += loaded_theory_covmat
-    return covmat
+    return dataset_inputs_exp_covmat_separate + loaded_theory_covmat
 
 
 def dataset_inputs_exp_covmat_separate(
@@ -482,9 +478,7 @@ def dataset_inputs_t0_total_covmat(dataset_inputs_t0_exp_covmat, loaded_theory_c
     by fitting_data_dict. In this case the t0 prescription is used for the experimental covmat
     and the multiplicative errors are included in it. Moreover, the theory covmat is added to experimental covmat.
     """
-    covmat = dataset_inputs_t0_exp_covmat
-    covmat += loaded_theory_covmat
-    return covmat
+    return dataset_inputs_t0_exp_covmat + loaded_theory_covmat
 
 
 def dataset_inputs_t0_exp_covmat(
@@ -517,9 +511,7 @@ def dataset_inputs_total_covmat(dataset_inputs_exp_covmat, loaded_theory_covmat)
     by fitting_data_dict. In this case the t0 prescription is not used for the experimental covmat
     and the multiplicative errors are included in it. Moreover, the theory covmat is added to experimental covmat.
     """
-    covmat = dataset_inputs_exp_covmat
-    covmat += loaded_theory_covmat
-    return covmat
+    return dataset_inputs_exp_covmat + loaded_theory_covmat
 
 
 def dataset_inputs_exp_covmat(

--- a/validphys2/src/validphys/tests/test_covmats.py
+++ b/validphys2/src/validphys/tests/test_covmats.py
@@ -9,7 +9,15 @@ import pytest
 
 from nnpdf_data.commondataparser import load_commondata
 from validphys.api import API
-from validphys.covmats import dataset_t0_predictions, reorder_thcovmat_as_expcovmat, sqrt_covmat
+from validphys.covmats import (
+    dataset_inputs_t0_total_covmat,
+    dataset_inputs_t0_total_covmat_separate,
+    dataset_inputs_total_covmat,
+    dataset_inputs_total_covmat_separate,
+    dataset_t0_predictions,
+    reorder_thcovmat_as_expcovmat,
+    sqrt_covmat,
+)
 from validphys.tests.conftest import DATA, HESSIAN_PDF, PDF, THEORYID
 
 # Experiments which have non trivial correlations between their datasets
@@ -153,3 +161,24 @@ def test_single_datapoint(single_data_single_point_internal_cuts_config):
     # Ensure the dataset is only a single datapoint
     assert ld.ndata == 1
     ld.systematic_errors(t0_predictions)
+
+
+@pytest.mark.parametrize(
+    "combine_fn",
+    [
+        dataset_inputs_t0_total_covmat_separate,
+        dataset_inputs_total_covmat_separate,
+        dataset_inputs_t0_total_covmat,
+        dataset_inputs_total_covmat,
+    ],
+)
+def test_covmat_summing_helpers_do_not_mutate_inputs(combine_fn):
+    exp = np.array([[1.0, 0.2], [0.2, 2.0]])
+    th = np.array([[0.5, 0.1], [0.1, 0.3]])
+    exp_before = exp.copy()
+
+    result = combine_fn(exp, th)
+
+    np.testing.assert_allclose(exp, exp_before)
+    np.testing.assert_allclose(result, exp_before + th)
+    assert result is not exp


### PR DESCRIPTION
This PR addresses a bug in the construction of the total covariance matrix entering the fit:

https://github.com/NNPDF/nnpdf/blob/44a5ddf499d43775b1f0dae5b5b8f2e367e8563a/validphys2/src/validphys/covmats.py#L479-L487

The line 

https://github.com/NNPDF/nnpdf/blob/44a5ddf499d43775b1f0dae5b5b8f2e367e8563a/validphys2/src/validphys/covmats.py#L485

links `covmat` to `dataset_inputs_t0_exp_covmat ` by reference, i.e. creates an alias, such that any subsequent changes to `covmat ` also mutate the original object `dataset_inputs_t0_exp_covmat `. 

- We have checked that n3fit calls/resolves the provider `dataset_inputs_t0_total_covmat` twice before starting the fit, which means that `dataset_inputs_t0_exp_covmat ` already includes the theory covmat after the first call such that the returned object that enters the fit after the second call is the experimental covmat plus **twice** the theory covmat.
- We have run an agent and it turns out this behaviour shows up in `covmats.py` in 3 other places. This PR fixes this too. It also added a dedicated test to check whether things are safe now.
- The filter utils function has also been modified for safety, because also here we modify the argument directly. I don't think this matters too much because the filter utils are not part of report engine, but better safe than sorry.

Report comparing the impact of the bug before and after the fix: https://vp.nnpdf.science/Gx02F1SqSaKSvTtOLhXFZg==/