### PR TITLE
Correct metadata for CMS_1JET_8TEV

### DIFF
--- a/nnpdf_data/nnpdf_data/commondata/CMS_1JET_8TEV/metadata.yaml
+++ b/nnpdf_data/nnpdf_data/commondata/CMS_1JET_8TEV/metadata.yaml
@@ -74,7 +74,6 @@ implemented_observables:
       - CMS_1JET_8TEV_PTY_BIN4
       - CMS_1JET_8TEV_PTY_BIN5
       - CMS_1JET_8TEV_PTY_BIN6
-      - CMS_1JET_8TEV_PTY_BIN7
     operation: 'null'
   plotting:
     dataset_label: CMS jets 8 TeV


### PR DESCRIPTION
As per NNPDF/theories_slim#81.