### PR TITLE
Fix mismatch in the FK tables naming in metadata

### DIFF
--- a/nnpdf_data/nnpdf_data/commondata/ATLAS_WPWM_13P6TEV_TOT/metadata.yaml
+++ b/nnpdf_data/nnpdf_data/commondata/ATLAS_WPWM_13P6TEV_TOT/metadata.yaml
@@ -50,8 +50,8 @@ implemented_observables:
     conversion_factor: 1.0
     operation: 'null'
     FK_tables:
-    - - ATLAS_WPWM_13p6TEV_TOT_WP
-      - ATLAS_WPWM_13p6TEV_TOT_WM
+    - - ATLAS_WPWM_13P6TEV_TOT_WP
+      - ATLAS_WPWM_13P6TEV_TOT_WM
   data_uncertainties:
   - uncertainties.yaml
   data_central: data.yaml

--- a/nnpdf_data/nnpdf_data/commondata/ATLAS_Z0_13P6TEV_TOT/metadata.yaml
+++ b/nnpdf_data/nnpdf_data/commondata/ATLAS_Z0_13P6TEV_TOT/metadata.yaml
@@ -48,7 +48,7 @@ implemented_observables:
     conversion_factor: 1.0
     operation: 'null'
     FK_tables:
-    - - ATLAS_WPWM_13p6TEV_TOT_Z0
+    - - ATLAS_WPWM_13P6TEV_TOT_Z0
   data_uncertainties:
   - uncertainties.yaml
   data_central: data.yaml


### PR DESCRIPTION
In the `metadata.yaml` files for the two datasets `ATLAS_Z0_13P6TEV_TOT` and `ATLAS_WPWM_13P6TEV_TOT`, the name of the FK Tables had a mismatch from the name of the grids needed for the computation. The names are now fixed.