### PR TITLE
Add the possibility of evolving the fit with hoppet

### DIFF
--- a/doc/sphinx/source/tutorials/evolution.rst
+++ b/doc/sphinx/source/tutorials/evolution.rst
@@ -14,6 +14,9 @@ Under the hood this command will take the PDF at the fitting scale and the theor
 used to run the fit, it will download the corresponding Evolution Kernel Operator and will produce
 a series of LHAPDF ``.dat`` files which can be used to prepare the grid.
 
+While the default underlying evolution code is ``EKO``, it is possible to also evolve the PDF using
+``HOPPET`` by adding the flag ``--hoppet``.
+
 It is also possible to evolve any other PDF or fit by directly accessing the evolution functions.
 In the following example, we use the function :py:func:`evolven3fit.evolve.evolve_exportgrids_into_lhapdf`
 to evolve the hessian version of ``PDF4LHC21`` using the settings of the NNPDF4.0 with MHOU fit.

--- a/n3fit/src/evolven3fit/evolve.py
+++ b/n3fit/src/evolven3fit/evolve.py
@@ -82,6 +82,11 @@ class ExportGrid:
         if self.labels is None:
             self.labels = [PIDS_DICT[i] for i in self.pids]
 
+        # Setting the charm to 0 gets matching results with EKO's expanded inversion
+
+    #         self.pdfgrid[:,self.pids.index(-4)] = 0.0
+    #         self.pdfgrid[:,self.pids.index(4)] = 0.0
+
     @property
     def pdfvalues(self):
         """Return the PDF, i.e., pdfgrid / xgrid,

--- a/n3fit/src/evolven3fit/evolve.py
+++ b/n3fit/src/evolven3fit/evolve.py
@@ -24,6 +24,8 @@ from eko.io import manipulate
 from validphys.pdfbases import PIDS_DICT
 from validphys.utils import yaml_safe
 
+from . import hoppet_evolve
+
 _logger = logging.getLogger(__name__)
 
 LOG_FILE = "evolven3fit.log"
@@ -95,58 +97,13 @@ class ExportGrid:
         return self.pdfgrid.T / self.xgrid
 
 
-def evolve_exportgrid(eko_path: pathlib.Path, exportgrids: list[ExportGrid]):
+def _evolve_exportgrids_with_eko(eko_op: pathlib.Path, exportgrids: list[ExportGrid]):
     """
-    Takes the path to an EKO and a list of exportgrids,
-    returns a tuple with an info file and the
-    evolved exportgrid as a dictionary of the form:
-
-    .. code-block:: python
-
-        {
-            (Q_1^2, nf1): (replica, flavours, x),
-            (Q_2^2, nf1): (replica, flavours, x),
-            ...
-            (Q_3^2, nf2): (replica, flavours, x),
-        }
-
-
-    with the output grouped by nf and sorted in ascending order by Q2.
-
-    Parameters
-    ----------
-    eko_path: pathlib.Path
-        Path to the evolution eko
-    exportgrids: list[ExportGrid]
-        List of ExportGrid objects to be evolved
-
-    Returns
-    -------
-    info_file: eko_box.info_file
-        Dict-like object with the info file information.
-    evolved_replicas: dict
-        a dictionary containing all evolved PDFs.
-        The format of the output is
-        { (q2, flavour number): np.ndarray(replica, flavours, x) }
+    Evolves the set of exportgrids using EKO.
     """
-    # Check that all exportgrid objects have been evaluated for 1) The same value of Q, the same value of x
     ref = exportgrids[0]
-    hessian_fit = ref.hessian
-
-    for egrid in exportgrids:
-        assert egrid.q20 == ref.q20, "Different values of q0 found among the exportgrids"
-        np.testing.assert_allclose(
-            ref.xgrid, egrid.xgrid, err_msg="ExportGrids are not all evaluate at the same x nodes"
-        )
-        assert (
-            hessian_fit == egrid.hessian
-        ), "Trying to evolve hessian and non-hessian fit at the same time"
-
-    # Read the EKO and the operator and theory cards
-    eko_op = eko.EKO.read(eko_path)
     theory = eko_op.theory_card
     op = eko_op.operator_card
-
     assert ref.q20 == op.mu20, f"The EKO can only evolve from {op.mu20}, PDF asked for {ref.q20}"
 
     _logger.debug(f"Theory card: {json.dumps(theory.raw)}")
@@ -160,7 +117,6 @@ def evolve_exportgrid(eko_path: pathlib.Path, exportgrids: list[ExportGrid]):
     if XGrid(x_grid) != eko_original_xgrid:
         new_xgrid = XGrid(x_grid)
         new_metadata = dataclasses.replace(eko_op.metadata, xgrid=new_xgrid)
-
         new_operators = {}
         for target_key in eko_op.operators:
             elem = eko_op[target_key.ep]
@@ -199,17 +155,84 @@ def evolve_exportgrid(eko_path: pathlib.Path, exportgrids: list[ExportGrid]):
 
     # output is a dictionary {(Q2, nf): (replica, flavour, x)}
     all_evolved, _ = apply.apply_grids(eko_op, np.array(all_replicas))
+    info = info_file.build(theory, op, 1, info_update={})
+
     # sort the output in terms of (Q2, nf) but grouped by nf
     sorted_evolved = dict(sorted(all_evolved.items(), key=lambda item: (item[0][1], item[0][0])))
 
-    info = info_file.build(theory, op, 1, info_update={})
+    return info, sorted_evolved
+
+
+def evolve_exportgrid(
+    eko_path: pathlib.Path, exportgrids: list[ExportGrid], theory_id: int = -1, hoppet: bool = False
+):
+    """
+    Takes the path to an EKO and a list of exportgrids,
+    returns a tuple with an info file and the
+    evolved exportgrid as a dictionary of the form:
+
+    .. code-block:: python
+
+        {
+            (Q_1^2, nf1): (replica, flavours, x),
+            (Q_2^2, nf1): (replica, flavours, x),
+            ...
+            (Q_3^2, nf2): (replica, flavours, x),
+        }
+
+
+    with the output grouped by nf and sorted in ascending order by Q2.
+
+    Parameters
+    ----------
+    eko_path: pathlib.Path
+        Path to the evolution eko
+    exportgrids: list[ExportGrid]
+        List of ExportGrid objects to be evolved
+    theory_id: int
+        Theory ID of evolution (only needed for hoppet)
+    hoppet: bool
+        Whether to use HOPPET evolution
+
+    Returns
+    -------
+    info_file: eko_box.info_file
+        Dict-like object with the info file information.
+    evolved_replicas: dict
+        a dictionary containing all evolved PDFs.
+        The format of the output is
+        { (q2, flavour number): np.ndarray(replica, flavours, x) }
+    """
+    # Check that all exportgrid objects have been evaluated for 1) The same value of Q, the same value of x
+    ref = exportgrids[0]
+    hessian_fit = ref.hessian
+
+    for egrid in exportgrids:
+        assert egrid.q20 == ref.q20, "Different values of q0 found among the exportgrids"
+        np.testing.assert_allclose(
+            ref.xgrid, egrid.xgrid, err_msg="ExportGrids are not all evaluate at the same x nodes"
+        )
+        assert (
+            hessian_fit == egrid.hessian
+        ), "Trying to evolve hessian and non-hessian fit at the same time"
+
+    if hoppet:
+        info, sorted_evolved = hoppet_evolve.evolve_exportgrids_with_hoppet(
+            eko_path, exportgrids, theory_id
+        )
+    else:
+        # We read the EKO to a temporary directory that will vanish upon exiting
+        with tempfile.TemporaryDirectory() as temp_dir:
+            eko_op = eko.EKO.read(eko_path, dest=pathlib.Path(temp_dir))
+            info, sorted_evolved = _evolve_exportgrids_with_eko(eko_op, exportgrids)
+
     info["NumMembers"] = "REPLACE_NREP"
     if hessian_fit:
         info["ErrorType"] = "hessian"
     else:
         info["ErrorType"] = "replicas"
-    info["XMin"] = float(x_grid[0])
-    info["XMax"] = float(x_grid[-1])
+    info["XMin"] = float(ref.xgrid[0])
+    info["XMax"] = float(ref.xgrid[-1])
     info["Flavors"] = basis_rotation.flavor_basis_pids
     info.setdefault("NumFlavors", 5)
 
@@ -222,6 +245,8 @@ def evolve_exportgrids_into_lhapdf(
     output_files: list[pathlib.Path],
     info_file: pathlib.Path,
     finalize: bool = False,
+    theory_id: int = -1,
+    hoppet: bool = False,
 ):
     """
     Exportgrid evolution function.
@@ -242,6 +267,10 @@ def evolve_exportgrids_into_lhapdf(
             path to the info file
         finalize: bool
             If True, try to finalize the info file, otherwise keep placeholders to be filled at a later step
+        theory_id: int
+            Theory ID of evolution (only needed for hoppet)
+        hoppet: bool
+            Whether to use HOPPET evolution
     """
     if len(exportgrids) != len(output_files):
         raise ValueError("The length of output_files and exportgrids must be equal")
@@ -253,56 +282,61 @@ def evolve_exportgrids_into_lhapdf(
 
     # all evolved is a dictionary {(Q2, nf): (replica, flavour, x)}
     # ordered first by nf and then by Q2 in ascending order
-    info, all_evolved = evolve_exportgrid(eko_path, exportgrids)
+    info, all_evolved = evolve_exportgrid(eko_path, exportgrids, theory_id=theory_id, hoppet=hoppet)
 
     # The ``dump`` functions from eko's genpdf are very opinionated regarding the output folder of the files
     # therefore we create a temporary directory where to put stuff and then move it to the right place
-    temp_dir = tempfile.TemporaryDirectory()
-    temp_path = pathlib.Path(temp_dir.name)
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = pathlib.Path(temp_dir)
 
-    if finalize:
-        info["NumMembers"] = len(exportgrids)
+        if finalize:
+            info["NumMembers"] = len(exportgrids)
 
-    genpdf.export.dump_info(temp_path, info)
-    temp_info = temp_path / f"{temp_path.stem}.info"
-    shutil.move(temp_info, info_file)
+        genpdf.export.dump_info(temp_path, info)
+        temp_info = temp_path / f"{temp_path.stem}.info"
+        shutil.move(temp_info, info_file)
 
-    # Dump LHAPDF files as .dat files in blocks of nf
-    targetgrid = exportgrids[0].xgrid.tolist()
-    q2block_per_nf = defaultdict(list)
-    for q2, nf in all_evolved.keys():
-        q2block_per_nf[nf].append(q2)
+        # Dump LHAPDF files as .dat files in blocks of nf
+        targetgrid = exportgrids[0].xgrid.tolist()
+        q2block_per_nf = defaultdict(list)
+        for q2, nf in all_evolved.keys():
+            q2block_per_nf[nf].append(q2)
 
-    for enum, (exportgrid, output_file) in enumerate(zip(exportgrids, output_files)):
-        replica_idx = exportgrid.replica
-        if replica_idx is None and exportgrid.hessian:
-            replica_idx = enum
-        blocks = []
+        for enum, (exportgrid, output_file) in enumerate(zip(exportgrids, output_files)):
+            replica_idx = exportgrid.replica
+            if replica_idx is None and exportgrid.hessian:
+                replica_idx = enum
+            blocks = []
 
-        for nf, q2grid in q2block_per_nf.items():
+            for nf, q2grid in q2block_per_nf.items():
 
-            def pdf_xq2(pid, x, Q2):
-                x_idx = targetgrid.index(x)
-                pid_idx = info["Flavors"].index(pid)
-                ret = x * all_evolved[(Q2, nf)][enum][pid_idx][x_idx]
-                return ret
+                def pdf_xq2(pid, x, Q2):
+                    x_idx = targetgrid.index(x)
+                    pid_idx = info["Flavors"].index(pid)
+                    ret = x * all_evolved[(Q2, nf)][enum][pid_idx][x_idx]
+                    return ret
 
-            block = genpdf.generate_block(
-                pdf_xq2, xgrid=targetgrid, sorted_q2grid=q2grid, pids=info["Flavors"]
-            )
-            blocks.append(block)
+                block = genpdf.generate_block(
+                    pdf_xq2, xgrid=targetgrid, sorted_q2grid=q2grid, pids=info["Flavors"]
+                )
+                blocks.append(block)
 
-        dat_path = dump_evolved_replica(blocks, temp_path, replica_idx, exportgrid.hessian)
-        if not dat_path.exists():
-            raise FileNotFoundError(
-                "The expected {dat_path} file was not found after dumping the blocks"
-            )
-        shutil.move(dat_path, output_file)
-
-    temp_dir.cleanup()
+            dat_path = dump_evolved_replica(blocks, temp_path, replica_idx, exportgrid.hessian)
+            if not dat_path.exists():
+                raise FileNotFoundError(
+                    "The expected {dat_path} file was not found after dumping the blocks"
+                )
+            shutil.move(dat_path, output_file)
 
 
-def evolve_fit(fit_folder, force, eko_path, hessian_fit=False):
+def evolve_fit(
+    fit_folder: pathlib.Path,
+    theory_id: int,
+    force: bool = False,
+    hessian_fit: bool = False,
+    eko_path: pathlib.Path = None,
+    hoppet: bool = False,
+):
     """
     Evolves all the fitted replica in fit_folder/nnfit
 
@@ -311,13 +345,16 @@ def evolve_fit(fit_folder, force, eko_path, hessian_fit=False):
 
         fit_folder: str or pathlib.Path
             path to the folder containing the fit
+        theory_id: int
+            Theory ID of evolution
         force: bool
             whether to force the evolution to be done again
-        eko_path: str or pathlib.Path
-            path where the eko is stored (if None the eko will be
-            recomputed)
         hessian_fit: bool
             wether the fit is hessian
+        eko_path: str or pathlib.Path
+            path where the eko is stored (if None the eko will be recomputed)
+        hoppet: bol
+            Whether to use HOPPET evolution
     """
     fit_folder = pathlib.Path(fit_folder)
     log_file = fit_folder / LOG_FILE
@@ -353,7 +390,9 @@ def evolve_fit(fit_folder, force, eko_path, hessian_fit=False):
         output_files.append(exportgrid_file.with_suffix(".dat"))
 
     info_path = fit_folder / "nnfit" / f"{fit_folder.name}.info"
-    evolve_exportgrids_into_lhapdf(eko_path, exportgrids, output_files, info_path)
+    evolve_exportgrids_into_lhapdf(
+        eko_path, exportgrids, output_files, info_path, theory_id=theory_id, hoppet=hoppet
+    )
 
 
 def dump_evolved_replica(evolved_blocks, dump_folder, replica_num, hessian_fit=False):

--- a/n3fit/src/evolven3fit/hoppet_evolve.py
+++ b/n3fit/src/evolven3fit/hoppet_evolve.py
@@ -8,25 +8,18 @@ from collections import defaultdict
 import dataclasses
 import functools
 import importlib
-import logging
 import pathlib
-import shutil
-import sys
 import tempfile
 
-from ekobox import genpdf, info_file
+from ekobox import info_file
 import numpy as np
 
 from eko import EKO, basis_rotation
 from eko.interpolation import InterpolatorDispatcher
 from nnpdf_data import THEORY_CARDS_PATH
 from nnpdf_data.theorydbutils import fetch_theory
-from validphys.utils import yaml_safe
 
 from . import eko_utils
-from .evolve import LOG_FILE, LOGGING_SETTINGS, ExportGrid, dump_evolved_replica
-
-_logger = logging.getLogger(__name__)
 
 HOPPET_QCD_PIDS = (-6, -5, -4, -3, -2, -1, 21, 1, 2, 3, 4, 5, 6)
 
@@ -132,17 +125,12 @@ def _build_cards(nnpdf_theory, x_grid, eko_path: pathlib.Path = None):
     return theory_card, op_card_eko
 
 
-def _configure_hoppet(hp, theory: HoppetTheory, x_grid, q_values, dy, lnlnq_order, y_order):
+def _configure_hoppet(hp, theory: HoppetTheory, x_grid, q_values, dy=0.025):
     """
     Calling a few hoppet function that need to be called before starting.
     We use hoppet's extended start to make sure we have the same
     range as the lhapdf grid that we use in NNPDF.
     """
-    if y_order is not None or lnlnq_order is not None:
-        hp.SetYLnlnQInterpOrders(
-            -1 if y_order is None else int(y_order), 4 if lnlnq_order is None else int(lnlnq_order)
-        )
-
     hp.SetExactDGLAP(True, True)
 
     xmin = float(x_grid[0])
@@ -190,9 +178,7 @@ def _nudge_q_at_threshold(q, nf, q_by_nf):
         return NotImplementedError("If you are playing with a 3-way threshold you can modify this")
 
 
-def _evolve_one_exportgrid(
-    hp, theory: HoppetTheory, exportgrid: ExportGrid, q_by_nf: list[tuple[float, int]]
-) -> dict:
+def _evolve_one_exportgrid(hp, theory, exportgrid, q_by_nf):
     """
     Receives one single exportgrid, and calls hoppet-evolve on it.
     Note, at this point hoppet must have already been started.
@@ -228,32 +214,15 @@ def _eval_pdf_grid(hp, x_grid, q):
     return np.array(values).T
 
 
-def evolve_exportgrid_with_hoppet(
-    nnpdf_theory,
-    exportgrids: list[ExportGrid],
-    dy: float = 0.025,
-    y_order: int = None,
-    lnlnq_order: int = None,
-    eko_path: pathlib.Path = None,
-):
-    """Same-old, same-old, hoppet version of ``evolve_exportgrid``."""
-    # TODO: we start with the same exact check as evolve_exportgrid
+def evolve_exportgrids_with_hoppet(eko_path, exportgrids, theory_id):
+    """ """
     ref = exportgrids[0]
-    hessian_fit = ref.hessian
-    for egrid in exportgrids:
-        assert egrid.q20 == ref.q20, "Different values of q0 found among the exportgrids"
-        np.testing.assert_allclose(
-            ref.xgrid, egrid.xgrid, err_msg="ExportGrids are not all evaluate at the same x nodes"
-        )
-        assert (
-            hessian_fit == egrid.hessian
-        ), "Trying to evolve hessian and non-hessian fit at the same time"
-    ######
+    nnpdf_theory = fetch_theory(THEORY_CARDS_PATH, theory_id, as_dict=False)
+    theory_card, op_card = _build_cards(nnpdf_theory, ref.xgrid, eko_path)
 
     # Build the theory and operator cards from the NNPDF theories.
     # _if_ an EKO path is given, extract the operator card directly from there.
     # This ensures that the xgrid/qgrid is exactly the same as the eko
-    theory_card, op_card = _build_cards(nnpdf_theory, ref.xgrid, eko_path)
     hoppet_theory = _nnpdf_theory_to_hoppet(nnpdf_theory)
     hoppet_module = _import_hoppet()
 
@@ -262,14 +231,8 @@ def evolve_exportgrid_with_hoppet(
     all_evolved = defaultdict(list)
 
     try:
-        _configure_hoppet(
-            hoppet_module, hoppet_theory, ref.xgrid, q_values, dy, lnlnq_order, y_order
-        )
+        _configure_hoppet(hoppet_module, hoppet_theory, ref.xgrid, q_values)
 
-        # EKO gets to do the whole set at once by creating one single
-        # tensor with replicas as an index.
-        # Hoppet instead will do them one by one, but hopefully
-        # caches the intermediate results?
         for exportgrid in exportgrids:
             evolved_replica = _evolve_one_exportgrid(
                 hoppet_module, hoppet_theory, exportgrid, eko_q_by_nf
@@ -280,174 +243,9 @@ def evolve_exportgrid_with_hoppet(
     finally:
         hoppet_module.DeleteAll()
 
-    # This is a copy from tehe vanilla evolution but we need the extra np.array
-    # to "concatenate" the replicas
+    info = info_file.build(theory_card, op_card, 1, info_update={})
     sorted_evolved = {
         key: np.array(value)
         for key, value in sorted(all_evolved.items(), key=lambda item: (item[0][1], item[0][0]))
     }
-
-    info = info_file.build(theory_card, op_card, 1, info_update={})
-    info["NumMembers"] = "REPLACE_NREP"
-    if hessian_fit:
-        info["ErrorType"] = "hessian"
-    else:
-        info["ErrorType"] = "replicas"
-    info["XMin"] = float(ref.xgrid[0])
-    info["XMax"] = float(ref.xgrid[-1])
-    info["Flavors"] = basis_rotation.flavor_basis_pids
-    info.setdefault("NumFlavors", 5)
-
-    # TODO Not sure why this doesn't work ootb, double check
-    if info.get("AlphaS_Qs"):
-        info["AlphaS_Qs"][0] = info["QMin"]
-        info["AlphaS_Qs"][-1] = info["QMax"]
-
     return info, sorted_evolved
-
-
-def evolve_exportgrids_into_lhapdf_with_hoppet(
-    nnpdf_theory,
-    exportgrids: list[ExportGrid],
-    output_files: list[pathlib.Path],
-    info_path: pathlib.Path,
-    finalize: bool = False,
-    dy: float = 0.025,
-    y_order: int = None,
-    lnlnq_order: int = None,
-    eko_path: pathlib.Path = None,
-):
-    """
-    Hoppet version of ``evolve_exportgrids_into_lhapdf``
-    """
-    if len(exportgrids) != len(output_files):
-        raise ValueError("The length of output_files and exportgrids must be equal")
-
-    for f in output_files:
-        pathlib.Path(f).parent.mkdir(exist_ok=True, parents=True)
-    pathlib.Path(info_path).parent.mkdir(exist_ok=True, parents=True)
-
-    # TODO: at this point everything other than _this_ call is a direct copy from the
-    # vanilla evolution for development convenience, both should be merged together before merging
-    # plz reviewer, scold me if I haven't done so
-    info, all_evolved = evolve_exportgrid_with_hoppet(
-        nnpdf_theory,
-        exportgrids,
-        dy=dy,
-        y_order=y_order,
-        lnlnq_order=lnlnq_order,
-        eko_path=eko_path,
-    )
-
-    with tempfile.TemporaryDirectory() as temp_dir:
-        temp_path = pathlib.Path(temp_dir)
-
-        if finalize:
-            info["NumMembers"] = len(exportgrids)
-
-        genpdf.export.dump_info(temp_path, info)
-        temp_info = temp_path / f"{temp_path.stem}.info"
-        shutil.move(temp_info, info_path)
-
-        # Dump LHAPDF files as .dat files in blocks of nf
-        targetgrid = exportgrids[0].xgrid.tolist()
-        q2block_per_nf = defaultdict(list)
-        for q2, nf in all_evolved.keys():
-            q2block_per_nf[nf].append(q2)
-
-        x_index = {x: idx for idx, x in enumerate(targetgrid)}
-        pid_index = {pid: idx for idx, pid in enumerate(info["Flavors"])}
-
-        for enum, (exportgrid, output_file) in enumerate(zip(exportgrids, output_files)):
-            replica_idx = exportgrid.replica
-            if replica_idx is None and exportgrid.hessian:
-                replica_idx = enum
-            blocks = []
-
-            for nf, q2grid in q2block_per_nf.items():
-
-                def pdf_xq2(pid, x, Q2):
-                    x_idx = x_index[x]
-                    pid_idx = pid_index[pid]
-                    return x * all_evolved[(Q2, nf)][enum][pid_idx][x_idx]
-
-                block = genpdf.generate_block(
-                    pdf_xq2, xgrid=targetgrid, sorted_q2grid=q2grid, pids=info["Flavors"]
-                )
-                blocks.append(block)
-
-            dat_path = dump_evolved_replica(blocks, temp_path, replica_idx, exportgrid.hessian)
-            if not dat_path.exists():
-                raise FileNotFoundError(
-                    f"The expected {dat_path} file was not found after dumping the blocks"
-                )
-            shutil.move(dat_path, output_file)
-
-
-def evolve_fit_with_hoppet(
-    fit_folder: pathlib.Path,
-    theory_id: int,
-    force: bool = False,
-    hessian_fit: bool = False,
-    dy: float = 0.025,
-    y_order: int = None,
-    lnlnq_order: int = None,
-    eko_path: pathlib.Path = None,
-):
-    """
-    Evolves all the fitted replica in fit_folder/nnfit.
-    Follows the same structure as ``evolven3fit.evolve.evolve_fit`` but using HOPPET
-    as the backend instead of a pre-computed EKO.
-    """
-    # Check that hoppet can be imported, otherwise fail early
-    _import_hoppet()
-
-    # TODO: at this point this piece is repeated here and in evole_fit
-    # so it should be lifted
-    fit_folder = pathlib.Path(fit_folder)
-    log_path = fit_folder / LOG_FILE
-    if log_path.exists():
-        if force:
-            log_path.unlink()
-        else:
-            raise FileExistsError(
-                f"Log file already exists: {log_file}. Has evolven3fit already been run?"
-            )
-
-    log_file = logging.FileHandler(log_path)
-    stdout_log = logging.StreamHandler(sys.stdout)
-    for log in [log_file, stdout_log]:
-        log.setFormatter(LOGGING_SETTINGS["formatter"])
-    log_file.setLevel(LOGGING_SETTINGS["level"])
-    stdout_log.setLevel(logging.INFO)
-
-    for logger in (_logger, logging.getLogger("evolven3fit")):
-        logger.handlers = []
-        logger.setLevel(LOGGING_SETTINGS["level"])
-        logger.propagate = False
-        logger.addHandler(log_file)
-        logger.addHandler(stdout_log)
-    #############################################
-
-    nnpdf_theory = fetch_theory(THEORY_CARDS_PATH, theory_id, as_dict=False)
-    _logger.info("Evolving %s with HOPPET using theory %s", fit_folder, theory_id)
-
-    output_files = []
-    exportgrids = []
-
-    for exportgrid_file in fit_folder.glob(f"nnfit/replica_*/{fit_folder.name}.exportgrid"):
-        data = yaml_safe.load(exportgrid_file.read_text(encoding="UTF-8"))
-        exportgrids.append(ExportGrid(**data, hessian=hessian_fit))
-        output_files.append(exportgrid_file.with_suffix(".dat"))
-
-    info_path = fit_folder / "nnfit" / f"{fit_folder.name}.info"
-    evolve_exportgrids_into_lhapdf_with_hoppet(
-        nnpdf_theory,
-        exportgrids,
-        output_files,
-        info_path,
-        dy=dy,
-        y_order=y_order,
-        lnlnq_order=lnlnq_order,
-        eko_path=eko_path,
-    )

--- a/n3fit/src/evolven3fit/hoppet_evolve.py
+++ b/n3fit/src/evolven3fit/hoppet_evolve.py
@@ -1,0 +1,458 @@
+"""Evolution of n3fit export grids with HOPPET.
+
+This module mirrors the LHAPDF-writing part of :mod:`evolven3fit.evolve`,
+but uses HOPPET for the DGLAP evolution instead of applying a precomputed EKO.
+"""
+
+from collections import defaultdict
+import dataclasses
+import functools
+import importlib
+import logging
+import pathlib
+import shutil
+import sys
+import tempfile
+
+from ekobox import genpdf, info_file
+import numpy as np
+
+from eko import EKO, basis_rotation
+from eko.interpolation import InterpolatorDispatcher
+from nnpdf_data import THEORY_CARDS_PATH
+from nnpdf_data.theorydbutils import fetch_theory
+from validphys.utils import yaml_safe
+
+from . import eko_utils
+from .evolve import LOG_FILE, LOGGING_SETTINGS, ExportGrid, dump_evolved_replica
+
+_logger = logging.getLogger(__name__)
+
+HOPPET_QCD_PIDS = (-6, -5, -4, -3, -2, -1, 21, 1, 2, 3, 4, 5, 6)
+
+
+def _import_hoppet():
+    """Import hoppet lazily since it is not part of the default installation."""
+    try:
+        return importlib.import_module("hoppet")
+    except ModuleNotFoundError as e:
+        raise ModuleNotFoundError("Can't evolve with hoppet without having hoppet installed") from e
+
+
+@dataclasses.dataclass(frozen=True)
+class HoppetTheory:
+    """HOPPET settings translated from an NNPDF theory card."""
+
+    alphas: float
+    qref: float
+    q0: float
+    nloop: int
+    mur_over_q: float
+    masses: tuple[float, float, float]
+    mass_scheme: str
+    fns: str
+    max_nf_pdf: int
+
+
+# TODO:
+# Hoppet asks for a function with a signature (x, Q), in this case Q would be fixed
+# so we need to create an interpolator in x following the exportgrid.
+# It would be nice if
+#   a) The exportgrid itself offered the interpolation (this is useful!)
+#   b) We had some very fine interpolation ready to go
+#   c) Pass directly the output of the NN!!
+#   d) This could also be done by eko
+#   e) So, on second thoughts, we want an exportgrid-compatible NN-interface :) # TODO
+# we could
+def _make_hoppet_pdf_callback(exportgrid, interpolation_degree=4):
+    """Creates an interpolation pdf(x) given an exportgrid.
+    NOTE: the function includes Q but this is dropped anyway
+    """
+    xgrid = exportgrid.xgrid
+    pid_columns = [exportgrid.pids.index(pid) for pid in HOPPET_QCD_PIDS]
+    pdfgrid = exportgrid.pdfgrid[:, pid_columns]
+
+    dispatcher = InterpolatorDispatcher(xgrid, interpolation_degree, mode_N=False)
+
+    @functools.cache  # assuming that an infinite cache is safe here
+    def pdf_callback(x, _q):
+        x = float(x)
+        if x <= xgrid[0]:
+            return pdfgrid[0].tolist()
+        if x >= xgrid[-1]:
+            return pdfgrid[-1].tolist()
+        weights = dispatcher.get_interpolation([x])[0]
+        return (weights @ pdfgrid).tolist()
+
+    return pdf_callback
+
+
+def _nnpdf_theory_to_hoppet(nnpdf_theory, polarized=False):
+    """Translation layer between the NNPDF theory card and hoppet's parameters."""
+    if polarized:
+        raise NotImplementedError("Polarized not implemented for hoppet")
+
+    if nnpdf_theory.QED != 0:
+        raise NotImplementedError("QED evolution not yet supported for hoppet")
+
+    if nnpdf_theory.PTO > 2:
+        raise NotImplementedError("Only up to NNLO for now with hoppet")
+
+    masses = (nnpdf_theory.mc, nnpdf_theory.mb, nnpdf_theory.mt)
+    # Note: for hoppet this is both the masses and the thresholds
+
+    nloop = nnpdf_theory.PTO + 1
+    fns = nnpdf_theory.FNS.split("-")[0]
+
+    return HoppetTheory(
+        alphas=nnpdf_theory.alphas,
+        qref=nnpdf_theory.Qref,
+        q0=nnpdf_theory.Q0,
+        nloop=nloop,
+        mur_over_q=nnpdf_theory.XIR,
+        masses=masses,
+        mass_scheme=nnpdf_theory.HQ,
+        fns=fns,
+        max_nf_pdf=nnpdf_theory.MaxNfPdf,
+    )
+
+
+def _build_cards(nnpdf_theory, x_grid, eko_path: pathlib.Path = None):
+    """Build the operator and theory cards that will later be used to define the
+    operators by hoppet. If an EKO is given, use that for the operator card instead."""
+    theory_card, op_card = eko_utils.construct_eko_cards(nnpdf_theory.asdict(), x_grid)
+    if eko_path is None:
+        return theory_card, op_card
+
+    # If we have an eko, load it and read the operator card
+    # this is a EKO-sized GBs penalty on /tmp, isn't there a get-eko-metadata function??
+    # we should clean after oulseves quickly
+    with tempfile.TemporaryDirectory() as temp_dir:
+        op_card_eko = EKO.read(eko_path, dest=pathlib.Path(temp_dir)).operator_card
+    return theory_card, op_card_eko
+
+
+def _configure_hoppet(hp, theory: HoppetTheory, x_grid, q_values, dy, lnlnq_order, y_order):
+    """
+    Calling a few hoppet function that need to be called before starting.
+    We use hoppet's extended start to make sure we have the same
+    range as the lhapdf grid that we use in NNPDF.
+    """
+    if y_order is not None or lnlnq_order is not None:
+        hp.SetYLnlnQInterpOrders(
+            -1 if y_order is None else int(y_order), 4 if lnlnq_order is None else int(lnlnq_order)
+        )
+
+    hp.SetExactDGLAP(True, True)
+
+    xmin = float(x_grid[0])
+    ymax = -np.log(xmin)
+
+    qmin = max(np.min(q_values), theory.q0)
+    # TODO: can hoppet do an invert pass over the charm threshold?
+    qmax = max(np.max(q_values), theory.q0)
+    hp.StartExtended(
+        ymax,
+        dy,
+        qmin,
+        qmax,
+        dy / 4.0,  # hoppet's suggestion
+        theory.nloop,
+        -6,  # interpolation order
+        hp.factscheme_MSbar,
+    )
+
+    masses = list(theory.masses)
+    if theory.max_nf_pdf < 5:
+        masses[1] = max(qmax * 2.0, masses[1])
+    if theory.max_nf_pdf < 6:
+        masses[2] = max(qmax * 2.0, masses[2])
+
+    if theory.fns == "FFNS":
+        hp.SetFFN(theory.max_nf_pdf)
+    elif theory.mass_scheme == "MSBAR":
+        hp.SetMSbarMassVFN(*masses)
+    else:
+        hp.SetPoleMassVFN(*masses)
+
+
+def _nudge_q_at_threshold(q, nf, q_by_nf):
+    """Nudge Q below/above threshold for the changes of NF."""
+    matching_nfs = [other_nf for other_q, other_nf in q_by_nf if np.isclose(other_q, q)]
+    if len(matching_nfs) < 2:
+        return q
+
+    if nf == min(matching_nfs):
+        return np.nextafter(q, q - 1.0)
+    elif nf == max(matching_nfs):
+        return np.nextafter(q, q + 1.0)
+    else:
+        return NotImplementedError("If you are playing with a 3-way threshold you can modify this")
+
+
+def _evolve_one_exportgrid(
+    hp, theory: HoppetTheory, exportgrid: ExportGrid, q_by_nf: list[tuple[float, int]]
+) -> dict:
+    """
+    Receives one single exportgrid, and calls hoppet-evolve on it.
+    Note, at this point hoppet must have already been started.
+    """
+    hp.Evolve(
+        theory.alphas,
+        theory.qref,
+        theory.nloop,
+        theory.mur_over_q,
+        _make_hoppet_pdf_callback(exportgrid),
+        np.sqrt(exportgrid.q20),
+    )
+
+    evolved = {}
+    for q, nf in q_by_nf:
+        q_eval = _nudge_q_at_threshold(q, nf, q_by_nf)
+        evolved[(q, nf)] = _eval_pdf_grid(hp, exportgrid.xgrid, q_eval)
+    return evolved
+
+
+def _eval_pdf_grid(hp, x_grid, q):
+    """Evaluate the PDF grid at the given value of Q.
+    This output is (flavour, x) to match what the rest of the evolution functions expect.
+    """
+    values = []
+    for x in x_grid:
+        xpdf = hp.Eval(x, q)
+        # This can be avoided by having the translation layer ready, later
+        xpdf_dict = dict(zip(HOPPET_QCD_PIDS, xpdf))
+        xpdf_dict[22] = 0.0
+        values.append([xpdf_dict[i] / x for i in basis_rotation.flavor_basis_pids])
+
+    return np.array(values).T
+
+
+def evolve_exportgrid_with_hoppet(
+    nnpdf_theory,
+    exportgrids: list[ExportGrid],
+    dy: float = 0.025,
+    y_order: int = None,
+    lnlnq_order: int = None,
+    eko_path: pathlib.Path = None,
+):
+    """Same-old, same-old, hoppet version of ``evolve_exportgrid``."""
+    # TODO: we start with the same exact check as evolve_exportgrid
+    ref = exportgrids[0]
+    hessian_fit = ref.hessian
+    for egrid in exportgrids:
+        assert egrid.q20 == ref.q20, "Different values of q0 found among the exportgrids"
+        np.testing.assert_allclose(
+            ref.xgrid, egrid.xgrid, err_msg="ExportGrids are not all evaluate at the same x nodes"
+        )
+        assert (
+            hessian_fit == egrid.hessian
+        ), "Trying to evolve hessian and non-hessian fit at the same time"
+    ######
+
+    # Build the theory and operator cards from the NNPDF theories.
+    # _if_ an EKO path is given, extract the operator card directly from there.
+    # This ensures that the xgrid/qgrid is exactly the same as the eko
+    theory_card, op_card = _build_cards(nnpdf_theory, ref.xgrid, eko_path)
+    hoppet_theory = _nnpdf_theory_to_hoppet(nnpdf_theory)
+    hoppet_module = _import_hoppet()
+
+    eko_q_by_nf = op_card.raw["mugrid"]
+    q_values = sorted({q for q, _ in eko_q_by_nf})
+    all_evolved = defaultdict(list)
+    zero_pdf = np.zeros((len(basis_rotation.flavor_basis_pids), len(ref.xgrid)))
+
+    try:
+        _configure_hoppet(
+            hoppet_module, hoppet_theory, ref.xgrid, q_values, dy, lnlnq_order, y_order
+        )
+
+        # EKO gets to do the whole set at once by creating one single
+        # tensor with replicas as an index.
+        # Hoppet instead will do them one by one, but hopefully
+        # caches the intermediate results?
+        # Fingers crossed! # TODO: ask Alexander
+        for exportgrid in exportgrids:
+            evolved_replica = _evolve_one_exportgrid(
+                hoppet_module, hoppet_theory, exportgrid, eko_q_by_nf
+            )
+
+            for q, nf in eko_q_by_nf:
+                if q < np.sqrt(ref.q20):
+                    all_evolved[(q**2, nf)].append(zero_pdf)
+                else:
+                    all_evolved[(q**2, nf)].append(evolved_replica[(q, nf)])
+    finally:
+        hoppet_module.DeleteAll()
+
+    # This is a copy from tehe vanilla evolution but we need the extra np.array
+    # to "concatenate" the replicas
+    sorted_evolved = {
+        key: np.array(value)
+        for key, value in sorted(all_evolved.items(), key=lambda item: (item[0][1], item[0][0]))
+    }
+
+    info = info_file.build(theory_card, op_card, 1, info_update={})
+    info["NumMembers"] = "REPLACE_NREP"
+    if hessian_fit:
+        info["ErrorType"] = "hessian"
+    else:
+        info["ErrorType"] = "replicas"
+    info["XMin"] = float(ref.xgrid[0])
+    info["XMax"] = float(ref.xgrid[-1])
+    info["Flavors"] = basis_rotation.flavor_basis_pids
+    info.setdefault("NumFlavors", 5)
+
+    # TODO Not sure why this doesn't work ootb, double check
+    if info.get("AlphaS_Qs"):
+        info["AlphaS_Qs"][0] = info["QMin"]
+        info["AlphaS_Qs"][-1] = info["QMax"]
+
+    return info, sorted_evolved
+
+
+def evolve_exportgrids_into_lhapdf_with_hoppet(
+    nnpdf_theory,
+    exportgrids: list[ExportGrid],
+    output_files: list[pathlib.Path],
+    info_path: pathlib.Path,
+    finalize: bool = False,
+    dy: float = 0.025,
+    y_order: int = None,
+    lnlnq_order: int = None,
+    eko_path: pathlib.Path = None,
+):
+    """
+    Hoppet version of ``evolve_exportgrids_into_lhapdf``
+    """
+    if len(exportgrids) != len(output_files):
+        raise ValueError("The length of output_files and exportgrids must be equal")
+
+    for f in output_files:
+        pathlib.Path(f).parent.mkdir(exist_ok=True, parents=True)
+    pathlib.Path(info_path).parent.mkdir(exist_ok=True, parents=True)
+
+    # TODO: at this point everything other than _this_ call is a direct copy from the
+    # vanilla evolution for development convenience, both should be merged together before merging
+    # plz reviewer, scold me if I haven't done so
+    info, all_evolved = evolve_exportgrid_with_hoppet(
+        nnpdf_theory,
+        exportgrids,
+        dy=dy,
+        y_order=y_order,
+        lnlnq_order=lnlnq_order,
+        eko_path=eko_path,
+    )
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = pathlib.Path(temp_dir)
+
+        if finalize:
+            info["NumMembers"] = len(exportgrids)
+
+        genpdf.export.dump_info(temp_path, info)
+        temp_info = temp_path / f"{temp_path.stem}.info"
+        shutil.move(temp_info, info_path)
+
+        # Dump LHAPDF files as .dat files in blocks of nf
+        targetgrid = exportgrids[0].xgrid.tolist()
+        q2block_per_nf = defaultdict(list)
+        for q2, nf in all_evolved.keys():
+            q2block_per_nf[nf].append(q2)
+
+        x_index = {x: idx for idx, x in enumerate(targetgrid)}
+        pid_index = {pid: idx for idx, pid in enumerate(info["Flavors"])}
+
+        for enum, (exportgrid, output_file) in enumerate(zip(exportgrids, output_files)):
+            replica_idx = exportgrid.replica
+            if replica_idx is None and exportgrid.hessian:
+                replica_idx = enum
+            blocks = []
+
+            for nf, q2grid in q2block_per_nf.items():
+
+                def pdf_xq2(pid, x, Q2):
+                    x_idx = x_index[x]
+                    pid_idx = pid_index[pid]
+                    return x * all_evolved[(Q2, nf)][enum][pid_idx][x_idx]
+
+                block = genpdf.generate_block(
+                    pdf_xq2, xgrid=targetgrid, sorted_q2grid=q2grid, pids=info["Flavors"]
+                )
+                blocks.append(block)
+
+            dat_path = dump_evolved_replica(blocks, temp_path, replica_idx, exportgrid.hessian)
+            if not dat_path.exists():
+                raise FileNotFoundError(
+                    f"The expected {dat_path} file was not found after dumping the blocks"
+                )
+            shutil.move(dat_path, output_file)
+
+
+def evolve_fit_with_hoppet(
+    fit_folder: pathlib.Path,
+    theory_id: int,
+    force: bool = False,
+    hessian_fit: bool = False,
+    dy: float = 0.025,
+    y_order: int = None,
+    lnlnq_order: int = None,
+    eko_path: pathlib.Path = None,
+):
+    """
+    Evolves all the fitted replica in fit_folder/nnfit.
+    Follows the same structure as ``evolven3fit.evolve.evolve_fit`` but using HOPPET
+    as the backend instead of a pre-computed EKO.
+    """
+    # Check that hoppet can be imported, otherwise fail early
+    _import_hoppet()
+
+    # TODO: at this point this piece is repeated here and in evole_fit
+    # so it should be lifted
+    fit_folder = pathlib.Path(fit_folder)
+    log_path = fit_folder / LOG_FILE
+    if log_path.exists():
+        if force:
+            log_path.unlink()
+        else:
+            raise FileExistsError(
+                f"Log file already exists: {log_file}. Has evolven3fit already been run?"
+            )
+
+    log_file = logging.FileHandler(log_path)
+    stdout_log = logging.StreamHandler(sys.stdout)
+    for log in [log_file, stdout_log]:
+        log.setFormatter(LOGGING_SETTINGS["formatter"])
+    log_file.setLevel(LOGGING_SETTINGS["level"])
+    stdout_log.setLevel(logging.INFO)
+
+    for logger in (_logger, logging.getLogger("evolven3fit")):
+        logger.handlers = []
+        logger.setLevel(LOGGING_SETTINGS["level"])
+        logger.propagate = False
+        logger.addHandler(log_file)
+        logger.addHandler(stdout_log)
+    #############################################
+
+    nnpdf_theory = fetch_theory(THEORY_CARDS_PATH, theory_id, as_dict=False)
+    _logger.info("Evolving %s with HOPPET using theory %s", fit_folder, theory_id)
+
+    output_files = []
+    exportgrids = []
+
+    for exportgrid_file in fit_folder.glob(f"nnfit/replica_*/{fit_folder.name}.exportgrid"):
+        data = yaml_safe.load(exportgrid_file.read_text(encoding="UTF-8"))
+        exportgrids.append(ExportGrid(**data, hessian=hessian_fit))
+        output_files.append(exportgrid_file.with_suffix(".dat"))
+
+    info_path = fit_folder / "nnfit" / f"{fit_folder.name}.info"
+    evolve_exportgrids_into_lhapdf_with_hoppet(
+        nnpdf_theory,
+        exportgrids,
+        output_files,
+        info_path,
+        dy=dy,
+        y_order=y_order,
+        lnlnq_order=lnlnq_order,
+        eko_path=eko_path,
+    )

--- a/n3fit/src/evolven3fit/hoppet_evolve.py
+++ b/n3fit/src/evolven3fit/hoppet_evolve.py
@@ -148,8 +148,7 @@ def _configure_hoppet(hp, theory: HoppetTheory, x_grid, q_values, dy, lnlnq_orde
     xmin = float(x_grid[0])
     ymax = -np.log(xmin)
 
-    qmin = max(np.min(q_values), theory.q0)
-    # TODO: can hoppet do an invert pass over the charm threshold?
+    qmin = min(np.min(q_values), theory.q0)
     qmax = max(np.max(q_values), theory.q0)
     hp.StartExtended(
         ymax,
@@ -168,6 +167,7 @@ def _configure_hoppet(hp, theory: HoppetTheory, x_grid, q_values, dy, lnlnq_orde
     if theory.max_nf_pdf < 6:
         masses[2] = max(qmax * 2.0, masses[2])
 
+    hp.SetPoleMassVFN(*masses)
     if theory.fns == "FFNS":
         hp.SetFFN(theory.max_nf_pdf)
     elif theory.mass_scheme == "MSBAR":
@@ -260,7 +260,6 @@ def evolve_exportgrid_with_hoppet(
     eko_q_by_nf = op_card.raw["mugrid"]
     q_values = sorted({q for q, _ in eko_q_by_nf})
     all_evolved = defaultdict(list)
-    zero_pdf = np.zeros((len(basis_rotation.flavor_basis_pids), len(ref.xgrid)))
 
     try:
         _configure_hoppet(
@@ -271,17 +270,13 @@ def evolve_exportgrid_with_hoppet(
         # tensor with replicas as an index.
         # Hoppet instead will do them one by one, but hopefully
         # caches the intermediate results?
-        # Fingers crossed! # TODO: ask Alexander
         for exportgrid in exportgrids:
             evolved_replica = _evolve_one_exportgrid(
                 hoppet_module, hoppet_theory, exportgrid, eko_q_by_nf
             )
 
             for q, nf in eko_q_by_nf:
-                if q < np.sqrt(ref.q20):
-                    all_evolved[(q**2, nf)].append(zero_pdf)
-                else:
-                    all_evolved[(q**2, nf)].append(evolved_replica[(q, nf)])
+                all_evolved[(q**2, nf)].append(evolved_replica[(q, nf)])
     finally:
         hoppet_module.DeleteAll()
 

--- a/n3fit/src/n3fit/scripts/evolven3fit.py
+++ b/n3fit/src/n3fit/scripts/evolven3fit.py
@@ -106,25 +106,6 @@ def construct_evolven3fit_parser(subparsers):
     parser.add_argument(
         "--hoppet", action="store_true", help="Use Hoppet instead of EKO for the evolution"
     )
-    # Hoppet overrides
-    # note that some defaults are a bit more aggressive than hoppet's manual would like
-    # but this is to improve the agreement with EKO
-    parser.add_argument(
-        "--dy", type=float, default=0.025, help="HOPPET ln(1/x) internal grid spacing."
-    )
-    # The two below are unimportant
-    parser.add_argument(
-        "--y-order",
-        type=int,
-        default=None,
-        help="Override HOPPET interpolation order in y=ln(1/x).",
-    )
-    parser.add_argument(
-        "--lnlnq-order",
-        type=int,
-        default=None,
-        help="Override HOPPET interpolation order in lnlnQ.",
-    )
     return parser
 
 
@@ -164,19 +145,16 @@ def main():
             # to be used for the evolution will be loaded from that path.
             eko_path = args.load
 
-        if args.hoppet:
-            hoppet_evolve.evolve_fit_with_hoppet(
-                fit_folder,
-                theoryID,
-                force=args.force,
-                hessian_fit=args.hessian_fit,
-                dy=args.dy,
-                y_order=args.y_order,
-                lnlnq_order=args.lnlnq_order,
-                eko_path=eko_path,
-            )
-        else:
-            cli.cli_evolven3fit(fit_folder, args.force, eko_path, args.hessian_fit)
+        utils.check_nnfit_folder(fit_folder)
+
+        evolve.evolve_fit(
+            fit_folder,
+            theoryID,
+            force=args.force,
+            hessian_fit=args.hessian_fit,
+            eko_path=eko_path,
+            hoppet=args.hoppet,
+        )
 
     else:
         # If we are in the business of producing an eko, do some checks before starting:

--- a/n3fit/src/n3fit/scripts/evolven3fit.py
+++ b/n3fit/src/n3fit/scripts/evolven3fit.py
@@ -8,7 +8,7 @@ import logging
 import pathlib
 import sys
 
-from evolven3fit import cli, eko_utils, evolve, utils
+from evolven3fit import cli, eko_utils, evolve, hoppet_evolve, utils
 import numpy as np
 
 from eko.runner.managed import solve
@@ -103,6 +103,28 @@ def construct_evolven3fit_parser(subparsers):
         action="store_true",
         help="Force the evolution to be done even if it has already been done",
     )
+    parser.add_argument(
+        "--hoppet", action="store_true", help="Use Hoppet instead of EKO for the evolution"
+    )
+    # Hoppet overrides
+    # note that some defaults are a bit more aggressive than hoppet's manual would like
+    # but this is to improve the agreement with EKO
+    parser.add_argument(
+        "--dy", type=float, default=0.025, help="HOPPET ln(1/x) internal grid spacing."
+    )
+    # The two below are unimportant
+    parser.add_argument(
+        "--y-order",
+        type=int,
+        default=None,
+        help="Override HOPPET interpolation order in y=ln(1/x).",
+    )
+    parser.add_argument(
+        "--lnlnq-order",
+        type=int,
+        default=None,
+        help="Override HOPPET interpolation order in lnlnQ.",
+    )
     return parser
 
 
@@ -129,10 +151,12 @@ def main():
     if args.actions == "evolve":
 
         fit_folder = pathlib.Path(args.fit_folder)
+        # TODO for now we require the EKO to exist to be able to do hoppet later
+        # just because these are the only ones we can test
+        theoryID = utils.get_theoryID_from_runcard(fit_folder)
         if args.load is None:
             # no path provided to load the eko, get it from the theory
             utils.check_filter(fit_folder)
-            theoryID = utils.get_theoryID_from_runcard(fit_folder)
             _logger.info(f"Loading eko from theory {theoryID}")
             eko_path = loader.check_eko(theoryID)
         else:
@@ -140,7 +164,20 @@ def main():
             # to be used for the evolution will be loaded from that path.
             eko_path = args.load
 
-        cli.cli_evolven3fit(fit_folder, args.force, eko_path, args.hessian_fit)
+        if args.hoppet:
+            hoppet_evolve.evolve_fit_with_hoppet(
+                fit_folder,
+                theoryID,
+                force=args.force,
+                hessian_fit=args.hessian_fit,
+                dy=args.dy,
+                y_order=args.y_order,
+                lnlnq_order=args.lnlnq_order,
+                eko_path=eko_path,
+            )
+        else:
+            cli.cli_evolven3fit(fit_folder, args.force, eko_path, args.hessian_fit)
+
     else:
         # If we are in the business of producing an eko, do some checks before starting:
         # 1. load the nnpdf theory early to check for inconsistent options and theory problems

--- a/nnpdf_data/nnpdf_data/theorydbutils.py
+++ b/nnpdf_data/nnpdf_data/theorydbutils.py
@@ -19,12 +19,15 @@ class TheoryNotFoundInDatabase(Exception):
 
 
 @lru_cache
-def _parse_theory_card(theory_card):
+def _parse_theory_card(theory_card, as_dict=True):
     """Read the theory card using validobj parsing
     Returns the theory as a dictionary
     """
     tcard = parse_yaml_inp(theory_card, TheoryCard)
-    return tcard.asdict()
+    if as_dict:
+        return tcard.asdict()
+    else:
+        return tcard
 
 
 @lru_cache
@@ -43,7 +46,7 @@ def _get_available_theory_cards(path):
     return available_theories
 
 
-def fetch_theory(theory_database: Path, theoryID: int):
+def fetch_theory(theory_database: Path, theoryID: int, as_dict=True):
     """Looks in the theory card folder and returns a dictionary of theory info for the
     theory number specified by `theoryID`.
 
@@ -73,8 +76,12 @@ def fetch_theory(theory_database: Path, theoryID: int):
     except KeyError as e:
         raise TheoryNotFoundInDatabase(f"Theorycard for theory not found: {e}")
 
-    tdict = _parse_theory_card(theoryfile)
-    if tdict["ID"] != theoryID:
+    tdict = _parse_theory_card(theoryfile, as_dict=as_dict)
+    if as_dict:
+        parsed_tid = tdict["ID"]
+    else:
+        parsed_tid = tdict.ID
+    if parsed_tid != theoryID:
         raise ValueError(f"The theory ID in {theoryfile} doesn't correspond with its ID entry")
     return tdict
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,8 @@ torch = {version = "*", optional = true}
 jax = {version = "*", optional = true}
 # parallel hyperopt
 pymongo = {version = "<4", optional = true}
+# HOPPET evolution backend
+hoppet = {version = "*", optional = true}
 
 # Optional dependencies
 [tool.poetry.extras]
@@ -115,6 +117,7 @@ torch = ["torch"]
 jax = ["jax"]
 hyperopt = ["hyperopt", "setuptools"]
 parallelhyperopt = ["pymongo", "hyperopt", "setuptools"]
+hoppet = ["hoppet"]
 
 [tool.poetry-dynamic-versioning]
 enable = true


### PR DESCRIPTION
This PR implements the evolution of the PDF using HOPPET with the `--hoppet` flag.

The generation of the xgrid, qgrid, etc, is the same as with the vanilla evolution and the results are, at NNLO, equivalent for Q > mc.

For Q < mc the way HOPPET and EKO invert the threshold is different, see:

EKO: https://eko.readthedocs.io/en/latest/theory/Matching.html#backward-evolution
HOPPET: https://github.com/hoppet-code/hoppet/blob/31a2ff92aa82f227505ee0ce111db8acfce340a0/src/evolution.f90#L329

We would need to set `inversion_method = expanded` and the mass of the charm to 0 to get the exact same results with both.

N3LO to be tested. 