### PR TITLE
Correct bug in ATLAS single top 8 TeV differential data

### DIFF
--- a/nnpdf_data/nnpdf_data/commondata/ATLAS_SINGLETOP_8TEV/uncertainties_legacy_T-RAP-NORM.yaml
+++ b/nnpdf_data/nnpdf_data/commondata/ATLAS_SINGLETOP_8TEV/uncertainties_legacy_T-RAP-NORM.yaml
@@ -1,8 +1,4 @@
 definitions:
-  stat:
-    description: Uncorrelated statistical uncertainties
-    treatment: ADD
-    type: UNCORR
   sys_corr_1:
     description: 'Sys uncertainty idx: 1'
     treatment: ADD
@@ -128,8 +124,7 @@ definitions:
     treatment: MULT
     type: CORR
 bins:
-- stat: 1.0e-10
-  sys_corr_1: 0.03431291149764
+- sys_corr_1: 0.03431291149764
   sys_corr_2: 0.01776339353473
   sys_corr_3: -0.007872012365677
   sys_corr_4: 0.01214243764654
@@ -160,8 +155,7 @@ bins:
   sys_corr_29: -0.001798879651339
   sys_corr_30: 0.0
   sys_corr_31: -0.001349159738504
-- stat: 1.0e-10
-  sys_corr_1: -0.03275245650654
+- sys_corr_1: -0.03275245650654
   sys_corr_2: 0.01453859691603
   sys_corr_3: -0.01068373724406
   sys_corr_4: 0.005201477482408
@@ -192,8 +186,7 @@ bins:
   sys_corr_29: -0.00650184685301
   sys_corr_30: 0.0
   sys_corr_31: -0.003034195198071
-- stat: 1.0e-10
-  sys_corr_1: 0.006004406725545
+- sys_corr_1: 0.006004406725545
   sys_corr_2: -0.02220685459717
   sys_corr_3: -0.01329140070776
   sys_corr_4: 0.0006957930726876

--- a/nnpdf_data/nnpdf_data/commondata/ATLAS_SINGLETOP_8TEV/uncertainties_legacy_TBAR-RAP-NORM.yaml
+++ b/nnpdf_data/nnpdf_data/commondata/ATLAS_SINGLETOP_8TEV/uncertainties_legacy_TBAR-RAP-NORM.yaml
@@ -1,8 +1,4 @@
 definitions:
-  stat:
-    description: Uncorrelated statistical uncertainties
-    treatment: ADD
-    type: UNCORR
   sys_corr_1:
     description: 'Sys uncertainty idx: 1'
     treatment: ADD
@@ -128,8 +124,7 @@ definitions:
     treatment: MULT
     type: CORR
 bins:
-- stat: 1.0e-10
-  sys_corr_1: 0.05280702749794
+- sys_corr_1: 0.05280702749794
   sys_corr_2: 0.02752323464781
   sys_corr_3: -0.01171176764426
   sys_corr_4: 0.002524371208836
@@ -160,8 +155,7 @@ bins:
   sys_corr_29: -0.007068239384741
   sys_corr_30: 0.0
   sys_corr_31: -0.004543868175905
-- stat: 1.0e-10
-  sys_corr_1: -0.05076241118724
+- sys_corr_1: -0.05076241118724
   sys_corr_2: 0.02202344288725
   sys_corr_3: -0.01596821962052
   sys_corr_4: 0.0004426488450228
@@ -192,8 +186,7 @@ bins:
   sys_corr_29: -0.01416476304073
   sys_corr_30: 0.0
   sys_corr_31: -0.0008852976900456
-- stat: 1.0e-10
-  sys_corr_1: 0.009778450578315
+- sys_corr_1: 0.009778450578315
   sys_corr_2: -0.03430575658088
   sys_corr_3: -0.01964745771597
   sys_corr_4: 0.01190272844771


### PR DESCRIPTION
This PR fixes another bug in the ATLAS 8 TeV single top differential distributions, similarly to #2489 .