### PR TITLE
Stop github workflows from running on empty branches

### DIFF
--- a/.github/workflows/all_tests_nnpdf.yml
+++ b/.github/workflows/all_tests_nnpdf.yml
@@ -18,6 +18,7 @@ env:
 
 jobs:
   run_package_tests:
+    if: github.event.commits[0] != null
     strategy:
       matrix:
         os: [ubuntu-latest, macos-14]
@@ -48,6 +49,7 @@ jobs:
   # if we find it fails too much, instead of changed files
   # we'll need to look at the CSV with some tolerance
   regression_setupfit:
+    if: github.event.commits[0] != null
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -66,6 +68,7 @@ jobs:
           path: .coverage
 
   regression_tests:
+    if: github.event.commits[0] != null
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -84,6 +87,7 @@ jobs:
           path: .coverage
 
   conda_tests:
+    if: github.event.commits[0] != null
     strategy:
       matrix:
         os: [ubuntu-latest, macos-14]
@@ -111,6 +115,7 @@ jobs:
           path: ${{ env.CONDA }}/envs/*/conda-bld/noarch/*.tar.bz2
 
   run_pytorch:
+    if: github.event.commits[0] != null
     runs-on: ubuntu-latest
     env:
       KERAS_BACKEND: torch
@@ -148,6 +153,7 @@ jobs:
         postfit 50 NNPDF40_nnlo_like_CI_testing_250616
 
   run_jax:
+    if: github.event.commits[0] != null
     runs-on: ubuntu-latest
     env:
       KERAS_BACKEND: jax
@@ -171,6 +177,7 @@ jobs:
         cat Basic_runcard/nnfit/*/Basic_runcard.json
 
   full_coverage:
+    if: github.event.commits[0] != null
     needs: [run_package_tests, regression_tests, regression_setupfit]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/check_newcd.yml
+++ b/.github/workflows/check_newcd.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   test-commondata:
+    if: github.event.commits[0] != null
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/upload_docs.yml
+++ b/.github/workflows/upload_docs.yml
@@ -8,6 +8,7 @@ env:
 
 jobs:
   deploy_docs:
+    if: github.event.commits[0] != null
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
It makes the tests in master run again when a new branch is opened even if there are no commits yet, wasting resources (don't care that much about github resources, but it also includes calls to our own poor servers)