### PR TITLE
0 = -0 in commondata files

### DIFF
--- a/nnpdf_data/nnpdf_data/commondata/ATLAS_1JET_8TEV_R06/uncertainties.yaml
+++ b/nnpdf_data/nnpdf_data/commondata/ATLAS_1JET_8TEV_R06/uncertainties.yaml
@@ -2926,13 +2926,13 @@ bins:
   syst_JES_EtaIntercalibration_Stat213_minus: 0.0
   syst_JES_EtaIntercalibration_Stat214_plus: 0.0
   syst_JES_EtaIntercalibration_Stat214_minus: 0.0
-  syst_JES_EtaIntercalibration_Stat215_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat215_plus: 0.0
   syst_JES_EtaIntercalibration_Stat215_minus: 0.0
   syst_JES_EtaIntercalibration_Stat216_plus: 3.05682262e-02
   syst_JES_EtaIntercalibration_Stat216_minus: 0.0
-  syst_JES_EtaIntercalibration_Stat217_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat217_plus: 0.0
   syst_JES_EtaIntercalibration_Stat217_minus: 9.46674559e-02
-  syst_JES_EtaIntercalibration_Stat218_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat218_plus: 0.0
   syst_JES_EtaIntercalibration_Stat218_minus: 3.91383603e-02
   syst_JES_EtaIntercalibration_Stat219_plus: 0.0
   syst_JES_EtaIntercalibration_Stat219_minus: 0.0
@@ -2978,13 +2978,13 @@ bins:
   syst_JES_EtaIntercalibration_Stat237_minus: 0.0
   syst_JES_EtaIntercalibration_Stat238_plus: -6.54498037e-02
   syst_JES_EtaIntercalibration_Stat238_minus: 0.0
-  syst_JES_EtaIntercalibration_Stat239_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat239_plus: 0.0
   syst_JES_EtaIntercalibration_Stat239_minus: 0.0
   syst_JES_EtaIntercalibration_Stat24_plus: 0.0
   syst_JES_EtaIntercalibration_Stat24_minus: 0.0
-  syst_JES_EtaIntercalibration_Stat240_plus: -0.0
-  syst_JES_EtaIntercalibration_Stat240_minus: -0.0
-  syst_JES_EtaIntercalibration_Stat241_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat240_plus: 0.0
+  syst_JES_EtaIntercalibration_Stat240_minus: 0.0
+  syst_JES_EtaIntercalibration_Stat241_plus: 0.0
   syst_JES_EtaIntercalibration_Stat241_minus: 0.0
   syst_JES_EtaIntercalibration_Stat242_plus: 0.0
   syst_JES_EtaIntercalibration_Stat242_minus: 0.0
@@ -3236,7 +3236,7 @@ bins:
   syst_JES_MJB_Stat5_minus: -7.68766493e-02
   syst_JES_MJB_Stat6_plus: 4.08919852e-02
   syst_JES_MJB_Stat6_minus: 0.0
-  syst_JES_MJB_Stat7_plus: -0.0
+  syst_JES_MJB_Stat7_plus: 0.0
   syst_JES_MJB_Stat7_minus: -3.61755829e-02
   syst_JES_MJB_Stat8_plus: 0.0
   syst_JES_MJB_Stat8_minus: -3.74837305e-02
@@ -3586,7 +3586,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat213_minus: 0.0
   syst_JES_EtaIntercalibration_Stat214_plus: 0.0
   syst_JES_EtaIntercalibration_Stat214_minus: 0.0
-  syst_JES_EtaIntercalibration_Stat215_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat215_plus: 0.0
   syst_JES_EtaIntercalibration_Stat215_minus: 1.88656089e-33
   syst_JES_EtaIntercalibration_Stat216_plus: 1.27279221e-02
   syst_JES_EtaIntercalibration_Stat216_minus: 0.0
@@ -3638,13 +3638,13 @@ bins:
   syst_JES_EtaIntercalibration_Stat237_minus: 0.0
   syst_JES_EtaIntercalibration_Stat238_plus: -2.72561380e-02
   syst_JES_EtaIntercalibration_Stat238_minus: 0.0
-  syst_JES_EtaIntercalibration_Stat239_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat239_plus: 0.0
   syst_JES_EtaIntercalibration_Stat239_minus: 0.0
   syst_JES_EtaIntercalibration_Stat24_plus: 0.0
   syst_JES_EtaIntercalibration_Stat24_minus: 0.0
-  syst_JES_EtaIntercalibration_Stat240_plus: -0.0
-  syst_JES_EtaIntercalibration_Stat240_minus: -0.0
-  syst_JES_EtaIntercalibration_Stat241_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat240_plus: 0.0
+  syst_JES_EtaIntercalibration_Stat240_minus: 0.0
+  syst_JES_EtaIntercalibration_Stat241_plus: 0.0
   syst_JES_EtaIntercalibration_Stat241_minus: 0.0
   syst_JES_EtaIntercalibration_Stat242_plus: 0.0
   syst_JES_EtaIntercalibration_Stat242_minus: 0.0
@@ -3658,9 +3658,9 @@ bins:
   syst_JES_EtaIntercalibration_Stat246_minus: 1.19218203e-01
   syst_JES_EtaIntercalibration_Stat247_plus: 0.0
   syst_JES_EtaIntercalibration_Stat247_minus: 1.46795368e-02
-  syst_JES_EtaIntercalibration_Stat248_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat248_plus: 0.0
   syst_JES_EtaIntercalibration_Stat248_minus: 9.63503700e-02
-  syst_JES_EtaIntercalibration_Stat249_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat249_plus: 0.0
   syst_JES_EtaIntercalibration_Stat249_minus: 1.46936789e-01
   syst_JES_EtaIntercalibration_Stat25_plus: 0.0
   syst_JES_EtaIntercalibration_Stat25_minus: 0.0
@@ -3896,12 +3896,12 @@ bins:
   syst_JES_MJB_Stat5_minus: -3.20107240e-02
   syst_JES_MJB_Stat6_plus: 1.70271313e-02
   syst_JES_MJB_Stat6_minus: 0.0
-  syst_JES_MJB_Stat7_plus: -0.0
+  syst_JES_MJB_Stat7_plus: 0.0
   syst_JES_MJB_Stat7_minus: -1.50613744e-02
-  syst_JES_MJB_Stat8_plus: -0.0
+  syst_JES_MJB_Stat8_plus: 0.0
   syst_JES_MJB_Stat8_minus: -1.56058467e-02
   syst_JES_MJB_Stat9_plus: 0.0
-  syst_JES_MJB_Stat9_minus: -0.0
+  syst_JES_MJB_Stat9_minus: 0.0
   syst_JES_MJB_Threshold_plus: 3.53341259e-03
   syst_JES_MJB_Threshold_minus: -3.87706648e-03
   syst_JES_Pileup_MuOffset_plus: -1.81655732e+01
@@ -4298,13 +4298,13 @@ bins:
   syst_JES_EtaIntercalibration_Stat237_minus: 0.0
   syst_JES_EtaIntercalibration_Stat238_plus: -1.24026529e-02
   syst_JES_EtaIntercalibration_Stat238_minus: 0.0
-  syst_JES_EtaIntercalibration_Stat239_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat239_plus: 0.0
   syst_JES_EtaIntercalibration_Stat239_minus: 0.0
   syst_JES_EtaIntercalibration_Stat24_plus: 0.0
   syst_JES_EtaIntercalibration_Stat24_minus: 0.0
-  syst_JES_EtaIntercalibration_Stat240_plus: -0.0
-  syst_JES_EtaIntercalibration_Stat240_minus: -0.0
-  syst_JES_EtaIntercalibration_Stat241_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat240_plus: 0.0
+  syst_JES_EtaIntercalibration_Stat240_minus: 0.0
+  syst_JES_EtaIntercalibration_Stat241_plus: 0.0
   syst_JES_EtaIntercalibration_Stat241_minus: 0.0
   syst_JES_EtaIntercalibration_Stat242_plus: 0.0
   syst_JES_EtaIntercalibration_Stat242_minus: 0.0
@@ -4316,11 +4316,11 @@ bins:
   syst_JES_EtaIntercalibration_Stat245_minus: 0.0
   syst_JES_EtaIntercalibration_Stat246_plus: -2.98045508e-02
   syst_JES_EtaIntercalibration_Stat246_minus: 5.42421612e-02
-  syst_JES_EtaIntercalibration_Stat247_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat247_plus: 0.0
   syst_JES_EtaIntercalibration_Stat247_minus: 6.67862355e-03
-  syst_JES_EtaIntercalibration_Stat248_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat248_plus: 0.0
   syst_JES_EtaIntercalibration_Stat248_minus: 4.38406204e-02
-  syst_JES_EtaIntercalibration_Stat249_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat249_plus: 0.0
   syst_JES_EtaIntercalibration_Stat249_minus: 6.68710883e-02
   syst_JES_EtaIntercalibration_Stat25_plus: 0.0
   syst_JES_EtaIntercalibration_Stat25_minus: 0.0
@@ -4545,7 +4545,7 @@ bins:
   syst_JES_MJB_Stat1_plus: -2.78310158e-02
   syst_JES_MJB_Stat1_minus: 1.18016122e-04
   syst_JES_MJB_Stat10_plus: 0.0
-  syst_JES_MJB_Stat10_minus: -0.0
+  syst_JES_MJB_Stat10_minus: 0.0
   syst_JES_MJB_Stat2_plus: 8.83954187e-04
   syst_JES_MJB_Stat2_minus: -2.26415591e-02
   syst_JES_MJB_Stat3_plus: -5.23259018e-03
@@ -4556,12 +4556,12 @@ bins:
   syst_JES_MJB_Stat5_minus: -1.45663997e-02
   syst_JES_MJB_Stat6_plus: 7.74706189e-03
   syst_JES_MJB_Stat6_minus: 0.0
-  syst_JES_MJB_Stat7_plus: -0.0
+  syst_JES_MJB_Stat7_plus: 0.0
   syst_JES_MJB_Stat7_minus: -6.85398603e-03
-  syst_JES_MJB_Stat8_plus: -0.0
+  syst_JES_MJB_Stat8_plus: 0.0
   syst_JES_MJB_Stat8_minus: -7.10147340e-03
   syst_JES_MJB_Stat9_plus: 0.0
-  syst_JES_MJB_Stat9_minus: -0.0
+  syst_JES_MJB_Stat9_minus: 0.0
   syst_JES_MJB_Threshold_plus: 1.65604408e-03
   syst_JES_MJB_Threshold_minus: -2.06758023e-03
   syst_JES_Pileup_MuOffset_plus: -7.18632622e+00
@@ -4958,13 +4958,13 @@ bins:
   syst_JES_EtaIntercalibration_Stat237_minus: 0.0
   syst_JES_EtaIntercalibration_Stat238_plus: -5.87322892e-03
   syst_JES_EtaIntercalibration_Stat238_minus: 0.0
-  syst_JES_EtaIntercalibration_Stat239_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat239_plus: 0.0
   syst_JES_EtaIntercalibration_Stat239_minus: 0.0
   syst_JES_EtaIntercalibration_Stat24_plus: 0.0
   syst_JES_EtaIntercalibration_Stat24_minus: 0.0
-  syst_JES_EtaIntercalibration_Stat240_plus: -0.0
-  syst_JES_EtaIntercalibration_Stat240_minus: -0.0
-  syst_JES_EtaIntercalibration_Stat241_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat240_plus: 0.0
+  syst_JES_EtaIntercalibration_Stat240_minus: 0.0
+  syst_JES_EtaIntercalibration_Stat241_plus: 0.0
   syst_JES_EtaIntercalibration_Stat241_minus: 0.0
   syst_JES_EtaIntercalibration_Stat242_plus: 0.0
   syst_JES_EtaIntercalibration_Stat242_minus: 0.0
@@ -4976,11 +4976,11 @@ bins:
   syst_JES_EtaIntercalibration_Stat245_minus: 0.0
   syst_JES_EtaIntercalibration_Stat246_plus: -1.41138514e-02
   syst_JES_EtaIntercalibration_Stat246_minus: 2.56891894e-02
-  syst_JES_EtaIntercalibration_Stat247_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat247_plus: 0.0
   syst_JES_EtaIntercalibration_Stat247_minus: 3.16288863e-03
-  syst_JES_EtaIntercalibration_Stat248_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat248_plus: 0.0
   syst_JES_EtaIntercalibration_Stat248_minus: 2.07606551e-02
-  syst_JES_EtaIntercalibration_Stat249_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat249_plus: 0.0
   syst_JES_EtaIntercalibration_Stat249_minus: 3.16642417e-02
   syst_JES_EtaIntercalibration_Stat25_plus: 0.0
   syst_JES_EtaIntercalibration_Stat25_minus: 0.0
@@ -5205,7 +5205,7 @@ bins:
   syst_JES_MJB_Stat1_plus: -1.65533697e-02
   syst_JES_MJB_Stat1_minus: 3.34461508e-03
   syst_JES_MJB_Stat10_plus: 0.0
-  syst_JES_MJB_Stat10_minus: -0.0
+  syst_JES_MJB_Stat10_minus: 0.0
   syst_JES_MJB_Stat2_plus: 5.17885007e-03
   syst_JES_MJB_Stat2_minus: -1.22965869e-02
   syst_JES_MJB_Stat3_plus: -2.91893679e-03
@@ -5216,12 +5216,12 @@ bins:
   syst_JES_MJB_Stat5_minus: -6.89782665e-03
   syst_JES_MJB_Stat6_plus: 3.66917709e-03
   syst_JES_MJB_Stat6_minus: 0.0
-  syst_JES_MJB_Stat7_plus: -0.0
+  syst_JES_MJB_Stat7_plus: 0.0
   syst_JES_MJB_Stat7_minus: -3.24632723e-03
-  syst_JES_MJB_Stat8_plus: -0.0
+  syst_JES_MJB_Stat8_plus: 0.0
   syst_JES_MJB_Stat8_minus: -3.36299985e-03
   syst_JES_MJB_Stat9_plus: 0.0
-  syst_JES_MJB_Stat9_minus: -0.0
+  syst_JES_MJB_Stat9_minus: 0.0
   syst_JES_MJB_Threshold_plus: -1.46017550e-02
   syst_JES_MJB_Threshold_minus: 1.50189480e-02
   syst_JES_Pileup_MuOffset_plus: -3.37431356e+00
@@ -5636,11 +5636,11 @@ bins:
   syst_JES_EtaIntercalibration_Stat245_minus: 0.0
   syst_JES_EtaIntercalibration_Stat246_plus: -6.92186828e-03
   syst_JES_EtaIntercalibration_Stat246_minus: 1.25935718e-02
-  syst_JES_EtaIntercalibration_Stat247_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat247_plus: 0.0
   syst_JES_EtaIntercalibration_Stat247_minus: 1.55068517e-03
-  syst_JES_EtaIntercalibration_Stat248_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat248_plus: 0.0
   syst_JES_EtaIntercalibration_Stat248_minus: 1.01823376e-02
-  syst_JES_EtaIntercalibration_Stat249_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat249_plus: 0.0
   syst_JES_EtaIntercalibration_Stat249_minus: 1.55280649e-02
   syst_JES_EtaIntercalibration_Stat25_plus: 0.0
   syst_JES_EtaIntercalibration_Stat25_minus: 0.0
@@ -5865,7 +5865,7 @@ bins:
   syst_JES_MJB_Stat1_plus: -2.16091832e-02
   syst_JES_MJB_Stat1_minus: 1.50896587e-02
   syst_JES_MJB_Stat10_plus: 0.0
-  syst_JES_MJB_Stat10_minus: -0.0
+  syst_JES_MJB_Stat10_minus: 0.0
   syst_JES_MJB_Stat2_plus: 1.00154604e-02
   syst_JES_MJB_Stat2_minus: -1.15187695e-02
   syst_JES_MJB_Stat3_plus: -2.83832662e-03
@@ -5876,12 +5876,12 @@ bins:
   syst_JES_MJB_Stat5_minus: -3.38209173e-03
   syst_JES_MJB_Stat6_plus: 1.79887965e-03
   syst_JES_MJB_Stat6_minus: 0.0
-  syst_JES_MJB_Stat7_plus: -0.0
+  syst_JES_MJB_Stat7_plus: 0.0
   syst_JES_MJB_Stat7_minus: -1.59169736e-03
-  syst_JES_MJB_Stat8_plus: -0.0
+  syst_JES_MJB_Stat8_plus: 0.0
   syst_JES_MJB_Stat8_minus: -1.64897301e-03
   syst_JES_MJB_Stat9_plus: 0.0
-  syst_JES_MJB_Stat9_minus: -0.0
+  syst_JES_MJB_Stat9_minus: 0.0
   syst_JES_MJB_Threshold_plus: -4.00363860e-02
   syst_JES_MJB_Threshold_minus: 4.42295292e-02
   syst_JES_Pileup_MuOffset_plus: -1.69705627e+00
@@ -6296,11 +6296,11 @@ bins:
   syst_JES_EtaIntercalibration_Stat245_minus: 0.0
   syst_JES_EtaIntercalibration_Stat246_plus: -3.49735014e-03
   syst_JES_EtaIntercalibration_Stat246_minus: 6.36466814e-03
-  syst_JES_EtaIntercalibration_Stat247_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat247_plus: 0.0
   syst_JES_EtaIntercalibration_Stat247_minus: 7.83757156e-04
-  syst_JES_EtaIntercalibration_Stat248_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat248_plus: 0.0
   syst_JES_EtaIntercalibration_Stat248_minus: 5.14420183e-03
-  syst_JES_EtaIntercalibration_Stat249_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat249_plus: 0.0
   syst_JES_EtaIntercalibration_Stat249_minus: 7.84676395e-03
   syst_JES_EtaIntercalibration_Stat25_plus: 0.0
   syst_JES_EtaIntercalibration_Stat25_minus: 0.0
@@ -6525,7 +6525,7 @@ bins:
   syst_JES_MJB_Stat1_plus: -2.85953982e-02
   syst_JES_MJB_Stat1_minus: 2.69358186e-02
   syst_JES_MJB_Stat10_plus: 0.0
-  syst_JES_MJB_Stat10_minus: -0.0
+  syst_JES_MJB_Stat10_minus: 0.0
   syst_JES_MJB_Stat2_plus: 9.45118924e-03
   syst_JES_MJB_Stat2_minus: -1.10803633e-02
   syst_JES_MJB_Stat3_plus: -2.55972655e-03
@@ -6536,12 +6536,12 @@ bins:
   syst_JES_MJB_Stat5_minus: -1.70907709e-03
   syst_JES_MJB_Stat6_plus: 9.09127189e-04
   syst_JES_MJB_Stat6_minus: 0.0
-  syst_JES_MJB_Stat7_plus: -0.0
+  syst_JES_MJB_Stat7_plus: 0.0
   syst_JES_MJB_Stat7_minus: -8.04333964e-04
-  syst_JES_MJB_Stat8_plus: -0.0
+  syst_JES_MJB_Stat8_plus: 0.0
   syst_JES_MJB_Stat8_minus: -8.33325342e-04
   syst_JES_MJB_Stat9_plus: 0.0
-  syst_JES_MJB_Stat9_minus: -0.0
+  syst_JES_MJB_Stat9_minus: 0.0
   syst_JES_MJB_Threshold_plus: -5.46310699e-02
   syst_JES_MJB_Threshold_minus: 6.30244274e-02
   syst_JES_Pileup_MuOffset_plus: -8.66983624e-01
@@ -6956,11 +6956,11 @@ bins:
   syst_JES_EtaIntercalibration_Stat245_minus: 0.0
   syst_JES_EtaIntercalibration_Stat246_plus: -1.79322280e-03
   syst_JES_EtaIntercalibration_Stat246_minus: 3.26259069e-03
-  syst_JES_EtaIntercalibration_Stat247_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat247_plus: 0.0
   syst_JES_EtaIntercalibration_Stat247_minus: 4.01778073e-04
-  syst_JES_EtaIntercalibration_Stat248_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat248_plus: 0.0
   syst_JES_EtaIntercalibration_Stat248_minus: 2.63750829e-03
-  syst_JES_EtaIntercalibration_Stat249_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat249_plus: 0.0
   syst_JES_EtaIntercalibration_Stat249_minus: 4.02273048e-03
   syst_JES_EtaIntercalibration_Stat25_plus: 0.0
   syst_JES_EtaIntercalibration_Stat25_minus: 0.0
@@ -7185,7 +7185,7 @@ bins:
   syst_JES_MJB_Stat1_plus: -2.49891536e-02
   syst_JES_MJB_Stat1_minus: 2.42325494e-02
   syst_JES_MJB_Stat10_plus: 0.0
-  syst_JES_MJB_Stat10_minus: -0.0
+  syst_JES_MJB_Stat10_minus: 0.0
   syst_JES_MJB_Stat2_plus: 3.08015714e-03
   syst_JES_MJB_Stat2_minus: -4.41376053e-03
   syst_JES_MJB_Stat3_plus: -1.57684812e-03
@@ -7198,10 +7198,10 @@ bins:
   syst_JES_MJB_Stat6_minus: 0.0
   syst_JES_MJB_Stat7_plus: 0.0
   syst_JES_MJB_Stat7_minus: -4.12313964e-04
-  syst_JES_MJB_Stat8_plus: -0.0
+  syst_JES_MJB_Stat8_plus: 0.0
   syst_JES_MJB_Stat8_minus: -4.27233917e-04
   syst_JES_MJB_Stat9_plus: 0.0
-  syst_JES_MJB_Stat9_minus: -0.0
+  syst_JES_MJB_Stat9_minus: 0.0
   syst_JES_MJB_Threshold_plus: -4.94338351e-02
   syst_JES_MJB_Threshold_minus: 5.35138412e-02
   syst_JES_Pileup_MuOffset_plus: -4.11536147e-01
@@ -7215,7 +7215,7 @@ bins:
   syst_JES_Punch_through_plus: 1.87171165e-01
   syst_JES_Punch_through_minus: -9.03753177e-02
   syst_JES_SingleParticle_HighPt_plus: 1.01399112e-03
-  syst_JES_SingleParticle_HighPt_minus: -0.0
+  syst_JES_SingleParticle_HighPt_minus: 0.0
   syst_JES_Zjet_JVF_plus: 2.56750472e-01
   syst_JES_Zjet_JVF_minus: -2.53922045e-01
   syst_JES_Zjet_MC_plus: 4.55447478e+00
@@ -7616,11 +7616,11 @@ bins:
   syst_JES_EtaIntercalibration_Stat245_minus: 0.0
   syst_JES_EtaIntercalibration_Stat246_plus: -9.49432275e-04
   syst_JES_EtaIntercalibration_Stat246_minus: 1.72746187e-03
-  syst_JES_EtaIntercalibration_Stat247_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat247_plus: 0.0
   syst_JES_EtaIntercalibration_Stat247_minus: 2.12768430e-04
-  syst_JES_EtaIntercalibration_Stat248_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat248_plus: 0.0
   syst_JES_EtaIntercalibration_Stat248_minus: 1.39653589e-03
-  syst_JES_EtaIntercalibration_Stat249_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat249_plus: 0.0
   syst_JES_EtaIntercalibration_Stat249_minus: 2.12980562e-03
   syst_JES_EtaIntercalibration_Stat25_plus: 0.0
   syst_JES_EtaIntercalibration_Stat25_minus: 0.0
@@ -7845,7 +7845,7 @@ bins:
   syst_JES_MJB_Stat1_plus: -1.30461201e-02
   syst_JES_MJB_Stat1_minus: 5.91282690e-03
   syst_JES_MJB_Stat10_plus: 0.0
-  syst_JES_MJB_Stat10_minus: -0.0
+  syst_JES_MJB_Stat10_minus: 0.0
   syst_JES_MJB_Stat2_plus: -6.82145912e-03
   syst_JES_MJB_Stat2_minus: 7.40199379e-03
   syst_JES_MJB_Stat3_plus: -1.51674405e-04
@@ -7875,7 +7875,7 @@ bins:
   syst_JES_Punch_through_plus: 7.93868783e-02
   syst_JES_Punch_through_minus: -4.05879292e-02
   syst_JES_SingleParticle_HighPt_plus: 5.36835468e-04
-  syst_JES_SingleParticle_HighPt_minus: -0.0
+  syst_JES_SingleParticle_HighPt_minus: 0.0
   syst_JES_Zjet_JVF_plus: 1.33572471e-01
   syst_JES_Zjet_JVF_minus: -1.43047702e-01
   syst_JES_Zjet_MC_plus: 2.47628795e+00
@@ -8276,7 +8276,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat245_minus: 0.0
   syst_JES_EtaIntercalibration_Stat246_plus: -5.26794552e-04
   syst_JES_EtaIntercalibration_Stat246_minus: 9.58624663e-04
-  syst_JES_EtaIntercalibration_Stat247_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat247_plus: 0.0
   syst_JES_EtaIntercalibration_Stat247_minus: 1.18016122e-04
   syst_JES_EtaIntercalibration_Stat248_plus: -1.22612316e-38
   syst_JES_EtaIntercalibration_Stat248_minus: 7.74776900e-04
@@ -8505,7 +8505,7 @@ bins:
   syst_JES_MJB_Stat1_plus: 0.0
   syst_JES_MJB_Stat1_minus: -6.52871691e-03
   syst_JES_MJB_Stat10_plus: 0.0
-  syst_JES_MJB_Stat10_minus: -0.0
+  syst_JES_MJB_Stat10_minus: 0.0
   syst_JES_MJB_Stat2_plus: -1.29754094e-02
   syst_JES_MJB_Stat2_minus: 1.45734708e-02
   syst_JES_MJB_Stat3_plus: 1.47361053e-03
@@ -8535,7 +8535,7 @@ bins:
   syst_JES_Punch_through_plus: 2.71656283e-02
   syst_JES_Punch_through_minus: -1.69917760e-02
   syst_JES_SingleParticle_HighPt_plus: 2.97833376e-04
-  syst_JES_SingleParticle_HighPt_minus: -0.0
+  syst_JES_SingleParticle_HighPt_minus: 0.0
   syst_JES_Zjet_JVF_plus: 6.68428040e-02
   syst_JES_Zjet_JVF_minus: -7.40765064e-02
   syst_JES_Zjet_MC_plus: 1.33572471e+00
@@ -9195,7 +9195,7 @@ bins:
   syst_JES_Punch_through_plus: 8.82964238e-03
   syst_JES_Punch_through_minus: -6.66023877e-03
   syst_JES_SingleParticle_HighPt_plus: 1.67160043e-04
-  syst_JES_SingleParticle_HighPt_minus: -0.0
+  syst_JES_SingleParticle_HighPt_minus: 0.0
   syst_JES_Zjet_JVF_plus: 3.24632723e-02
   syst_JES_Zjet_JVF_minus: -3.56381818e-02
   syst_JES_Zjet_MC_plus: 6.91479721e-01
@@ -9855,7 +9855,7 @@ bins:
   syst_JES_Punch_through_plus: 3.69675425e-03
   syst_JES_Punch_through_minus: -3.03207388e-03
   syst_JES_SingleParticle_HighPt_plus: 9.67887762e-05
-  syst_JES_SingleParticle_HighPt_minus: -0.0
+  syst_JES_SingleParticle_HighPt_minus: 0.0
   syst_JES_Zjet_JVF_plus: 1.74513954e-02
   syst_JES_Zjet_JVF_minus: -1.85261977e-02
   syst_JES_Zjet_MC_plus: 3.58220295e-01
@@ -10515,7 +10515,7 @@ bins:
   syst_JES_Punch_through_plus: 2.25284220e-03
   syst_JES_Punch_through_minus: -2.07182287e-03
   syst_JES_SingleParticle_HighPt_plus: 5.54513138e-05
-  syst_JES_SingleParticle_HighPt_minus: -0.0
+  syst_JES_SingleParticle_HighPt_minus: 0.0
   syst_JES_Zjet_JVF_plus: 1.02954747e-02
   syst_JES_Zjet_JVF_minus: -1.05641753e-02
   syst_JES_Zjet_MC_plus: 1.78968726e-01
@@ -11175,7 +11175,7 @@ bins:
   syst_JES_Punch_through_plus: 1.75716035e-03
   syst_JES_Punch_through_minus: -2.02939646e-03
   syst_JES_SingleParticle_HighPt_plus: 3.27602572e-05
-  syst_JES_SingleParticle_HighPt_minus: -0.0
+  syst_JES_SingleParticle_HighPt_minus: 0.0
   syst_JES_Zjet_JVF_plus: 6.12708026e-03
   syst_JES_Zjet_JVF_minus: -6.15890006e-03
   syst_JES_Zjet_MC_plus: 9.04177441e-02
@@ -11835,7 +11835,7 @@ bins:
   syst_JES_Punch_through_plus: 1.49482374e-03
   syst_JES_Punch_through_minus: -1.92262334e-03
   syst_JES_SingleParticle_HighPt_plus: 2.00464772e-05
-  syst_JES_SingleParticle_HighPt_minus: -0.0
+  syst_JES_SingleParticle_HighPt_minus: 0.0
   syst_JES_Zjet_JVF_plus: 3.62604357e-03
   syst_JES_Zjet_JVF_minus: -3.44431713e-03
   syst_JES_Zjet_MC_plus: 4.64922709e-02
@@ -12495,7 +12495,7 @@ bins:
   syst_JES_Punch_through_plus: 1.35905923e-03
   syst_JES_Punch_through_minus: -1.61856742e-03
   syst_JES_SingleParticle_HighPt_plus: 1.24026529e-05
-  syst_JES_SingleParticle_HighPt_minus: -0.0
+  syst_JES_SingleParticle_HighPt_minus: 0.0
   syst_JES_Zjet_JVF_plus: 2.14394776e-03
   syst_JES_Zjet_JVF_minus: -1.94100811e-03
   syst_JES_Zjet_MC_plus: 2.37375746e-02
@@ -25349,7 +25349,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat206_plus: 7.44583441e-02
   syst_JES_EtaIntercalibration_Stat206_minus: 0.0
   syst_JES_EtaIntercalibration_Stat207_plus: -2.16586807e-02
-  syst_JES_EtaIntercalibration_Stat207_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat207_minus: 0.0
   syst_JES_EtaIntercalibration_Stat208_plus: 0.0
   syst_JES_EtaIntercalibration_Stat208_minus: 0.0
   syst_JES_EtaIntercalibration_Stat209_plus: 0.0
@@ -25364,9 +25364,9 @@ bins:
   syst_JES_EtaIntercalibration_Stat212_minus: 0.0
   syst_JES_EtaIntercalibration_Stat213_plus: 0.0
   syst_JES_EtaIntercalibration_Stat213_minus: 0.0
-  syst_JES_EtaIntercalibration_Stat214_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat214_plus: 0.0
   syst_JES_EtaIntercalibration_Stat214_minus: 0.0
-  syst_JES_EtaIntercalibration_Stat215_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat215_plus: 0.0
   syst_JES_EtaIntercalibration_Stat215_minus: 5.67170349e-02
   syst_JES_EtaIntercalibration_Stat216_plus: 1.38097954e-02
   syst_JES_EtaIntercalibration_Stat216_minus: 0.0
@@ -25374,7 +25374,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat217_minus: 1.24380083e-02
   syst_JES_EtaIntercalibration_Stat218_plus: -8.23355136e-02
   syst_JES_EtaIntercalibration_Stat218_minus: 0.0
-  syst_JES_EtaIntercalibration_Stat219_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat219_plus: 0.0
   syst_JES_EtaIntercalibration_Stat219_minus: 3.48532932e-02
   syst_JES_EtaIntercalibration_Stat22_plus: 0.0
   syst_JES_EtaIntercalibration_Stat22_minus: 0.0
@@ -25402,7 +25402,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat23_minus: 0.0
   syst_JES_EtaIntercalibration_Stat230_plus: -6.87590634e-02
   syst_JES_EtaIntercalibration_Stat230_minus: 8.39618592e-02
-  syst_JES_EtaIntercalibration_Stat231_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat231_plus: 0.0
   syst_JES_EtaIntercalibration_Stat231_minus: 0.0
   syst_JES_EtaIntercalibration_Stat232_plus: 0.0
   syst_JES_EtaIntercalibration_Stat232_minus: 0.0
@@ -25416,7 +25416,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat236_minus: 0.0
   syst_JES_EtaIntercalibration_Stat237_plus: 2.28536912e-02
   syst_JES_EtaIntercalibration_Stat237_minus: -2.50315801e-02
-  syst_JES_EtaIntercalibration_Stat238_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat238_plus: 0.0
   syst_JES_EtaIntercalibration_Stat238_minus: 0.0
   syst_JES_EtaIntercalibration_Stat239_plus: 4.28365288e-02
   syst_JES_EtaIntercalibration_Stat239_minus: 0.0
@@ -25670,7 +25670,7 @@ bins:
   syst_JES_MJB_Stat2_minus: -5.94464671e-02
   syst_JES_MJB_Stat3_plus: -6.61356972e-02
   syst_JES_MJB_Stat3_minus: 3.63382175e-13
-  syst_JES_MJB_Stat4_plus: -0.0
+  syst_JES_MJB_Stat4_plus: 0.0
   syst_JES_MJB_Stat4_minus: -2.99247590e-02
   syst_JES_MJB_Stat5_plus: 5.23753993e-02
   syst_JES_MJB_Stat5_minus: -4.15000970e-02
@@ -26009,7 +26009,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat206_plus: 3.00591093e-02
   syst_JES_EtaIntercalibration_Stat206_minus: 0.0
   syst_JES_EtaIntercalibration_Stat207_plus: -8.74337535e-03
-  syst_JES_EtaIntercalibration_Stat207_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat207_minus: 0.0
   syst_JES_EtaIntercalibration_Stat208_plus: 0.0
   syst_JES_EtaIntercalibration_Stat208_minus: 0.0
   syst_JES_EtaIntercalibration_Stat209_plus: 0.0
@@ -26026,7 +26026,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat213_minus: 0.0
   syst_JES_EtaIntercalibration_Stat214_plus: -3.41815418e-43
   syst_JES_EtaIntercalibration_Stat214_minus: 1.22895159e-43
-  syst_JES_EtaIntercalibration_Stat215_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat215_plus: 0.0
   syst_JES_EtaIntercalibration_Stat215_minus: 2.28961176e-02
   syst_JES_EtaIntercalibration_Stat216_plus: 5.57341565e-03
   syst_JES_EtaIntercalibration_Stat216_minus: 0.0
@@ -26062,7 +26062,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat23_minus: 0.0
   syst_JES_EtaIntercalibration_Stat230_plus: -2.77546483e-02
   syst_JES_EtaIntercalibration_Stat230_minus: 3.38916280e-02
-  syst_JES_EtaIntercalibration_Stat231_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat231_plus: 0.0
   syst_JES_EtaIntercalibration_Stat231_minus: 0.0
   syst_JES_EtaIntercalibration_Stat232_plus: 0.0
   syst_JES_EtaIntercalibration_Stat232_minus: 0.0
@@ -26076,7 +26076,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat236_minus: 0.0
   syst_JES_EtaIntercalibration_Stat237_plus: 9.22491507e-03
   syst_JES_EtaIntercalibration_Stat237_minus: -1.01045559e-02
-  syst_JES_EtaIntercalibration_Stat238_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat238_plus: 0.0
   syst_JES_EtaIntercalibration_Stat238_minus: 0.0
   syst_JES_EtaIntercalibration_Stat239_plus: 1.72887608e-02
   syst_JES_EtaIntercalibration_Stat239_minus: 0.0
@@ -26092,7 +26092,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat243_minus: 0.0
   syst_JES_EtaIntercalibration_Stat244_plus: 0.0
   syst_JES_EtaIntercalibration_Stat244_minus: 0.0
-  syst_JES_EtaIntercalibration_Stat245_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat245_plus: 0.0
   syst_JES_EtaIntercalibration_Stat245_minus: 0.0
   syst_JES_EtaIntercalibration_Stat246_plus: 1.90565278e-02
   syst_JES_EtaIntercalibration_Stat246_minus: 0.0
@@ -26330,7 +26330,7 @@ bins:
   syst_JES_MJB_Stat2_minus: -2.39921331e-02
   syst_JES_MJB_Stat3_plus: -2.66932810e-02
   syst_JES_MJB_Stat3_minus: 2.86590378e-08
-  syst_JES_MJB_Stat4_plus: -0.0
+  syst_JES_MJB_Stat4_plus: 0.0
   syst_JES_MJB_Stat4_minus: -1.20773838e-02
   syst_JES_MJB_Stat5_plus: 2.11424928e-02
   syst_JES_MJB_Stat5_minus: -1.67513596e-02
@@ -26669,7 +26669,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat206_plus: 1.37815112e-02
   syst_JES_EtaIntercalibration_Stat206_minus: 0.0
   syst_JES_EtaIntercalibration_Stat207_plus: -4.00858834e-03
-  syst_JES_EtaIntercalibration_Stat207_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat207_minus: 0.0
   syst_JES_EtaIntercalibration_Stat208_plus: 0.0
   syst_JES_EtaIntercalibration_Stat208_minus: 0.0
   syst_JES_EtaIntercalibration_Stat209_plus: 0.0
@@ -26722,7 +26722,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat23_minus: 0.0
   syst_JES_EtaIntercalibration_Stat230_plus: -1.27208510e-02
   syst_JES_EtaIntercalibration_Stat230_minus: 1.55351360e-02
-  syst_JES_EtaIntercalibration_Stat231_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat231_plus: 0.0
   syst_JES_EtaIntercalibration_Stat231_minus: 5.08480486e-40
   syst_JES_EtaIntercalibration_Stat232_plus: 0.0
   syst_JES_EtaIntercalibration_Stat232_minus: 0.0
@@ -26736,7 +26736,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat236_minus: 0.0
   syst_JES_EtaIntercalibration_Stat237_plus: 4.22920566e-03
   syst_JES_EtaIntercalibration_Stat237_minus: -4.63154942e-03
-  syst_JES_EtaIntercalibration_Stat238_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat238_plus: 0.0
   syst_JES_EtaIntercalibration_Stat238_minus: 0.0
   syst_JES_EtaIntercalibration_Stat239_plus: 7.92666702e-03
   syst_JES_EtaIntercalibration_Stat239_minus: 0.0
@@ -26752,7 +26752,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat243_minus: 0.0
   syst_JES_EtaIntercalibration_Stat244_plus: 0.0
   syst_JES_EtaIntercalibration_Stat244_minus: 0.0
-  syst_JES_EtaIntercalibration_Stat245_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat245_plus: 0.0
   syst_JES_EtaIntercalibration_Stat245_minus: 0.0
   syst_JES_EtaIntercalibration_Stat246_plus: 8.73630428e-03
   syst_JES_EtaIntercalibration_Stat246_minus: 0.0
@@ -26990,7 +26990,7 @@ bins:
   syst_JES_MJB_Stat2_minus: -1.10520790e-02
   syst_JES_MJB_Stat3_plus: -1.22400184e-02
   syst_JES_MJB_Stat3_minus: 1.45805418e-05
-  syst_JES_MJB_Stat4_plus: -0.0
+  syst_JES_MJB_Stat4_plus: 0.0
   syst_JES_MJB_Stat4_minus: -5.53735320e-03
   syst_JES_MJB_Stat5_plus: 9.69089844e-03
   syst_JES_MJB_Stat5_minus: -7.67917964e-03
@@ -27393,10 +27393,10 @@ bins:
   syst_JES_EtaIntercalibration_Stat235_plus: 0.0
   syst_JES_EtaIntercalibration_Stat235_minus: 0.0
   syst_JES_EtaIntercalibration_Stat236_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat236_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat236_minus: 0.0
   syst_JES_EtaIntercalibration_Stat237_plus: 1.98909138e-03
   syst_JES_EtaIntercalibration_Stat237_minus: -2.17788889e-03
-  syst_JES_EtaIntercalibration_Stat238_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat238_plus: 0.0
   syst_JES_EtaIntercalibration_Stat238_minus: 0.0
   syst_JES_EtaIntercalibration_Stat239_plus: 3.72786695e-03
   syst_JES_EtaIntercalibration_Stat239_minus: 0.0
@@ -27412,7 +27412,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat243_minus: 0.0
   syst_JES_EtaIntercalibration_Stat244_plus: 0.0
   syst_JES_EtaIntercalibration_Stat244_minus: 0.0
-  syst_JES_EtaIntercalibration_Stat245_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat245_plus: 0.0
   syst_JES_EtaIntercalibration_Stat245_minus: 0.0
   syst_JES_EtaIntercalibration_Stat246_plus: 4.10829040e-03
   syst_JES_EtaIntercalibration_Stat246_minus: 0.0
@@ -28019,7 +28019,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat22_plus: 0.0
   syst_JES_EtaIntercalibration_Stat22_minus: 0.0
   syst_JES_EtaIntercalibration_Stat220_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat220_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat220_minus: 0.0
   syst_JES_EtaIntercalibration_Stat221_plus: 0.0
   syst_JES_EtaIntercalibration_Stat221_minus: 0.0
   syst_JES_EtaIntercalibration_Stat222_plus: 0.0
@@ -28045,7 +28045,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat231_plus: -3.14874650e-25
   syst_JES_EtaIntercalibration_Stat231_minus: 1.14551299e-19
   syst_JES_EtaIntercalibration_Stat232_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat232_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat232_minus: 0.0
   syst_JES_EtaIntercalibration_Stat233_plus: 0.0
   syst_JES_EtaIntercalibration_Stat233_minus: 0.0
   syst_JES_EtaIntercalibration_Stat234_plus: 0.0
@@ -28053,10 +28053,10 @@ bins:
   syst_JES_EtaIntercalibration_Stat235_plus: 0.0
   syst_JES_EtaIntercalibration_Stat235_minus: 0.0
   syst_JES_EtaIntercalibration_Stat236_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat236_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat236_minus: 0.0
   syst_JES_EtaIntercalibration_Stat237_plus: 9.72413245e-04
   syst_JES_EtaIntercalibration_Stat237_minus: -1.06490281e-03
-  syst_JES_EtaIntercalibration_Stat238_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat238_plus: 0.0
   syst_JES_EtaIntercalibration_Stat238_minus: 5.63422683e-42
   syst_JES_EtaIntercalibration_Stat239_plus: 1.82292128e-03
   syst_JES_EtaIntercalibration_Stat239_minus: 0.0
@@ -28069,10 +28069,10 @@ bins:
   syst_JES_EtaIntercalibration_Stat242_plus: -2.47840927e-03
   syst_JES_EtaIntercalibration_Stat242_minus: 8.66417939e-42
   syst_JES_EtaIntercalibration_Stat243_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat243_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat243_minus: 0.0
   syst_JES_EtaIntercalibration_Stat244_plus: 0.0
   syst_JES_EtaIntercalibration_Stat244_minus: 0.0
-  syst_JES_EtaIntercalibration_Stat245_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat245_plus: 0.0
   syst_JES_EtaIntercalibration_Stat245_minus: 0.0
   syst_JES_EtaIntercalibration_Stat246_plus: 2.00889037e-03
   syst_JES_EtaIntercalibration_Stat246_minus: 0.0
@@ -28679,7 +28679,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat22_plus: 0.0
   syst_JES_EtaIntercalibration_Stat22_minus: 0.0
   syst_JES_EtaIntercalibration_Stat220_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat220_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat220_minus: 0.0
   syst_JES_EtaIntercalibration_Stat221_plus: 0.0
   syst_JES_EtaIntercalibration_Stat221_minus: 0.0
   syst_JES_EtaIntercalibration_Stat222_plus: 0.0
@@ -28705,7 +28705,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat231_plus: -5.52533239e-18
   syst_JES_EtaIntercalibration_Stat231_minus: 4.35648488e-14
   syst_JES_EtaIntercalibration_Stat232_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat232_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat232_minus: 0.0
   syst_JES_EtaIntercalibration_Stat233_plus: 0.0
   syst_JES_EtaIntercalibration_Stat233_minus: 0.0
   syst_JES_EtaIntercalibration_Stat234_plus: 0.0
@@ -28713,10 +28713,10 @@ bins:
   syst_JES_EtaIntercalibration_Stat235_plus: 0.0
   syst_JES_EtaIntercalibration_Stat235_minus: 0.0
   syst_JES_EtaIntercalibration_Stat236_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat236_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat236_minus: 0.0
   syst_JES_EtaIntercalibration_Stat237_plus: 4.91509924e-04
   syst_JES_EtaIntercalibration_Stat237_minus: -5.38320393e-04
-  syst_JES_EtaIntercalibration_Stat238_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat238_plus: 0.0
   syst_JES_EtaIntercalibration_Stat238_minus: 1.47148921e-30
   syst_JES_EtaIntercalibration_Stat239_plus: 9.21360136e-04
   syst_JES_EtaIntercalibration_Stat239_minus: 0.0
@@ -28729,10 +28729,10 @@ bins:
   syst_JES_EtaIntercalibration_Stat242_plus: -1.25299322e-03
   syst_JES_EtaIntercalibration_Stat242_minus: 2.26344881e-30
   syst_JES_EtaIntercalibration_Stat243_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat243_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat243_minus: 0.0
   syst_JES_EtaIntercalibration_Stat244_plus: 0.0
   syst_JES_EtaIntercalibration_Stat244_minus: 0.0
-  syst_JES_EtaIntercalibration_Stat245_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat245_plus: 0.0
   syst_JES_EtaIntercalibration_Stat245_minus: 0.0
   syst_JES_EtaIntercalibration_Stat246_plus: 1.01540534e-03
   syst_JES_EtaIntercalibration_Stat246_minus: 0.0
@@ -29339,7 +29339,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat22_plus: 0.0
   syst_JES_EtaIntercalibration_Stat22_minus: 0.0
   syst_JES_EtaIntercalibration_Stat220_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat220_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat220_minus: 0.0
   syst_JES_EtaIntercalibration_Stat221_plus: 0.0
   syst_JES_EtaIntercalibration_Stat221_minus: 0.0
   syst_JES_EtaIntercalibration_Stat222_plus: 0.0
@@ -29365,7 +29365,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat231_plus: -8.03697567e-13
   syst_JES_EtaIntercalibration_Stat231_minus: 3.16783838e-10
   syst_JES_EtaIntercalibration_Stat232_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat232_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat232_minus: 0.0
   syst_JES_EtaIntercalibration_Stat233_plus: 0.0
   syst_JES_EtaIntercalibration_Stat233_minus: 0.0
   syst_JES_EtaIntercalibration_Stat234_plus: 0.0
@@ -29373,7 +29373,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat235_plus: 0.0
   syst_JES_EtaIntercalibration_Stat235_minus: 0.0
   syst_JES_EtaIntercalibration_Stat236_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat236_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat236_minus: 0.0
   syst_JES_EtaIntercalibration_Stat237_plus: 2.54699863e-04
   syst_JES_EtaIntercalibration_Stat237_minus: -2.78939483e-04
   syst_JES_EtaIntercalibration_Stat238_plus: -9.21501557e-44
@@ -29389,10 +29389,10 @@ bins:
   syst_JES_EtaIntercalibration_Stat242_plus: -6.49194736e-04
   syst_JES_EtaIntercalibration_Stat242_minus: 6.30173563e-22
   syst_JES_EtaIntercalibration_Stat243_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat243_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat243_minus: 0.0
   syst_JES_EtaIntercalibration_Stat244_plus: 0.0
   syst_JES_EtaIntercalibration_Stat244_minus: 0.0
-  syst_JES_EtaIntercalibration_Stat245_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat245_plus: 0.0
   syst_JES_EtaIntercalibration_Stat245_minus: 0.0
   syst_JES_EtaIntercalibration_Stat246_plus: 5.26158156e-04
   syst_JES_EtaIntercalibration_Stat246_minus: 0.0
@@ -29999,7 +29999,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat22_plus: 0.0
   syst_JES_EtaIntercalibration_Stat22_minus: 0.0
   syst_JES_EtaIntercalibration_Stat220_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat220_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat220_minus: 0.0
   syst_JES_EtaIntercalibration_Stat221_plus: 0.0
   syst_JES_EtaIntercalibration_Stat221_minus: 0.0
   syst_JES_EtaIntercalibration_Stat222_plus: 0.0
@@ -30025,7 +30025,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat231_plus: -1.92403755e-09
   syst_JES_EtaIntercalibration_Stat231_minus: 8.20880262e-08
   syst_JES_EtaIntercalibration_Stat232_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat232_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat232_minus: 0.0
   syst_JES_EtaIntercalibration_Stat233_plus: 0.0
   syst_JES_EtaIntercalibration_Stat233_minus: 0.0
   syst_JES_EtaIntercalibration_Stat234_plus: 0.0
@@ -30033,7 +30033,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat235_plus: 0.0
   syst_JES_EtaIntercalibration_Stat235_minus: 0.0
   syst_JES_EtaIntercalibration_Stat236_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat236_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat236_minus: 0.0
   syst_JES_EtaIntercalibration_Stat237_plus: 1.34208867e-04
   syst_JES_EtaIntercalibration_Stat237_minus: -1.47007500e-04
   syst_JES_EtaIntercalibration_Stat238_plus: -2.27051987e-32
@@ -30049,10 +30049,10 @@ bins:
   syst_JES_EtaIntercalibration_Stat242_plus: -3.42168971e-04
   syst_JES_EtaIntercalibration_Stat242_minus: 4.31688690e-16
   syst_JES_EtaIntercalibration_Stat243_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat243_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat243_minus: 0.0
   syst_JES_EtaIntercalibration_Stat244_plus: 0.0
   syst_JES_EtaIntercalibration_Stat244_minus: 0.0
-  syst_JES_EtaIntercalibration_Stat245_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat245_plus: 0.0
   syst_JES_EtaIntercalibration_Stat245_minus: 0.0
   syst_JES_EtaIntercalibration_Stat246_plus: 2.77306066e-04
   syst_JES_EtaIntercalibration_Stat246_minus: 0.0
@@ -30659,7 +30659,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat22_plus: 0.0
   syst_JES_EtaIntercalibration_Stat22_minus: 0.0
   syst_JES_EtaIntercalibration_Stat220_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat220_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat220_minus: 0.0
   syst_JES_EtaIntercalibration_Stat221_plus: 0.0
   syst_JES_EtaIntercalibration_Stat221_minus: 0.0
   syst_JES_EtaIntercalibration_Stat222_plus: 0.0
@@ -30685,7 +30685,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat231_plus: -2.72632091e-07
   syst_JES_EtaIntercalibration_Stat231_minus: 2.23162900e-06
   syst_JES_EtaIntercalibration_Stat232_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat232_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat232_minus: 0.0
   syst_JES_EtaIntercalibration_Stat233_plus: 0.0
   syst_JES_EtaIntercalibration_Stat233_minus: 0.0
   syst_JES_EtaIntercalibration_Stat234_plus: 0.0
@@ -30693,7 +30693,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat235_plus: 0.0
   syst_JES_EtaIntercalibration_Stat235_minus: 0.0
   syst_JES_EtaIntercalibration_Stat236_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat236_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat236_minus: 0.0
   syst_JES_EtaIntercalibration_Stat237_plus: 7.43027806e-05
   syst_JES_EtaIntercalibration_Stat237_minus: -8.13809194e-05
   syst_JES_EtaIntercalibration_Stat238_plus: -3.99444621e-24
@@ -30709,7 +30709,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat242_plus: -1.89363196e-04
   syst_JES_EtaIntercalibration_Stat242_minus: 4.36497016e-12
   syst_JES_EtaIntercalibration_Stat243_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat243_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat243_minus: 0.0
   syst_JES_EtaIntercalibration_Stat244_plus: 0.0
   syst_JES_EtaIntercalibration_Stat244_minus: 0.0
   syst_JES_EtaIntercalibration_Stat245_plus: -1.12147135e-38
@@ -31319,7 +31319,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat22_plus: 0.0
   syst_JES_EtaIntercalibration_Stat22_minus: 0.0
   syst_JES_EtaIntercalibration_Stat220_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat220_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat220_minus: 0.0
   syst_JES_EtaIntercalibration_Stat221_plus: 0.0
   syst_JES_EtaIntercalibration_Stat221_minus: 0.0
   syst_JES_EtaIntercalibration_Stat222_plus: 0.0
@@ -31345,7 +31345,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat231_plus: -5.21208408e-06
   syst_JES_EtaIntercalibration_Stat231_minus: 1.27562063e-05
   syst_JES_EtaIntercalibration_Stat232_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat232_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat232_minus: 0.0
   syst_JES_EtaIntercalibration_Stat233_plus: 0.0
   syst_JES_EtaIntercalibration_Stat233_minus: 0.0
   syst_JES_EtaIntercalibration_Stat234_plus: 0.0
@@ -31353,7 +31353,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat235_plus: 0.0
   syst_JES_EtaIntercalibration_Stat235_minus: 0.0
   syst_JES_EtaIntercalibration_Stat236_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat236_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat236_minus: 0.0
   syst_JES_EtaIntercalibration_Stat237_plus: 4.10546197e-05
   syst_JES_EtaIntercalibration_Stat237_minus: -4.49578491e-05
   syst_JES_EtaIntercalibration_Stat238_plus: -3.51997756e-18
@@ -31369,7 +31369,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat242_plus: -1.04651804e-04
   syst_JES_EtaIntercalibration_Stat242_minus: 2.10434978e-09
   syst_JES_EtaIntercalibration_Stat243_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat243_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat243_minus: 0.0
   syst_JES_EtaIntercalibration_Stat244_plus: 0.0
   syst_JES_EtaIntercalibration_Stat244_minus: 0.0
   syst_JES_EtaIntercalibration_Stat245_plus: -1.43542677e-29
@@ -31979,7 +31979,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat22_plus: 0.0
   syst_JES_EtaIntercalibration_Stat22_minus: 0.0
   syst_JES_EtaIntercalibration_Stat220_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat220_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat220_minus: 0.0
   syst_JES_EtaIntercalibration_Stat221_plus: 0.0
   syst_JES_EtaIntercalibration_Stat221_minus: 0.0
   syst_JES_EtaIntercalibration_Stat222_plus: 0.0
@@ -32005,7 +32005,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat231_plus: -2.64175093e-05
   syst_JES_EtaIntercalibration_Stat231_minus: 2.79179899e-05
   syst_JES_EtaIntercalibration_Stat232_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat232_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat232_minus: 0.0
   syst_JES_EtaIntercalibration_Stat233_plus: 0.0
   syst_JES_EtaIntercalibration_Stat233_minus: 0.0
   syst_JES_EtaIntercalibration_Stat234_plus: 0.0
@@ -32013,7 +32013,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat235_plus: 0.0
   syst_JES_EtaIntercalibration_Stat235_minus: 0.0
   syst_JES_EtaIntercalibration_Stat236_plus: 9.48795879e-35
-  syst_JES_EtaIntercalibration_Stat236_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat236_minus: 0.0
   syst_JES_EtaIntercalibration_Stat237_plus: 2.35395847e-05
   syst_JES_EtaIntercalibration_Stat237_minus: -2.57669711e-05
   syst_JES_EtaIntercalibration_Stat238_plus: -6.62276211e-14
@@ -32029,7 +32029,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat242_plus: -5.99980104e-05
   syst_JES_EtaIntercalibration_Stat242_minus: 1.20349574e-07
   syst_JES_EtaIntercalibration_Stat243_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat243_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat243_minus: 0.0
   syst_JES_EtaIntercalibration_Stat244_plus: 0.0
   syst_JES_EtaIntercalibration_Stat244_minus: 0.0
   syst_JES_EtaIntercalibration_Stat245_plus: -8.02919750e-23
@@ -32294,7 +32294,7 @@ bins:
   syst_JES_Pileup_Rho_topology_minus: -4.37557676e-01
   syst_JES_Punch_through_plus: 4.12526096e-03
   syst_JES_Punch_through_minus: -3.50512831e-03
-  syst_JES_SingleParticle_HighPt_plus: -0.0
+  syst_JES_SingleParticle_HighPt_plus: 0.0
   syst_JES_SingleParticle_HighPt_minus: 0.0
   syst_JES_Zjet_JVF_plus: 1.70483445e-02
   syst_JES_Zjet_JVF_minus: -1.83494210e-02
@@ -32639,7 +32639,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat22_plus: 0.0
   syst_JES_EtaIntercalibration_Stat22_minus: 0.0
   syst_JES_EtaIntercalibration_Stat220_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat220_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat220_minus: 0.0
   syst_JES_EtaIntercalibration_Stat221_plus: 0.0
   syst_JES_EtaIntercalibration_Stat221_minus: 0.0
   syst_JES_EtaIntercalibration_Stat222_plus: 0.0
@@ -32665,7 +32665,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat231_plus: -5.81524617e-05
   syst_JES_EtaIntercalibration_Stat231_minus: 4.01707362e-05
   syst_JES_EtaIntercalibration_Stat232_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat232_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat232_minus: 0.0
   syst_JES_EtaIntercalibration_Stat233_plus: 0.0
   syst_JES_EtaIntercalibration_Stat233_minus: 0.0
   syst_JES_EtaIntercalibration_Stat234_plus: 0.0
@@ -32689,7 +32689,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat242_plus: -3.45916637e-05
   syst_JES_EtaIntercalibration_Stat242_minus: 1.65180144e-06
   syst_JES_EtaIntercalibration_Stat243_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat243_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat243_minus: 0.0
   syst_JES_EtaIntercalibration_Stat244_plus: 0.0
   syst_JES_EtaIntercalibration_Stat244_minus: 0.0
   syst_JES_EtaIntercalibration_Stat245_plus: -1.11227897e-17
@@ -32954,7 +32954,7 @@ bins:
   syst_JES_Pileup_Rho_topology_minus: -2.32213867e-01
   syst_JES_Punch_through_plus: 2.09940003e-03
   syst_JES_Punch_through_minus: -2.20688026e-03
-  syst_JES_SingleParticle_HighPt_plus: -0.0
+  syst_JES_SingleParticle_HighPt_plus: 0.0
   syst_JES_SingleParticle_HighPt_minus: 0.0
   syst_JES_Zjet_JVF_plus: 9.29421153e-03
   syst_JES_Zjet_JVF_minus: -9.97161983e-03
@@ -33614,7 +33614,7 @@ bins:
   syst_JES_Pileup_Rho_topology_minus: -1.28269170e-01
   syst_JES_Punch_through_plus: 1.29612673e-03
   syst_JES_Punch_through_minus: -1.53512882e-03
-  syst_JES_SingleParticle_HighPt_plus: -0.0
+  syst_JES_SingleParticle_HighPt_plus: 0.0
   syst_JES_SingleParticle_HighPt_minus: 0.0
   syst_JES_Zjet_JVF_plus: 5.56634458e-03
   syst_JES_Zjet_JVF_minus: -5.51401868e-03
@@ -34274,7 +34274,7 @@ bins:
   syst_JES_Pileup_Rho_topology_minus: -7.29522066e-02
   syst_JES_Punch_through_plus: 1.12076425e-03
   syst_JES_Punch_through_minus: -1.24945768e-03
-  syst_JES_SingleParticle_HighPt_plus: -0.0
+  syst_JES_SingleParticle_HighPt_plus: 0.0
   syst_JES_SingleParticle_HighPt_minus: 0.0
   syst_JES_Zjet_JVF_plus: 3.27531861e-03
   syst_JES_Zjet_JVF_minus: -3.06460079e-03
@@ -34934,7 +34934,7 @@ bins:
   syst_JES_Pileup_Rho_topology_minus: -4.05667160e-02
   syst_JES_Punch_through_plus: 1.04510382e-03
   syst_JES_Punch_through_minus: -1.16248355e-03
-  syst_JES_SingleParticle_HighPt_plus: -0.0
+  syst_JES_SingleParticle_HighPt_plus: 0.0
   syst_JES_SingleParticle_HighPt_minus: 0.0
   syst_JES_Zjet_JVF_plus: 1.80453651e-03
   syst_JES_Zjet_JVF_minus: -1.66028672e-03
@@ -35594,7 +35594,7 @@ bins:
   syst_JES_Pileup_Rho_topology_minus: -2.28324780e-02
   syst_JES_Punch_through_plus: 9.26522015e-04
   syst_JES_Punch_through_minus: -1.06348860e-03
-  syst_JES_SingleParticle_HighPt_plus: -0.0
+  syst_JES_SingleParticle_HighPt_plus: 0.0
   syst_JES_SingleParticle_HighPt_minus: 0.0
   syst_JES_Zjet_JVF_plus: 1.02176930e-03
   syst_JES_Zjet_JVF_minus: -9.59331770e-04
@@ -36254,7 +36254,7 @@ bins:
   syst_JES_Pileup_Rho_topology_minus: -1.29400541e-02
   syst_JES_Punch_through_plus: 7.90545381e-04
   syst_JES_Punch_through_minus: -8.52982910e-04
-  syst_JES_SingleParticle_HighPt_plus: -0.0
+  syst_JES_SingleParticle_HighPt_plus: 0.0
   syst_JES_SingleParticle_HighPt_minus: 0.0
   syst_JES_Zjet_JVF_plus: 5.88242131e-04
   syst_JES_Zjet_JVF_minus: -5.87817867e-04
@@ -36914,7 +36914,7 @@ bins:
   syst_JES_Pileup_Rho_topology_minus: -7.43452070e-03
   syst_JES_Punch_through_plus: 6.38800266e-04
   syst_JES_Punch_through_minus: -6.27345136e-04
-  syst_JES_SingleParticle_HighPt_plus: -0.0
+  syst_JES_SingleParticle_HighPt_plus: 0.0
   syst_JES_SingleParticle_HighPt_minus: 0.0
   syst_JES_Zjet_JVF_plus: 3.39128412e-04
   syst_JES_Zjet_JVF_minus: -3.55533290e-04
@@ -37574,7 +37574,7 @@ bins:
   syst_JES_Pileup_Rho_topology_minus: -4.30415898e-03
   syst_JES_Punch_through_plus: 4.77862763e-04
   syst_JES_Punch_through_minus: -4.45265140e-04
-  syst_JES_SingleParticle_HighPt_plus: -0.0
+  syst_JES_SingleParticle_HighPt_plus: 0.0
   syst_JES_SingleParticle_HighPt_minus: 0.0
   syst_JES_Zjet_JVF_plus: 2.02798225e-04
   syst_JES_Zjet_JVF_minus: -2.03929596e-04
@@ -47142,9 +47142,9 @@ bins:
   syst_JES_EtaIntercalibration_Stat211_minus: 0.0
   syst_JES_EtaIntercalibration_Stat212_plus: 0.0
   syst_JES_EtaIntercalibration_Stat212_minus: 0.0
-  syst_JES_EtaIntercalibration_Stat213_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat213_plus: 0.0
   syst_JES_EtaIntercalibration_Stat213_minus: 0.0
-  syst_JES_EtaIntercalibration_Stat214_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat214_plus: 0.0
   syst_JES_EtaIntercalibration_Stat214_minus: 8.91166676e-02
   syst_JES_EtaIntercalibration_Stat215_plus: 0.0
   syst_JES_EtaIntercalibration_Stat215_minus: 0.0
@@ -47160,13 +47160,13 @@ bins:
   syst_JES_EtaIntercalibration_Stat22_minus: 0.0
   syst_JES_EtaIntercalibration_Stat220_plus: -5.60877099e-02
   syst_JES_EtaIntercalibration_Stat220_minus: 0.0
-  syst_JES_EtaIntercalibration_Stat221_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat221_plus: 0.0
   syst_JES_EtaIntercalibration_Stat221_minus: 0.0
   syst_JES_EtaIntercalibration_Stat222_plus: 0.0
   syst_JES_EtaIntercalibration_Stat222_minus: 0.0
   syst_JES_EtaIntercalibration_Stat223_plus: 0.0
   syst_JES_EtaIntercalibration_Stat223_minus: 0.0
-  syst_JES_EtaIntercalibration_Stat224_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat224_plus: 0.0
   syst_JES_EtaIntercalibration_Stat224_minus: 4.10616908e-02
   syst_JES_EtaIntercalibration_Stat225_plus: 0.0
   syst_JES_EtaIntercalibration_Stat225_minus: 0.0
@@ -47190,9 +47190,9 @@ bins:
   syst_JES_EtaIntercalibration_Stat233_minus: 0.0
   syst_JES_EtaIntercalibration_Stat234_plus: 0.0
   syst_JES_EtaIntercalibration_Stat234_minus: 0.0
-  syst_JES_EtaIntercalibration_Stat235_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat235_plus: 0.0
   syst_JES_EtaIntercalibration_Stat235_minus: 3.72008878e-02
-  syst_JES_EtaIntercalibration_Stat236_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat236_plus: 0.0
   syst_JES_EtaIntercalibration_Stat236_minus: 7.57594205e-02
   syst_JES_EtaIntercalibration_Stat237_plus: -4.80196215e-02
   syst_JES_EtaIntercalibration_Stat237_minus: 2.06545891e-01
@@ -47826,7 +47826,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat222_minus: 0.0
   syst_JES_EtaIntercalibration_Stat223_plus: 0.0
   syst_JES_EtaIntercalibration_Stat223_minus: 0.0
-  syst_JES_EtaIntercalibration_Stat224_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat224_plus: 0.0
   syst_JES_EtaIntercalibration_Stat224_minus: 1.67301464e-02
   syst_JES_EtaIntercalibration_Stat225_plus: 0.0
   syst_JES_EtaIntercalibration_Stat225_minus: 0.0
@@ -47850,9 +47850,9 @@ bins:
   syst_JES_EtaIntercalibration_Stat233_minus: 0.0
   syst_JES_EtaIntercalibration_Stat234_plus: 0.0
   syst_JES_EtaIntercalibration_Stat234_minus: 0.0
-  syst_JES_EtaIntercalibration_Stat235_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat235_plus: 0.0
   syst_JES_EtaIntercalibration_Stat235_minus: 1.51603694e-02
-  syst_JES_EtaIntercalibration_Stat236_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat236_plus: 0.0
   syst_JES_EtaIntercalibration_Stat236_minus: 3.08722821e-02
   syst_JES_EtaIntercalibration_Stat237_plus: -1.95656446e-02
   syst_JES_EtaIntercalibration_Stat237_minus: 8.41669202e-02
@@ -48121,7 +48121,7 @@ bins:
   syst_JES_MJB_Stat8_plus: 1.15329116e-02
   syst_JES_MJB_Stat8_minus: -2.18990970e-02
   syst_JES_MJB_Stat9_plus: 2.88570277e-02
-  syst_JES_MJB_Stat9_minus: -0.0
+  syst_JES_MJB_Stat9_minus: 0.0
   syst_JES_MJB_Threshold_plus: 4.58417326e-03
   syst_JES_MJB_Threshold_minus: -3.40189072e-03
   syst_JES_Pileup_MuOffset_plus: -1.86110505e+01
@@ -48486,7 +48486,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat222_minus: 0.0
   syst_JES_EtaIntercalibration_Stat223_plus: 0.0
   syst_JES_EtaIntercalibration_Stat223_minus: 0.0
-  syst_JES_EtaIntercalibration_Stat224_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat224_plus: 0.0
   syst_JES_EtaIntercalibration_Stat224_minus: 7.71948473e-03
   syst_JES_EtaIntercalibration_Stat225_plus: 4.73195858e-31
   syst_JES_EtaIntercalibration_Stat225_minus: 0.0
@@ -48510,9 +48510,9 @@ bins:
   syst_JES_EtaIntercalibration_Stat233_minus: 0.0
   syst_JES_EtaIntercalibration_Stat234_plus: 0.0
   syst_JES_EtaIntercalibration_Stat234_minus: 0.0
-  syst_JES_EtaIntercalibration_Stat235_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat235_plus: 0.0
   syst_JES_EtaIntercalibration_Stat235_minus: 6.99470028e-03
-  syst_JES_EtaIntercalibration_Stat236_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat236_plus: 0.0
   syst_JES_EtaIntercalibration_Stat236_minus: 1.42411306e-02
   syst_JES_EtaIntercalibration_Stat237_plus: -9.02833938e-03
   syst_JES_EtaIntercalibration_Stat237_minus: 3.88343044e-02
@@ -48781,7 +48781,7 @@ bins:
   syst_JES_MJB_Stat8_plus: 5.31956431e-03
   syst_JES_MJB_Stat8_minus: -1.01045559e-02
   syst_JES_MJB_Stat9_plus: 1.33148207e-02
-  syst_JES_MJB_Stat9_minus: -0.0
+  syst_JES_MJB_Stat9_minus: 0.0
   syst_JES_MJB_Threshold_plus: 1.87241876e-03
   syst_JES_MJB_Threshold_minus: -3.99303199e-03
   syst_JES_Pileup_MuOffset_plus: -6.65741034e+00
@@ -49170,9 +49170,9 @@ bins:
   syst_JES_EtaIntercalibration_Stat233_minus: 0.0
   syst_JES_EtaIntercalibration_Stat234_plus: 0.0
   syst_JES_EtaIntercalibration_Stat234_minus: 0.0
-  syst_JES_EtaIntercalibration_Stat235_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat235_plus: 0.0
   syst_JES_EtaIntercalibration_Stat235_minus: 3.20248661e-03
-  syst_JES_EtaIntercalibration_Stat236_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat236_plus: 0.0
   syst_JES_EtaIntercalibration_Stat236_minus: 6.52164584e-03
   syst_JES_EtaIntercalibration_Stat237_plus: -4.13374624e-03
   syst_JES_EtaIntercalibration_Stat237_minus: 1.77766645e-02
@@ -49441,7 +49441,7 @@ bins:
   syst_JES_MJB_Stat8_plus: 2.43527575e-03
   syst_JES_MJB_Stat8_minus: -4.62659967e-03
   syst_JES_MJB_Stat9_plus: 6.09667467e-03
-  syst_JES_MJB_Stat9_minus: -0.0
+  syst_JES_MJB_Stat9_minus: 0.0
   syst_JES_MJB_Threshold_plus: -1.47997449e-02
   syst_JES_MJB_Threshold_minus: 2.79491026e-03
   syst_JES_Pileup_MuOffset_plus: -3.11621958e+00
@@ -49830,7 +49830,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat233_minus: 0.0
   syst_JES_EtaIntercalibration_Stat234_plus: 0.0
   syst_JES_EtaIntercalibration_Stat234_minus: 0.0
-  syst_JES_EtaIntercalibration_Stat235_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat235_plus: 0.0
   syst_JES_EtaIntercalibration_Stat235_minus: 1.53866436e-03
   syst_JES_EtaIntercalibration_Stat236_plus: -5.87605735e-42
   syst_JES_EtaIntercalibration_Stat236_minus: 3.13319015e-03
@@ -50101,7 +50101,7 @@ bins:
   syst_JES_MJB_Stat8_plus: 1.17026172e-03
   syst_JES_MJB_Stat8_minus: -2.22243661e-03
   syst_JES_MJB_Stat9_plus: 2.92883629e-03
-  syst_JES_MJB_Stat9_minus: -0.0
+  syst_JES_MJB_Stat9_minus: 0.0
   syst_JES_MJB_Threshold_plus: -2.77504056e-02
   syst_JES_MJB_Threshold_minus: 2.25496353e-02
   syst_JES_Pileup_MuOffset_plus: -1.53866436e+00
@@ -50761,7 +50761,7 @@ bins:
   syst_JES_MJB_Stat8_plus: 5.91494822e-04
   syst_JES_MJB_Stat8_minus: -1.12359268e-03
   syst_JES_MJB_Stat9_plus: 1.48068160e-03
-  syst_JES_MJB_Stat9_minus: -0.0
+  syst_JES_MJB_Stat9_minus: 0.0
   syst_JES_MJB_Threshold_plus: -3.35380746e-02
   syst_JES_MJB_Threshold_minus: 4.08707720e-02
   syst_JES_Pileup_MuOffset_plus: -6.70973625e-01
@@ -51421,7 +51421,7 @@ bins:
   syst_JES_MJB_Stat8_plus: 2.95853477e-04
   syst_JES_MJB_Stat8_minus: -5.62008470e-04
   syst_JES_MJB_Stat9_plus: 7.40552932e-04
-  syst_JES_MJB_Stat9_minus: -0.0
+  syst_JES_MJB_Stat9_minus: 0.0
   syst_JES_MJB_Threshold_plus: -3.29723892e-02
   syst_JES_MJB_Threshold_minus: 3.96333351e-02
   syst_JES_Pileup_MuOffset_plus: -2.78861701e-01
@@ -52095,7 +52095,7 @@ bins:
   syst_JES_Punch_through_plus: 4.87974390e-02
   syst_JES_Punch_through_minus: -3.61472987e-02
   syst_JES_SingleParticle_HighPt_plus: 0.0
-  syst_JES_SingleParticle_HighPt_minus: -0.0
+  syst_JES_SingleParticle_HighPt_minus: 0.0
   syst_JES_Zjet_JVF_plus: 9.14996175e-02
   syst_JES_Zjet_JVF_minus: -9.03611756e-02
   syst_JES_Zjet_MC_plus: 1.85615530e+00
@@ -52755,7 +52755,7 @@ bins:
   syst_JES_Punch_through_plus: 2.25142799e-02
   syst_JES_Punch_through_minus: -1.65533697e-02
   syst_JES_SingleParticle_HighPt_plus: 0.0
-  syst_JES_SingleParticle_HighPt_minus: -0.0
+  syst_JES_SingleParticle_HighPt_minus: 0.0
   syst_JES_Zjet_JVF_plus: 4.77721341e-02
   syst_JES_Zjet_JVF_minus: -4.83943881e-02
   syst_JES_Zjet_MC_plus: 9.95323505e-01
@@ -53415,7 +53415,7 @@ bins:
   syst_JES_Punch_through_plus: 1.20985970e-02
   syst_JES_Punch_through_minus: -9.28714046e-03
   syst_JES_SingleParticle_HighPt_plus: 0.0
-  syst_JES_SingleParticle_HighPt_minus: -0.0
+  syst_JES_SingleParticle_HighPt_minus: 0.0
   syst_JES_Zjet_JVF_plus: 2.57174736e-02
   syst_JES_Zjet_JVF_minus: -2.59932453e-02
   syst_JES_Zjet_MC_plus: 5.16187950e-01
@@ -54075,7 +54075,7 @@ bins:
   syst_JES_Punch_through_plus: 7.16016327e-03
   syst_JES_Punch_through_minus: -6.14758636e-03
   syst_JES_SingleParticle_HighPt_plus: 0.0
-  syst_JES_SingleParticle_HighPt_minus: -0.0
+  syst_JES_SingleParticle_HighPt_minus: 0.0
   syst_JES_Zjet_JVF_plus: 1.46441814e-02
   syst_JES_Zjet_JVF_minus: -1.42552727e-02
   syst_JES_Zjet_MC_plus: 2.61700220e-01
@@ -54735,7 +54735,7 @@ bins:
   syst_JES_Punch_through_plus: 4.24759043e-03
   syst_JES_Punch_through_minus: -3.90181522e-03
   syst_JES_SingleParticle_HighPt_plus: 0.0
-  syst_JES_SingleParticle_HighPt_minus: -0.0
+  syst_JES_SingleParticle_HighPt_minus: 0.0
   syst_JES_Zjet_JVF_plus: 7.80080201e-03
   syst_JES_Zjet_JVF_minus: -7.25562268e-03
   syst_JES_Zjet_MC_plus: 1.26713535e-01
@@ -55395,7 +55395,7 @@ bins:
   syst_JES_Punch_through_plus: 2.57033315e-03
   syst_JES_Punch_through_minus: -2.36951482e-03
   syst_JES_SingleParticle_HighPt_plus: 0.0
-  syst_JES_SingleParticle_HighPt_minus: -0.0
+  syst_JES_SingleParticle_HighPt_minus: 0.0
   syst_JES_Zjet_JVF_plus: 4.03050865e-03
   syst_JES_Zjet_JVF_minus: -3.69816847e-03
   syst_JES_Zjet_MC_plus: 6.17092088e-02
@@ -56055,7 +56055,7 @@ bins:
   syst_JES_Punch_through_plus: 1.63341666e-03
   syst_JES_Punch_through_minus: -1.46371104e-03
   syst_JES_SingleParticle_HighPt_plus: 0.0
-  syst_JES_SingleParticle_HighPt_minus: -0.0
+  syst_JES_SingleParticle_HighPt_minus: 0.0
   syst_JES_Zjet_JVF_plus: 2.22385083e-03
   syst_JES_Zjet_JVF_minus: -2.07747972e-03
   syst_JES_Zjet_MC_plus: 3.04480180e-02
@@ -56715,7 +56715,7 @@ bins:
   syst_JES_Punch_through_plus: 1.06278149e-03
   syst_JES_Punch_through_minus: -9.64140096e-04
   syst_JES_SingleParticle_HighPt_plus: 0.0
-  syst_JES_SingleParticle_HighPt_minus: -0.0
+  syst_JES_SingleParticle_HighPt_minus: 0.0
   syst_JES_Zjet_JVF_plus: 1.29612673e-03
   syst_JES_Zjet_JVF_minus: -1.27420642e-03
   syst_JES_Zjet_MC_plus: 1.49906638e-02
@@ -57375,7 +57375,7 @@ bins:
   syst_JES_Punch_through_plus: 6.86388552e-04
   syst_JES_Punch_through_minus: -6.79812459e-04
   syst_JES_SingleParticle_HighPt_plus: 0.0
-  syst_JES_SingleParticle_HighPt_minus: -0.0
+  syst_JES_SingleParticle_HighPt_minus: 0.0
   syst_JES_Zjet_JVF_plus: 7.58796287e-04
   syst_JES_Zjet_JVF_minus: -7.66362329e-04
   syst_JES_Zjet_MC_plus: 7.50240295e-03
@@ -68258,9 +68258,9 @@ bins:
   syst_JES_EtaIntercalibration_Stat21_minus: 0.0
   syst_JES_EtaIntercalibration_Stat210_plus: -8.73913271e-37
   syst_JES_EtaIntercalibration_Stat210_minus: 2.17788889e-36
-  syst_JES_EtaIntercalibration_Stat211_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat211_plus: 0.0
   syst_JES_EtaIntercalibration_Stat211_minus: 1.69917760e-01
-  syst_JES_EtaIntercalibration_Stat212_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat212_plus: 0.0
   syst_JES_EtaIntercalibration_Stat212_minus: 2.15526147e-01
   syst_JES_EtaIntercalibration_Stat213_plus: -8.36578033e-02
   syst_JES_EtaIntercalibration_Stat213_minus: 0.0
@@ -68577,7 +68577,7 @@ bins:
   syst_JES_MJB_Stat6_plus: -1.43542677e-01
   syst_JES_MJB_Stat6_minus: 6.16950667e-02
   syst_JES_MJB_Stat7_plus: 2.27334830e-02
-  syst_JES_MJB_Stat7_minus: -0.0
+  syst_JES_MJB_Stat7_minus: 0.0
   syst_JES_MJB_Stat8_plus: 2.26344881e-02
   syst_JES_MJB_Stat8_minus: -2.10576399e-02
   syst_JES_MJB_Stat9_plus: 7.67140147e-02
@@ -69237,7 +69237,7 @@ bins:
   syst_JES_MJB_Stat6_plus: -5.70988726e-02
   syst_JES_MJB_Stat6_minus: 2.45436764e-02
   syst_JES_MJB_Stat7_plus: 9.04530994e-03
-  syst_JES_MJB_Stat7_minus: -0.0
+  syst_JES_MJB_Stat7_minus: 0.0
   syst_JES_MJB_Stat8_plus: 9.00571197e-03
   syst_JES_MJB_Stat8_minus: -8.37850825e-03
   syst_JES_MJB_Stat9_plus: 3.05187287e-02
@@ -69897,7 +69897,7 @@ bins:
   syst_JES_MJB_Stat6_plus: -2.45295342e-02
   syst_JES_MJB_Stat6_minus: 1.05429621e-02
   syst_JES_MJB_Stat7_plus: 3.88555176e-03
-  syst_JES_MJB_Stat7_minus: -0.0
+  syst_JES_MJB_Stat7_minus: 0.0
   syst_JES_MJB_Stat8_plus: 3.86858120e-03
   syst_JES_MJB_Stat8_minus: -3.59917352e-03
   syst_JES_MJB_Stat9_plus: 1.31097597e-02
@@ -70557,7 +70557,7 @@ bins:
   syst_JES_MJB_Stat6_plus: -1.14834141e-02
   syst_JES_MJB_Stat6_minus: 4.93701955e-03
   syst_JES_MJB_Stat7_plus: 1.81938575e-03
-  syst_JES_MJB_Stat7_minus: -0.0
+  syst_JES_MJB_Stat7_minus: 0.0
   syst_JES_MJB_Stat8_plus: 1.81160757e-03
   syst_JES_MJB_Stat8_minus: -1.68503546e-03
   syst_JES_MJB_Stat9_plus: 6.13910107e-03
@@ -71217,7 +71217,7 @@ bins:
   syst_JES_MJB_Stat6_plus: -5.53381767e-03
   syst_JES_MJB_Stat6_minus: 2.37870721e-03
   syst_JES_MJB_Stat7_plus: 8.76670987e-04
-  syst_JES_MJB_Stat7_minus: -0.0
+  syst_JES_MJB_Stat7_minus: 0.0
   syst_JES_MJB_Stat8_plus: 8.72852611e-04
   syst_JES_MJB_Stat8_minus: -8.12041428e-04
   syst_JES_MJB_Stat9_plus: 2.95782767e-03
@@ -87817,7 +87817,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat101_plus: 0.0
   syst_JES_EtaIntercalibration_Stat101_minus: 0.0
   syst_JES_EtaIntercalibration_Stat102_plus: 9.47240244e-13
-  syst_JES_EtaIntercalibration_Stat102_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat102_minus: 0.0
   syst_JES_EtaIntercalibration_Stat103_plus: 1.06843835e+00
   syst_JES_EtaIntercalibration_Stat103_minus: -4.11748279e+00
   syst_JES_EtaIntercalibration_Stat104_plus: 3.45421663e+00
@@ -87861,7 +87861,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat121_plus: 0.0
   syst_JES_EtaIntercalibration_Stat121_minus: 0.0
   syst_JES_EtaIntercalibration_Stat122_plus: 9.47310955e-13
-  syst_JES_EtaIntercalibration_Stat122_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat122_minus: 0.0
   syst_JES_EtaIntercalibration_Stat123_plus: -6.55770829e-01
   syst_JES_EtaIntercalibration_Stat123_minus: 4.38123362e-01
   syst_JES_EtaIntercalibration_Stat124_plus: -1.72887608e+00
@@ -87903,7 +87903,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat140_plus: 0.0
   syst_JES_EtaIntercalibration_Stat140_minus: 0.0
   syst_JES_EtaIntercalibration_Stat141_plus: 9.50987910e-13
-  syst_JES_EtaIntercalibration_Stat141_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat141_minus: 0.0
   syst_JES_EtaIntercalibration_Stat142_plus: -7.94010205e-02
   syst_JES_EtaIntercalibration_Stat142_minus: 4.15283813e-02
   syst_JES_EtaIntercalibration_Stat143_plus: -2.23021479e-01
@@ -87939,7 +87939,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat157_plus: 0.0
   syst_JES_EtaIntercalibration_Stat157_minus: 0.0
   syst_JES_EtaIntercalibration_Stat158_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat158_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat158_minus: 0.0
   syst_JES_EtaIntercalibration_Stat159_plus: -3.60907301e-02
   syst_JES_EtaIntercalibration_Stat159_minus: 3.03702363e-03
   syst_JES_EtaIntercalibration_Stat16_plus: 1.04156829e+01
@@ -87979,7 +87979,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat175_plus: 0.0
   syst_JES_EtaIntercalibration_Stat175_minus: 0.0
   syst_JES_EtaIntercalibration_Stat176_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat176_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat176_minus: 0.0
   syst_JES_EtaIntercalibration_Stat177_plus: 0.0
   syst_JES_EtaIntercalibration_Stat177_minus: -1.56694863e-01
   syst_JES_EtaIntercalibration_Stat178_plus: 0.0
@@ -88017,7 +88017,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat192_plus: 0.0
   syst_JES_EtaIntercalibration_Stat192_minus: 0.0
   syst_JES_EtaIntercalibration_Stat193_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat193_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat193_minus: 0.0
   syst_JES_EtaIntercalibration_Stat194_plus: -1.71049130e-18
   syst_JES_EtaIntercalibration_Stat194_minus: 1.02742615e-18
   syst_JES_EtaIntercalibration_Stat195_plus: -1.10308658e-01
@@ -88051,7 +88051,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat207_plus: 0.0
   syst_JES_EtaIntercalibration_Stat207_minus: 0.0
   syst_JES_EtaIntercalibration_Stat208_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat208_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat208_minus: 0.0
   syst_JES_EtaIntercalibration_Stat209_plus: 8.55669916e-03
   syst_JES_EtaIntercalibration_Stat209_minus: -3.18127341e-02
   syst_JES_EtaIntercalibration_Stat21_plus: 0.0
@@ -88081,10 +88081,10 @@ bins:
   syst_JES_EtaIntercalibration_Stat220_plus: 0.0
   syst_JES_EtaIntercalibration_Stat220_minus: 0.0
   syst_JES_EtaIntercalibration_Stat221_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat221_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat221_minus: 0.0
   syst_JES_EtaIntercalibration_Stat222_plus: 3.38138463e-02
   syst_JES_EtaIntercalibration_Stat222_minus: 0.0
-  syst_JES_EtaIntercalibration_Stat223_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat223_plus: 0.0
   syst_JES_EtaIntercalibration_Stat223_minus: 2.87651039e-01
   syst_JES_EtaIntercalibration_Stat224_plus: 0.0
   syst_JES_EtaIntercalibration_Stat224_minus: 0.0
@@ -88107,8 +88107,8 @@ bins:
   syst_JES_EtaIntercalibration_Stat232_plus: 0.0
   syst_JES_EtaIntercalibration_Stat232_minus: 0.0
   syst_JES_EtaIntercalibration_Stat233_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat233_minus: -0.0
-  syst_JES_EtaIntercalibration_Stat234_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat233_minus: 0.0
+  syst_JES_EtaIntercalibration_Stat234_plus: 0.0
   syst_JES_EtaIntercalibration_Stat234_minus: 1.59876843e-02
   syst_JES_EtaIntercalibration_Stat235_plus: 0.0
   syst_JES_EtaIntercalibration_Stat235_minus: 0.0
@@ -88267,7 +88267,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat80_plus: 0.0
   syst_JES_EtaIntercalibration_Stat80_minus: 0.0
   syst_JES_EtaIntercalibration_Stat81_plus: 9.46321005e-13
-  syst_JES_EtaIntercalibration_Stat81_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat81_minus: 0.0
   syst_JES_EtaIntercalibration_Stat82_plus: 5.75372788e+00
   syst_JES_EtaIntercalibration_Stat82_minus: -2.85671140e+00
   syst_JES_EtaIntercalibration_Stat83_plus: 2.19415234e+01
@@ -88373,7 +88373,7 @@ bins:
   syst_JES_MJB_Stat4_plus: -2.17223203e-01
   syst_JES_MJB_Stat4_minus: 2.14111933e-01
   syst_JES_MJB_Stat5_plus: 0.0
-  syst_JES_MJB_Stat5_minus: -0.0
+  syst_JES_MJB_Stat5_minus: 0.0
   syst_JES_MJB_Stat6_plus: -1.35976634e+00
   syst_JES_MJB_Stat6_minus: 0.0
   syst_JES_MJB_Stat7_plus: 0.0
@@ -88477,7 +88477,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat101_plus: 0.0
   syst_JES_EtaIntercalibration_Stat101_minus: 0.0
   syst_JES_EtaIntercalibration_Stat102_plus: 7.05904700e-08
-  syst_JES_EtaIntercalibration_Stat102_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat102_minus: 0.0
   syst_JES_EtaIntercalibration_Stat103_plus: 4.96671803e-01
   syst_JES_EtaIntercalibration_Stat103_minus: -1.62068874e+00
   syst_JES_EtaIntercalibration_Stat104_plus: 3.39976940e+00
@@ -88521,7 +88521,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat121_plus: 0.0
   syst_JES_EtaIntercalibration_Stat121_minus: 0.0
   syst_JES_EtaIntercalibration_Stat122_plus: 7.05975410e-08
-  syst_JES_EtaIntercalibration_Stat122_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat122_minus: 0.0
   syst_JES_EtaIntercalibration_Stat123_plus: 1.82716392e-01
   syst_JES_EtaIntercalibration_Stat123_minus: 0.0
   syst_JES_EtaIntercalibration_Stat124_plus: -5.04379267e-02
@@ -88563,7 +88563,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat140_plus: 0.0
   syst_JES_EtaIntercalibration_Stat140_minus: 0.0
   syst_JES_EtaIntercalibration_Stat141_plus: 7.08733127e-08
-  syst_JES_EtaIntercalibration_Stat141_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat141_minus: 0.0
   syst_JES_EtaIntercalibration_Stat142_plus: -1.43118413e-01
   syst_JES_EtaIntercalibration_Stat142_minus: 9.37623592e-02
   syst_JES_EtaIntercalibration_Stat143_plus: -4.46042958e-01
@@ -88599,7 +88599,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat157_plus: 0.0
   syst_JES_EtaIntercalibration_Stat157_minus: 0.0
   syst_JES_EtaIntercalibration_Stat158_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat158_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat158_minus: 0.0
   syst_JES_EtaIntercalibration_Stat159_plus: -1.37673690e-02
   syst_JES_EtaIntercalibration_Stat159_minus: 1.70271313e-02
   syst_JES_EtaIntercalibration_Stat16_plus: 2.81032519e+00
@@ -88639,7 +88639,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat175_plus: 0.0
   syst_JES_EtaIntercalibration_Stat175_minus: 0.0
   syst_JES_EtaIntercalibration_Stat176_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat176_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat176_minus: 0.0
   syst_JES_EtaIntercalibration_Stat177_plus: 0.0
   syst_JES_EtaIntercalibration_Stat177_minus: -5.97788073e-02
   syst_JES_EtaIntercalibration_Stat178_plus: 0.0
@@ -88677,7 +88677,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat192_plus: 0.0
   syst_JES_EtaIntercalibration_Stat192_minus: 0.0
   syst_JES_EtaIntercalibration_Stat193_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat193_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat193_minus: 0.0
   syst_JES_EtaIntercalibration_Stat194_plus: -1.90141013e-11
   syst_JES_EtaIntercalibration_Stat194_minus: 1.14197745e-11
   syst_JES_EtaIntercalibration_Stat195_plus: -4.20728535e-02
@@ -88711,7 +88711,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat207_plus: 0.0
   syst_JES_EtaIntercalibration_Stat207_minus: 0.0
   syst_JES_EtaIntercalibration_Stat208_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat208_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat208_minus: 0.0
   syst_JES_EtaIntercalibration_Stat209_plus: 3.26400490e-03
   syst_JES_EtaIntercalibration_Stat209_minus: -1.21339524e-02
   syst_JES_EtaIntercalibration_Stat21_plus: 0.0
@@ -88741,10 +88741,10 @@ bins:
   syst_JES_EtaIntercalibration_Stat220_plus: 0.0
   syst_JES_EtaIntercalibration_Stat220_minus: 0.0
   syst_JES_EtaIntercalibration_Stat221_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat221_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat221_minus: 0.0
   syst_JES_EtaIntercalibration_Stat222_plus: 1.28976277e-02
   syst_JES_EtaIntercalibration_Stat222_minus: 0.0
-  syst_JES_EtaIntercalibration_Stat223_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat223_plus: 0.0
   syst_JES_EtaIntercalibration_Stat223_minus: 1.09742972e-01
   syst_JES_EtaIntercalibration_Stat224_plus: 0.0
   syst_JES_EtaIntercalibration_Stat224_minus: 0.0
@@ -88767,8 +88767,8 @@ bins:
   syst_JES_EtaIntercalibration_Stat232_plus: 0.0
   syst_JES_EtaIntercalibration_Stat232_minus: 0.0
   syst_JES_EtaIntercalibration_Stat233_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat233_minus: -0.0
-  syst_JES_EtaIntercalibration_Stat234_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat233_minus: 0.0
+  syst_JES_EtaIntercalibration_Stat234_plus: 0.0
   syst_JES_EtaIntercalibration_Stat234_minus: 6.09738177e-03
   syst_JES_EtaIntercalibration_Stat235_plus: 0.0
   syst_JES_EtaIntercalibration_Stat235_minus: 0.0
@@ -88927,7 +88927,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat80_plus: 0.0
   syst_JES_EtaIntercalibration_Stat80_minus: 0.0
   syst_JES_EtaIntercalibration_Stat81_plus: 7.05268304e-08
-  syst_JES_EtaIntercalibration_Stat81_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat81_minus: 0.0
   syst_JES_EtaIntercalibration_Stat82_plus: 3.01934596e+00
   syst_JES_EtaIntercalibration_Stat82_minus: -1.91838070e+00
   syst_JES_EtaIntercalibration_Stat83_plus: 1.10520790e+01
@@ -89033,13 +89033,13 @@ bins:
   syst_JES_MJB_Stat4_plus: -8.28658437e-02
   syst_JES_MJB_Stat4_minus: 8.16708332e-02
   syst_JES_MJB_Stat5_plus: 0.0
-  syst_JES_MJB_Stat5_minus: -0.0
+  syst_JES_MJB_Stat5_minus: 0.0
   syst_JES_MJB_Stat6_plus: -5.18521403e-01
   syst_JES_MJB_Stat6_minus: 0.0
-  syst_JES_MJB_Stat7_plus: -0.0
+  syst_JES_MJB_Stat7_plus: 0.0
   syst_JES_MJB_Stat7_minus: 0.0
-  syst_JES_MJB_Stat8_plus: -0.0
-  syst_JES_MJB_Stat8_minus: -0.0
+  syst_JES_MJB_Stat8_plus: 0.0
+  syst_JES_MJB_Stat8_minus: 0.0
   syst_JES_MJB_Stat9_plus: 0.0
   syst_JES_MJB_Stat9_minus: 0.0
   syst_JES_MJB_Threshold_plus: 1.73736136e-03
@@ -89137,7 +89137,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat101_plus: 0.0
   syst_JES_EtaIntercalibration_Stat101_minus: 0.0
   syst_JES_EtaIntercalibration_Stat102_plus: 3.23572063e-05
-  syst_JES_EtaIntercalibration_Stat102_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat102_minus: 0.0
   syst_JES_EtaIntercalibration_Stat103_plus: 5.06359166e-01
   syst_JES_EtaIntercalibration_Stat103_minus: -6.86034999e-01
   syst_JES_EtaIntercalibration_Stat104_plus: 3.00237539e+00
@@ -89181,7 +89181,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat121_plus: 0.0
   syst_JES_EtaIntercalibration_Stat121_minus: 0.0
   syst_JES_EtaIntercalibration_Stat122_plus: 3.23642774e-05
-  syst_JES_EtaIntercalibration_Stat122_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat122_minus: 0.0
   syst_JES_EtaIntercalibration_Stat123_plus: 3.25410541e-01
   syst_JES_EtaIntercalibration_Stat123_minus: -6.41982247e-02
   syst_JES_EtaIntercalibration_Stat124_plus: 7.21178206e-01
@@ -89223,7 +89223,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat140_plus: 0.0
   syst_JES_EtaIntercalibration_Stat140_minus: 0.0
   syst_JES_EtaIntercalibration_Stat141_plus: 3.24844855e-05
-  syst_JES_EtaIntercalibration_Stat141_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat141_minus: 0.0
   syst_JES_EtaIntercalibration_Stat142_plus: -1.46583236e-02
   syst_JES_EtaIntercalibration_Stat142_minus: 9.17400338e-02
   syst_JES_EtaIntercalibration_Stat143_plus: -3.03348809e-01
@@ -89259,7 +89259,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat157_plus: 0.0
   syst_JES_EtaIntercalibration_Stat157_minus: 0.0
   syst_JES_EtaIntercalibration_Stat158_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat158_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat158_minus: 0.0
   syst_JES_EtaIntercalibration_Stat159_plus: -5.68655273e-03
   syst_JES_EtaIntercalibration_Stat159_minus: 1.87736850e-02
   syst_JES_EtaIntercalibration_Stat16_plus: 1.00090965e+00
@@ -89299,7 +89299,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat175_plus: 0.0
   syst_JES_EtaIntercalibration_Stat175_minus: 0.0
   syst_JES_EtaIntercalibration_Stat176_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat176_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat176_minus: 0.0
   syst_JES_EtaIntercalibration_Stat177_plus: -2.46921688e-02
   syst_JES_EtaIntercalibration_Stat177_minus: 3.40118362e-03
   syst_JES_EtaIntercalibration_Stat178_plus: -2.59649610e-02
@@ -89337,7 +89337,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat192_plus: 0.0
   syst_JES_EtaIntercalibration_Stat192_minus: 0.0
   syst_JES_EtaIntercalibration_Stat193_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat193_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat193_minus: 0.0
   syst_JES_EtaIntercalibration_Stat194_plus: -2.61417377e-07
   syst_JES_EtaIntercalibration_Stat194_minus: 1.57119127e-07
   syst_JES_EtaIntercalibration_Stat195_plus: -1.73806847e-02
@@ -89371,7 +89371,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat207_plus: 0.0
   syst_JES_EtaIntercalibration_Stat207_minus: 0.0
   syst_JES_EtaIntercalibration_Stat208_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat208_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat208_minus: 0.0
   syst_JES_EtaIntercalibration_Stat209_plus: 1.34774552e-03
   syst_JES_EtaIntercalibration_Stat209_minus: -5.01197287e-03
   syst_JES_EtaIntercalibration_Stat21_plus: 0.0
@@ -89401,7 +89401,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat220_plus: 0.0
   syst_JES_EtaIntercalibration_Stat220_minus: 0.0
   syst_JES_EtaIntercalibration_Stat221_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat221_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat221_minus: 0.0
   syst_JES_EtaIntercalibration_Stat222_plus: 5.32734249e-03
   syst_JES_EtaIntercalibration_Stat222_minus: 0.0
   syst_JES_EtaIntercalibration_Stat223_plus: -9.11955616e-40
@@ -89427,7 +89427,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat232_plus: 0.0
   syst_JES_EtaIntercalibration_Stat232_minus: 0.0
   syst_JES_EtaIntercalibration_Stat233_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat233_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat233_minus: 0.0
   syst_JES_EtaIntercalibration_Stat234_plus: -1.00409163e-39
   syst_JES_EtaIntercalibration_Stat234_minus: 2.51871435e-03
   syst_JES_EtaIntercalibration_Stat235_plus: 0.0
@@ -89587,7 +89587,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat80_plus: 0.0
   syst_JES_EtaIntercalibration_Stat80_minus: 0.0
   syst_JES_EtaIntercalibration_Stat81_plus: 3.23289220e-05
-  syst_JES_EtaIntercalibration_Stat81_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat81_minus: 0.0
   syst_JES_EtaIntercalibration_Stat82_plus: 1.58038366e+00
   syst_JES_EtaIntercalibration_Stat82_minus: -1.31804704e+00
   syst_JES_EtaIntercalibration_Stat83_plus: 5.14773737e+00
@@ -89693,14 +89693,14 @@ bins:
   syst_JES_MJB_Stat4_plus: -3.42239682e-02
   syst_JES_MJB_Stat4_minus: 3.37360645e-02
   syst_JES_MJB_Stat5_plus: 0.0
-  syst_JES_MJB_Stat5_minus: -0.0
+  syst_JES_MJB_Stat5_minus: 0.0
   syst_JES_MJB_Stat6_plus: -2.14182644e-01
   syst_JES_MJB_Stat6_minus: 0.0
-  syst_JES_MJB_Stat7_plus: -0.0
+  syst_JES_MJB_Stat7_plus: 0.0
   syst_JES_MJB_Stat7_minus: 0.0
-  syst_JES_MJB_Stat8_plus: -0.0
-  syst_JES_MJB_Stat8_minus: -0.0
-  syst_JES_MJB_Stat9_plus: -0.0
+  syst_JES_MJB_Stat8_plus: 0.0
+  syst_JES_MJB_Stat8_minus: 0.0
+  syst_JES_MJB_Stat9_plus: 0.0
   syst_JES_MJB_Stat9_minus: 0.0
   syst_JES_MJB_Threshold_plus: 2.01313301e-04
   syst_JES_MJB_Threshold_minus: 0.0
@@ -89797,7 +89797,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat101_plus: 0.0
   syst_JES_EtaIntercalibration_Stat101_minus: 0.0
   syst_JES_EtaIntercalibration_Stat102_plus: 8.21799501e-04
-  syst_JES_EtaIntercalibration_Stat102_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat102_minus: 0.0
   syst_JES_EtaIntercalibration_Stat103_plus: 4.74610072e-01
   syst_JES_EtaIntercalibration_Stat103_minus: -3.56381818e-01
   syst_JES_EtaIntercalibration_Stat104_plus: 1.79605122e+00
@@ -89841,7 +89841,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat121_plus: 0.0
   syst_JES_EtaIntercalibration_Stat121_minus: 0.0
   syst_JES_EtaIntercalibration_Stat122_plus: 8.21870212e-04
-  syst_JES_EtaIntercalibration_Stat122_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat122_minus: 0.0
   syst_JES_EtaIntercalibration_Stat123_plus: 3.20107240e-01
   syst_JES_EtaIntercalibration_Stat123_minus: -1.93040151e-01
   syst_JES_EtaIntercalibration_Stat124_plus: 8.65569411e-01
@@ -89883,7 +89883,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat140_plus: 0.0
   syst_JES_EtaIntercalibration_Stat140_minus: 0.0
   syst_JES_EtaIntercalibration_Stat141_plus: 8.25052192e-04
-  syst_JES_EtaIntercalibration_Stat141_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat141_minus: 0.0
   syst_JES_EtaIntercalibration_Stat142_plus: 9.25744198e-02
   syst_JES_EtaIntercalibration_Stat142_minus: 0.0
   syst_JES_EtaIntercalibration_Stat143_plus: 3.76392940e-02
@@ -89919,7 +89919,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat157_plus: 0.0
   syst_JES_EtaIntercalibration_Stat157_minus: 0.0
   syst_JES_EtaIntercalibration_Stat158_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat158_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat158_minus: 0.0
   syst_JES_EtaIntercalibration_Stat159_plus: -2.53851334e-03
   syst_JES_EtaIntercalibration_Stat159_minus: 1.13137085e-02
   syst_JES_EtaIntercalibration_Stat16_plus: 4.68811796e-01
@@ -89959,7 +89959,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat175_plus: 0.0
   syst_JES_EtaIntercalibration_Stat175_minus: 0.0
   syst_JES_EtaIntercalibration_Stat176_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat176_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat176_minus: 0.0
   syst_JES_EtaIntercalibration_Stat177_plus: -1.10237947e-02
   syst_JES_EtaIntercalibration_Stat177_minus: 7.82413653e-03
   syst_JES_EtaIntercalibration_Stat178_plus: -3.46906587e-02
@@ -89997,7 +89997,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat192_plus: 0.0
   syst_JES_EtaIntercalibration_Stat192_minus: 0.0
   syst_JES_EtaIntercalibration_Stat193_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat193_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat193_minus: 0.0
   syst_JES_EtaIntercalibration_Stat194_plus: -7.73999083e-05
   syst_JES_EtaIntercalibration_Stat194_minus: 4.75387889e-05
   syst_JES_EtaIntercalibration_Stat195_plus: -7.89626143e-03
@@ -90031,7 +90031,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat207_plus: 0.0
   syst_JES_EtaIntercalibration_Stat207_minus: 0.0
   syst_JES_EtaIntercalibration_Stat208_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat208_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat208_minus: 0.0
   syst_JES_EtaIntercalibration_Stat209_plus: 6.02030714e-04
   syst_JES_EtaIntercalibration_Stat209_minus: -2.23799296e-03
   syst_JES_EtaIntercalibration_Stat21_plus: 0.0
@@ -90061,7 +90061,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat220_plus: 0.0
   syst_JES_EtaIntercalibration_Stat220_minus: 0.0
   syst_JES_EtaIntercalibration_Stat221_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat221_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat221_minus: 0.0
   syst_JES_EtaIntercalibration_Stat222_plus: 2.37870721e-03
   syst_JES_EtaIntercalibration_Stat222_minus: 0.0
   syst_JES_EtaIntercalibration_Stat223_plus: -1.10025815e-27
@@ -90087,7 +90087,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat232_plus: 0.0
   syst_JES_EtaIntercalibration_Stat232_minus: 0.0
   syst_JES_EtaIntercalibration_Stat233_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat233_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat233_minus: 0.0
   syst_JES_EtaIntercalibration_Stat234_plus: -1.21127392e-27
   syst_JES_EtaIntercalibration_Stat234_minus: 1.12500689e-03
   syst_JES_EtaIntercalibration_Stat235_plus: 0.0
@@ -90247,7 +90247,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat80_plus: 0.0
   syst_JES_EtaIntercalibration_Stat80_minus: 0.0
   syst_JES_EtaIntercalibration_Stat81_plus: 8.21092394e-04
-  syst_JES_EtaIntercalibration_Stat81_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat81_minus: 0.0
   syst_JES_EtaIntercalibration_Stat82_plus: 7.46068365e-01
   syst_JES_EtaIntercalibration_Stat82_minus: -6.16031428e-01
   syst_JES_EtaIntercalibration_Stat83_plus: 2.18495995e+00
@@ -90356,11 +90356,11 @@ bins:
   syst_JES_MJB_Stat5_minus: -1.82221418e-36
   syst_JES_MJB_Stat6_plus: -9.56503343e-02
   syst_JES_MJB_Stat6_minus: 0.0
-  syst_JES_MJB_Stat7_plus: -0.0
+  syst_JES_MJB_Stat7_plus: 0.0
   syst_JES_MJB_Stat7_minus: 0.0
-  syst_JES_MJB_Stat8_plus: -0.0
-  syst_JES_MJB_Stat8_minus: -0.0
-  syst_JES_MJB_Stat9_plus: -0.0
+  syst_JES_MJB_Stat8_plus: 0.0
+  syst_JES_MJB_Stat8_minus: 0.0
+  syst_JES_MJB_Stat9_plus: 0.0
   syst_JES_MJB_Stat9_minus: 0.0
   syst_JES_MJB_Threshold_plus: -6.43396460e-03
   syst_JES_MJB_Threshold_minus: 2.55265548e-03
@@ -90457,7 +90457,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat101_plus: 0.0
   syst_JES_EtaIntercalibration_Stat101_minus: 0.0
   syst_JES_EtaIntercalibration_Stat102_plus: 2.81082017e-03
-  syst_JES_EtaIntercalibration_Stat102_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat102_minus: 0.0
   syst_JES_EtaIntercalibration_Stat103_plus: 2.58730371e-01
   syst_JES_EtaIntercalibration_Stat103_minus: -1.86746901e-01
   syst_JES_EtaIntercalibration_Stat104_plus: 8.42305598e-01
@@ -90501,7 +90501,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat121_plus: 0.0
   syst_JES_EtaIntercalibration_Stat121_minus: 0.0
   syst_JES_EtaIntercalibration_Stat122_plus: 2.81110301e-03
-  syst_JES_EtaIntercalibration_Stat122_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat122_minus: 0.0
   syst_JES_EtaIntercalibration_Stat123_plus: 2.22950768e-01
   syst_JES_EtaIntercalibration_Stat123_minus: -1.86534769e-01
   syst_JES_EtaIntercalibration_Stat124_plus: 7.39845825e-01
@@ -90543,7 +90543,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat140_plus: 0.0
   syst_JES_EtaIntercalibration_Stat140_minus: 0.0
   syst_JES_EtaIntercalibration_Stat141_plus: 2.82192174e-03
-  syst_JES_EtaIntercalibration_Stat141_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat141_minus: 0.0
   syst_JES_EtaIntercalibration_Stat142_plus: 1.13702770e-01
   syst_JES_EtaIntercalibration_Stat142_minus: -4.21294220e-02
   syst_JES_EtaIntercalibration_Stat143_plus: 1.97919188e-01
@@ -90579,7 +90579,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat157_plus: 0.0
   syst_JES_EtaIntercalibration_Stat157_minus: 0.0
   syst_JES_EtaIntercalibration_Stat158_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat158_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat158_minus: 0.0
   syst_JES_EtaIntercalibration_Stat159_plus: -9.94404266e-04
   syst_JES_EtaIntercalibration_Stat159_minus: 5.38886078e-03
   syst_JES_EtaIntercalibration_Stat16_plus: 1.88514668e-01
@@ -90619,7 +90619,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat175_plus: 0.0
   syst_JES_EtaIntercalibration_Stat175_minus: 0.0
   syst_JES_EtaIntercalibration_Stat176_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat176_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat176_minus: 0.0
   syst_JES_EtaIntercalibration_Stat177_plus: -4.95399011e-03
   syst_JES_EtaIntercalibration_Stat177_minus: 7.09864498e-03
   syst_JES_EtaIntercalibration_Stat178_plus: -3.41744707e-04
@@ -90657,7 +90657,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat192_plus: 0.0
   syst_JES_EtaIntercalibration_Stat192_minus: 0.0
   syst_JES_EtaIntercalibration_Stat193_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat193_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat193_minus: 0.0
   syst_JES_EtaIntercalibration_Stat194_plus: -1.26147850e-03
   syst_JES_EtaIntercalibration_Stat194_minus: 9.18885262e-04
   syst_JES_EtaIntercalibration_Stat195_plus: -6.03657059e-03
@@ -90691,7 +90691,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat207_plus: 0.0
   syst_JES_EtaIntercalibration_Stat207_minus: 0.0
   syst_JES_EtaIntercalibration_Stat208_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat208_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat208_minus: 0.0
   syst_JES_EtaIntercalibration_Stat209_plus: 2.78175808e-04
   syst_JES_EtaIntercalibration_Stat209_minus: -1.03379011e-03
   syst_JES_EtaIntercalibration_Stat21_plus: 0.0
@@ -90721,7 +90721,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat220_plus: 0.0
   syst_JES_EtaIntercalibration_Stat220_minus: 0.0
   syst_JES_EtaIntercalibration_Stat221_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat221_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat221_minus: 0.0
   syst_JES_EtaIntercalibration_Stat222_plus: 1.09955104e-03
   syst_JES_EtaIntercalibration_Stat222_minus: 0.0
   syst_JES_EtaIntercalibration_Stat223_plus: -1.84413449e-19
@@ -90747,7 +90747,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat232_plus: 0.0
   syst_JES_EtaIntercalibration_Stat232_minus: 0.0
   syst_JES_EtaIntercalibration_Stat233_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat233_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat233_minus: 0.0
   syst_JES_EtaIntercalibration_Stat234_plus: -2.03081068e-19
   syst_JES_EtaIntercalibration_Stat234_minus: 5.19652773e-04
   syst_JES_EtaIntercalibration_Stat235_plus: 0.0
@@ -90907,7 +90907,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat80_plus: 0.0
   syst_JES_EtaIntercalibration_Stat80_minus: 0.0
   syst_JES_EtaIntercalibration_Stat81_plus: 2.80827458e-03
-  syst_JES_EtaIntercalibration_Stat81_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat81_minus: 0.0
   syst_JES_EtaIntercalibration_Stat82_plus: 2.88923831e-01
   syst_JES_EtaIntercalibration_Stat82_minus: -2.29880415e-01
   syst_JES_EtaIntercalibration_Stat83_plus: 8.20173155e-01
@@ -91016,11 +91016,11 @@ bins:
   syst_JES_MJB_Stat5_minus: -5.28350187e-26
   syst_JES_MJB_Stat6_plus: -4.41941738e-02
   syst_JES_MJB_Stat6_minus: 7.54341514e-33
-  syst_JES_MJB_Stat7_plus: -0.0
+  syst_JES_MJB_Stat7_plus: 0.0
   syst_JES_MJB_Stat7_minus: 0.0
-  syst_JES_MJB_Stat8_plus: -0.0
-  syst_JES_MJB_Stat8_minus: -0.0
-  syst_JES_MJB_Stat9_plus: -0.0
+  syst_JES_MJB_Stat8_plus: 0.0
+  syst_JES_MJB_Stat8_minus: 0.0
+  syst_JES_MJB_Stat9_plus: 0.0
   syst_JES_MJB_Stat9_minus: 0.0
   syst_JES_MJB_Threshold_plus: -1.25652875e-02
   syst_JES_MJB_Threshold_minus: 1.07268099e-02
@@ -91676,11 +91676,11 @@ bins:
   syst_JES_MJB_Stat5_minus: -8.72994032e-19
   syst_JES_MJB_Stat6_plus: -2.10364267e-02
   syst_JES_MJB_Stat6_minus: 1.02106219e-23
-  syst_JES_MJB_Stat7_plus: -0.0
+  syst_JES_MJB_Stat7_plus: 0.0
   syst_JES_MJB_Stat7_minus: 0.0
-  syst_JES_MJB_Stat8_plus: -0.0
-  syst_JES_MJB_Stat8_minus: -0.0
-  syst_JES_MJB_Stat9_plus: -0.0
+  syst_JES_MJB_Stat8_plus: 0.0
+  syst_JES_MJB_Stat8_minus: 0.0
+  syst_JES_MJB_Stat9_plus: 0.0
   syst_JES_MJB_Stat9_minus: 0.0
   syst_JES_MJB_Threshold_plus: -1.98414163e-02
   syst_JES_MJB_Threshold_minus: 1.89009643e-02
@@ -92336,11 +92336,11 @@ bins:
   syst_JES_MJB_Stat5_minus: -1.14622009e-13
   syst_JES_MJB_Stat6_plus: -9.83939086e-03
   syst_JES_MJB_Stat6_minus: 4.26385389e-17
-  syst_JES_MJB_Stat7_plus: -0.0
+  syst_JES_MJB_Stat7_plus: 0.0
   syst_JES_MJB_Stat7_minus: 5.25168206e-44
-  syst_JES_MJB_Stat8_plus: -0.0
-  syst_JES_MJB_Stat8_minus: -0.0
-  syst_JES_MJB_Stat9_plus: -0.0
+  syst_JES_MJB_Stat8_plus: 0.0
+  syst_JES_MJB_Stat8_minus: 0.0
+  syst_JES_MJB_Stat9_plus: 0.0
   syst_JES_MJB_Stat9_minus: 0.0
   syst_JES_MJB_Threshold_plus: -1.90423856e-02
   syst_JES_MJB_Threshold_minus: 1.73948268e-02
@@ -92998,9 +92998,9 @@ bins:
   syst_JES_MJB_Stat6_minus: 1.22470895e-12
   syst_JES_MJB_Stat7_plus: -5.48573441e-41
   syst_JES_MJB_Stat7_minus: 1.17309015e-32
-  syst_JES_MJB_Stat8_plus: -0.0
+  syst_JES_MJB_Stat8_plus: 0.0
   syst_JES_MJB_Stat8_minus: -1.19076782e-41
-  syst_JES_MJB_Stat9_plus: -0.0
+  syst_JES_MJB_Stat9_plus: 0.0
   syst_JES_MJB_Stat9_minus: 0.0
   syst_JES_MJB_Threshold_plus: -1.11722871e-02
   syst_JES_MJB_Threshold_minus: 4.34092853e-03
@@ -93660,7 +93660,7 @@ bins:
   syst_JES_MJB_Stat7_minus: 1.86110505e-24
   syst_JES_MJB_Stat8_plus: 0.0
   syst_JES_MJB_Stat8_minus: -1.48845977e-31
-  syst_JES_MJB_Stat9_plus: -0.0
+  syst_JES_MJB_Stat9_plus: 0.0
   syst_JES_MJB_Stat9_minus: 0.0
   syst_JES_MJB_Threshold_plus: 0.0
   syst_JES_MJB_Threshold_minus: -4.28365288e-03

--- a/nnpdf_data/nnpdf_data/commondata/ATLAS_1JET_8TEV_R06/uncertainties_decorrelated.yaml
+++ b/nnpdf_data/nnpdf_data/commondata/ATLAS_1JET_8TEV_R06/uncertainties_decorrelated.yaml
@@ -2974,13 +2974,13 @@ bins:
   syst_JES_EtaIntercalibration_Stat213_minus: 0.0
   syst_JES_EtaIntercalibration_Stat214_plus: 0.0
   syst_JES_EtaIntercalibration_Stat214_minus: 0.0
-  syst_JES_EtaIntercalibration_Stat215_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat215_plus: 0.0
   syst_JES_EtaIntercalibration_Stat215_minus: 0.0
   syst_JES_EtaIntercalibration_Stat216_plus: 3.05682262e-02
   syst_JES_EtaIntercalibration_Stat216_minus: 0.0
-  syst_JES_EtaIntercalibration_Stat217_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat217_plus: 0.0
   syst_JES_EtaIntercalibration_Stat217_minus: 9.46674559e-02
-  syst_JES_EtaIntercalibration_Stat218_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat218_plus: 0.0
   syst_JES_EtaIntercalibration_Stat218_minus: 3.91383603e-02
   syst_JES_EtaIntercalibration_Stat219_plus: 0.0
   syst_JES_EtaIntercalibration_Stat219_minus: 0.0
@@ -3026,13 +3026,13 @@ bins:
   syst_JES_EtaIntercalibration_Stat237_minus: 0.0
   syst_JES_EtaIntercalibration_Stat238_plus: -6.54498037e-02
   syst_JES_EtaIntercalibration_Stat238_minus: 0.0
-  syst_JES_EtaIntercalibration_Stat239_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat239_plus: 0.0
   syst_JES_EtaIntercalibration_Stat239_minus: 0.0
   syst_JES_EtaIntercalibration_Stat24_plus: 0.0
   syst_JES_EtaIntercalibration_Stat24_minus: 0.0
-  syst_JES_EtaIntercalibration_Stat240_plus: -0.0
-  syst_JES_EtaIntercalibration_Stat240_minus: -0.0
-  syst_JES_EtaIntercalibration_Stat241_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat240_plus: 0.0
+  syst_JES_EtaIntercalibration_Stat240_minus: 0.0
+  syst_JES_EtaIntercalibration_Stat241_plus: 0.0
   syst_JES_EtaIntercalibration_Stat241_minus: 0.0
   syst_JES_EtaIntercalibration_Stat242_plus: 0.0
   syst_JES_EtaIntercalibration_Stat242_minus: 0.0
@@ -3280,7 +3280,7 @@ bins:
   syst_JES_MJB_Stat5_minus: -7.68766493e-02
   syst_JES_MJB_Stat6_plus: 4.08919852e-02
   syst_JES_MJB_Stat6_minus: 0.0
-  syst_JES_MJB_Stat7_plus: -0.0
+  syst_JES_MJB_Stat7_plus: 0.0
   syst_JES_MJB_Stat7_minus: -3.61755829e-02
   syst_JES_MJB_Stat8_plus: 0.0
   syst_JES_MJB_Stat8_minus: -3.74837305e-02
@@ -3340,18 +3340,18 @@ bins:
   syst_Unfolding_bias_minus: 2.96801000e+01
   syst_jetselection_BCH_plus: 9.50082813e+01
   syst_jetselection_BCH_minus: -9.50082813e+01
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 1.32653232e+03
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -1.23566910e+03
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 5.70705883e-04
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -6.24163156e-04
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -1.41011234e+03
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_minus: 1.53180542e+03
   syst_splitted_3_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 2.24223560e+02
@@ -3646,7 +3646,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat213_minus: 0.0
   syst_JES_EtaIntercalibration_Stat214_plus: 0.0
   syst_JES_EtaIntercalibration_Stat214_minus: 0.0
-  syst_JES_EtaIntercalibration_Stat215_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat215_plus: 0.0
   syst_JES_EtaIntercalibration_Stat215_minus: 1.88656089e-33
   syst_JES_EtaIntercalibration_Stat216_plus: 1.27279221e-02
   syst_JES_EtaIntercalibration_Stat216_minus: 0.0
@@ -3698,13 +3698,13 @@ bins:
   syst_JES_EtaIntercalibration_Stat237_minus: 0.0
   syst_JES_EtaIntercalibration_Stat238_plus: -2.72561380e-02
   syst_JES_EtaIntercalibration_Stat238_minus: 0.0
-  syst_JES_EtaIntercalibration_Stat239_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat239_plus: 0.0
   syst_JES_EtaIntercalibration_Stat239_minus: 0.0
   syst_JES_EtaIntercalibration_Stat24_plus: 0.0
   syst_JES_EtaIntercalibration_Stat24_minus: 0.0
-  syst_JES_EtaIntercalibration_Stat240_plus: -0.0
-  syst_JES_EtaIntercalibration_Stat240_minus: -0.0
-  syst_JES_EtaIntercalibration_Stat241_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat240_plus: 0.0
+  syst_JES_EtaIntercalibration_Stat240_minus: 0.0
+  syst_JES_EtaIntercalibration_Stat241_plus: 0.0
   syst_JES_EtaIntercalibration_Stat241_minus: 0.0
   syst_JES_EtaIntercalibration_Stat242_plus: 0.0
   syst_JES_EtaIntercalibration_Stat242_minus: 0.0
@@ -3718,9 +3718,9 @@ bins:
   syst_JES_EtaIntercalibration_Stat246_minus: 1.19218203e-01
   syst_JES_EtaIntercalibration_Stat247_plus: 0.0
   syst_JES_EtaIntercalibration_Stat247_minus: 1.46795368e-02
-  syst_JES_EtaIntercalibration_Stat248_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat248_plus: 0.0
   syst_JES_EtaIntercalibration_Stat248_minus: 9.63503700e-02
-  syst_JES_EtaIntercalibration_Stat249_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat249_plus: 0.0
   syst_JES_EtaIntercalibration_Stat249_minus: 1.46936789e-01
   syst_JES_EtaIntercalibration_Stat25_plus: 0.0
   syst_JES_EtaIntercalibration_Stat25_minus: 0.0
@@ -3952,12 +3952,12 @@ bins:
   syst_JES_MJB_Stat5_minus: -3.20107240e-02
   syst_JES_MJB_Stat6_plus: 1.70271313e-02
   syst_JES_MJB_Stat6_minus: 0.0
-  syst_JES_MJB_Stat7_plus: -0.0
+  syst_JES_MJB_Stat7_plus: 0.0
   syst_JES_MJB_Stat7_minus: -1.50613744e-02
-  syst_JES_MJB_Stat8_plus: -0.0
+  syst_JES_MJB_Stat8_plus: 0.0
   syst_JES_MJB_Stat8_minus: -1.56058467e-02
   syst_JES_MJB_Stat9_plus: 0.0
-  syst_JES_MJB_Stat9_minus: -0.0
+  syst_JES_MJB_Stat9_minus: 0.0
   syst_JES_MJB_Threshold_plus: 3.53341259e-03
   syst_JES_MJB_Threshold_minus: -3.87706648e-03
   syst_JES_Pileup_MuOffset_plus: -1.81655732e+01
@@ -4012,18 +4012,18 @@ bins:
   syst_Unfolding_bias_minus: -3.64089282e+00
   syst_jetselection_BCH_plus: 4.72842305e+01
   syst_jetselection_BCH_minus: -4.72842305e+01
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 4.72616030e+02
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -4.38632479e+02
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 3.42734657e-03
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -3.75544411e-03
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -5.29460345e+02
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_minus: 5.70981655e+02
   syst_splitted_3_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 7.98868028e+01
@@ -4370,13 +4370,13 @@ bins:
   syst_JES_EtaIntercalibration_Stat237_minus: 0.0
   syst_JES_EtaIntercalibration_Stat238_plus: -1.24026529e-02
   syst_JES_EtaIntercalibration_Stat238_minus: 0.0
-  syst_JES_EtaIntercalibration_Stat239_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat239_plus: 0.0
   syst_JES_EtaIntercalibration_Stat239_minus: 0.0
   syst_JES_EtaIntercalibration_Stat24_plus: 0.0
   syst_JES_EtaIntercalibration_Stat24_minus: 0.0
-  syst_JES_EtaIntercalibration_Stat240_plus: -0.0
-  syst_JES_EtaIntercalibration_Stat240_minus: -0.0
-  syst_JES_EtaIntercalibration_Stat241_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat240_plus: 0.0
+  syst_JES_EtaIntercalibration_Stat240_minus: 0.0
+  syst_JES_EtaIntercalibration_Stat241_plus: 0.0
   syst_JES_EtaIntercalibration_Stat241_minus: 0.0
   syst_JES_EtaIntercalibration_Stat242_plus: 0.0
   syst_JES_EtaIntercalibration_Stat242_minus: 0.0
@@ -4388,11 +4388,11 @@ bins:
   syst_JES_EtaIntercalibration_Stat245_minus: 0.0
   syst_JES_EtaIntercalibration_Stat246_plus: -2.98045508e-02
   syst_JES_EtaIntercalibration_Stat246_minus: 5.42421612e-02
-  syst_JES_EtaIntercalibration_Stat247_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat247_plus: 0.0
   syst_JES_EtaIntercalibration_Stat247_minus: 6.67862355e-03
-  syst_JES_EtaIntercalibration_Stat248_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat248_plus: 0.0
   syst_JES_EtaIntercalibration_Stat248_minus: 4.38406204e-02
-  syst_JES_EtaIntercalibration_Stat249_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat249_plus: 0.0
   syst_JES_EtaIntercalibration_Stat249_minus: 6.68710883e-02
   syst_JES_EtaIntercalibration_Stat25_plus: 0.0
   syst_JES_EtaIntercalibration_Stat25_minus: 0.0
@@ -4613,7 +4613,7 @@ bins:
   syst_JES_MJB_Stat1_plus: -2.78310158e-02
   syst_JES_MJB_Stat1_minus: 1.18016122e-04
   syst_JES_MJB_Stat10_plus: 0.0
-  syst_JES_MJB_Stat10_minus: -0.0
+  syst_JES_MJB_Stat10_minus: 0.0
   syst_JES_MJB_Stat2_plus: 8.83954187e-04
   syst_JES_MJB_Stat2_minus: -2.26415591e-02
   syst_JES_MJB_Stat3_plus: -5.23259018e-03
@@ -4624,12 +4624,12 @@ bins:
   syst_JES_MJB_Stat5_minus: -1.45663997e-02
   syst_JES_MJB_Stat6_plus: 7.74706189e-03
   syst_JES_MJB_Stat6_minus: 0.0
-  syst_JES_MJB_Stat7_plus: -0.0
+  syst_JES_MJB_Stat7_plus: 0.0
   syst_JES_MJB_Stat7_minus: -6.85398603e-03
-  syst_JES_MJB_Stat8_plus: -0.0
+  syst_JES_MJB_Stat8_plus: 0.0
   syst_JES_MJB_Stat8_minus: -7.10147340e-03
   syst_JES_MJB_Stat9_plus: 0.0
-  syst_JES_MJB_Stat9_minus: -0.0
+  syst_JES_MJB_Stat9_minus: 0.0
   syst_JES_MJB_Threshold_plus: 1.65604408e-03
   syst_JES_MJB_Threshold_minus: -2.06758023e-03
   syst_JES_Pileup_MuOffset_plus: -7.18632622e+00
@@ -4690,12 +4690,12 @@ bins:
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -1.78480823e+02
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 1.62210296e-03
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -2.00323351e-03
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -2.23848794e+02
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_minus: 2.35332208e+02
   syst_splitted_3_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 3.20729494e+01
@@ -5042,13 +5042,13 @@ bins:
   syst_JES_EtaIntercalibration_Stat237_minus: 0.0
   syst_JES_EtaIntercalibration_Stat238_plus: -5.87322892e-03
   syst_JES_EtaIntercalibration_Stat238_minus: 0.0
-  syst_JES_EtaIntercalibration_Stat239_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat239_plus: 0.0
   syst_JES_EtaIntercalibration_Stat239_minus: 0.0
   syst_JES_EtaIntercalibration_Stat24_plus: 0.0
   syst_JES_EtaIntercalibration_Stat24_minus: 0.0
-  syst_JES_EtaIntercalibration_Stat240_plus: -0.0
-  syst_JES_EtaIntercalibration_Stat240_minus: -0.0
-  syst_JES_EtaIntercalibration_Stat241_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat240_plus: 0.0
+  syst_JES_EtaIntercalibration_Stat240_minus: 0.0
+  syst_JES_EtaIntercalibration_Stat241_plus: 0.0
   syst_JES_EtaIntercalibration_Stat241_minus: 0.0
   syst_JES_EtaIntercalibration_Stat242_plus: 0.0
   syst_JES_EtaIntercalibration_Stat242_minus: 0.0
@@ -5060,11 +5060,11 @@ bins:
   syst_JES_EtaIntercalibration_Stat245_minus: 0.0
   syst_JES_EtaIntercalibration_Stat246_plus: -1.41138514e-02
   syst_JES_EtaIntercalibration_Stat246_minus: 2.56891894e-02
-  syst_JES_EtaIntercalibration_Stat247_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat247_plus: 0.0
   syst_JES_EtaIntercalibration_Stat247_minus: 3.16288863e-03
-  syst_JES_EtaIntercalibration_Stat248_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat248_plus: 0.0
   syst_JES_EtaIntercalibration_Stat248_minus: 2.07606551e-02
-  syst_JES_EtaIntercalibration_Stat249_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat249_plus: 0.0
   syst_JES_EtaIntercalibration_Stat249_minus: 3.16642417e-02
   syst_JES_EtaIntercalibration_Stat25_plus: 0.0
   syst_JES_EtaIntercalibration_Stat25_minus: 0.0
@@ -5285,7 +5285,7 @@ bins:
   syst_JES_MJB_Stat1_plus: -1.65533697e-02
   syst_JES_MJB_Stat1_minus: 3.34461508e-03
   syst_JES_MJB_Stat10_plus: 0.0
-  syst_JES_MJB_Stat10_minus: -0.0
+  syst_JES_MJB_Stat10_minus: 0.0
   syst_JES_MJB_Stat2_plus: 5.17885007e-03
   syst_JES_MJB_Stat2_minus: -1.22965869e-02
   syst_JES_MJB_Stat3_plus: -2.91893679e-03
@@ -5296,12 +5296,12 @@ bins:
   syst_JES_MJB_Stat5_minus: -6.89782665e-03
   syst_JES_MJB_Stat6_plus: 3.66917709e-03
   syst_JES_MJB_Stat6_minus: 0.0
-  syst_JES_MJB_Stat7_plus: -0.0
+  syst_JES_MJB_Stat7_plus: 0.0
   syst_JES_MJB_Stat7_minus: -3.24632723e-03
-  syst_JES_MJB_Stat8_plus: -0.0
+  syst_JES_MJB_Stat8_plus: 0.0
   syst_JES_MJB_Stat8_minus: -3.36299985e-03
   syst_JES_MJB_Stat9_plus: 0.0
-  syst_JES_MJB_Stat9_minus: -0.0
+  syst_JES_MJB_Stat9_minus: 0.0
   syst_JES_MJB_Threshold_plus: -1.46017550e-02
   syst_JES_MJB_Threshold_minus: 1.50189480e-02
   syst_JES_Pileup_MuOffset_plus: -3.37431356e+00
@@ -5362,11 +5362,11 @@ bins:
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -7.55140545e+01
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: -1.40360696e-02
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 1.45027601e-02
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
-  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
+  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -9.87700894e+01
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_minus: 1.02792113e+02
@@ -5732,11 +5732,11 @@ bins:
   syst_JES_EtaIntercalibration_Stat245_minus: 0.0
   syst_JES_EtaIntercalibration_Stat246_plus: -6.92186828e-03
   syst_JES_EtaIntercalibration_Stat246_minus: 1.25935718e-02
-  syst_JES_EtaIntercalibration_Stat247_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat247_plus: 0.0
   syst_JES_EtaIntercalibration_Stat247_minus: 1.55068517e-03
-  syst_JES_EtaIntercalibration_Stat248_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat248_plus: 0.0
   syst_JES_EtaIntercalibration_Stat248_minus: 1.01823376e-02
-  syst_JES_EtaIntercalibration_Stat249_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat249_plus: 0.0
   syst_JES_EtaIntercalibration_Stat249_minus: 1.55280649e-02
   syst_JES_EtaIntercalibration_Stat25_plus: 0.0
   syst_JES_EtaIntercalibration_Stat25_minus: 0.0
@@ -5957,7 +5957,7 @@ bins:
   syst_JES_MJB_Stat1_plus: -2.16091832e-02
   syst_JES_MJB_Stat1_minus: 1.50896587e-02
   syst_JES_MJB_Stat10_plus: 0.0
-  syst_JES_MJB_Stat10_minus: -0.0
+  syst_JES_MJB_Stat10_minus: 0.0
   syst_JES_MJB_Stat2_plus: 1.00154604e-02
   syst_JES_MJB_Stat2_minus: -1.15187695e-02
   syst_JES_MJB_Stat3_plus: -2.83832662e-03
@@ -5968,12 +5968,12 @@ bins:
   syst_JES_MJB_Stat5_minus: -3.38209173e-03
   syst_JES_MJB_Stat6_plus: 1.79887965e-03
   syst_JES_MJB_Stat6_minus: 0.0
-  syst_JES_MJB_Stat7_plus: -0.0
+  syst_JES_MJB_Stat7_plus: 0.0
   syst_JES_MJB_Stat7_minus: -1.59169736e-03
-  syst_JES_MJB_Stat8_plus: -0.0
+  syst_JES_MJB_Stat8_plus: 0.0
   syst_JES_MJB_Stat8_minus: -1.64897301e-03
   syst_JES_MJB_Stat9_plus: 0.0
-  syst_JES_MJB_Stat9_minus: -0.0
+  syst_JES_MJB_Stat9_minus: 0.0
   syst_JES_MJB_Threshold_plus: -4.00363860e-02
   syst_JES_MJB_Threshold_minus: 4.42295292e-02
   syst_JES_Pileup_MuOffset_plus: -1.69705627e+00
@@ -6034,11 +6034,11 @@ bins:
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -3.32021989e+01
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: -3.84595378e-02
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 4.25466150e-02
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
-  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
+  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -4.51091700e+01
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_minus: 4.71845284e+01
@@ -6404,11 +6404,11 @@ bins:
   syst_JES_EtaIntercalibration_Stat245_minus: 0.0
   syst_JES_EtaIntercalibration_Stat246_plus: -3.49735014e-03
   syst_JES_EtaIntercalibration_Stat246_minus: 6.36466814e-03
-  syst_JES_EtaIntercalibration_Stat247_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat247_plus: 0.0
   syst_JES_EtaIntercalibration_Stat247_minus: 7.83757156e-04
-  syst_JES_EtaIntercalibration_Stat248_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat248_plus: 0.0
   syst_JES_EtaIntercalibration_Stat248_minus: 5.14420183e-03
-  syst_JES_EtaIntercalibration_Stat249_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat249_plus: 0.0
   syst_JES_EtaIntercalibration_Stat249_minus: 7.84676395e-03
   syst_JES_EtaIntercalibration_Stat25_plus: 0.0
   syst_JES_EtaIntercalibration_Stat25_minus: 0.0
@@ -6629,7 +6629,7 @@ bins:
   syst_JES_MJB_Stat1_plus: -2.85953982e-02
   syst_JES_MJB_Stat1_minus: 2.69358186e-02
   syst_JES_MJB_Stat10_plus: 0.0
-  syst_JES_MJB_Stat10_minus: -0.0
+  syst_JES_MJB_Stat10_minus: 0.0
   syst_JES_MJB_Stat2_plus: 9.45118924e-03
   syst_JES_MJB_Stat2_minus: -1.10803633e-02
   syst_JES_MJB_Stat3_plus: -2.55972655e-03
@@ -6640,12 +6640,12 @@ bins:
   syst_JES_MJB_Stat5_minus: -1.70907709e-03
   syst_JES_MJB_Stat6_plus: 9.09127189e-04
   syst_JES_MJB_Stat6_minus: 0.0
-  syst_JES_MJB_Stat7_plus: -0.0
+  syst_JES_MJB_Stat7_plus: 0.0
   syst_JES_MJB_Stat7_minus: -8.04333964e-04
-  syst_JES_MJB_Stat8_plus: -0.0
+  syst_JES_MJB_Stat8_plus: 0.0
   syst_JES_MJB_Stat8_minus: -8.33325342e-04
   syst_JES_MJB_Stat9_plus: 0.0
-  syst_JES_MJB_Stat9_minus: -0.0
+  syst_JES_MJB_Stat9_minus: 0.0
   syst_JES_MJB_Threshold_plus: -5.46310699e-02
   syst_JES_MJB_Threshold_minus: 6.30244274e-02
   syst_JES_Pileup_MuOffset_plus: -8.66983624e-01
@@ -6706,11 +6706,11 @@ bins:
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -1.52381511e+01
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: -5.27218816e-02
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 6.04293455e-02
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
-  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
+  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -2.15455436e+01
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_minus: 2.23587164e+01
@@ -7076,11 +7076,11 @@ bins:
   syst_JES_EtaIntercalibration_Stat245_minus: 0.0
   syst_JES_EtaIntercalibration_Stat246_plus: -1.79322280e-03
   syst_JES_EtaIntercalibration_Stat246_minus: 3.26259069e-03
-  syst_JES_EtaIntercalibration_Stat247_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat247_plus: 0.0
   syst_JES_EtaIntercalibration_Stat247_minus: 4.01778073e-04
-  syst_JES_EtaIntercalibration_Stat248_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat248_plus: 0.0
   syst_JES_EtaIntercalibration_Stat248_minus: 2.63750829e-03
-  syst_JES_EtaIntercalibration_Stat249_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat249_plus: 0.0
   syst_JES_EtaIntercalibration_Stat249_minus: 4.02273048e-03
   syst_JES_EtaIntercalibration_Stat25_plus: 0.0
   syst_JES_EtaIntercalibration_Stat25_minus: 0.0
@@ -7301,7 +7301,7 @@ bins:
   syst_JES_MJB_Stat1_plus: -2.49891536e-02
   syst_JES_MJB_Stat1_minus: 2.42325494e-02
   syst_JES_MJB_Stat10_plus: 0.0
-  syst_JES_MJB_Stat10_minus: -0.0
+  syst_JES_MJB_Stat10_minus: 0.0
   syst_JES_MJB_Stat2_plus: 3.08015714e-03
   syst_JES_MJB_Stat2_minus: -4.41376053e-03
   syst_JES_MJB_Stat3_plus: -1.57684812e-03
@@ -7314,10 +7314,10 @@ bins:
   syst_JES_MJB_Stat6_minus: 0.0
   syst_JES_MJB_Stat7_plus: 0.0
   syst_JES_MJB_Stat7_minus: -4.12313964e-04
-  syst_JES_MJB_Stat8_plus: -0.0
+  syst_JES_MJB_Stat8_plus: 0.0
   syst_JES_MJB_Stat8_minus: -4.27233917e-04
   syst_JES_MJB_Stat9_plus: 0.0
-  syst_JES_MJB_Stat9_minus: -0.0
+  syst_JES_MJB_Stat9_minus: 0.0
   syst_JES_MJB_Threshold_plus: -4.94338351e-02
   syst_JES_MJB_Threshold_minus: 5.35138412e-02
   syst_JES_Pileup_MuOffset_plus: -4.11536147e-01
@@ -7329,7 +7329,7 @@ bins:
   syst_JES_Punch_through_plus: 1.87171165e-01
   syst_JES_Punch_through_minus: -9.03753177e-02
   syst_JES_SingleParticle_HighPt_plus: 1.01399112e-03
-  syst_JES_SingleParticle_HighPt_minus: -0.0
+  syst_JES_SingleParticle_HighPt_minus: 0.0
   syst_JES_Zjet_JVF_plus: 2.56750472e-01
   syst_JES_Zjet_JVF_minus: -2.53922045e-01
   syst_JES_Zjet_MC_plus: 4.55447478e+00
@@ -7378,11 +7378,11 @@ bins:
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -7.04136933e+00
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: -4.80903322e-02
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 5.12935259e-02
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
-  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
+  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -1.03944697e+01
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_minus: 1.07763073e+01
@@ -7748,11 +7748,11 @@ bins:
   syst_JES_EtaIntercalibration_Stat245_minus: 0.0
   syst_JES_EtaIntercalibration_Stat246_plus: -9.49432275e-04
   syst_JES_EtaIntercalibration_Stat246_minus: 1.72746187e-03
-  syst_JES_EtaIntercalibration_Stat247_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat247_plus: 0.0
   syst_JES_EtaIntercalibration_Stat247_minus: 2.12768430e-04
-  syst_JES_EtaIntercalibration_Stat248_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat248_plus: 0.0
   syst_JES_EtaIntercalibration_Stat248_minus: 1.39653589e-03
-  syst_JES_EtaIntercalibration_Stat249_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat249_plus: 0.0
   syst_JES_EtaIntercalibration_Stat249_minus: 2.12980562e-03
   syst_JES_EtaIntercalibration_Stat25_plus: 0.0
   syst_JES_EtaIntercalibration_Stat25_minus: 0.0
@@ -7973,7 +7973,7 @@ bins:
   syst_JES_MJB_Stat1_plus: -1.30461201e-02
   syst_JES_MJB_Stat1_minus: 5.91282690e-03
   syst_JES_MJB_Stat10_plus: 0.0
-  syst_JES_MJB_Stat10_minus: -0.0
+  syst_JES_MJB_Stat10_minus: 0.0
   syst_JES_MJB_Stat2_plus: -6.82145912e-03
   syst_JES_MJB_Stat2_minus: 7.40199379e-03
   syst_JES_MJB_Stat3_plus: -1.51674405e-04
@@ -8001,7 +8001,7 @@ bins:
   syst_JES_Punch_through_plus: 7.93868783e-02
   syst_JES_Punch_through_minus: -4.05879292e-02
   syst_JES_SingleParticle_HighPt_plus: 5.36835468e-04
-  syst_JES_SingleParticle_HighPt_minus: -0.0
+  syst_JES_SingleParticle_HighPt_minus: 0.0
   syst_JES_Zjet_JVF_plus: 1.33572471e-01
   syst_JES_Zjet_JVF_minus: -1.43047702e-01
   syst_JES_Zjet_MC_plus: 2.47628795e+00
@@ -8050,11 +8050,11 @@ bins:
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -3.34602929e+00
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: -3.47684404e-02
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 3.04480180e-02
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
-  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
+  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -5.11026071e+00
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_minus: 5.32097853e+00
@@ -8420,7 +8420,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat245_minus: 0.0
   syst_JES_EtaIntercalibration_Stat246_plus: -5.26794552e-04
   syst_JES_EtaIntercalibration_Stat246_minus: 9.58624663e-04
-  syst_JES_EtaIntercalibration_Stat247_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat247_plus: 0.0
   syst_JES_EtaIntercalibration_Stat247_minus: 1.18016122e-04
   syst_JES_EtaIntercalibration_Stat248_plus: -1.22612316e-38
   syst_JES_EtaIntercalibration_Stat248_minus: 7.74776900e-04
@@ -8645,7 +8645,7 @@ bins:
   syst_JES_MJB_Stat1_plus: 0.0
   syst_JES_MJB_Stat1_minus: -6.52871691e-03
   syst_JES_MJB_Stat10_plus: 0.0
-  syst_JES_MJB_Stat10_minus: -0.0
+  syst_JES_MJB_Stat10_minus: 0.0
   syst_JES_MJB_Stat2_plus: -1.29754094e-02
   syst_JES_MJB_Stat2_minus: 1.45734708e-02
   syst_JES_MJB_Stat3_plus: 1.47361053e-03
@@ -8673,7 +8673,7 @@ bins:
   syst_JES_Punch_through_plus: 2.71656283e-02
   syst_JES_Punch_through_minus: -1.69917760e-02
   syst_JES_SingleParticle_HighPt_plus: 2.97833376e-04
-  syst_JES_SingleParticle_HighPt_minus: -0.0
+  syst_JES_SingleParticle_HighPt_minus: 0.0
   syst_JES_Zjet_JVF_plus: 6.68428040e-02
   syst_JES_Zjet_JVF_minus: -7.40765064e-02
   syst_JES_Zjet_MC_plus: 1.33572471e+00
@@ -8722,11 +8722,11 @@ bins:
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -1.67513596e+00
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: -1.69493495e-02
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 1.19713178e-02
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
-  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
+  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -2.58588950e+00
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_minus: 2.67569206e+00
@@ -9345,7 +9345,7 @@ bins:
   syst_JES_Punch_through_plus: 8.82964238e-03
   syst_JES_Punch_through_minus: -6.66023877e-03
   syst_JES_SingleParticle_HighPt_plus: 1.67160043e-04
-  syst_JES_SingleParticle_HighPt_minus: -0.0
+  syst_JES_SingleParticle_HighPt_minus: 0.0
   syst_JES_Zjet_JVF_plus: 3.24632723e-02
   syst_JES_Zjet_JVF_minus: -3.56381818e-02
   syst_JES_Zjet_MC_plus: 6.91479721e-01
@@ -9394,12 +9394,12 @@ bins:
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -8.48316005e-01
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 5.20784144e-03
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -5.71837254e-03
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -1.29188409e+00
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_minus: 1.33006786e+00
   syst_splitted_3_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 2.98328351e-01
@@ -10017,7 +10017,7 @@ bins:
   syst_JES_Punch_through_plus: 3.69675425e-03
   syst_JES_Punch_through_minus: -3.03207388e-03
   syst_JES_SingleParticle_HighPt_plus: 9.67887762e-05
-  syst_JES_SingleParticle_HighPt_minus: -0.0
+  syst_JES_SingleParticle_HighPt_minus: 0.0
   syst_JES_Zjet_JVF_plus: 1.74513954e-02
   syst_JES_Zjet_JVF_minus: -1.85261977e-02
   syst_JES_Zjet_MC_plus: 3.58220295e-01
@@ -10066,12 +10066,12 @@ bins:
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -4.43426662e-01
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 2.13334116e-02
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -1.90141013e-02
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -6.58740677e-01
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_minus: 6.81933780e-01
   syst_splitted_3_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 1.71968369e-01
@@ -10689,7 +10689,7 @@ bins:
   syst_JES_Punch_through_plus: 2.25284220e-03
   syst_JES_Punch_through_minus: -2.07182287e-03
   syst_JES_SingleParticle_HighPt_plus: 5.54513138e-05
-  syst_JES_SingleParticle_HighPt_minus: -0.0
+  syst_JES_SingleParticle_HighPt_minus: 0.0
   syst_JES_Zjet_JVF_plus: 1.02954747e-02
   syst_JES_Zjet_JVF_minus: -1.05641753e-02
   syst_JES_Zjet_MC_plus: 1.78968726e-01
@@ -10738,12 +10738,12 @@ bins:
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -2.31931024e-01
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 2.63609408e-02
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -2.45366053e-02
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -3.35310036e-01
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_minus: 3.49876435e-01
   syst_splitted_3_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 9.87474620e-02
@@ -11361,7 +11361,7 @@ bins:
   syst_JES_Punch_through_plus: 1.75716035e-03
   syst_JES_Punch_through_minus: -2.02939646e-03
   syst_JES_SingleParticle_HighPt_plus: 3.27602572e-05
-  syst_JES_SingleParticle_HighPt_minus: -0.0
+  syst_JES_SingleParticle_HighPt_minus: 0.0
   syst_JES_Zjet_JVF_plus: 6.12708026e-03
   syst_JES_Zjet_JVF_minus: -6.15890006e-03
   syst_JES_Zjet_MC_plus: 9.04177441e-02
@@ -11410,12 +11410,12 @@ bins:
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -1.27137799e-01
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 2.37587878e-02
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -2.32850263e-02
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -1.81160757e-01
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_minus: 1.88938932e-01
   syst_splitted_3_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 5.79898271e-02
@@ -12033,7 +12033,7 @@ bins:
   syst_JES_Punch_through_plus: 1.49482374e-03
   syst_JES_Punch_through_minus: -1.92262334e-03
   syst_JES_SingleParticle_HighPt_plus: 2.00464772e-05
-  syst_JES_SingleParticle_HighPt_minus: -0.0
+  syst_JES_SingleParticle_HighPt_minus: 0.0
   syst_JES_Zjet_JVF_plus: 3.62604357e-03
   syst_JES_Zjet_JVF_minus: -3.44431713e-03
   syst_JES_Zjet_MC_plus: 4.64922709e-02
@@ -12082,12 +12082,12 @@ bins:
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -7.20683231e-02
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 1.86322637e-02
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -1.86817612e-02
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -1.03661854e-01
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_minus: 1.07833784e-01
   syst_splitted_3_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 3.49805725e-02
@@ -12705,7 +12705,7 @@ bins:
   syst_JES_Punch_through_plus: 1.35905923e-03
   syst_JES_Punch_through_minus: -1.61856742e-03
   syst_JES_SingleParticle_HighPt_plus: 1.24026529e-05
-  syst_JES_SingleParticle_HighPt_minus: -0.0
+  syst_JES_SingleParticle_HighPt_minus: 0.0
   syst_JES_Zjet_JVF_plus: 2.14394776e-03
   syst_JES_Zjet_JVF_minus: -1.94100811e-03
   syst_JES_Zjet_MC_plus: 2.37375746e-02
@@ -12754,12 +12754,12 @@ bins:
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -4.09202694e-02
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 1.34491710e-02
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -1.35269527e-02
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -6.06909750e-02
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_minus: 6.29820010e-02
   syst_splitted_3_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 2.12485588e-02
@@ -13426,12 +13426,12 @@ bins:
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -2.27334830e-02
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 8.98308455e-03
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -9.03965309e-03
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -3.50795674e-02
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_minus: 3.61331565e-02
   syst_splitted_3_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 1.25723586e-02
@@ -14098,12 +14098,12 @@ bins:
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -1.28198459e-02
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 5.83504516e-03
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -5.86474364e-03
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -2.06333759e-02
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_minus: 2.10222846e-02
   syst_splitted_3_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 7.48896792e-03
@@ -14770,12 +14770,12 @@ bins:
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -7.31431254e-03
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 3.72503852e-03
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -3.72079588e-03
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -1.23390133e-02
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_minus: 1.24662926e-02
   syst_splitted_3_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 4.51699812e-03
@@ -15442,12 +15442,12 @@ bins:
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -4.12667518e-03
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 2.34264477e-03
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -2.31789603e-03
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -7.33764707e-03
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_minus: 7.38643744e-03
   syst_splitted_3_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 2.70927963e-03
@@ -16114,12 +16114,12 @@ bins:
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -2.37375746e-03
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 1.54078568e-03
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -1.50967298e-03
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -4.43426662e-03
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_minus: 4.48234989e-03
   syst_splitted_3_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 1.66311515e-03
@@ -16786,12 +16786,12 @@ bins:
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -1.37108005e-03
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 1.05005357e-03
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -1.02389062e-03
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -2.66296414e-03
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_minus: 2.71104740e-03
   syst_splitted_3_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 1.02106219e-03
@@ -17458,12 +17458,12 @@ bins:
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -8.02990461e-04
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 7.34825367e-04
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -7.22875262e-04
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -1.60654661e-03
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_minus: 1.63978063e-03
   syst_splitted_3_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 6.27557268e-04
@@ -18130,12 +18130,12 @@ bins:
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -4.72205908e-04
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 5.17531453e-04
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -5.16753636e-04
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -9.70291925e-04
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_minus: 9.88535280e-04
   syst_splitted_3_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 3.83039743e-04
@@ -18802,12 +18802,12 @@ bins:
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -2.78402082e-04
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 3.66422734e-04
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -3.68331922e-04
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -5.86827918e-04
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_minus: 5.96798123e-04
   syst_splitted_3_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 2.34688741e-04
@@ -19474,12 +19474,12 @@ bins:
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -1.61503189e-04
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 2.54841284e-04
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -2.55124127e-04
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -3.48037958e-04
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_minus: 3.54614051e-04
   syst_splitted_3_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 1.42835570e-04
@@ -20146,12 +20146,12 @@ bins:
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -9.29279732e-05
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 1.73806847e-04
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -1.72392633e-04
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -2.03576042e-04
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_minus: 2.08101526e-04
   syst_splitted_3_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 8.70024184e-05
@@ -20818,12 +20818,12 @@ bins:
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -5.38037550e-05
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 1.16106933e-04
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -1.14409877e-04
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -1.18935361e-04
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_minus: 1.21622366e-04
   syst_splitted_3_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 5.33229224e-05
@@ -21490,12 +21490,12 @@ bins:
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -3.11834091e-05
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 7.50664559e-05
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -7.39421561e-05
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -6.91479721e-05
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_minus: 7.04844039e-05
   syst_splitted_3_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 3.25976226e-05
@@ -22162,12 +22162,12 @@ bins:
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -1.83069946e-05
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 4.79913372e-05
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -4.74327229e-05
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -4.05808582e-05
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_minus: 4.11677568e-05
   syst_splitted_3_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 2.01737565e-05
@@ -22834,12 +22834,12 @@ bins:
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -9.88181727e-06
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 2.79179899e-05
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -2.77419203e-05
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -2.17647467e-05
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_minus: 2.19627366e-05
   syst_splitted_3_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 1.15399827e-05
@@ -23506,12 +23506,12 @@ bins:
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -3.88201623e-06
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 1.19642467e-05
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -1.18723229e-05
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -8.39618592e-06
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_minus: 8.46053264e-06
   syst_splitted_3_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 4.95045458e-06
@@ -24178,12 +24178,12 @@ bins:
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -8.84873426e-07
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 3.06601500e-06
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -2.96631295e-06
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -1.89151064e-06
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_minus: 1.93747258e-06
   syst_splitted_3_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 1.33996735e-06
@@ -24850,12 +24850,12 @@ bins:
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -8.52205093e-08
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 3.53341259e-07
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -3.45068109e-07
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -1.80524361e-07
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_minus: 1.84908423e-07
   syst_splitted_3_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 1.76918117e-07
@@ -25522,12 +25522,12 @@ bins:
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -1.44037651e-09
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 7.87151269e-09
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -7.67564411e-09
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -3.70523953e-09
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_minus: 3.71018928e-09
   syst_splitted_3_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 5.58826489e-09
@@ -25805,7 +25805,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat206_plus: 7.44583441e-02
   syst_JES_EtaIntercalibration_Stat206_minus: 0.0
   syst_JES_EtaIntercalibration_Stat207_plus: -2.16586807e-02
-  syst_JES_EtaIntercalibration_Stat207_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat207_minus: 0.0
   syst_JES_EtaIntercalibration_Stat208_plus: 0.0
   syst_JES_EtaIntercalibration_Stat208_minus: 0.0
   syst_JES_EtaIntercalibration_Stat209_plus: 0.0
@@ -25820,9 +25820,9 @@ bins:
   syst_JES_EtaIntercalibration_Stat212_minus: 0.0
   syst_JES_EtaIntercalibration_Stat213_plus: 0.0
   syst_JES_EtaIntercalibration_Stat213_minus: 0.0
-  syst_JES_EtaIntercalibration_Stat214_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat214_plus: 0.0
   syst_JES_EtaIntercalibration_Stat214_minus: 0.0
-  syst_JES_EtaIntercalibration_Stat215_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat215_plus: 0.0
   syst_JES_EtaIntercalibration_Stat215_minus: 5.67170349e-02
   syst_JES_EtaIntercalibration_Stat216_plus: 1.38097954e-02
   syst_JES_EtaIntercalibration_Stat216_minus: 0.0
@@ -25830,7 +25830,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat217_minus: 1.24380083e-02
   syst_JES_EtaIntercalibration_Stat218_plus: -8.23355136e-02
   syst_JES_EtaIntercalibration_Stat218_minus: 0.0
-  syst_JES_EtaIntercalibration_Stat219_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat219_plus: 0.0
   syst_JES_EtaIntercalibration_Stat219_minus: 3.48532932e-02
   syst_JES_EtaIntercalibration_Stat22_plus: 0.0
   syst_JES_EtaIntercalibration_Stat22_minus: 0.0
@@ -25858,7 +25858,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat23_minus: 0.0
   syst_JES_EtaIntercalibration_Stat230_plus: -6.87590634e-02
   syst_JES_EtaIntercalibration_Stat230_minus: 8.39618592e-02
-  syst_JES_EtaIntercalibration_Stat231_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat231_plus: 0.0
   syst_JES_EtaIntercalibration_Stat231_minus: 0.0
   syst_JES_EtaIntercalibration_Stat232_plus: 0.0
   syst_JES_EtaIntercalibration_Stat232_minus: 0.0
@@ -25872,7 +25872,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat236_minus: 0.0
   syst_JES_EtaIntercalibration_Stat237_plus: 2.28536912e-02
   syst_JES_EtaIntercalibration_Stat237_minus: -2.50315801e-02
-  syst_JES_EtaIntercalibration_Stat238_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat238_plus: 0.0
   syst_JES_EtaIntercalibration_Stat238_minus: 0.0
   syst_JES_EtaIntercalibration_Stat239_plus: 4.28365288e-02
   syst_JES_EtaIntercalibration_Stat239_minus: 0.0
@@ -26122,7 +26122,7 @@ bins:
   syst_JES_MJB_Stat2_minus: -5.94464671e-02
   syst_JES_MJB_Stat3_plus: -6.61356972e-02
   syst_JES_MJB_Stat3_minus: 3.63382175e-13
-  syst_JES_MJB_Stat4_plus: -0.0
+  syst_JES_MJB_Stat4_plus: 0.0
   syst_JES_MJB_Stat4_minus: -2.99247590e-02
   syst_JES_MJB_Stat5_plus: 5.23753993e-02
   syst_JES_MJB_Stat5_minus: -4.15000970e-02
@@ -26188,17 +26188,17 @@ bins:
   syst_Unfolding_bias_minus: 5.51642284e+01
   syst_jetselection_BCH_plus: 9.61933923e+01
   syst_jetselection_BCH_minus: -9.61933923e+01
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 1.14346238e+03
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -1.06850906e+03
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: -1.07904495e-01
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 2.87226775e-08
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
-  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
+  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -1.53208826e+03
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_minus: 1.65759972e+03
@@ -26477,7 +26477,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat206_plus: 3.00591093e-02
   syst_JES_EtaIntercalibration_Stat206_minus: 0.0
   syst_JES_EtaIntercalibration_Stat207_plus: -8.74337535e-03
-  syst_JES_EtaIntercalibration_Stat207_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat207_minus: 0.0
   syst_JES_EtaIntercalibration_Stat208_plus: 0.0
   syst_JES_EtaIntercalibration_Stat208_minus: 0.0
   syst_JES_EtaIntercalibration_Stat209_plus: 0.0
@@ -26494,7 +26494,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat213_minus: 0.0
   syst_JES_EtaIntercalibration_Stat214_plus: -3.41815418e-43
   syst_JES_EtaIntercalibration_Stat214_minus: 1.22895159e-43
-  syst_JES_EtaIntercalibration_Stat215_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat215_plus: 0.0
   syst_JES_EtaIntercalibration_Stat215_minus: 2.28961176e-02
   syst_JES_EtaIntercalibration_Stat216_plus: 5.57341565e-03
   syst_JES_EtaIntercalibration_Stat216_minus: 0.0
@@ -26530,7 +26530,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat23_minus: 0.0
   syst_JES_EtaIntercalibration_Stat230_plus: -2.77546483e-02
   syst_JES_EtaIntercalibration_Stat230_minus: 3.38916280e-02
-  syst_JES_EtaIntercalibration_Stat231_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat231_plus: 0.0
   syst_JES_EtaIntercalibration_Stat231_minus: 0.0
   syst_JES_EtaIntercalibration_Stat232_plus: 0.0
   syst_JES_EtaIntercalibration_Stat232_minus: 0.0
@@ -26544,7 +26544,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat236_minus: 0.0
   syst_JES_EtaIntercalibration_Stat237_plus: 9.22491507e-03
   syst_JES_EtaIntercalibration_Stat237_minus: -1.01045559e-02
-  syst_JES_EtaIntercalibration_Stat238_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat238_plus: 0.0
   syst_JES_EtaIntercalibration_Stat238_minus: 0.0
   syst_JES_EtaIntercalibration_Stat239_plus: 1.72887608e-02
   syst_JES_EtaIntercalibration_Stat239_minus: 0.0
@@ -26560,7 +26560,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat243_minus: 0.0
   syst_JES_EtaIntercalibration_Stat244_plus: 0.0
   syst_JES_EtaIntercalibration_Stat244_minus: 0.0
-  syst_JES_EtaIntercalibration_Stat245_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat245_plus: 0.0
   syst_JES_EtaIntercalibration_Stat245_minus: 0.0
   syst_JES_EtaIntercalibration_Stat246_plus: 1.90565278e-02
   syst_JES_EtaIntercalibration_Stat246_minus: 0.0
@@ -26794,7 +26794,7 @@ bins:
   syst_JES_MJB_Stat2_minus: -2.39921331e-02
   syst_JES_MJB_Stat3_plus: -2.66932810e-02
   syst_JES_MJB_Stat3_minus: 2.86590378e-08
-  syst_JES_MJB_Stat4_plus: -0.0
+  syst_JES_MJB_Stat4_plus: 0.0
   syst_JES_MJB_Stat4_minus: -1.20773838e-02
   syst_JES_MJB_Stat5_plus: 2.11424928e-02
   syst_JES_MJB_Stat5_minus: -1.67513596e-02
@@ -26860,17 +26860,17 @@ bins:
   syst_Unfolding_bias_minus: 5.12157442e-01
   syst_jetselection_BCH_plus: 4.66329851e+01
   syst_jetselection_BCH_minus: -4.66329851e+01
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 3.89474415e+02
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -3.66514658e+02
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: -4.35648488e-02
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 4.53891843e-05
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
-  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
+  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -5.66781440e+02
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_minus: 6.09236132e+02
@@ -27149,7 +27149,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat206_plus: 1.37815112e-02
   syst_JES_EtaIntercalibration_Stat206_minus: 0.0
   syst_JES_EtaIntercalibration_Stat207_plus: -4.00858834e-03
-  syst_JES_EtaIntercalibration_Stat207_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat207_minus: 0.0
   syst_JES_EtaIntercalibration_Stat208_plus: 0.0
   syst_JES_EtaIntercalibration_Stat208_minus: 0.0
   syst_JES_EtaIntercalibration_Stat209_plus: 0.0
@@ -27202,7 +27202,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat23_minus: 0.0
   syst_JES_EtaIntercalibration_Stat230_plus: -1.27208510e-02
   syst_JES_EtaIntercalibration_Stat230_minus: 1.55351360e-02
-  syst_JES_EtaIntercalibration_Stat231_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat231_plus: 0.0
   syst_JES_EtaIntercalibration_Stat231_minus: 5.08480486e-40
   syst_JES_EtaIntercalibration_Stat232_plus: 0.0
   syst_JES_EtaIntercalibration_Stat232_minus: 0.0
@@ -27216,7 +27216,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat236_minus: 0.0
   syst_JES_EtaIntercalibration_Stat237_plus: 4.22920566e-03
   syst_JES_EtaIntercalibration_Stat237_minus: -4.63154942e-03
-  syst_JES_EtaIntercalibration_Stat238_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat238_plus: 0.0
   syst_JES_EtaIntercalibration_Stat238_minus: 0.0
   syst_JES_EtaIntercalibration_Stat239_plus: 7.92666702e-03
   syst_JES_EtaIntercalibration_Stat239_minus: 0.0
@@ -27232,7 +27232,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat243_minus: 0.0
   syst_JES_EtaIntercalibration_Stat244_plus: 0.0
   syst_JES_EtaIntercalibration_Stat244_minus: 0.0
-  syst_JES_EtaIntercalibration_Stat245_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat245_plus: 0.0
   syst_JES_EtaIntercalibration_Stat245_minus: 0.0
   syst_JES_EtaIntercalibration_Stat246_plus: 8.73630428e-03
   syst_JES_EtaIntercalibration_Stat246_minus: 0.0
@@ -27466,7 +27466,7 @@ bins:
   syst_JES_MJB_Stat2_minus: -1.10520790e-02
   syst_JES_MJB_Stat3_plus: -1.22400184e-02
   syst_JES_MJB_Stat3_minus: 1.45805418e-05
-  syst_JES_MJB_Stat4_plus: -0.0
+  syst_JES_MJB_Stat4_plus: 0.0
   syst_JES_MJB_Stat4_minus: -5.53735320e-03
   syst_JES_MJB_Stat5_plus: 9.69089844e-03
   syst_JES_MJB_Stat5_minus: -7.67917964e-03
@@ -27538,11 +27538,11 @@ bins:
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -1.49058109e+02
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: -2.00676905e-02
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 1.68432835e-03
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
-  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
+  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -2.40882996e+02
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_minus: 2.57238376e+02
@@ -27885,10 +27885,10 @@ bins:
   syst_JES_EtaIntercalibration_Stat235_plus: 0.0
   syst_JES_EtaIntercalibration_Stat235_minus: 0.0
   syst_JES_EtaIntercalibration_Stat236_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat236_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat236_minus: 0.0
   syst_JES_EtaIntercalibration_Stat237_plus: 1.98909138e-03
   syst_JES_EtaIntercalibration_Stat237_minus: -2.17788889e-03
-  syst_JES_EtaIntercalibration_Stat238_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat238_plus: 0.0
   syst_JES_EtaIntercalibration_Stat238_minus: 0.0
   syst_JES_EtaIntercalibration_Stat239_plus: 3.72786695e-03
   syst_JES_EtaIntercalibration_Stat239_minus: 0.0
@@ -27904,7 +27904,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat243_minus: 0.0
   syst_JES_EtaIntercalibration_Stat244_plus: 0.0
   syst_JES_EtaIntercalibration_Stat244_minus: 0.0
-  syst_JES_EtaIntercalibration_Stat245_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat245_plus: 0.0
   syst_JES_EtaIntercalibration_Stat245_minus: 0.0
   syst_JES_EtaIntercalibration_Stat246_plus: 4.10829040e-03
   syst_JES_EtaIntercalibration_Stat246_minus: 0.0
@@ -28210,11 +28210,11 @@ bins:
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -6.20005368e+01
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: -1.25370032e-02
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 7.68978625e-03
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
-  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
+  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -1.03280016e+02
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_minus: 1.10216734e+02
@@ -28523,7 +28523,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat22_plus: 0.0
   syst_JES_EtaIntercalibration_Stat22_minus: 0.0
   syst_JES_EtaIntercalibration_Stat220_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat220_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat220_minus: 0.0
   syst_JES_EtaIntercalibration_Stat221_plus: 0.0
   syst_JES_EtaIntercalibration_Stat221_minus: 0.0
   syst_JES_EtaIntercalibration_Stat222_plus: 0.0
@@ -28549,7 +28549,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat231_plus: -3.14874650e-25
   syst_JES_EtaIntercalibration_Stat231_minus: 1.14551299e-19
   syst_JES_EtaIntercalibration_Stat232_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat232_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat232_minus: 0.0
   syst_JES_EtaIntercalibration_Stat233_plus: 0.0
   syst_JES_EtaIntercalibration_Stat233_minus: 0.0
   syst_JES_EtaIntercalibration_Stat234_plus: 0.0
@@ -28557,10 +28557,10 @@ bins:
   syst_JES_EtaIntercalibration_Stat235_plus: 0.0
   syst_JES_EtaIntercalibration_Stat235_minus: 0.0
   syst_JES_EtaIntercalibration_Stat236_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat236_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat236_minus: 0.0
   syst_JES_EtaIntercalibration_Stat237_plus: 9.72413245e-04
   syst_JES_EtaIntercalibration_Stat237_minus: -1.06490281e-03
-  syst_JES_EtaIntercalibration_Stat238_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat238_plus: 0.0
   syst_JES_EtaIntercalibration_Stat238_minus: 5.63422683e-42
   syst_JES_EtaIntercalibration_Stat239_plus: 1.82292128e-03
   syst_JES_EtaIntercalibration_Stat239_minus: 0.0
@@ -28573,10 +28573,10 @@ bins:
   syst_JES_EtaIntercalibration_Stat242_plus: -2.47840927e-03
   syst_JES_EtaIntercalibration_Stat242_minus: 8.66417939e-42
   syst_JES_EtaIntercalibration_Stat243_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat243_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat243_minus: 0.0
   syst_JES_EtaIntercalibration_Stat244_plus: 0.0
   syst_JES_EtaIntercalibration_Stat244_minus: 0.0
-  syst_JES_EtaIntercalibration_Stat245_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat245_plus: 0.0
   syst_JES_EtaIntercalibration_Stat245_minus: 0.0
   syst_JES_EtaIntercalibration_Stat246_plus: 2.00889037e-03
   syst_JES_EtaIntercalibration_Stat246_minus: 0.0
@@ -28882,11 +28882,11 @@ bins:
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -2.70185501e+01
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: -2.25496353e-02
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 1.54149278e-02
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
-  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
+  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -4.60651784e+01
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_minus: 4.87748116e+01
@@ -29195,7 +29195,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat22_plus: 0.0
   syst_JES_EtaIntercalibration_Stat22_minus: 0.0
   syst_JES_EtaIntercalibration_Stat220_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat220_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat220_minus: 0.0
   syst_JES_EtaIntercalibration_Stat221_plus: 0.0
   syst_JES_EtaIntercalibration_Stat221_minus: 0.0
   syst_JES_EtaIntercalibration_Stat222_plus: 0.0
@@ -29221,7 +29221,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat231_plus: -5.52533239e-18
   syst_JES_EtaIntercalibration_Stat231_minus: 4.35648488e-14
   syst_JES_EtaIntercalibration_Stat232_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat232_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat232_minus: 0.0
   syst_JES_EtaIntercalibration_Stat233_plus: 0.0
   syst_JES_EtaIntercalibration_Stat233_minus: 0.0
   syst_JES_EtaIntercalibration_Stat234_plus: 0.0
@@ -29229,10 +29229,10 @@ bins:
   syst_JES_EtaIntercalibration_Stat235_plus: 0.0
   syst_JES_EtaIntercalibration_Stat235_minus: 0.0
   syst_JES_EtaIntercalibration_Stat236_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat236_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat236_minus: 0.0
   syst_JES_EtaIntercalibration_Stat237_plus: 4.91509924e-04
   syst_JES_EtaIntercalibration_Stat237_minus: -5.38320393e-04
-  syst_JES_EtaIntercalibration_Stat238_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat238_plus: 0.0
   syst_JES_EtaIntercalibration_Stat238_minus: 1.47148921e-30
   syst_JES_EtaIntercalibration_Stat239_plus: 9.21360136e-04
   syst_JES_EtaIntercalibration_Stat239_minus: 0.0
@@ -29245,10 +29245,10 @@ bins:
   syst_JES_EtaIntercalibration_Stat242_plus: -1.25299322e-03
   syst_JES_EtaIntercalibration_Stat242_minus: 2.26344881e-30
   syst_JES_EtaIntercalibration_Stat243_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat243_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat243_minus: 0.0
   syst_JES_EtaIntercalibration_Stat244_plus: 0.0
   syst_JES_EtaIntercalibration_Stat244_minus: 0.0
-  syst_JES_EtaIntercalibration_Stat245_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat245_plus: 0.0
   syst_JES_EtaIntercalibration_Stat245_minus: 0.0
   syst_JES_EtaIntercalibration_Stat246_plus: 1.01540534e-03
   syst_JES_EtaIntercalibration_Stat246_minus: 0.0
@@ -29554,11 +29554,11 @@ bins:
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -1.23602265e+01
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: -3.91171471e-02
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 2.91681547e-02
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
-  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
+  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -2.14536197e+01
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_minus: 2.23516454e+01
@@ -29867,7 +29867,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat22_plus: 0.0
   syst_JES_EtaIntercalibration_Stat22_minus: 0.0
   syst_JES_EtaIntercalibration_Stat220_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat220_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat220_minus: 0.0
   syst_JES_EtaIntercalibration_Stat221_plus: 0.0
   syst_JES_EtaIntercalibration_Stat221_minus: 0.0
   syst_JES_EtaIntercalibration_Stat222_plus: 0.0
@@ -29893,7 +29893,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat231_plus: -8.03697567e-13
   syst_JES_EtaIntercalibration_Stat231_minus: 3.16783838e-10
   syst_JES_EtaIntercalibration_Stat232_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat232_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat232_minus: 0.0
   syst_JES_EtaIntercalibration_Stat233_plus: 0.0
   syst_JES_EtaIntercalibration_Stat233_minus: 0.0
   syst_JES_EtaIntercalibration_Stat234_plus: 0.0
@@ -29901,7 +29901,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat235_plus: 0.0
   syst_JES_EtaIntercalibration_Stat235_minus: 0.0
   syst_JES_EtaIntercalibration_Stat236_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat236_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat236_minus: 0.0
   syst_JES_EtaIntercalibration_Stat237_plus: 2.54699863e-04
   syst_JES_EtaIntercalibration_Stat237_minus: -2.78939483e-04
   syst_JES_EtaIntercalibration_Stat238_plus: -9.21501557e-44
@@ -29917,10 +29917,10 @@ bins:
   syst_JES_EtaIntercalibration_Stat242_plus: -6.49194736e-04
   syst_JES_EtaIntercalibration_Stat242_minus: 6.30173563e-22
   syst_JES_EtaIntercalibration_Stat243_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat243_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat243_minus: 0.0
   syst_JES_EtaIntercalibration_Stat244_plus: 0.0
   syst_JES_EtaIntercalibration_Stat244_minus: 0.0
-  syst_JES_EtaIntercalibration_Stat245_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat245_plus: 0.0
   syst_JES_EtaIntercalibration_Stat245_minus: 0.0
   syst_JES_EtaIntercalibration_Stat246_plus: 5.26158156e-04
   syst_JES_EtaIntercalibration_Stat246_minus: 0.0
@@ -30226,11 +30226,11 @@ bins:
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -5.78908322e+00
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: -3.55179736e-02
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 3.59139534e-02
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
-  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
+  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -1.02459773e+01
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_minus: 1.05924596e+01
@@ -30539,7 +30539,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat22_plus: 0.0
   syst_JES_EtaIntercalibration_Stat22_minus: 0.0
   syst_JES_EtaIntercalibration_Stat220_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat220_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat220_minus: 0.0
   syst_JES_EtaIntercalibration_Stat221_plus: 0.0
   syst_JES_EtaIntercalibration_Stat221_minus: 0.0
   syst_JES_EtaIntercalibration_Stat222_plus: 0.0
@@ -30565,7 +30565,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat231_plus: -1.92403755e-09
   syst_JES_EtaIntercalibration_Stat231_minus: 8.20880262e-08
   syst_JES_EtaIntercalibration_Stat232_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat232_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat232_minus: 0.0
   syst_JES_EtaIntercalibration_Stat233_plus: 0.0
   syst_JES_EtaIntercalibration_Stat233_minus: 0.0
   syst_JES_EtaIntercalibration_Stat234_plus: 0.0
@@ -30573,7 +30573,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat235_plus: 0.0
   syst_JES_EtaIntercalibration_Stat235_minus: 0.0
   syst_JES_EtaIntercalibration_Stat236_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat236_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat236_minus: 0.0
   syst_JES_EtaIntercalibration_Stat237_plus: 1.34208867e-04
   syst_JES_EtaIntercalibration_Stat237_minus: -1.47007500e-04
   syst_JES_EtaIntercalibration_Stat238_plus: -2.27051987e-32
@@ -30589,10 +30589,10 @@ bins:
   syst_JES_EtaIntercalibration_Stat242_plus: -3.42168971e-04
   syst_JES_EtaIntercalibration_Stat242_minus: 4.31688690e-16
   syst_JES_EtaIntercalibration_Stat243_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat243_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat243_minus: 0.0
   syst_JES_EtaIntercalibration_Stat244_plus: 0.0
   syst_JES_EtaIntercalibration_Stat244_minus: 0.0
-  syst_JES_EtaIntercalibration_Stat245_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat245_plus: 0.0
   syst_JES_EtaIntercalibration_Stat245_minus: 0.0
   syst_JES_EtaIntercalibration_Stat246_plus: 2.77306066e-04
   syst_JES_EtaIntercalibration_Stat246_minus: 0.0
@@ -30898,11 +30898,11 @@ bins:
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -2.73678609e+00
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: -1.95727157e-02
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 2.38860671e-02
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
-  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
+  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -4.96318250e+00
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_minus: 5.14066630e+00
@@ -31211,7 +31211,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat22_plus: 0.0
   syst_JES_EtaIntercalibration_Stat22_minus: 0.0
   syst_JES_EtaIntercalibration_Stat220_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat220_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat220_minus: 0.0
   syst_JES_EtaIntercalibration_Stat221_plus: 0.0
   syst_JES_EtaIntercalibration_Stat221_minus: 0.0
   syst_JES_EtaIntercalibration_Stat222_plus: 0.0
@@ -31237,7 +31237,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat231_plus: -2.72632091e-07
   syst_JES_EtaIntercalibration_Stat231_minus: 2.23162900e-06
   syst_JES_EtaIntercalibration_Stat232_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat232_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat232_minus: 0.0
   syst_JES_EtaIntercalibration_Stat233_plus: 0.0
   syst_JES_EtaIntercalibration_Stat233_minus: 0.0
   syst_JES_EtaIntercalibration_Stat234_plus: 0.0
@@ -31245,7 +31245,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat235_plus: 0.0
   syst_JES_EtaIntercalibration_Stat235_minus: 0.0
   syst_JES_EtaIntercalibration_Stat236_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat236_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat236_minus: 0.0
   syst_JES_EtaIntercalibration_Stat237_plus: 7.43027806e-05
   syst_JES_EtaIntercalibration_Stat237_minus: -8.13809194e-05
   syst_JES_EtaIntercalibration_Stat238_plus: -3.99444621e-24
@@ -31261,7 +31261,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat242_plus: -1.89363196e-04
   syst_JES_EtaIntercalibration_Stat242_minus: 4.36497016e-12
   syst_JES_EtaIntercalibration_Stat243_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat243_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat243_minus: 0.0
   syst_JES_EtaIntercalibration_Stat244_plus: 0.0
   syst_JES_EtaIntercalibration_Stat244_minus: 0.0
   syst_JES_EtaIntercalibration_Stat245_plus: -1.12147135e-38
@@ -31570,11 +31570,11 @@ bins:
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -1.36330187e+00
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: -5.96727413e-03
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 3.98878935e-03
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
-  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
+  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -2.51942146e+00
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_minus: 2.58659661e+00
@@ -31883,7 +31883,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat22_plus: 0.0
   syst_JES_EtaIntercalibration_Stat22_minus: 0.0
   syst_JES_EtaIntercalibration_Stat220_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat220_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat220_minus: 0.0
   syst_JES_EtaIntercalibration_Stat221_plus: 0.0
   syst_JES_EtaIntercalibration_Stat221_minus: 0.0
   syst_JES_EtaIntercalibration_Stat222_plus: 0.0
@@ -31909,7 +31909,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat231_plus: -5.21208408e-06
   syst_JES_EtaIntercalibration_Stat231_minus: 1.27562063e-05
   syst_JES_EtaIntercalibration_Stat232_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat232_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat232_minus: 0.0
   syst_JES_EtaIntercalibration_Stat233_plus: 0.0
   syst_JES_EtaIntercalibration_Stat233_minus: 0.0
   syst_JES_EtaIntercalibration_Stat234_plus: 0.0
@@ -31917,7 +31917,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat235_plus: 0.0
   syst_JES_EtaIntercalibration_Stat235_minus: 0.0
   syst_JES_EtaIntercalibration_Stat236_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat236_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat236_minus: 0.0
   syst_JES_EtaIntercalibration_Stat237_plus: 4.10546197e-05
   syst_JES_EtaIntercalibration_Stat237_minus: -4.49578491e-05
   syst_JES_EtaIntercalibration_Stat238_plus: -3.51997756e-18
@@ -31933,7 +31933,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat242_plus: -1.04651804e-04
   syst_JES_EtaIntercalibration_Stat242_minus: 2.10434978e-09
   syst_JES_EtaIntercalibration_Stat243_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat243_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat243_minus: 0.0
   syst_JES_EtaIntercalibration_Stat244_plus: 0.0
   syst_JES_EtaIntercalibration_Stat244_minus: 0.0
   syst_JES_EtaIntercalibration_Stat245_plus: -1.43542677e-29
@@ -32242,12 +32242,12 @@ bins:
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -6.85893578e-01
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 6.73094945e-03
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -9.52119281e-03
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -1.26713535e+00
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_minus: 1.29046988e+00
   syst_splitted_3_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 4.64569155e-01
@@ -32555,7 +32555,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat22_plus: 0.0
   syst_JES_EtaIntercalibration_Stat22_minus: 0.0
   syst_JES_EtaIntercalibration_Stat220_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat220_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat220_minus: 0.0
   syst_JES_EtaIntercalibration_Stat221_plus: 0.0
   syst_JES_EtaIntercalibration_Stat221_minus: 0.0
   syst_JES_EtaIntercalibration_Stat222_plus: 0.0
@@ -32581,7 +32581,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat231_plus: -2.64175093e-05
   syst_JES_EtaIntercalibration_Stat231_minus: 2.79179899e-05
   syst_JES_EtaIntercalibration_Stat232_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat232_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat232_minus: 0.0
   syst_JES_EtaIntercalibration_Stat233_plus: 0.0
   syst_JES_EtaIntercalibration_Stat233_minus: 0.0
   syst_JES_EtaIntercalibration_Stat234_plus: 0.0
@@ -32589,7 +32589,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat235_plus: 0.0
   syst_JES_EtaIntercalibration_Stat235_minus: 0.0
   syst_JES_EtaIntercalibration_Stat236_plus: 9.48795879e-35
-  syst_JES_EtaIntercalibration_Stat236_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat236_minus: 0.0
   syst_JES_EtaIntercalibration_Stat237_plus: 2.35395847e-05
   syst_JES_EtaIntercalibration_Stat237_minus: -2.57669711e-05
   syst_JES_EtaIntercalibration_Stat238_plus: -6.62276211e-14
@@ -32605,7 +32605,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat242_plus: -5.99980104e-05
   syst_JES_EtaIntercalibration_Stat242_minus: 1.20349574e-07
   syst_JES_EtaIntercalibration_Stat243_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat243_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat243_minus: 0.0
   syst_JES_EtaIntercalibration_Stat244_plus: 0.0
   syst_JES_EtaIntercalibration_Stat244_minus: 0.0
   syst_JES_EtaIntercalibration_Stat245_plus: -8.02919750e-23
@@ -32864,7 +32864,7 @@ bins:
   syst_JES_Pileup_Pt_term_minus: -1.66099383e-01
   syst_JES_Punch_through_plus: 4.12526096e-03
   syst_JES_Punch_through_minus: -3.50512831e-03
-  syst_JES_SingleParticle_HighPt_plus: -0.0
+  syst_JES_SingleParticle_HighPt_plus: 0.0
   syst_JES_SingleParticle_HighPt_minus: 0.0
   syst_JES_Zjet_JVF_plus: 1.70483445e-02
   syst_JES_Zjet_JVF_minus: -1.83494210e-02
@@ -32914,12 +32914,12 @@ bins:
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -3.59422377e-01
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 1.53866436e-02
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -1.51108719e-02
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -6.54427326e-01
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_minus: 6.75711240e-01
   syst_splitted_3_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 2.55901944e-01
@@ -33227,7 +33227,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat22_plus: 0.0
   syst_JES_EtaIntercalibration_Stat22_minus: 0.0
   syst_JES_EtaIntercalibration_Stat220_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat220_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat220_minus: 0.0
   syst_JES_EtaIntercalibration_Stat221_plus: 0.0
   syst_JES_EtaIntercalibration_Stat221_minus: 0.0
   syst_JES_EtaIntercalibration_Stat222_plus: 0.0
@@ -33253,7 +33253,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat231_plus: -5.81524617e-05
   syst_JES_EtaIntercalibration_Stat231_minus: 4.01707362e-05
   syst_JES_EtaIntercalibration_Stat232_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat232_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat232_minus: 0.0
   syst_JES_EtaIntercalibration_Stat233_plus: 0.0
   syst_JES_EtaIntercalibration_Stat233_minus: 0.0
   syst_JES_EtaIntercalibration_Stat234_plus: 0.0
@@ -33277,7 +33277,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat242_plus: -3.45916637e-05
   syst_JES_EtaIntercalibration_Stat242_minus: 1.65180144e-06
   syst_JES_EtaIntercalibration_Stat243_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat243_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat243_minus: 0.0
   syst_JES_EtaIntercalibration_Stat244_plus: 0.0
   syst_JES_EtaIntercalibration_Stat244_minus: 0.0
   syst_JES_EtaIntercalibration_Stat245_plus: -1.11227897e-17
@@ -33536,7 +33536,7 @@ bins:
   syst_JES_Pileup_Pt_term_minus: -9.07712975e-02
   syst_JES_Punch_through_plus: 2.09940003e-03
   syst_JES_Punch_through_minus: -2.20688026e-03
-  syst_JES_SingleParticle_HighPt_plus: -0.0
+  syst_JES_SingleParticle_HighPt_plus: 0.0
   syst_JES_SingleParticle_HighPt_minus: 0.0
   syst_JES_Zjet_JVF_plus: 9.29421153e-03
   syst_JES_Zjet_JVF_minus: -9.97161983e-03
@@ -33586,12 +33586,12 @@ bins:
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -1.88726800e-01
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 1.72887608e-02
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -1.57331259e-02
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -3.39694098e-01
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_minus: 3.58078874e-01
   syst_splitted_3_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 1.42694148e-01
@@ -34208,7 +34208,7 @@ bins:
   syst_JES_Pileup_Pt_term_minus: -5.26016735e-02
   syst_JES_Punch_through_plus: 1.29612673e-03
   syst_JES_Punch_through_minus: -1.53512882e-03
-  syst_JES_SingleParticle_HighPt_plus: -0.0
+  syst_JES_SingleParticle_HighPt_plus: 0.0
   syst_JES_SingleParticle_HighPt_minus: 0.0
   syst_JES_Zjet_JVF_plus: 5.56634458e-03
   syst_JES_Zjet_JVF_minus: -5.51401868e-03
@@ -34258,12 +34258,12 @@ bins:
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -1.03025458e-01
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 1.45946840e-02
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -1.39441457e-02
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -1.87029744e-01
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_minus: 1.96646396e-01
   syst_splitted_3_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 8.05394624e-02
@@ -34880,7 +34880,7 @@ bins:
   syst_JES_Pileup_Pt_term_minus: -3.15793888e-02
   syst_JES_Punch_through_plus: 1.12076425e-03
   syst_JES_Punch_through_minus: -1.24945768e-03
-  syst_JES_SingleParticle_HighPt_plus: -0.0
+  syst_JES_SingleParticle_HighPt_plus: 0.0
   syst_JES_SingleParticle_HighPt_minus: 0.0
   syst_JES_Zjet_JVF_plus: 3.27531861e-03
   syst_JES_Zjet_JVF_minus: -3.06460079e-03
@@ -34930,12 +34930,12 @@ bins:
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -5.79332586e-02
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 1.10591501e-02
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -1.11793582e-02
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -1.08116627e-01
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_minus: 1.11015765e-01
   syst_splitted_3_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 4.56932402e-02
@@ -35552,7 +35552,7 @@ bins:
   syst_JES_Pileup_Pt_term_minus: -1.83635631e-02
   syst_JES_Punch_through_plus: 1.04510382e-03
   syst_JES_Punch_through_minus: -1.16248355e-03
-  syst_JES_SingleParticle_HighPt_plus: -0.0
+  syst_JES_SingleParticle_HighPt_plus: 0.0
   syst_JES_SingleParticle_HighPt_minus: 0.0
   syst_JES_Zjet_JVF_plus: 1.80453651e-03
   syst_JES_Zjet_JVF_minus: -1.66028672e-03
@@ -35602,12 +35602,12 @@ bins:
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -3.18127341e-02
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 7.87575533e-03
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -7.95919393e-03
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -6.16667824e-02
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_minus: 6.22183257e-02
   syst_splitted_3_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 2.54487731e-02
@@ -36224,7 +36224,7 @@ bins:
   syst_JES_Pileup_Pt_term_minus: -1.06631703e-02
   syst_JES_Punch_through_plus: 9.26522015e-04
   syst_JES_Punch_through_minus: -1.06348860e-03
-  syst_JES_SingleParticle_HighPt_plus: -0.0
+  syst_JES_SingleParticle_HighPt_plus: 0.0
   syst_JES_SingleParticle_HighPt_minus: 0.0
   syst_JES_Zjet_JVF_plus: 1.02176930e-03
   syst_JES_Zjet_JVF_minus: -9.59331770e-04
@@ -36274,12 +36274,12 @@ bins:
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -1.76635274e-02
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 5.43482272e-03
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -5.33512066e-03
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -3.56593950e-02
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_minus: 3.60129484e-02
   syst_splitted_3_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 1.46441814e-02
@@ -36896,7 +36896,7 @@ bins:
   syst_JES_Pileup_Pt_term_minus: -6.20132647e-03
   syst_JES_Punch_through_plus: 7.90545381e-04
   syst_JES_Punch_through_minus: -8.52982910e-04
-  syst_JES_SingleParticle_HighPt_plus: -0.0
+  syst_JES_SingleParticle_HighPt_plus: 0.0
   syst_JES_SingleParticle_HighPt_minus: 0.0
   syst_JES_Zjet_JVF_plus: 5.88242131e-04
   syst_JES_Zjet_JVF_minus: -5.87817867e-04
@@ -36946,12 +36946,12 @@ bins:
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -9.86626092e-03
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 3.56098975e-03
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -3.42593235e-03
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -2.07606551e-02
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_minus: 2.10647110e-02
   syst_splitted_3_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 8.54962809e-03
@@ -37568,7 +37568,7 @@ bins:
   syst_JES_Pileup_Pt_term_minus: -3.58573849e-03
   syst_JES_Punch_through_plus: 6.38800266e-04
   syst_JES_Punch_through_minus: -6.27345136e-04
-  syst_JES_SingleParticle_HighPt_plus: -0.0
+  syst_JES_SingleParticle_HighPt_plus: 0.0
   syst_JES_SingleParticle_HighPt_minus: 0.0
   syst_JES_Zjet_JVF_plus: 3.39128412e-04
   syst_JES_Zjet_JVF_minus: -3.55533290e-04
@@ -37618,12 +37618,12 @@ bins:
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -5.58260804e-03
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 2.26274170e-03
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -2.16940360e-03
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -1.21905209e-02
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_minus: 1.23460844e-02
   syst_splitted_3_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 5.01409419e-03
@@ -38240,7 +38240,7 @@ bins:
   syst_JES_Pileup_Pt_term_minus: -1.98767716e-03
   syst_JES_Punch_through_plus: 4.77862763e-04
   syst_JES_Punch_through_minus: -4.45265140e-04
-  syst_JES_SingleParticle_HighPt_plus: -0.0
+  syst_JES_SingleParticle_HighPt_plus: 0.0
   syst_JES_SingleParticle_HighPt_minus: 0.0
   syst_JES_Zjet_JVF_plus: 2.02798225e-04
   syst_JES_Zjet_JVF_minus: -2.03929596e-04
@@ -38290,12 +38290,12 @@ bins:
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -3.18056630e-03
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 1.43047702e-03
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -1.39158615e-03
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -7.13258610e-03
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_minus: 7.21178206e-03
   syst_splitted_3_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 2.93095761e-03
@@ -38962,12 +38962,12 @@ bins:
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -1.85120555e-03
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 9.37765013e-04
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -9.36138668e-04
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -4.22496302e-03
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_minus: 4.30274476e-03
   syst_splitted_3_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 1.74584664e-03
@@ -39634,12 +39634,12 @@ bins:
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -1.07550941e-03
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 6.32012041e-04
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -6.40921586e-04
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -2.50457222e-03
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_minus: 2.57952554e-03
   syst_splitted_3_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 1.04086118e-03
@@ -40306,12 +40306,12 @@ bins:
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -6.17092088e-04
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 4.35365645e-04
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -4.39537575e-04
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -1.48916688e-03
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_minus: 1.54361410e-03
   syst_splitted_3_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 6.20415490e-04
@@ -40978,12 +40978,12 @@ bins:
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -3.50654253e-04
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 3.03914495e-04
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -3.02358860e-04
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -8.89823173e-04
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_minus: 9.22350085e-04
   syst_splitted_3_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 3.71726035e-04
@@ -41650,12 +41650,12 @@ bins:
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -1.96858528e-04
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 2.10505689e-04
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -2.06545891e-04
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -5.26228867e-04
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_minus: 5.44684354e-04
   syst_splitted_3_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 2.21536555e-04
@@ -42322,12 +42322,12 @@ bins:
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -1.12854242e-04
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 1.46088261e-04
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -1.42340595e-04
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -3.14308964e-04
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_minus: 3.24703434e-04
   syst_splitted_3_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 1.33784603e-04
@@ -42994,12 +42994,12 @@ bins:
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -6.36183971e-05
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 9.64281518e-05
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -9.42502629e-05
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -1.82221418e-04
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_minus: 1.87029744e-04
   syst_splitted_3_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 7.82696496e-05
@@ -43666,12 +43666,12 @@ bins:
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -3.62392225e-05
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 6.22607521e-05
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -6.13627265e-05
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -1.05995306e-04
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_minus: 1.07692363e-04
   syst_splitted_3_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 4.58700169e-05
@@ -44338,12 +44338,12 @@ bins:
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -2.04636702e-05
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 3.88201623e-05
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -3.85514617e-05
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -6.09313913e-05
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_minus: 6.14546504e-05
   syst_splitted_3_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 2.66437835e-05
@@ -45010,12 +45010,12 @@ bins:
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -1.12217846e-05
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 2.30941075e-05
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -2.30163257e-05
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -3.39835519e-05
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_minus: 3.41673997e-05
   syst_splitted_3_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 1.51108719e-05
@@ -45682,12 +45682,12 @@ bins:
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -5.62927709e-06
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 1.24875058e-05
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -1.24238661e-05
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -1.73099740e-05
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_minus: 1.74372532e-05
   syst_splitted_3_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 7.93020255e-06
@@ -46354,12 +46354,12 @@ bins:
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -2.15526147e-06
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 5.22127647e-06
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -5.14420183e-06
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -6.77337586e-06
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_minus: 6.85964288e-06
   syst_splitted_3_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 3.27673282e-06
@@ -47026,12 +47026,12 @@ bins:
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -4.16556605e-07
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 1.10591501e-06
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -1.07692363e-06
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -1.39865721e-06
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_minus: 1.40360696e-06
   syst_splitted_3_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 7.23228816e-07
@@ -47698,12 +47698,12 @@ bins:
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -9.98434775e-09
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 3.08439978e-08
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -3.06106526e-08
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -4.60750779e-08
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_minus: 4.34304985e-08
   syst_splitted_3_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 2.79943575e-08
@@ -47994,9 +47994,9 @@ bins:
   syst_JES_EtaIntercalibration_Stat211_minus: 0.0
   syst_JES_EtaIntercalibration_Stat212_plus: 0.0
   syst_JES_EtaIntercalibration_Stat212_minus: 0.0
-  syst_JES_EtaIntercalibration_Stat213_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat213_plus: 0.0
   syst_JES_EtaIntercalibration_Stat213_minus: 0.0
-  syst_JES_EtaIntercalibration_Stat214_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat214_plus: 0.0
   syst_JES_EtaIntercalibration_Stat214_minus: 8.91166676e-02
   syst_JES_EtaIntercalibration_Stat215_plus: 0.0
   syst_JES_EtaIntercalibration_Stat215_minus: 0.0
@@ -48012,13 +48012,13 @@ bins:
   syst_JES_EtaIntercalibration_Stat22_minus: 0.0
   syst_JES_EtaIntercalibration_Stat220_plus: -5.60877099e-02
   syst_JES_EtaIntercalibration_Stat220_minus: 0.0
-  syst_JES_EtaIntercalibration_Stat221_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat221_plus: 0.0
   syst_JES_EtaIntercalibration_Stat221_minus: 0.0
   syst_JES_EtaIntercalibration_Stat222_plus: 0.0
   syst_JES_EtaIntercalibration_Stat222_minus: 0.0
   syst_JES_EtaIntercalibration_Stat223_plus: 0.0
   syst_JES_EtaIntercalibration_Stat223_minus: 0.0
-  syst_JES_EtaIntercalibration_Stat224_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat224_plus: 0.0
   syst_JES_EtaIntercalibration_Stat224_minus: 4.10616908e-02
   syst_JES_EtaIntercalibration_Stat225_plus: 0.0
   syst_JES_EtaIntercalibration_Stat225_minus: 0.0
@@ -48042,9 +48042,9 @@ bins:
   syst_JES_EtaIntercalibration_Stat233_minus: 0.0
   syst_JES_EtaIntercalibration_Stat234_plus: 0.0
   syst_JES_EtaIntercalibration_Stat234_minus: 0.0
-  syst_JES_EtaIntercalibration_Stat235_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat235_plus: 0.0
   syst_JES_EtaIntercalibration_Stat235_minus: 3.72008878e-02
-  syst_JES_EtaIntercalibration_Stat236_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat236_plus: 0.0
   syst_JES_EtaIntercalibration_Stat236_minus: 7.57594205e-02
   syst_JES_EtaIntercalibration_Stat237_plus: -4.80196215e-02
   syst_JES_EtaIntercalibration_Stat237_minus: 2.06545891e-01
@@ -48364,16 +48364,16 @@ bins:
   syst_Unfolding_bias_minus: 6.26475395e+01
   syst_jetselection_BCH_plus: 8.60570166e+01
   syst_jetselection_BCH_minus: -8.60570166e+01
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 6.26652172e+02
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -5.97413306e+02
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 9.78352942e-05
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -7.10288762e-05
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -1.52572430e+03
@@ -48690,7 +48690,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat222_minus: 0.0
   syst_JES_EtaIntercalibration_Stat223_plus: 0.0
   syst_JES_EtaIntercalibration_Stat223_minus: 0.0
-  syst_JES_EtaIntercalibration_Stat224_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat224_plus: 0.0
   syst_JES_EtaIntercalibration_Stat224_minus: 1.67301464e-02
   syst_JES_EtaIntercalibration_Stat225_plus: 0.0
   syst_JES_EtaIntercalibration_Stat225_minus: 0.0
@@ -48714,9 +48714,9 @@ bins:
   syst_JES_EtaIntercalibration_Stat233_minus: 0.0
   syst_JES_EtaIntercalibration_Stat234_plus: 0.0
   syst_JES_EtaIntercalibration_Stat234_minus: 0.0
-  syst_JES_EtaIntercalibration_Stat235_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat235_plus: 0.0
   syst_JES_EtaIntercalibration_Stat235_minus: 1.51603694e-02
-  syst_JES_EtaIntercalibration_Stat236_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat236_plus: 0.0
   syst_JES_EtaIntercalibration_Stat236_minus: 3.08722821e-02
   syst_JES_EtaIntercalibration_Stat237_plus: -1.95656446e-02
   syst_JES_EtaIntercalibration_Stat237_minus: 8.41669202e-02
@@ -48981,7 +48981,7 @@ bins:
   syst_JES_MJB_Stat8_plus: 1.15329116e-02
   syst_JES_MJB_Stat8_minus: -2.18990970e-02
   syst_JES_MJB_Stat9_plus: 2.88570277e-02
-  syst_JES_MJB_Stat9_minus: -0.0
+  syst_JES_MJB_Stat9_minus: 0.0
   syst_JES_MJB_Threshold_plus: 4.58417326e-03
   syst_JES_MJB_Threshold_minus: -3.40189072e-03
   syst_JES_Pileup_MuOffset_plus: -1.86110505e+01
@@ -49036,16 +49036,16 @@ bins:
   syst_Unfolding_bias_minus: 4.14435284e+00
   syst_jetselection_BCH_plus: 3.82827611e+01
   syst_jetselection_BCH_minus: -3.82827611e+01
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 2.15222091e+02
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -2.09077333e+02
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 5.73180757e-04
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -4.25395440e-04
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -5.62538800e+02
@@ -49362,7 +49362,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat222_minus: 0.0
   syst_JES_EtaIntercalibration_Stat223_plus: 0.0
   syst_JES_EtaIntercalibration_Stat223_minus: 0.0
-  syst_JES_EtaIntercalibration_Stat224_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat224_plus: 0.0
   syst_JES_EtaIntercalibration_Stat224_minus: 7.71948473e-03
   syst_JES_EtaIntercalibration_Stat225_plus: 4.73195858e-31
   syst_JES_EtaIntercalibration_Stat225_minus: 0.0
@@ -49386,9 +49386,9 @@ bins:
   syst_JES_EtaIntercalibration_Stat233_minus: 0.0
   syst_JES_EtaIntercalibration_Stat234_plus: 0.0
   syst_JES_EtaIntercalibration_Stat234_minus: 0.0
-  syst_JES_EtaIntercalibration_Stat235_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat235_plus: 0.0
   syst_JES_EtaIntercalibration_Stat235_minus: 6.99470028e-03
-  syst_JES_EtaIntercalibration_Stat236_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat236_plus: 0.0
   syst_JES_EtaIntercalibration_Stat236_minus: 1.42411306e-02
   syst_JES_EtaIntercalibration_Stat237_plus: -9.02833938e-03
   syst_JES_EtaIntercalibration_Stat237_minus: 3.88343044e-02
@@ -49653,7 +49653,7 @@ bins:
   syst_JES_MJB_Stat8_plus: 5.31956431e-03
   syst_JES_MJB_Stat8_minus: -1.01045559e-02
   syst_JES_MJB_Stat9_plus: 1.33148207e-02
-  syst_JES_MJB_Stat9_minus: -0.0
+  syst_JES_MJB_Stat9_minus: 0.0
   syst_JES_MJB_Threshold_plus: 1.87241876e-03
   syst_JES_MJB_Threshold_minus: -3.99303199e-03
   syst_JES_Pileup_MuOffset_plus: -6.65741034e+00
@@ -49708,16 +49708,16 @@ bins:
   syst_Unfolding_bias_minus: -7.44512730e+00
   syst_jetselection_BCH_plus: 1.89080353e+01
   syst_jetselection_BCH_minus: -1.89080353e+01
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 8.77434663e+01
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -8.56384094e+01
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -6.99823581e-01
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 7.34188971e-01
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 2.34405898e-04
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -4.99217388e-04
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -2.34158411e+02
@@ -50058,9 +50058,9 @@ bins:
   syst_JES_EtaIntercalibration_Stat233_minus: 0.0
   syst_JES_EtaIntercalibration_Stat234_plus: 0.0
   syst_JES_EtaIntercalibration_Stat234_minus: 0.0
-  syst_JES_EtaIntercalibration_Stat235_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat235_plus: 0.0
   syst_JES_EtaIntercalibration_Stat235_minus: 3.20248661e-03
-  syst_JES_EtaIntercalibration_Stat236_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat236_plus: 0.0
   syst_JES_EtaIntercalibration_Stat236_minus: 6.52164584e-03
   syst_JES_EtaIntercalibration_Stat237_plus: -4.13374624e-03
   syst_JES_EtaIntercalibration_Stat237_minus: 1.77766645e-02
@@ -50325,7 +50325,7 @@ bins:
   syst_JES_MJB_Stat8_plus: 2.43527575e-03
   syst_JES_MJB_Stat8_minus: -4.62659967e-03
   syst_JES_MJB_Stat9_plus: 6.09667467e-03
-  syst_JES_MJB_Stat9_minus: -0.0
+  syst_JES_MJB_Stat9_minus: 0.0
   syst_JES_MJB_Threshold_plus: -1.47997449e-02
   syst_JES_MJB_Threshold_minus: 2.79491026e-03
   syst_JES_Pileup_MuOffset_plus: -3.11621958e+00
@@ -50380,16 +50380,16 @@ bins:
   syst_Unfolding_bias_minus: 1.11652161e+00
   syst_jetselection_BCH_plus: 9.44623949e+00
   syst_jetselection_BCH_minus: -9.44623949e+00
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 3.57308128e+01
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -3.48638998e+01
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -8.30072650e-01
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 8.59983267e-01
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: -1.84413449e-03
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 3.47825826e-04
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -9.57917556e+01
@@ -50730,7 +50730,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat233_minus: 0.0
   syst_JES_EtaIntercalibration_Stat234_plus: 0.0
   syst_JES_EtaIntercalibration_Stat234_minus: 0.0
-  syst_JES_EtaIntercalibration_Stat235_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat235_plus: 0.0
   syst_JES_EtaIntercalibration_Stat235_minus: 1.53866436e-03
   syst_JES_EtaIntercalibration_Stat236_plus: -5.87605735e-42
   syst_JES_EtaIntercalibration_Stat236_minus: 3.13319015e-03
@@ -50997,7 +50997,7 @@ bins:
   syst_JES_MJB_Stat8_plus: 1.17026172e-03
   syst_JES_MJB_Stat8_minus: -2.22243661e-03
   syst_JES_MJB_Stat9_plus: 2.92883629e-03
-  syst_JES_MJB_Stat9_minus: -0.0
+  syst_JES_MJB_Stat9_minus: 0.0
   syst_JES_MJB_Threshold_plus: -2.77504056e-02
   syst_JES_MJB_Threshold_minus: 2.25496353e-02
   syst_JES_Pileup_MuOffset_plus: -1.53866436e+00
@@ -51052,16 +51052,16 @@ bins:
   syst_Unfolding_bias_minus: -7.24501608e-01
   syst_jetselection_BCH_plus: 4.24193358e+00
   syst_jetselection_BCH_minus: -4.24193358e+00
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 1.52805775e+01
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -1.50048059e+01
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -5.79544718e-01
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 5.96585991e-01
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: -3.44219581e-03
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 2.79844580e-03
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -4.17221285e+01
@@ -51669,7 +51669,7 @@ bins:
   syst_JES_MJB_Stat8_plus: 5.91494822e-04
   syst_JES_MJB_Stat8_minus: -1.12359268e-03
   syst_JES_MJB_Stat9_plus: 1.48068160e-03
-  syst_JES_MJB_Stat9_minus: -0.0
+  syst_JES_MJB_Stat9_minus: 0.0
   syst_JES_MJB_Threshold_plus: -3.35380746e-02
   syst_JES_MJB_Threshold_minus: 4.08707720e-02
   syst_JES_Pileup_MuOffset_plus: -6.70973625e-01
@@ -51724,16 +51724,16 @@ bins:
   syst_Unfolding_bias_minus: 6.72246417e-02
   syst_jetselection_BCH_plus: 1.74372532e+00
   syst_jetselection_BCH_minus: -1.74372532e+00
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 6.88863426e+00
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -6.77266875e+00
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -3.62180093e-01
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 3.73281670e-01
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: -4.15495945e-03
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 5.05793481e-03
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -1.93322994e+01
@@ -52341,7 +52341,7 @@ bins:
   syst_JES_MJB_Stat8_plus: 2.95853477e-04
   syst_JES_MJB_Stat8_minus: -5.62008470e-04
   syst_JES_MJB_Stat9_plus: 7.40552932e-04
-  syst_JES_MJB_Stat9_minus: -0.0
+  syst_JES_MJB_Stat9_minus: 0.0
   syst_JES_MJB_Threshold_plus: -3.29723892e-02
   syst_JES_MJB_Threshold_minus: 3.96333351e-02
   syst_JES_Pileup_MuOffset_plus: -2.78861701e-01
@@ -52396,16 +52396,16 @@ bins:
   syst_Unfolding_bias_minus: -6.49406868e-02
   syst_jetselection_BCH_plus: 7.77676038e-01
   syst_jetselection_BCH_minus: -7.77676038e-01
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 3.06318658e+00
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -3.01863885e+00
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -2.08101526e-01
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 2.14324065e-01
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: -4.10546197e-03
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 4.90237131e-03
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -8.86499772e+00
@@ -53025,7 +53025,7 @@ bins:
   syst_JES_Punch_through_plus: 4.87974390e-02
   syst_JES_Punch_through_minus: -3.61472987e-02
   syst_JES_SingleParticle_HighPt_plus: 0.0
-  syst_JES_SingleParticle_HighPt_minus: -0.0
+  syst_JES_SingleParticle_HighPt_minus: 0.0
   syst_JES_Zjet_JVF_plus: 9.14996175e-02
   syst_JES_Zjet_JVF_minus: -9.03611756e-02
   syst_JES_Zjet_MC_plus: 1.85615530e+00
@@ -53068,16 +53068,16 @@ bins:
   syst_Unfolding_bias_minus: 2.78607143e-02
   syst_jetselection_BCH_plus: 4.27375339e-01
   syst_jetselection_BCH_minus: -4.27375339e-01
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 1.42694148e+00
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -1.41633488e+00
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -1.17874700e-01
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 1.21410234e-01
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: -3.11692669e-03
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 3.20885057e-03
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -4.22567012e+00
@@ -53697,7 +53697,7 @@ bins:
   syst_JES_Punch_through_plus: 2.25142799e-02
   syst_JES_Punch_through_minus: -1.65533697e-02
   syst_JES_SingleParticle_HighPt_plus: 0.0
-  syst_JES_SingleParticle_HighPt_minus: -0.0
+  syst_JES_SingleParticle_HighPt_minus: 0.0
   syst_JES_Zjet_JVF_plus: 4.77721341e-02
   syst_JES_Zjet_JVF_minus: -4.83943881e-02
   syst_JES_Zjet_MC_plus: 9.95323505e-01
@@ -53740,16 +53740,16 @@ bins:
   syst_Unfolding_bias_minus: -1.25794296e-02
   syst_jetselection_BCH_plus: 2.50740065e-01
   syst_jetselection_BCH_minus: -2.50740065e-01
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 7.07389624e-01
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -6.97207286e-01
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -6.74579869e-02
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 7.03005562e-02
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: -1.78403041e-03
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 1.14834141e-03
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -2.10647110e+00
@@ -54369,7 +54369,7 @@ bins:
   syst_JES_Punch_through_plus: 1.20985970e-02
   syst_JES_Punch_through_minus: -9.28714046e-03
   syst_JES_SingleParticle_HighPt_plus: 0.0
-  syst_JES_SingleParticle_HighPt_minus: -0.0
+  syst_JES_SingleParticle_HighPt_minus: 0.0
   syst_JES_Zjet_JVF_plus: 2.57174736e-02
   syst_JES_Zjet_JVF_minus: -2.59932453e-02
   syst_JES_Zjet_MC_plus: 5.16187950e-01
@@ -54412,16 +54412,16 @@ bins:
   syst_Unfolding_bias_minus: 3.01863885e-04
   syst_jetselection_BCH_plus: 1.46724657e-01
   syst_jetselection_BCH_minus: -1.46724657e-01
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 3.57513189e-01
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -3.46482323e-01
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: -0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -3.83181165e-02
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 4.01778073e-02
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -9.52119281e-04
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -1.06702413e+00
@@ -55041,7 +55041,7 @@ bins:
   syst_JES_Punch_through_plus: 7.16016327e-03
   syst_JES_Punch_through_minus: -6.14758636e-03
   syst_JES_SingleParticle_HighPt_plus: 0.0
-  syst_JES_SingleParticle_HighPt_minus: -0.0
+  syst_JES_SingleParticle_HighPt_minus: 0.0
   syst_JES_Zjet_JVF_plus: 1.46441814e-02
   syst_JES_Zjet_JVF_minus: -1.42552727e-02
   syst_JES_Zjet_MC_plus: 2.61700220e-01
@@ -55084,16 +55084,16 @@ bins:
   syst_Unfolding_bias_minus: -4.46537932e-03
   syst_jetselection_BCH_plus: 8.84166319e-02
   syst_jetselection_BCH_minus: -8.84166319e-02
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 1.86251926e-01
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -1.78968726e-01
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -2.21890108e-02
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 2.30870364e-02
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 1.71473394e-03
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -2.23233611e-03
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -5.60382124e-01
@@ -55713,7 +55713,7 @@ bins:
   syst_JES_Punch_through_plus: 4.24759043e-03
   syst_JES_Punch_through_minus: -3.90181522e-03
   syst_JES_SingleParticle_HighPt_plus: 0.0
-  syst_JES_SingleParticle_HighPt_minus: -0.0
+  syst_JES_SingleParticle_HighPt_minus: 0.0
   syst_JES_Zjet_JVF_plus: 7.80080201e-03
   syst_JES_Zjet_JVF_minus: -7.25562268e-03
   syst_JES_Zjet_MC_plus: 1.26713535e-01
@@ -55756,16 +55756,16 @@ bins:
   syst_Unfolding_bias_minus: 1.77766645e-03
   syst_jetselection_BCH_plus: 5.20430591e-02
   syst_jetselection_BCH_minus: -5.20430591e-02
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 9.68736290e-02
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -9.30057549e-02
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -1.27491353e-02
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 1.31804704e-02
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 2.38012143e-03
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -2.48053059e-03
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -2.94934238e-01
@@ -56385,7 +56385,7 @@ bins:
   syst_JES_Punch_through_plus: 2.57033315e-03
   syst_JES_Punch_through_minus: -2.36951482e-03
   syst_JES_SingleParticle_HighPt_plus: 0.0
-  syst_JES_SingleParticle_HighPt_minus: -0.0
+  syst_JES_SingleParticle_HighPt_minus: 0.0
   syst_JES_Zjet_JVF_plus: 4.03050865e-03
   syst_JES_Zjet_JVF_minus: -3.69816847e-03
   syst_JES_Zjet_MC_plus: 6.17092088e-02
@@ -56428,16 +56428,16 @@ bins:
   syst_Unfolding_bias_minus: -1.36400898e-03
   syst_jetselection_BCH_plus: 3.02146728e-02
   syst_jetselection_BCH_minus: -3.02146728e-02
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 5.19864906e-02
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -5.02045815e-02
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -7.54058671e-03
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 7.76827510e-03
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 2.12344166e-03
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -2.13263405e-03
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -1.61644610e-01
@@ -57057,7 +57057,7 @@ bins:
   syst_JES_Punch_through_plus: 1.63341666e-03
   syst_JES_Punch_through_minus: -1.46371104e-03
   syst_JES_SingleParticle_HighPt_plus: 0.0
-  syst_JES_SingleParticle_HighPt_minus: -0.0
+  syst_JES_SingleParticle_HighPt_minus: 0.0
   syst_JES_Zjet_JVF_plus: 2.22385083e-03
   syst_JES_Zjet_JVF_minus: -2.07747972e-03
   syst_JES_Zjet_MC_plus: 3.04480180e-02
@@ -57100,16 +57100,16 @@ bins:
   syst_Unfolding_bias_minus: 4.71003827e-04
   syst_jetselection_BCH_plus: 1.73524004e-02
   syst_jetselection_BCH_minus: -1.73524004e-02
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 2.85176165e-02
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -2.77390919e-02
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -4.56083874e-03
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 4.67044029e-03
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 1.63483088e-03
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -1.63129534e-03
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -9.13723383e-02
@@ -57729,7 +57729,7 @@ bins:
   syst_JES_Punch_through_plus: 1.06278149e-03
   syst_JES_Punch_through_minus: -9.64140096e-04
   syst_JES_SingleParticle_HighPt_plus: 0.0
-  syst_JES_SingleParticle_HighPt_minus: -0.0
+  syst_JES_SingleParticle_HighPt_minus: 0.0
   syst_JES_Zjet_JVF_plus: 1.29612673e-03
   syst_JES_Zjet_JVF_minus: -1.27420642e-03
   syst_JES_Zjet_MC_plus: 1.49906638e-02
@@ -57772,16 +57772,16 @@ bins:
   syst_Unfolding_bias_minus: -1.27067089e-04
   syst_jetselection_BCH_plus: 1.01964798e-02
   syst_jetselection_BCH_minus: -1.01964798e-02
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 1.55209938e-02
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -1.51815826e-02
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -2.72384603e-03
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 2.78529361e-03
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 1.16389776e-03
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -1.15965512e-03
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -5.12723127e-02
@@ -58401,7 +58401,7 @@ bins:
   syst_JES_Punch_through_plus: 6.86388552e-04
   syst_JES_Punch_through_minus: -6.79812459e-04
   syst_JES_SingleParticle_HighPt_plus: 0.0
-  syst_JES_SingleParticle_HighPt_minus: -0.0
+  syst_JES_SingleParticle_HighPt_minus: 0.0
   syst_JES_Zjet_JVF_plus: 7.58796287e-04
   syst_JES_Zjet_JVF_minus: -7.66362329e-04
   syst_JES_Zjet_MC_plus: 7.50240295e-03
@@ -58444,16 +58444,16 @@ bins:
   syst_Unfolding_bias_minus: -5.32592828e-04
   syst_jetselection_BCH_plus: 6.52730270e-03
   syst_jetselection_BCH_minus: -6.52730270e-03
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 8.46689660e-03
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -8.31840417e-03
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -1.61786032e-03
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 1.66170094e-03
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 7.81494415e-04
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -7.78100302e-04
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -2.87438907e-02
@@ -59116,16 +59116,16 @@ bins:
   syst_Unfolding_bias_minus: 2.53922045e-04
   syst_jetselection_BCH_plus: 4.41163921e-03
   syst_jetselection_BCH_minus: -4.41163921e-03
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 4.68528953e-03
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -4.61457885e-03
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -9.71564717e-04
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 9.99495435e-04
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 5.08056222e-04
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -5.01480129e-04
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -1.63624509e-02
@@ -59788,16 +59788,16 @@ bins:
   syst_Unfolding_bias_minus: -2.27122698e-05
   syst_jetselection_BCH_plus: 2.87792460e-03
   syst_jetselection_BCH_minus: -2.87792460e-03
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 2.58306107e-03
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -2.55689812e-03
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -5.81100353e-04
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 5.92979747e-04
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 3.19753686e-04
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -3.14379675e-04
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -9.31471763e-03
@@ -60460,16 +60460,16 @@ bins:
   syst_Unfolding_bias_minus: -1.50260191e-04
   syst_jetselection_BCH_plus: 1.74938218e-03
   syst_jetselection_BCH_minus: -1.74938218e-03
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 1.39865721e-03
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -1.39370747e-03
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -3.40118362e-04
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 3.42168971e-04
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 1.95656446e-04
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -1.93676547e-04
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -5.20501302e-03
@@ -61132,16 +61132,16 @@ bins:
   syst_Unfolding_bias_minus: 5.37471864e-05
   syst_jetselection_BCH_plus: 1.02530483e-03
   syst_jetselection_BCH_minus: -1.02530483e-03
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 7.59220551e-04
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -7.58654866e-04
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -1.97989899e-04
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 1.96929239e-04
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 1.21056681e-04
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -1.21198102e-04
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -2.90267334e-03
@@ -61804,16 +61804,16 @@ bins:
   syst_Unfolding_bias_minus: -2.29597572e-06
   syst_jetselection_BCH_plus: 5.94252539e-04
   syst_jetselection_BCH_minus: -5.94252539e-04
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 4.16203051e-04
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -4.15142391e-04
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -1.15611959e-04
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 1.14622009e-04
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 7.75484007e-05
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -7.83262182e-05
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -1.62775981e-03
@@ -62476,16 +62476,16 @@ bins:
   syst_Unfolding_bias_minus: -5.11238203e-08
   syst_jetselection_BCH_plus: 3.49310750e-04
   syst_jetselection_BCH_minus: -3.49310750e-04
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 2.30446100e-04
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -2.28607622e-04
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -6.77479007e-05
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 6.76064793e-05
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 5.15410133e-05
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -5.19582063e-05
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -9.18319577e-04
@@ -63148,16 +63148,16 @@ bins:
   syst_Unfolding_bias_minus: -2.00394062e-06
   syst_jetselection_BCH_plus: 2.06758023e-04
   syst_jetselection_BCH_minus: -2.06758023e-04
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 1.25087190e-04
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -1.22753737e-04
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -3.86787409e-05
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 3.92019999e-05
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 3.41037601e-05
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -3.38916280e-05
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -5.05934902e-04
@@ -63820,16 +63820,16 @@ bins:
   syst_Unfolding_bias_minus: -4.92782716e-06
   syst_jetselection_BCH_plus: 1.24733636e-04
   syst_jetselection_BCH_minus: -1.24733636e-04
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 6.81368094e-05
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -6.59023520e-05
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -2.20475894e-05
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 2.27334830e-05
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 2.25849906e-05
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -2.20617316e-05
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -2.78918270e-04
@@ -64492,16 +64492,16 @@ bins:
   syst_Unfolding_bias_minus: -4.68033978e-06
   syst_jetselection_BCH_plus: 7.18774043e-05
   syst_jetselection_BCH_minus: -7.18774043e-05
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 3.63947860e-05
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -3.49098618e-05
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -1.22824448e-05
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 1.27986327e-05
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 1.44108362e-05
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -1.39158615e-05
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -1.50472323e-04
@@ -65164,16 +65164,16 @@ bins:
   syst_Unfolding_bias_minus: -2.44163972e-06
   syst_jetselection_BCH_plus: 3.89474415e-05
   syst_jetselection_BCH_minus: -3.89474415e-05
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 1.90848120e-05
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -1.83140656e-05
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -6.70195807e-06
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 6.99611449e-06
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 8.82752106e-06
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -8.50225194e-06
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -7.96626500e-05
@@ -65836,16 +65836,16 @@ bins:
   syst_Unfolding_bias_minus: -1.33431050e-06
   syst_jetselection_BCH_plus: 2.03222489e-05
   syst_jetselection_BCH_minus: -2.03222489e-05
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 9.71706139e-06
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -9.36562932e-06
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -3.55533290e-06
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 3.68968318e-06
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 5.11874599e-06
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -4.94833325e-06
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -4.10404776e-05
@@ -66508,16 +66508,16 @@ bins:
   syst_Unfolding_bias_minus: -6.33496965e-07
   syst_jetselection_BCH_plus: 1.05853885e-05
   syst_jetselection_BCH_minus: -1.05853885e-05
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 4.79347687e-06
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -4.68033978e-06
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -1.84342738e-06
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 1.88373247e-06
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 2.80587042e-06
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -2.73975593e-06
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -2.06970155e-05
@@ -67180,16 +67180,16 @@ bins:
   syst_Unfolding_bias_minus: -3.44502424e-07
   syst_jetselection_BCH_plus: 5.48573441e-06
   syst_jetselection_BCH_minus: -5.48573441e-06
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 2.32001735e-06
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -2.33769502e-06
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -9.51695017e-07
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 9.45826031e-07
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 1.48351003e-06
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -1.47361053e-06
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -1.04015408e-05
@@ -67852,16 +67852,16 @@ bins:
   syst_Unfolding_bias_minus: -6.96924444e-08
   syst_jetselection_BCH_plus: 2.28607622e-06
   syst_jetselection_BCH_minus: -2.28607622e-06
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 9.39037805e-07
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -9.98859039e-07
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -4.19880007e-07
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 4.00575992e-07
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 6.51528188e-07
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -6.64963217e-07
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -4.45760115e-06
@@ -68524,16 +68524,16 @@ bins:
   syst_Unfolding_bias_minus: 1.32016836e-06
   syst_jetselection_BCH_plus: 4.82671089e-07
   syst_jetselection_BCH_minus: -4.82671089e-07
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 2.27617673e-07
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -2.59437478e-07
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -1.15116984e-07
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 1.04581093e-07
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 1.70342024e-07
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -1.80312229e-07
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -1.17309015e-06
@@ -69196,16 +69196,16 @@ bins:
   syst_Unfolding_bias_minus: -3.43441764e-07
   syst_jetselection_BCH_plus: 1.35693791e-08
   syst_jetselection_BCH_minus: -1.35693791e-08
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 9.75665937e-09
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -8.83459212e-09
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -4.74892914e-09
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 5.41997348e-09
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 8.28517016e-09
   syst_splitted_2_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -7.03429826e-09
   syst_splitted_3_perbinPercrossOpt14_JES_Flavour_Response_plus: -4.33527168e-08
@@ -69494,9 +69494,9 @@ bins:
   syst_JES_EtaIntercalibration_Stat21_minus: 0.0
   syst_JES_EtaIntercalibration_Stat210_plus: -8.73913271e-37
   syst_JES_EtaIntercalibration_Stat210_minus: 2.17788889e-36
-  syst_JES_EtaIntercalibration_Stat211_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat211_plus: 0.0
   syst_JES_EtaIntercalibration_Stat211_minus: 1.69917760e-01
-  syst_JES_EtaIntercalibration_Stat212_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat212_plus: 0.0
   syst_JES_EtaIntercalibration_Stat212_minus: 2.15526147e-01
   syst_JES_EtaIntercalibration_Stat213_plus: -8.36578033e-02
   syst_JES_EtaIntercalibration_Stat213_minus: 0.0
@@ -69809,7 +69809,7 @@ bins:
   syst_JES_MJB_Stat6_plus: -1.43542677e-01
   syst_JES_MJB_Stat6_minus: 6.16950667e-02
   syst_JES_MJB_Stat7_plus: 2.27334830e-02
-  syst_JES_MJB_Stat7_minus: -0.0
+  syst_JES_MJB_Stat7_minus: 0.0
   syst_JES_MJB_Stat8_plus: 2.26344881e-02
   syst_JES_MJB_Stat8_minus: -2.10576399e-02
   syst_JES_MJB_Stat9_plus: 7.67140147e-02
@@ -69868,13 +69868,13 @@ bins:
   syst_Unfolding_bias_minus: 5.58175951e+01
   syst_jetselection_BCH_plus: 6.54851590e+01
   syst_jetselection_BCH_minus: -6.54851590e+01
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 1.57005990e+02
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -1.47226703e+02
@@ -70481,7 +70481,7 @@ bins:
   syst_JES_MJB_Stat6_plus: -5.70988726e-02
   syst_JES_MJB_Stat6_minus: 2.45436764e-02
   syst_JES_MJB_Stat7_plus: 9.04530994e-03
-  syst_JES_MJB_Stat7_minus: -0.0
+  syst_JES_MJB_Stat7_minus: 0.0
   syst_JES_MJB_Stat8_plus: 9.00571197e-03
   syst_JES_MJB_Stat8_minus: -8.37850825e-03
   syst_JES_MJB_Stat9_plus: 3.05187287e-02
@@ -70540,13 +70540,13 @@ bins:
   syst_Unfolding_bias_minus: 3.00873935e+00
   syst_jetselection_BCH_plus: 2.49184430e+01
   syst_jetselection_BCH_minus: -2.49184430e+01
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 5.37514291e+01
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -5.06083394e+01
@@ -71153,7 +71153,7 @@ bins:
   syst_JES_MJB_Stat6_plus: -2.45295342e-02
   syst_JES_MJB_Stat6_minus: 1.05429621e-02
   syst_JES_MJB_Stat7_plus: 3.88555176e-03
-  syst_JES_MJB_Stat7_minus: -0.0
+  syst_JES_MJB_Stat7_minus: 0.0
   syst_JES_MJB_Stat8_plus: 3.86858120e-03
   syst_JES_MJB_Stat8_minus: -3.59917352e-03
   syst_JES_MJB_Stat9_plus: 1.31097597e-02
@@ -71212,10 +71212,10 @@ bins:
   syst_Unfolding_bias_minus: -6.55982961e+00
   syst_jetselection_BCH_plus: 1.18440386e+01
   syst_jetselection_BCH_minus: -1.18440386e+01
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -1.45381154e+00
@@ -71825,7 +71825,7 @@ bins:
   syst_JES_MJB_Stat6_plus: -1.14834141e-02
   syst_JES_MJB_Stat6_minus: 4.93701955e-03
   syst_JES_MJB_Stat7_plus: 1.81938575e-03
-  syst_JES_MJB_Stat7_minus: -0.0
+  syst_JES_MJB_Stat7_minus: 0.0
   syst_JES_MJB_Stat8_plus: 1.81160757e-03
   syst_JES_MJB_Stat8_minus: -1.68503546e-03
   syst_JES_MJB_Stat9_plus: 6.13910107e-03
@@ -71884,11 +71884,11 @@ bins:
   syst_Unfolding_bias_minus: 9.20370186e-01
   syst_jetselection_BCH_plus: 6.15112189e+00
   syst_jetselection_BCH_minus: -6.15112189e+00
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -1.81090047e+00
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 1.88585379e+00
@@ -72497,7 +72497,7 @@ bins:
   syst_JES_MJB_Stat6_plus: -5.53381767e-03
   syst_JES_MJB_Stat6_minus: 2.37870721e-03
   syst_JES_MJB_Stat7_plus: 8.76670987e-04
-  syst_JES_MJB_Stat7_minus: -0.0
+  syst_JES_MJB_Stat7_minus: 0.0
   syst_JES_MJB_Stat8_plus: 8.72852611e-04
   syst_JES_MJB_Stat8_minus: -8.12041428e-04
   syst_JES_MJB_Stat9_plus: 2.95782767e-03
@@ -72556,11 +72556,11 @@ bins:
   syst_Unfolding_bias_minus: -6.49053314e-01
   syst_jetselection_BCH_plus: 3.04055916e+00
   syst_jetselection_BCH_minus: -3.04055916e+00
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -1.28693434e+00
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 1.34915974e+00
@@ -73228,11 +73228,11 @@ bins:
   syst_Unfolding_bias_minus: 2.25142799e-02
   syst_jetselection_BCH_plus: 1.39441457e+00
   syst_jetselection_BCH_minus: -1.39441457e+00
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -7.90262539e-01
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 8.21658080e-01
@@ -73900,11 +73900,11 @@ bins:
   syst_Unfolding_bias_minus: -6.20769043e-02
   syst_jetselection_BCH_plus: 5.96232438e-01
   syst_jetselection_BCH_minus: -5.96232438e-01
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -4.48234989e-01
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 4.61952860e-01
@@ -74572,11 +74572,11 @@ bins:
   syst_Unfolding_bias_minus: 1.44249783e-02
   syst_jetselection_BCH_plus: 2.79611234e-01
   syst_jetselection_BCH_minus: -2.79611234e-01
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -2.45153921e-01
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 2.55548391e-01
@@ -75244,12 +75244,12 @@ bins:
   syst_Unfolding_bias_minus: -1.18228254e-02
   syst_jetselection_BCH_plus: 1.57189837e-01
   syst_jetselection_BCH_minus: -1.57189837e-01
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: -0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -1.34350288e-01
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 1.41916331e-01
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 1.56270599e-01
@@ -75916,12 +75916,12 @@ bins:
   syst_Unfolding_bias_minus: 1.10520790e-03
   syst_jetselection_BCH_plus: 9.84999746e-02
   syst_jetselection_BCH_minus: -9.84999746e-02
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -7.31996940e-02
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 7.66220908e-02
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 7.66150197e-02
@@ -76588,12 +76588,12 @@ bins:
   syst_Unfolding_bias_minus: -4.90449263e-03
   syst_jetselection_BCH_plus: 6.56831489e-02
   syst_jetselection_BCH_minus: -6.56831489e-02
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -4.03404419e-02
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 4.15000970e-02
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 3.81342687e-02
@@ -77260,12 +77260,12 @@ bins:
   syst_Unfolding_bias_minus: 2.10576399e-03
   syst_jetselection_BCH_plus: 4.26102546e-02
   syst_jetselection_BCH_minus: -4.26102546e-02
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -2.18495995e-02
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 2.24011428e-02
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 1.89999592e-02
@@ -77932,12 +77932,12 @@ bins:
   syst_Unfolding_bias_minus: -1.77200959e-03
   syst_jetselection_BCH_plus: 2.53639202e-02
   syst_jetselection_BCH_minus: -2.53639202e-02
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -1.23107291e-02
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 1.27067089e-02
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 1.00409163e-02
@@ -78604,12 +78604,12 @@ bins:
   syst_Unfolding_bias_minus: 3.62321515e-04
   syst_jetselection_BCH_plus: 1.35057395e-02
   syst_jetselection_BCH_minus: -1.35057395e-02
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -7.15167798e-03
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 7.35956738e-03
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 5.43694404e-03
@@ -79276,12 +79276,12 @@ bins:
   syst_Unfolding_bias_minus: -1.54007857e-04
   syst_jetselection_BCH_plus: 6.57680017e-03
   syst_jetselection_BCH_minus: -6.57680017e-03
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -4.02980155e-03
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 4.10334065e-03
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 2.84044794e-03
@@ -79948,12 +79948,12 @@ bins:
   syst_Unfolding_bias_minus: -3.76039386e-04
   syst_jetselection_BCH_plus: 3.21097189e-03
   syst_jetselection_BCH_minus: -3.21097189e-03
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -2.13404827e-03
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 2.16798939e-03
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 1.41562778e-03
@@ -80620,12 +80620,12 @@ bins:
   syst_Unfolding_bias_minus: 1.04368961e-04
   syst_jetselection_BCH_plus: 1.82999235e-03
   syst_jetselection_BCH_minus: -1.82999235e-03
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -1.16036223e-03
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 1.18793939e-03
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 7.36593134e-04
@@ -81292,12 +81292,12 @@ bins:
   syst_Unfolding_bias_minus: -4.75529310e-05
   syst_jetselection_BCH_plus: 1.09318708e-03
   syst_jetselection_BCH_minus: -1.09318708e-03
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -6.11505944e-04
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 6.35971839e-04
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 3.77170757e-04
@@ -81964,12 +81964,12 @@ bins:
   syst_Unfolding_bias_minus: -7.94646601e-05
   syst_jetselection_BCH_plus: 6.44952095e-04
   syst_jetselection_BCH_minus: -6.44952095e-04
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -3.11621958e-04
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 3.32128055e-04
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 1.89787460e-04
@@ -82636,12 +82636,12 @@ bins:
   syst_Unfolding_bias_minus: 2.04424570e-05
   syst_jetselection_BCH_plus: 3.81342687e-04
   syst_jetselection_BCH_minus: -3.81342687e-04
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -1.59735422e-04
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 1.72675476e-04
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 9.51977860e-05
@@ -83308,12 +83308,12 @@ bins:
   syst_Unfolding_bias_minus: -4.65417683e-06
   syst_jetselection_BCH_plus: 2.11707770e-04
   syst_jetselection_BCH_minus: -2.11707770e-04
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -7.96697210e-05
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 8.45346157e-05
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 4.47245039e-05
@@ -83980,12 +83980,12 @@ bins:
   syst_Unfolding_bias_minus: -8.23496557e-06
   syst_jetselection_BCH_plus: 1.11015765e-04
   syst_jetselection_BCH_minus: -1.11015765e-04
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -3.97323300e-05
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 3.97959696e-05
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 2.01666854e-05
@@ -84652,12 +84652,12 @@ bins:
   syst_Unfolding_bias_minus: -3.12753329e-06
   syst_jetselection_BCH_plus: 5.70705883e-05
   syst_jetselection_BCH_minus: -5.70705883e-05
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -1.96787817e-05
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 1.84554870e-05
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 8.99298404e-06
@@ -85324,12 +85324,12 @@ bins:
   syst_Unfolding_bias_minus: -1.16814040e-06
   syst_jetselection_BCH_plus: 2.94227132e-05
   syst_jetselection_BCH_minus: -2.94227132e-05
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -9.23340035e-06
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 8.47538188e-06
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 3.97747564e-06
@@ -85996,12 +85996,12 @@ bins:
   syst_Unfolding_bias_minus: -8.13031377e-07
   syst_jetselection_BCH_plus: 1.56058467e-05
   syst_jetselection_BCH_minus: -1.56058467e-05
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -4.18819346e-06
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 3.97747564e-06
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 1.78756594e-06
@@ -86668,12 +86668,12 @@ bins:
   syst_Unfolding_bias_minus: -4.87125862e-07
   syst_jetselection_BCH_plus: 7.70534259e-06
   syst_jetselection_BCH_minus: -7.70534259e-06
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -1.75221060e-06
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 1.75645324e-06
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 7.55402174e-07
@@ -87340,12 +87340,12 @@ bins:
   syst_Unfolding_bias_minus: -1.34915974e-07
   syst_jetselection_BCH_plus: 3.22864956e-06
   syst_jetselection_BCH_minus: -3.22864956e-06
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -6.50608949e-07
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 6.79529617e-07
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 2.81987113e-07
@@ -88012,12 +88012,12 @@ bins:
   syst_Unfolding_bias_minus: 8.70094894e-08
   syst_jetselection_BCH_plus: 1.44744758e-06
   syst_jetselection_BCH_minus: -1.44744758e-06
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -2.74753411e-07
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 2.91893679e-07
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 1.17945411e-07
@@ -88684,12 +88684,12 @@ bins:
   syst_Unfolding_bias_minus: 2.85741850e-07
   syst_jetselection_BCH_plus: 4.73973675e-07
   syst_jetselection_BCH_minus: -4.73973675e-07
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -8.76176013e-08
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 9.24188563e-08
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 3.65149942e-08
@@ -89356,12 +89356,12 @@ bins:
   syst_Unfolding_bias_minus: -1.67584307e-07
   syst_jetselection_BCH_plus: 3.92585685e-08
   syst_jetselection_BCH_minus: -3.92585685e-08
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -4.63720627e-09
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 3.53129127e-09
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 1.48563135e-09
@@ -89413,7 +89413,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat101_plus: 0.0
   syst_JES_EtaIntercalibration_Stat101_minus: 0.0
   syst_JES_EtaIntercalibration_Stat102_plus: 9.47240244e-13
-  syst_JES_EtaIntercalibration_Stat102_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat102_minus: 0.0
   syst_JES_EtaIntercalibration_Stat103_plus: 1.06843835e+00
   syst_JES_EtaIntercalibration_Stat103_minus: -4.11748279e+00
   syst_JES_EtaIntercalibration_Stat104_plus: 3.45421663e+00
@@ -89457,7 +89457,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat121_plus: 0.0
   syst_JES_EtaIntercalibration_Stat121_minus: 0.0
   syst_JES_EtaIntercalibration_Stat122_plus: 9.47310955e-13
-  syst_JES_EtaIntercalibration_Stat122_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat122_minus: 0.0
   syst_JES_EtaIntercalibration_Stat123_plus: -6.55770829e-01
   syst_JES_EtaIntercalibration_Stat123_minus: 4.38123362e-01
   syst_JES_EtaIntercalibration_Stat124_plus: -1.72887608e+00
@@ -89499,7 +89499,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat140_plus: 0.0
   syst_JES_EtaIntercalibration_Stat140_minus: 0.0
   syst_JES_EtaIntercalibration_Stat141_plus: 9.50987910e-13
-  syst_JES_EtaIntercalibration_Stat141_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat141_minus: 0.0
   syst_JES_EtaIntercalibration_Stat142_plus: -7.94010205e-02
   syst_JES_EtaIntercalibration_Stat142_minus: 4.15283813e-02
   syst_JES_EtaIntercalibration_Stat143_plus: -2.23021479e-01
@@ -89535,7 +89535,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat157_plus: 0.0
   syst_JES_EtaIntercalibration_Stat157_minus: 0.0
   syst_JES_EtaIntercalibration_Stat158_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat158_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat158_minus: 0.0
   syst_JES_EtaIntercalibration_Stat159_plus: -3.60907301e-02
   syst_JES_EtaIntercalibration_Stat159_minus: 3.03702363e-03
   syst_JES_EtaIntercalibration_Stat16_plus: 1.04156829e+01
@@ -89575,7 +89575,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat175_plus: 0.0
   syst_JES_EtaIntercalibration_Stat175_minus: 0.0
   syst_JES_EtaIntercalibration_Stat176_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat176_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat176_minus: 0.0
   syst_JES_EtaIntercalibration_Stat177_plus: 0.0
   syst_JES_EtaIntercalibration_Stat177_minus: -1.56694863e-01
   syst_JES_EtaIntercalibration_Stat178_plus: 0.0
@@ -89613,7 +89613,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat192_plus: 0.0
   syst_JES_EtaIntercalibration_Stat192_minus: 0.0
   syst_JES_EtaIntercalibration_Stat193_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat193_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat193_minus: 0.0
   syst_JES_EtaIntercalibration_Stat194_plus: -1.71049130e-18
   syst_JES_EtaIntercalibration_Stat194_minus: 1.02742615e-18
   syst_JES_EtaIntercalibration_Stat195_plus: -1.10308658e-01
@@ -89647,7 +89647,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat207_plus: 0.0
   syst_JES_EtaIntercalibration_Stat207_minus: 0.0
   syst_JES_EtaIntercalibration_Stat208_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat208_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat208_minus: 0.0
   syst_JES_EtaIntercalibration_Stat209_plus: 8.55669916e-03
   syst_JES_EtaIntercalibration_Stat209_minus: -3.18127341e-02
   syst_JES_EtaIntercalibration_Stat21_plus: 0.0
@@ -89677,10 +89677,10 @@ bins:
   syst_JES_EtaIntercalibration_Stat220_plus: 0.0
   syst_JES_EtaIntercalibration_Stat220_minus: 0.0
   syst_JES_EtaIntercalibration_Stat221_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat221_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat221_minus: 0.0
   syst_JES_EtaIntercalibration_Stat222_plus: 3.38138463e-02
   syst_JES_EtaIntercalibration_Stat222_minus: 0.0
-  syst_JES_EtaIntercalibration_Stat223_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat223_plus: 0.0
   syst_JES_EtaIntercalibration_Stat223_minus: 2.87651039e-01
   syst_JES_EtaIntercalibration_Stat224_plus: 0.0
   syst_JES_EtaIntercalibration_Stat224_minus: 0.0
@@ -89703,8 +89703,8 @@ bins:
   syst_JES_EtaIntercalibration_Stat232_plus: 0.0
   syst_JES_EtaIntercalibration_Stat232_minus: 0.0
   syst_JES_EtaIntercalibration_Stat233_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat233_minus: -0.0
-  syst_JES_EtaIntercalibration_Stat234_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat233_minus: 0.0
+  syst_JES_EtaIntercalibration_Stat234_plus: 0.0
   syst_JES_EtaIntercalibration_Stat234_minus: 1.59876843e-02
   syst_JES_EtaIntercalibration_Stat235_plus: 0.0
   syst_JES_EtaIntercalibration_Stat235_minus: 0.0
@@ -89863,7 +89863,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat80_plus: 0.0
   syst_JES_EtaIntercalibration_Stat80_minus: 0.0
   syst_JES_EtaIntercalibration_Stat81_plus: 9.46321005e-13
-  syst_JES_EtaIntercalibration_Stat81_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat81_minus: 0.0
   syst_JES_EtaIntercalibration_Stat82_plus: 5.75372788e+00
   syst_JES_EtaIntercalibration_Stat82_minus: -2.85671140e+00
   syst_JES_EtaIntercalibration_Stat83_plus: 2.19415234e+01
@@ -89965,7 +89965,7 @@ bins:
   syst_JES_MJB_Stat4_plus: -2.17223203e-01
   syst_JES_MJB_Stat4_minus: 2.14111933e-01
   syst_JES_MJB_Stat5_plus: 0.0
-  syst_JES_MJB_Stat5_minus: -0.0
+  syst_JES_MJB_Stat5_minus: 0.0
   syst_JES_MJB_Stat6_plus: -1.35976634e+00
   syst_JES_MJB_Stat6_minus: 0.0
   syst_JES_MJB_Stat7_plus: 0.0
@@ -90028,13 +90028,13 @@ bins:
   syst_Unfolding_bias_minus: 4.24681262e+01
   syst_jetselection_BCH_plus: 4.74963625e+01
   syst_jetselection_BCH_minus: -4.74963625e+01
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 4.26583379e+02
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -4.02131626e+02
@@ -90085,7 +90085,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat101_plus: 0.0
   syst_JES_EtaIntercalibration_Stat101_minus: 0.0
   syst_JES_EtaIntercalibration_Stat102_plus: 7.05904700e-08
-  syst_JES_EtaIntercalibration_Stat102_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat102_minus: 0.0
   syst_JES_EtaIntercalibration_Stat103_plus: 4.96671803e-01
   syst_JES_EtaIntercalibration_Stat103_minus: -1.62068874e+00
   syst_JES_EtaIntercalibration_Stat104_plus: 3.39976940e+00
@@ -90129,7 +90129,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat121_plus: 0.0
   syst_JES_EtaIntercalibration_Stat121_minus: 0.0
   syst_JES_EtaIntercalibration_Stat122_plus: 7.05975410e-08
-  syst_JES_EtaIntercalibration_Stat122_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat122_minus: 0.0
   syst_JES_EtaIntercalibration_Stat123_plus: 1.82716392e-01
   syst_JES_EtaIntercalibration_Stat123_minus: 0.0
   syst_JES_EtaIntercalibration_Stat124_plus: -5.04379267e-02
@@ -90171,7 +90171,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat140_plus: 0.0
   syst_JES_EtaIntercalibration_Stat140_minus: 0.0
   syst_JES_EtaIntercalibration_Stat141_plus: 7.08733127e-08
-  syst_JES_EtaIntercalibration_Stat141_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat141_minus: 0.0
   syst_JES_EtaIntercalibration_Stat142_plus: -1.43118413e-01
   syst_JES_EtaIntercalibration_Stat142_minus: 9.37623592e-02
   syst_JES_EtaIntercalibration_Stat143_plus: -4.46042958e-01
@@ -90207,7 +90207,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat157_plus: 0.0
   syst_JES_EtaIntercalibration_Stat157_minus: 0.0
   syst_JES_EtaIntercalibration_Stat158_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat158_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat158_minus: 0.0
   syst_JES_EtaIntercalibration_Stat159_plus: -1.37673690e-02
   syst_JES_EtaIntercalibration_Stat159_minus: 1.70271313e-02
   syst_JES_EtaIntercalibration_Stat16_plus: 2.81032519e+00
@@ -90247,7 +90247,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat175_plus: 0.0
   syst_JES_EtaIntercalibration_Stat175_minus: 0.0
   syst_JES_EtaIntercalibration_Stat176_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat176_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat176_minus: 0.0
   syst_JES_EtaIntercalibration_Stat177_plus: 0.0
   syst_JES_EtaIntercalibration_Stat177_minus: -5.97788073e-02
   syst_JES_EtaIntercalibration_Stat178_plus: 0.0
@@ -90285,7 +90285,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat192_plus: 0.0
   syst_JES_EtaIntercalibration_Stat192_minus: 0.0
   syst_JES_EtaIntercalibration_Stat193_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat193_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat193_minus: 0.0
   syst_JES_EtaIntercalibration_Stat194_plus: -1.90141013e-11
   syst_JES_EtaIntercalibration_Stat194_minus: 1.14197745e-11
   syst_JES_EtaIntercalibration_Stat195_plus: -4.20728535e-02
@@ -90319,7 +90319,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat207_plus: 0.0
   syst_JES_EtaIntercalibration_Stat207_minus: 0.0
   syst_JES_EtaIntercalibration_Stat208_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat208_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat208_minus: 0.0
   syst_JES_EtaIntercalibration_Stat209_plus: 3.26400490e-03
   syst_JES_EtaIntercalibration_Stat209_minus: -1.21339524e-02
   syst_JES_EtaIntercalibration_Stat21_plus: 0.0
@@ -90349,10 +90349,10 @@ bins:
   syst_JES_EtaIntercalibration_Stat220_plus: 0.0
   syst_JES_EtaIntercalibration_Stat220_minus: 0.0
   syst_JES_EtaIntercalibration_Stat221_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat221_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat221_minus: 0.0
   syst_JES_EtaIntercalibration_Stat222_plus: 1.28976277e-02
   syst_JES_EtaIntercalibration_Stat222_minus: 0.0
-  syst_JES_EtaIntercalibration_Stat223_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat223_plus: 0.0
   syst_JES_EtaIntercalibration_Stat223_minus: 1.09742972e-01
   syst_JES_EtaIntercalibration_Stat224_plus: 0.0
   syst_JES_EtaIntercalibration_Stat224_minus: 0.0
@@ -90375,8 +90375,8 @@ bins:
   syst_JES_EtaIntercalibration_Stat232_plus: 0.0
   syst_JES_EtaIntercalibration_Stat232_minus: 0.0
   syst_JES_EtaIntercalibration_Stat233_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat233_minus: -0.0
-  syst_JES_EtaIntercalibration_Stat234_plus: -0.0
+  syst_JES_EtaIntercalibration_Stat233_minus: 0.0
+  syst_JES_EtaIntercalibration_Stat234_plus: 0.0
   syst_JES_EtaIntercalibration_Stat234_minus: 6.09738177e-03
   syst_JES_EtaIntercalibration_Stat235_plus: 0.0
   syst_JES_EtaIntercalibration_Stat235_minus: 0.0
@@ -90535,7 +90535,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat80_plus: 0.0
   syst_JES_EtaIntercalibration_Stat80_minus: 0.0
   syst_JES_EtaIntercalibration_Stat81_plus: 7.05268304e-08
-  syst_JES_EtaIntercalibration_Stat81_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat81_minus: 0.0
   syst_JES_EtaIntercalibration_Stat82_plus: 3.01934596e+00
   syst_JES_EtaIntercalibration_Stat82_minus: -1.91838070e+00
   syst_JES_EtaIntercalibration_Stat83_plus: 1.10520790e+01
@@ -90637,13 +90637,13 @@ bins:
   syst_JES_MJB_Stat4_plus: -8.28658437e-02
   syst_JES_MJB_Stat4_minus: 8.16708332e-02
   syst_JES_MJB_Stat5_plus: 0.0
-  syst_JES_MJB_Stat5_minus: -0.0
+  syst_JES_MJB_Stat5_minus: 0.0
   syst_JES_MJB_Stat6_plus: -5.18521403e-01
   syst_JES_MJB_Stat6_minus: 0.0
-  syst_JES_MJB_Stat7_plus: -0.0
+  syst_JES_MJB_Stat7_plus: 0.0
   syst_JES_MJB_Stat7_minus: 0.0
-  syst_JES_MJB_Stat8_plus: -0.0
-  syst_JES_MJB_Stat8_minus: -0.0
+  syst_JES_MJB_Stat8_plus: 0.0
+  syst_JES_MJB_Stat8_minus: 0.0
   syst_JES_MJB_Stat9_plus: 0.0
   syst_JES_MJB_Stat9_minus: 0.0
   syst_JES_MJB_Threshold_plus: 1.73736136e-03
@@ -90700,13 +90700,13 @@ bins:
   syst_Unfolding_bias_minus: 7.81352993e-01
   syst_jetselection_BCH_plus: 1.52664354e+01
   syst_jetselection_BCH_minus: -1.52664354e+01
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 1.41739554e+02
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -1.32950217e+02
@@ -90757,7 +90757,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat101_plus: 0.0
   syst_JES_EtaIntercalibration_Stat101_minus: 0.0
   syst_JES_EtaIntercalibration_Stat102_plus: 3.23572063e-05
-  syst_JES_EtaIntercalibration_Stat102_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat102_minus: 0.0
   syst_JES_EtaIntercalibration_Stat103_plus: 5.06359166e-01
   syst_JES_EtaIntercalibration_Stat103_minus: -6.86034999e-01
   syst_JES_EtaIntercalibration_Stat104_plus: 3.00237539e+00
@@ -90801,7 +90801,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat121_plus: 0.0
   syst_JES_EtaIntercalibration_Stat121_minus: 0.0
   syst_JES_EtaIntercalibration_Stat122_plus: 3.23642774e-05
-  syst_JES_EtaIntercalibration_Stat122_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat122_minus: 0.0
   syst_JES_EtaIntercalibration_Stat123_plus: 3.25410541e-01
   syst_JES_EtaIntercalibration_Stat123_minus: -6.41982247e-02
   syst_JES_EtaIntercalibration_Stat124_plus: 7.21178206e-01
@@ -90843,7 +90843,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat140_plus: 0.0
   syst_JES_EtaIntercalibration_Stat140_minus: 0.0
   syst_JES_EtaIntercalibration_Stat141_plus: 3.24844855e-05
-  syst_JES_EtaIntercalibration_Stat141_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat141_minus: 0.0
   syst_JES_EtaIntercalibration_Stat142_plus: -1.46583236e-02
   syst_JES_EtaIntercalibration_Stat142_minus: 9.17400338e-02
   syst_JES_EtaIntercalibration_Stat143_plus: -3.03348809e-01
@@ -90879,7 +90879,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat157_plus: 0.0
   syst_JES_EtaIntercalibration_Stat157_minus: 0.0
   syst_JES_EtaIntercalibration_Stat158_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat158_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat158_minus: 0.0
   syst_JES_EtaIntercalibration_Stat159_plus: -5.68655273e-03
   syst_JES_EtaIntercalibration_Stat159_minus: 1.87736850e-02
   syst_JES_EtaIntercalibration_Stat16_plus: 1.00090965e+00
@@ -90919,7 +90919,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat175_plus: 0.0
   syst_JES_EtaIntercalibration_Stat175_minus: 0.0
   syst_JES_EtaIntercalibration_Stat176_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat176_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat176_minus: 0.0
   syst_JES_EtaIntercalibration_Stat177_plus: -2.46921688e-02
   syst_JES_EtaIntercalibration_Stat177_minus: 3.40118362e-03
   syst_JES_EtaIntercalibration_Stat178_plus: -2.59649610e-02
@@ -90957,7 +90957,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat192_plus: 0.0
   syst_JES_EtaIntercalibration_Stat192_minus: 0.0
   syst_JES_EtaIntercalibration_Stat193_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat193_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat193_minus: 0.0
   syst_JES_EtaIntercalibration_Stat194_plus: -2.61417377e-07
   syst_JES_EtaIntercalibration_Stat194_minus: 1.57119127e-07
   syst_JES_EtaIntercalibration_Stat195_plus: -1.73806847e-02
@@ -90991,7 +90991,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat207_plus: 0.0
   syst_JES_EtaIntercalibration_Stat207_minus: 0.0
   syst_JES_EtaIntercalibration_Stat208_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat208_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat208_minus: 0.0
   syst_JES_EtaIntercalibration_Stat209_plus: 1.34774552e-03
   syst_JES_EtaIntercalibration_Stat209_minus: -5.01197287e-03
   syst_JES_EtaIntercalibration_Stat21_plus: 0.0
@@ -91021,7 +91021,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat220_plus: 0.0
   syst_JES_EtaIntercalibration_Stat220_minus: 0.0
   syst_JES_EtaIntercalibration_Stat221_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat221_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat221_minus: 0.0
   syst_JES_EtaIntercalibration_Stat222_plus: 5.32734249e-03
   syst_JES_EtaIntercalibration_Stat222_minus: 0.0
   syst_JES_EtaIntercalibration_Stat223_plus: -9.11955616e-40
@@ -91047,7 +91047,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat232_plus: 0.0
   syst_JES_EtaIntercalibration_Stat232_minus: 0.0
   syst_JES_EtaIntercalibration_Stat233_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat233_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat233_minus: 0.0
   syst_JES_EtaIntercalibration_Stat234_plus: -1.00409163e-39
   syst_JES_EtaIntercalibration_Stat234_minus: 2.51871435e-03
   syst_JES_EtaIntercalibration_Stat235_plus: 0.0
@@ -91207,7 +91207,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat80_plus: 0.0
   syst_JES_EtaIntercalibration_Stat80_minus: 0.0
   syst_JES_EtaIntercalibration_Stat81_plus: 3.23289220e-05
-  syst_JES_EtaIntercalibration_Stat81_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat81_minus: 0.0
   syst_JES_EtaIntercalibration_Stat82_plus: 1.58038366e+00
   syst_JES_EtaIntercalibration_Stat82_minus: -1.31804704e+00
   syst_JES_EtaIntercalibration_Stat83_plus: 5.14773737e+00
@@ -91309,14 +91309,14 @@ bins:
   syst_JES_MJB_Stat4_plus: -3.42239682e-02
   syst_JES_MJB_Stat4_minus: 3.37360645e-02
   syst_JES_MJB_Stat5_plus: 0.0
-  syst_JES_MJB_Stat5_minus: -0.0
+  syst_JES_MJB_Stat5_minus: 0.0
   syst_JES_MJB_Stat6_plus: -2.14182644e-01
   syst_JES_MJB_Stat6_minus: 0.0
-  syst_JES_MJB_Stat7_plus: -0.0
+  syst_JES_MJB_Stat7_plus: 0.0
   syst_JES_MJB_Stat7_minus: 0.0
-  syst_JES_MJB_Stat8_plus: -0.0
-  syst_JES_MJB_Stat8_minus: -0.0
-  syst_JES_MJB_Stat9_plus: -0.0
+  syst_JES_MJB_Stat8_plus: 0.0
+  syst_JES_MJB_Stat8_minus: 0.0
+  syst_JES_MJB_Stat9_plus: 0.0
   syst_JES_MJB_Stat9_minus: 0.0
   syst_JES_MJB_Threshold_plus: 2.01313301e-04
   syst_JES_MJB_Threshold_minus: 0.0
@@ -91372,10 +91372,10 @@ bins:
   syst_Unfolding_bias_minus: -5.98848733e+00
   syst_jetselection_BCH_plus: 6.36042550e+00
   syst_jetselection_BCH_minus: -6.36042550e+00
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -1.62068874e+00
@@ -91429,7 +91429,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat101_plus: 0.0
   syst_JES_EtaIntercalibration_Stat101_minus: 0.0
   syst_JES_EtaIntercalibration_Stat102_plus: 8.21799501e-04
-  syst_JES_EtaIntercalibration_Stat102_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat102_minus: 0.0
   syst_JES_EtaIntercalibration_Stat103_plus: 4.74610072e-01
   syst_JES_EtaIntercalibration_Stat103_minus: -3.56381818e-01
   syst_JES_EtaIntercalibration_Stat104_plus: 1.79605122e+00
@@ -91473,7 +91473,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat121_plus: 0.0
   syst_JES_EtaIntercalibration_Stat121_minus: 0.0
   syst_JES_EtaIntercalibration_Stat122_plus: 8.21870212e-04
-  syst_JES_EtaIntercalibration_Stat122_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat122_minus: 0.0
   syst_JES_EtaIntercalibration_Stat123_plus: 3.20107240e-01
   syst_JES_EtaIntercalibration_Stat123_minus: -1.93040151e-01
   syst_JES_EtaIntercalibration_Stat124_plus: 8.65569411e-01
@@ -91515,7 +91515,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat140_plus: 0.0
   syst_JES_EtaIntercalibration_Stat140_minus: 0.0
   syst_JES_EtaIntercalibration_Stat141_plus: 8.25052192e-04
-  syst_JES_EtaIntercalibration_Stat141_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat141_minus: 0.0
   syst_JES_EtaIntercalibration_Stat142_plus: 9.25744198e-02
   syst_JES_EtaIntercalibration_Stat142_minus: 0.0
   syst_JES_EtaIntercalibration_Stat143_plus: 3.76392940e-02
@@ -91551,7 +91551,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat157_plus: 0.0
   syst_JES_EtaIntercalibration_Stat157_minus: 0.0
   syst_JES_EtaIntercalibration_Stat158_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat158_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat158_minus: 0.0
   syst_JES_EtaIntercalibration_Stat159_plus: -2.53851334e-03
   syst_JES_EtaIntercalibration_Stat159_minus: 1.13137085e-02
   syst_JES_EtaIntercalibration_Stat16_plus: 4.68811796e-01
@@ -91591,7 +91591,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat175_plus: 0.0
   syst_JES_EtaIntercalibration_Stat175_minus: 0.0
   syst_JES_EtaIntercalibration_Stat176_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat176_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat176_minus: 0.0
   syst_JES_EtaIntercalibration_Stat177_plus: -1.10237947e-02
   syst_JES_EtaIntercalibration_Stat177_minus: 7.82413653e-03
   syst_JES_EtaIntercalibration_Stat178_plus: -3.46906587e-02
@@ -91629,7 +91629,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat192_plus: 0.0
   syst_JES_EtaIntercalibration_Stat192_minus: 0.0
   syst_JES_EtaIntercalibration_Stat193_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat193_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat193_minus: 0.0
   syst_JES_EtaIntercalibration_Stat194_plus: -7.73999083e-05
   syst_JES_EtaIntercalibration_Stat194_minus: 4.75387889e-05
   syst_JES_EtaIntercalibration_Stat195_plus: -7.89626143e-03
@@ -91663,7 +91663,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat207_plus: 0.0
   syst_JES_EtaIntercalibration_Stat207_minus: 0.0
   syst_JES_EtaIntercalibration_Stat208_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat208_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat208_minus: 0.0
   syst_JES_EtaIntercalibration_Stat209_plus: 6.02030714e-04
   syst_JES_EtaIntercalibration_Stat209_minus: -2.23799296e-03
   syst_JES_EtaIntercalibration_Stat21_plus: 0.0
@@ -91693,7 +91693,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat220_plus: 0.0
   syst_JES_EtaIntercalibration_Stat220_minus: 0.0
   syst_JES_EtaIntercalibration_Stat221_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat221_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat221_minus: 0.0
   syst_JES_EtaIntercalibration_Stat222_plus: 2.37870721e-03
   syst_JES_EtaIntercalibration_Stat222_minus: 0.0
   syst_JES_EtaIntercalibration_Stat223_plus: -1.10025815e-27
@@ -91719,7 +91719,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat232_plus: 0.0
   syst_JES_EtaIntercalibration_Stat232_minus: 0.0
   syst_JES_EtaIntercalibration_Stat233_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat233_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat233_minus: 0.0
   syst_JES_EtaIntercalibration_Stat234_plus: -1.21127392e-27
   syst_JES_EtaIntercalibration_Stat234_minus: 1.12500689e-03
   syst_JES_EtaIntercalibration_Stat235_plus: 0.0
@@ -91879,7 +91879,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat80_plus: 0.0
   syst_JES_EtaIntercalibration_Stat80_minus: 0.0
   syst_JES_EtaIntercalibration_Stat81_plus: 8.21092394e-04
-  syst_JES_EtaIntercalibration_Stat81_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat81_minus: 0.0
   syst_JES_EtaIntercalibration_Stat82_plus: 7.46068365e-01
   syst_JES_EtaIntercalibration_Stat82_minus: -6.16031428e-01
   syst_JES_EtaIntercalibration_Stat83_plus: 2.18495995e+00
@@ -91984,11 +91984,11 @@ bins:
   syst_JES_MJB_Stat5_minus: -1.82221418e-36
   syst_JES_MJB_Stat6_plus: -9.56503343e-02
   syst_JES_MJB_Stat6_minus: 0.0
-  syst_JES_MJB_Stat7_plus: -0.0
+  syst_JES_MJB_Stat7_plus: 0.0
   syst_JES_MJB_Stat7_minus: 0.0
-  syst_JES_MJB_Stat8_plus: -0.0
-  syst_JES_MJB_Stat8_minus: -0.0
-  syst_JES_MJB_Stat9_plus: -0.0
+  syst_JES_MJB_Stat8_plus: 0.0
+  syst_JES_MJB_Stat8_minus: 0.0
+  syst_JES_MJB_Stat9_plus: 0.0
   syst_JES_MJB_Stat9_minus: 0.0
   syst_JES_MJB_Threshold_plus: -6.43396460e-03
   syst_JES_MJB_Threshold_minus: 2.55265548e-03
@@ -92044,11 +92044,11 @@ bins:
   syst_Unfolding_bias_minus: 5.97575941e-01
   syst_jetselection_BCH_plus: 3.36017142e+00
   syst_jetselection_BCH_minus: -3.36017142e+00
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -1.88161114e+00
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 1.98131320e+00
@@ -92101,7 +92101,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat101_plus: 0.0
   syst_JES_EtaIntercalibration_Stat101_minus: 0.0
   syst_JES_EtaIntercalibration_Stat102_plus: 2.81082017e-03
-  syst_JES_EtaIntercalibration_Stat102_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat102_minus: 0.0
   syst_JES_EtaIntercalibration_Stat103_plus: 2.58730371e-01
   syst_JES_EtaIntercalibration_Stat103_minus: -1.86746901e-01
   syst_JES_EtaIntercalibration_Stat104_plus: 8.42305598e-01
@@ -92145,7 +92145,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat121_plus: 0.0
   syst_JES_EtaIntercalibration_Stat121_minus: 0.0
   syst_JES_EtaIntercalibration_Stat122_plus: 2.81110301e-03
-  syst_JES_EtaIntercalibration_Stat122_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat122_minus: 0.0
   syst_JES_EtaIntercalibration_Stat123_plus: 2.22950768e-01
   syst_JES_EtaIntercalibration_Stat123_minus: -1.86534769e-01
   syst_JES_EtaIntercalibration_Stat124_plus: 7.39845825e-01
@@ -92187,7 +92187,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat140_plus: 0.0
   syst_JES_EtaIntercalibration_Stat140_minus: 0.0
   syst_JES_EtaIntercalibration_Stat141_plus: 2.82192174e-03
-  syst_JES_EtaIntercalibration_Stat141_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat141_minus: 0.0
   syst_JES_EtaIntercalibration_Stat142_plus: 1.13702770e-01
   syst_JES_EtaIntercalibration_Stat142_minus: -4.21294220e-02
   syst_JES_EtaIntercalibration_Stat143_plus: 1.97919188e-01
@@ -92223,7 +92223,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat157_plus: 0.0
   syst_JES_EtaIntercalibration_Stat157_minus: 0.0
   syst_JES_EtaIntercalibration_Stat158_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat158_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat158_minus: 0.0
   syst_JES_EtaIntercalibration_Stat159_plus: -9.94404266e-04
   syst_JES_EtaIntercalibration_Stat159_minus: 5.38886078e-03
   syst_JES_EtaIntercalibration_Stat16_plus: 1.88514668e-01
@@ -92263,7 +92263,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat175_plus: 0.0
   syst_JES_EtaIntercalibration_Stat175_minus: 0.0
   syst_JES_EtaIntercalibration_Stat176_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat176_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat176_minus: 0.0
   syst_JES_EtaIntercalibration_Stat177_plus: -4.95399011e-03
   syst_JES_EtaIntercalibration_Stat177_minus: 7.09864498e-03
   syst_JES_EtaIntercalibration_Stat178_plus: -3.41744707e-04
@@ -92301,7 +92301,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat192_plus: 0.0
   syst_JES_EtaIntercalibration_Stat192_minus: 0.0
   syst_JES_EtaIntercalibration_Stat193_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat193_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat193_minus: 0.0
   syst_JES_EtaIntercalibration_Stat194_plus: -1.26147850e-03
   syst_JES_EtaIntercalibration_Stat194_minus: 9.18885262e-04
   syst_JES_EtaIntercalibration_Stat195_plus: -6.03657059e-03
@@ -92335,7 +92335,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat207_plus: 0.0
   syst_JES_EtaIntercalibration_Stat207_minus: 0.0
   syst_JES_EtaIntercalibration_Stat208_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat208_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat208_minus: 0.0
   syst_JES_EtaIntercalibration_Stat209_plus: 2.78175808e-04
   syst_JES_EtaIntercalibration_Stat209_minus: -1.03379011e-03
   syst_JES_EtaIntercalibration_Stat21_plus: 0.0
@@ -92365,7 +92365,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat220_plus: 0.0
   syst_JES_EtaIntercalibration_Stat220_minus: 0.0
   syst_JES_EtaIntercalibration_Stat221_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat221_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat221_minus: 0.0
   syst_JES_EtaIntercalibration_Stat222_plus: 1.09955104e-03
   syst_JES_EtaIntercalibration_Stat222_minus: 0.0
   syst_JES_EtaIntercalibration_Stat223_plus: -1.84413449e-19
@@ -92391,7 +92391,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat232_plus: 0.0
   syst_JES_EtaIntercalibration_Stat232_minus: 0.0
   syst_JES_EtaIntercalibration_Stat233_plus: 0.0
-  syst_JES_EtaIntercalibration_Stat233_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat233_minus: 0.0
   syst_JES_EtaIntercalibration_Stat234_plus: -2.03081068e-19
   syst_JES_EtaIntercalibration_Stat234_minus: 5.19652773e-04
   syst_JES_EtaIntercalibration_Stat235_plus: 0.0
@@ -92551,7 +92551,7 @@ bins:
   syst_JES_EtaIntercalibration_Stat80_plus: 0.0
   syst_JES_EtaIntercalibration_Stat80_minus: 0.0
   syst_JES_EtaIntercalibration_Stat81_plus: 2.80827458e-03
-  syst_JES_EtaIntercalibration_Stat81_minus: -0.0
+  syst_JES_EtaIntercalibration_Stat81_minus: 0.0
   syst_JES_EtaIntercalibration_Stat82_plus: 2.88923831e-01
   syst_JES_EtaIntercalibration_Stat82_minus: -2.29880415e-01
   syst_JES_EtaIntercalibration_Stat83_plus: 8.20173155e-01
@@ -92656,11 +92656,11 @@ bins:
   syst_JES_MJB_Stat5_minus: -5.28350187e-26
   syst_JES_MJB_Stat6_plus: -4.41941738e-02
   syst_JES_MJB_Stat6_minus: 7.54341514e-33
-  syst_JES_MJB_Stat7_plus: -0.0
+  syst_JES_MJB_Stat7_plus: 0.0
   syst_JES_MJB_Stat7_minus: 0.0
-  syst_JES_MJB_Stat8_plus: -0.0
-  syst_JES_MJB_Stat8_minus: -0.0
-  syst_JES_MJB_Stat9_plus: -0.0
+  syst_JES_MJB_Stat8_plus: 0.0
+  syst_JES_MJB_Stat8_minus: 0.0
+  syst_JES_MJB_Stat9_plus: 0.0
   syst_JES_MJB_Stat9_minus: 0.0
   syst_JES_MJB_Threshold_plus: -1.25652875e-02
   syst_JES_MJB_Threshold_minus: 1.07268099e-02
@@ -92716,11 +92716,11 @@ bins:
   syst_Unfolding_bias_minus: -6.24728841e-01
   syst_jetselection_BCH_plus: 1.72039080e+00
   syst_jetselection_BCH_minus: -1.72039080e+00
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -1.27703485e+00
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 1.30319780e+00
@@ -93328,11 +93328,11 @@ bins:
   syst_JES_MJB_Stat5_minus: -8.72994032e-19
   syst_JES_MJB_Stat6_plus: -2.10364267e-02
   syst_JES_MJB_Stat6_minus: 1.02106219e-23
-  syst_JES_MJB_Stat7_plus: -0.0
+  syst_JES_MJB_Stat7_plus: 0.0
   syst_JES_MJB_Stat7_minus: 0.0
-  syst_JES_MJB_Stat8_plus: -0.0
-  syst_JES_MJB_Stat8_minus: -0.0
-  syst_JES_MJB_Stat9_plus: -0.0
+  syst_JES_MJB_Stat8_plus: 0.0
+  syst_JES_MJB_Stat8_minus: 0.0
+  syst_JES_MJB_Stat9_plus: 0.0
   syst_JES_MJB_Stat9_minus: 0.0
   syst_JES_MJB_Threshold_plus: -1.98414163e-02
   syst_JES_MJB_Threshold_minus: 1.89009643e-02
@@ -93388,11 +93388,11 @@ bins:
   syst_Unfolding_bias_minus: 7.71099945e-02
   syst_jetselection_BCH_plus: 8.81550024e-01
   syst_jetselection_BCH_minus: -8.81550024e-01
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -7.65230959e-01
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 7.66786594e-01
@@ -94000,11 +94000,11 @@ bins:
   syst_JES_MJB_Stat5_minus: -1.14622009e-13
   syst_JES_MJB_Stat6_plus: -9.83939086e-03
   syst_JES_MJB_Stat6_minus: 4.26385389e-17
-  syst_JES_MJB_Stat7_plus: -0.0
+  syst_JES_MJB_Stat7_plus: 0.0
   syst_JES_MJB_Stat7_minus: 5.25168206e-44
-  syst_JES_MJB_Stat8_plus: -0.0
-  syst_JES_MJB_Stat8_minus: -0.0
-  syst_JES_MJB_Stat9_plus: -0.0
+  syst_JES_MJB_Stat8_plus: 0.0
+  syst_JES_MJB_Stat8_minus: 0.0
+  syst_JES_MJB_Stat9_plus: 0.0
   syst_JES_MJB_Stat9_minus: 0.0
   syst_JES_MJB_Threshold_plus: -1.90423856e-02
   syst_JES_MJB_Threshold_minus: 1.73948268e-02
@@ -94060,11 +94060,11 @@ bins:
   syst_Unfolding_bias_minus: -7.71029234e-02
   syst_jetselection_BCH_plus: 4.19102189e-01
   syst_jetselection_BCH_minus: -4.19102189e-01
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -4.09980512e-01
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 4.19314321e-01
@@ -94674,9 +94674,9 @@ bins:
   syst_JES_MJB_Stat6_minus: 1.22470895e-12
   syst_JES_MJB_Stat7_plus: -5.48573441e-41
   syst_JES_MJB_Stat7_minus: 1.17309015e-32
-  syst_JES_MJB_Stat8_plus: -0.0
+  syst_JES_MJB_Stat8_plus: 0.0
   syst_JES_MJB_Stat8_minus: -1.19076782e-41
-  syst_JES_MJB_Stat9_plus: -0.0
+  syst_JES_MJB_Stat9_plus: 0.0
   syst_JES_MJB_Stat9_minus: 0.0
   syst_JES_MJB_Threshold_plus: -1.11722871e-02
   syst_JES_MJB_Threshold_minus: 4.34092853e-03
@@ -94732,11 +94732,11 @@ bins:
   syst_Unfolding_bias_minus: 1.85898373e-02
   syst_jetselection_BCH_plus: 1.85615530e-01
   syst_jetselection_BCH_minus: -1.85615530e-01
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -2.11283506e-01
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 2.20193052e-01
@@ -95348,7 +95348,7 @@ bins:
   syst_JES_MJB_Stat7_minus: 1.86110505e-24
   syst_JES_MJB_Stat8_plus: 0.0
   syst_JES_MJB_Stat8_minus: -1.48845977e-31
-  syst_JES_MJB_Stat9_plus: -0.0
+  syst_JES_MJB_Stat9_plus: 0.0
   syst_JES_MJB_Stat9_minus: 0.0
   syst_JES_MJB_Threshold_plus: 0.0
   syst_JES_MJB_Threshold_minus: -4.28365288e-03
@@ -95404,12 +95404,12 @@ bins:
   syst_Unfolding_bias_minus: -1.88443957e-02
   syst_jetselection_BCH_plus: 8.88479671e-02
   syst_jetselection_BCH_minus: -8.88479671e-02
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: -0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -1.11227897e-01
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 1.16177644e-01
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 3.06389368e-01
@@ -96076,12 +96076,12 @@ bins:
   syst_Unfolding_bias_minus: 2.10859242e-03
   syst_jetselection_BCH_plus: 4.60326515e-02
   syst_jetselection_BCH_minus: -4.60326515e-02
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -5.77423398e-02
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 5.93686853e-02
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 1.35835213e-01
@@ -96748,12 +96748,12 @@ bins:
   syst_Unfolding_bias_minus: -3.27390440e-03
   syst_jetselection_BCH_plus: 2.58659661e-02
   syst_jetselection_BCH_minus: -2.58659661e-02
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -3.11551248e-02
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 3.17066681e-02
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 6.42830775e-02
@@ -97420,12 +97420,12 @@ bins:
   syst_Unfolding_bias_minus: 1.83564920e-04
   syst_jetselection_BCH_plus: 1.39724300e-02
   syst_jetselection_BCH_minus: -1.39724300e-02
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -1.61786032e-02
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 1.66028672e-02
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 3.03278098e-02
@@ -98092,12 +98092,12 @@ bins:
   syst_Unfolding_bias_minus: -9.26309883e-04
   syst_jetselection_BCH_plus: 7.18774043e-03
   syst_jetselection_BCH_minus: -7.18774043e-03
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -8.44426918e-03
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 8.51073722e-03
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 1.42269884e-02
@@ -98764,12 +98764,12 @@ bins:
   syst_Unfolding_bias_minus: -1.01540534e-04
   syst_jetselection_BCH_plus: 3.53129127e-03
   syst_jetselection_BCH_minus: -3.53129127e-03
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -4.32678639e-03
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 4.16627315e-03
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 6.48558340e-03
@@ -99436,12 +99436,12 @@ bins:
   syst_Unfolding_bias_minus: -1.29541962e-04
   syst_jetselection_BCH_plus: 1.68715678e-03
   syst_jetselection_BCH_minus: -1.68715678e-03
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -2.04919545e-03
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 1.92120912e-03
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 2.86307536e-03
@@ -100108,12 +100108,12 @@ bins:
   syst_Unfolding_bias_minus: -5.28915872e-05
   syst_jetselection_BCH_plus: 7.89201878e-04
   syst_jetselection_BCH_minus: -7.89201878e-04
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -8.71084844e-04
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 8.22648029e-04
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 1.21975920e-03
@@ -100780,12 +100780,12 @@ bins:
   syst_Unfolding_bias_minus: -2.25920617e-05
   syst_jetselection_BCH_plus: 3.73423091e-04
   syst_jetselection_BCH_minus: -3.73423091e-04
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -3.51927045e-04
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 3.37431356e-04
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 5.14632315e-04
@@ -101452,12 +101452,12 @@ bins:
   syst_Unfolding_bias_minus: -6.19496251e-07
   syst_jetselection_BCH_plus: 1.57401969e-04
   syst_jetselection_BCH_minus: -1.57401969e-04
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -1.27915617e-04
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 1.23602265e-04
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 1.97282792e-04
@@ -102124,12 +102124,12 @@ bins:
   syst_Unfolding_bias_minus: -9.87616041e-06
   syst_jetselection_BCH_plus: 6.00404368e-05
   syst_jetselection_BCH_minus: -6.00404368e-05
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -4.62164992e-05
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 4.42578134e-05
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 7.33411153e-05
@@ -102796,12 +102796,12 @@ bins:
   syst_Unfolding_bias_minus: -3.40471915e-06
   syst_jetselection_BCH_plus: 1.92474466e-05
   syst_jetselection_BCH_minus: -1.92474466e-05
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -1.56694863e-05
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 1.49765216e-05
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 2.47840927e-05
@@ -103468,12 +103468,12 @@ bins:
   syst_Unfolding_bias_minus: -3.26683333e-06
   syst_jetselection_BCH_plus: 6.01465028e-06
   syst_jetselection_BCH_minus: -6.01465028e-06
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -5.22693333e-06
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 5.48997705e-06
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 8.68892813e-06
@@ -104140,12 +104140,12 @@ bins:
   syst_Unfolding_bias_minus: -1.46229682e-06
   syst_jetselection_BCH_plus: 1.69634917e-06
   syst_jetselection_BCH_minus: -1.69634917e-06
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -1.42835570e-06
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 1.89787460e-06
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 2.82432591e-06
@@ -104812,12 +104812,12 @@ bins:
   syst_Unfolding_bias_minus: 3.04833733e-07
   syst_jetselection_BCH_plus: 3.71443192e-07
   syst_jetselection_BCH_minus: -3.71443192e-07
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -2.71755278e-07
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 5.03035764e-07
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 7.02510587e-07
@@ -105484,12 +105484,12 @@ bins:
   syst_Unfolding_bias_minus: -2.67569206e-07
   syst_jetselection_BCH_plus: 4.72700883e-08
   syst_jetselection_BCH_minus: -4.72700883e-08
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -1.38522218e-08
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 9.68807001e-08
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 1.16601908e-07
@@ -106156,13 +106156,13 @@ bins:
   syst_Unfolding_bias_minus: 2.92424009e+01
   syst_jetselection_BCH_plus: 2.73713964e+01
   syst_jetselection_BCH_minus: -2.73713964e+01
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 5.10757370e+02
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -4.74461579e+02
@@ -106828,13 +106828,13 @@ bins:
   syst_Unfolding_bias_minus: -5.04944952e-01
   syst_jetselection_BCH_plus: 1.04227540e+01
   syst_jetselection_BCH_minus: -1.04227540e+01
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
-  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 1.62295148e+02
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -1.49934922e+02
@@ -107500,10 +107500,10 @@ bins:
   syst_Unfolding_bias_minus: -5.21137698e+00
   syst_jetselection_BCH_plus: 4.19526453e+00
   syst_jetselection_BCH_minus: -4.19526453e+00
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -1.41633488e+00
@@ -108172,11 +108172,11 @@ bins:
   syst_Unfolding_bias_minus: 3.56311107e-01
   syst_jetselection_BCH_plus: 1.71261262e+00
   syst_jetselection_BCH_minus: -1.71261262e+00
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -1.60654661e+00
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 1.67089332e+00
@@ -108844,11 +108844,11 @@ bins:
   syst_Unfolding_bias_minus: -5.03460028e-01
   syst_jetselection_BCH_plus: 7.37229530e-01
   syst_jetselection_BCH_minus: -7.37229530e-01
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -1.01681955e+00
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 1.06843835e+00
@@ -109516,11 +109516,11 @@ bins:
   syst_Unfolding_bias_minus: -1.36471609e-03
   syst_jetselection_BCH_plus: 3.08722821e-01
   syst_jetselection_BCH_minus: -3.08722821e-01
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -5.02823632e-01
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 5.32663538e-01
@@ -110188,11 +110188,11 @@ bins:
   syst_Unfolding_bias_minus: -5.88737106e-02
   syst_jetselection_BCH_plus: 1.30036937e-01
   syst_jetselection_BCH_minus: -1.30036937e-01
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -2.30587521e-01
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 2.40699148e-01
@@ -110860,12 +110860,12 @@ bins:
   syst_Unfolding_bias_minus: -7.74635479e-03
   syst_jetselection_BCH_plus: 5.30188665e-02
   syst_jetselection_BCH_minus: -5.30188665e-02
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: -0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -1.00239457e-01
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 1.04581093e-01
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 4.74115097e-01
@@ -111532,12 +111532,12 @@ bins:
   syst_Unfolding_bias_minus: -7.74211215e-03
   syst_jetselection_BCH_plus: 2.16303964e-02
   syst_jetselection_BCH_minus: -2.16303964e-02
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -4.30981583e-02
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 4.53891843e-02
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 1.86676190e-01
@@ -112204,12 +112204,12 @@ bins:
   syst_Unfolding_bias_minus: -2.08950054e-03
   syst_jetselection_BCH_plus: 8.60619663e-03
   syst_jetselection_BCH_minus: -8.60619663e-03
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -1.77625223e-02
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 1.89504617e-02
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 6.96924444e-02
@@ -112876,12 +112876,12 @@ bins:
   syst_Unfolding_bias_minus: -3.33330137e-04
   syst_jetselection_BCH_plus: 3.28451100e-03
   syst_jetselection_BCH_minus: -3.28451100e-03
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -7.25350136e-03
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 7.65513801e-03
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 2.50245090e-02
@@ -113548,12 +113548,12 @@ bins:
   syst_Unfolding_bias_minus: -3.56098975e-04
   syst_jetselection_BCH_plus: 1.19430335e-03
   syst_jetselection_BCH_minus: -1.19430335e-03
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -3.07520739e-03
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 3.05045865e-03
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 8.94772921e-03
@@ -114220,12 +114220,12 @@ bins:
   syst_Unfolding_bias_minus: -3.48250090e-04
   syst_jetselection_BCH_plus: 3.89545126e-04
   syst_jetselection_BCH_minus: -3.89545126e-04
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -1.19925310e-03
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 1.12854242e-03
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 3.00732514e-03
@@ -114892,12 +114892,12 @@ bins:
   syst_Unfolding_bias_minus: -8.91237387e-05
   syst_jetselection_BCH_plus: 1.13985613e-04
   syst_jetselection_BCH_minus: -1.13985613e-04
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -3.85868170e-04
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 3.59139534e-04
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 8.94985053e-04
@@ -115564,12 +115564,12 @@ bins:
   syst_Unfolding_bias_minus: -4.96035407e-05
   syst_jetselection_BCH_plus: 3.83322586e-05
   syst_jetselection_BCH_minus: -3.83322586e-05
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -1.04227540e-04
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 1.00479874e-04
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 2.46356003e-04
@@ -116236,12 +116236,12 @@ bins:
   syst_Unfolding_bias_minus: -1.77271670e-05
   syst_jetselection_BCH_plus: 1.42906280e-05
   syst_jetselection_BCH_minus: -1.42906280e-05
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -1.68362125e-05
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 1.94525076e-05
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 4.79984083e-05
@@ -116908,12 +116908,12 @@ bins:
   syst_Unfolding_bias_minus: -2.08384368e-05
   syst_jetselection_BCH_plus: 5.84989440e-06
   syst_jetselection_BCH_minus: -5.84989440e-06
-  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: -0.0
+  syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: -2.23940718e-06
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_minus: 4.28153156e-06
   syst_splitted_2_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 1.00069752e-05
@@ -117583,7 +117583,7 @@ bins:
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_plus: 0.0
   syst_splitted_1_perbinPercrossOpt14_JES_Flavour_Response_minus: 0.0
   syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_plus: 0.0
-  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: -0.0
+  syst_splitted_1_perbinPercrossOpt16_JES_Pileup_Rho_topology_minus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_plus: 0.0
   syst_splitted_1_perbinPercrossOpt17_JES_MJB_Fragmentation_minus: 0.0
   syst_splitted_2_perbinPercrossOpt14_JES_Flavour_Response_plus: 7.03995511e-07

--- a/nnpdf_data/nnpdf_data/commondata/ATLAS_2JET_7TEV_R06/uncertainties.yaml
+++ b/nnpdf_data/nnpdf_data/commondata/ATLAS_2JET_7TEV_R06/uncertainties.yaml
@@ -902,92 +902,92 @@ definitions:
 bins:
 - art_sys_1: 0.0
   art_sys_2: 8.66600397e+03
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 1.65603952e+01
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 1.00466592e+01
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 1.26565519e-01
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 3.24886915e-02
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
+  art_sys_22: 0.0
   art_sys_23: 5.12875512e-03
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 1.53888278e-03
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 7.95614472e-05
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 4.88924054e-05
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
+  art_sys_43: 0.0
   art_sys_44: 1.68570003e-05
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 3.46238064e-06
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 9.73326696e-07
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 3.97603562e-07
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 1.98321791e-08
   art_sys_62: 0.0
-  art_sys_63: -0.0
+  art_sys_63: 0.0
   art_sys_64: 5.04287641e-08
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
   art_sys_69: 3.05546432e-08
-  art_sys_70: -0.0
+  art_sys_70: 0.0
   art_sys_71: 8.29975820e-09
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 2.32783123e-09
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 1.54448543e-09
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 5.30147707e-10
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
   art_sys_90: 1.40299436e-11
   sys_1: 2.34547319e+04
@@ -995,13 +995,13 @@ bins:
   sys_3: 6.05283405e+03
   sys_4: -6.05283405e+03
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 2.26981277e+03
   sys_8: -3.02641702e+03
   sys_9: 1.13490638e+04
   sys_10: -1.13490638e+04
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 0.0
   sys_14: -7.56604256e+02
   sys_15: 4.53962554e+03
@@ -1017,25 +1017,25 @@ bins:
   sys_25: 4.53962554e+03
   sys_26: -4.53962554e+03
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 0.0
-  sys_30: -0.0
+  sys_30: 0.0
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 0.0
-  sys_38: -0.0
+  sys_38: 0.0
   sys_39: 0.0
-  sys_40: -0.0
+  sys_40: 0.0
   sys_41: 0.0
-  sys_42: -0.0
+  sys_42: 0.0
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
   sys_48: -7.56604256e+02
   sys_49: 0.0
@@ -1053,11 +1053,11 @@ bins:
   sys_61: 7.56604256e+02
   sys_62: -7.56604256e+02
   sys_63: 0.0
-  sys_64: -0.0
+  sys_64: 0.0
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
   sys_70: -7.56604256e+02
   sys_71: 0.0
@@ -1065,47 +1065,47 @@ bins:
   sys_73: 7.56604256e+02
   sys_74: -7.56604256e+02
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 3.78302128e+03
   sys_110: -3.78302128e+03
   sys_111: 2.95075660e+04
   sys_112: -2.72377532e+04
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: -3.02641702e+03
   sys_118: 3.78302128e+03
   sys_119: -9.83585533e+03
@@ -1127,92 +1127,92 @@ bins:
   luminosity_uncertainty: 1.92600000e+04
 - art_sys_1: 0.0
   art_sys_2: -4.77033220e+01
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 3.14268214e+03
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 3.50642944e+01
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 6.62067632e+00
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 8.28376346e-02
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
+  art_sys_22: 0.0
   art_sys_23: 1.14440868e-02
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 7.91206859e-03
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: -5.40010282e-04
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 4.01656084e-04
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
+  art_sys_43: 0.0
   art_sys_44: -1.50718011e-05
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 2.16191112e-06
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: -4.46031889e-06
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 8.14636149e-08
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 4.17082996e-07
   art_sys_62: 0.0
-  art_sys_63: -0.0
+  art_sys_63: 0.0
   art_sys_64: 1.05694529e-08
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
   art_sys_69: 1.25633584e-08
-  art_sys_70: -0.0
+  art_sys_70: 0.0
   art_sys_71: -2.95765951e-08
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: -9.14156780e-09
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 1.96642808e-09
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 1.01309289e-09
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
   art_sys_90: 4.60286375e-11
   sys_1: 9.18673130e+03
@@ -1220,15 +1220,15 @@ bins:
   sys_3: 1.72251212e+03
   sys_4: -1.72251212e+03
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 8.61256059e+02
   sys_8: -8.61256059e+02
   sys_9: 3.73210959e+03
   sys_10: -3.44502424e+03
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 1.43542677e+03
   sys_16: -1.43542677e+03
   sys_17: 2.87085353e+02
@@ -1244,27 +1244,27 @@ bins:
   sys_27: 0.0
   sys_28: -2.87085353e+02
   sys_29: 0.0
-  sys_30: -0.0
+  sys_30: 0.0
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
   sys_36: -2.87085353e+02
   sys_37: 0.0
-  sys_38: -0.0
+  sys_38: 0.0
   sys_39: 0.0
   sys_40: -2.87085353e+02
   sys_41: 0.0
   sys_42: -2.87085353e+02
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
   sys_52: -2.87085353e+02
   sys_53: 2.87085353e+02
@@ -1278,59 +1278,59 @@ bins:
   sys_61: 8.61256059e+02
   sys_62: -5.74170706e+02
   sys_63: 0.0
-  sys_64: -0.0
+  sys_64: 0.0
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 2.87085353e+02
   sys_74: -2.87085353e+02
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 1.14834141e+03
   sys_110: -1.14834141e+03
   sys_111: 1.06221581e+04
   sys_112: -9.76090201e+03
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: -1.14834141e+03
   sys_118: 1.43542677e+03
   sys_119: -3.15793888e+03
@@ -1352,92 +1352,92 @@ bins:
   luminosity_uncertainty: 7.30800000e+03
 - art_sys_1: 0.0
   art_sys_2: -7.00122739e+01
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -9.20257933e+01
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 1.21913825e+03
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 1.80626131e+01
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 2.28059505e+00
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
+  art_sys_22: 0.0
   art_sys_23: 7.90198445e-02
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 1.06746073e-02
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: -2.44464005e-03
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 4.47952792e-04
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
+  art_sys_43: 0.0
   art_sys_44: 1.08646766e-04
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: -9.08624166e-06
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: -3.11648575e-06
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 5.35926874e-07
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 2.29584162e-06
   art_sys_62: 0.0
-  art_sys_63: -0.0
+  art_sys_63: 0.0
   art_sys_64: 1.07006478e-06
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
   art_sys_69: 1.28227265e-07
-  art_sys_70: -0.0
+  art_sys_70: 0.0
   art_sys_71: -6.24732027e-08
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 6.45561067e-09
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 1.59017767e-09
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 1.05553387e-08
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
   art_sys_90: -3.63513279e-11
   sys_1: 3.65432785e+03
@@ -1445,15 +1445,15 @@ bins:
   sys_3: 5.37401154e+02
   sys_4: -5.37401154e+02
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 2.14960461e+02
   sys_8: -3.22440692e+02
   sys_9: 1.18228254e+03
   sys_10: -1.07480231e+03
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 5.37401154e+02
   sys_16: -4.29920923e+02
   sys_17: 1.07480231e+02
@@ -1469,29 +1469,29 @@ bins:
   sys_27: 0.0
   sys_28: -1.07480231e+02
   sys_29: 0.0
-  sys_30: -0.0
+  sys_30: 0.0
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 1.07480231e+02
   sys_36: -1.07480231e+02
   sys_37: 0.0
-  sys_38: -0.0
+  sys_38: 0.0
   sys_39: 1.07480231e+02
   sys_40: -1.07480231e+02
   sys_41: 1.07480231e+02
   sys_42: -1.07480231e+02
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 1.07480231e+02
   sys_54: -1.07480231e+02
   sys_55: 1.07480231e+02
@@ -1505,57 +1505,57 @@ bins:
   sys_63: 1.07480231e+02
   sys_64: 0.0
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 1.07480231e+02
   sys_74: -1.07480231e+02
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 4.29920923e+02
   sys_110: -4.29920923e+02
   sys_111: 3.65432785e+03
   sys_112: -3.33188715e+03
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: -5.37401154e+02
   sys_118: 5.37401154e+02
   sys_119: -1.07480231e+03
@@ -1577,92 +1577,92 @@ bins:
   luminosity_uncertainty: 2.73600000e+03
 - art_sys_1: 0.0
   art_sys_2: 9.77545258e-01
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -3.96231596e+01
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: -4.64375276e+01
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 4.82951674e+02
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 5.44666874e+00
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
+  art_sys_22: 0.0
   art_sys_23: 7.84822573e-01
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 6.48303771e-02
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: -3.61645081e-03
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: -7.83601275e-04
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
+  art_sys_43: 0.0
   art_sys_44: 6.52654718e-04
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 5.20483996e-05
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 9.48094386e-06
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 8.85394144e-06
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: -1.78779821e-06
   art_sys_62: 0.0
-  art_sys_63: -0.0
+  art_sys_63: 0.0
   art_sys_64: -7.30851279e-07
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
   art_sys_69: 1.74720749e-07
-  art_sys_70: -0.0
+  art_sys_70: 0.0
   art_sys_71: -2.62337554e-08
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: -3.64352323e-08
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 1.29471700e-08
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 9.46016641e-09
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
   art_sys_90: -6.30046326e-11
   sys_1: 1.58547482e+03
@@ -1670,15 +1670,15 @@ bins:
   sys_3: 2.14253355e+02
   sys_4: -1.71402684e+02
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 8.57013419e+01
   sys_8: -8.57013419e+01
   sys_9: 3.85656038e+02
   sys_10: -3.85656038e+02
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 1.71402684e+02
   sys_16: -1.71402684e+02
   sys_17: 4.28506709e+01
@@ -1708,17 +1708,17 @@ bins:
   sys_41: 8.57013419e+01
   sys_42: -8.57013419e+01
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 4.28506709e+01
   sys_56: -4.28506709e+01
   sys_57: 4.28506709e+01
@@ -1730,57 +1730,57 @@ bins:
   sys_63: 4.28506709e+01
   sys_64: -4.28506709e+01
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 4.28506709e+01
   sys_74: -4.28506709e+01
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 4.28506709e+01
   sys_80: -4.28506709e+01
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 1.28552013e+02
   sys_110: -1.28552013e+02
   sys_111: 1.28552013e+03
   sys_112: -1.19981879e+03
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: -2.14253355e+02
   sys_118: 2.14253355e+02
   sys_119: -3.85656038e+02
@@ -1796,98 +1796,98 @@ bins:
   sys_129: 8.57013419e+01
   sys_130: -8.57013419e+01
   sys_131: 0.0
-  sys_132: -0.0
+  sys_132: 0.0
   sys_133: 2.14253355e+02
   sys_134: -2.14253355e+02
   luminosity_uncertainty: 1.09080000e+03
 - art_sys_1: 0.0
   art_sys_2: -6.24445985e-01
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 8.09690516e-01
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: -1.26198742e+01
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: -1.33691170e+01
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 2.00649923e+02
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
+  art_sys_22: 0.0
   art_sys_23: 4.88886178e-01
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 5.72530475e-01
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: -3.85693232e-02
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: -4.09551998e-03
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
+  art_sys_43: 0.0
   art_sys_44: -5.10668135e-04
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: -3.58839834e-04
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 4.01512348e-05
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 9.94951973e-06
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 2.04343429e-05
   art_sys_62: 0.0
-  art_sys_63: -0.0
+  art_sys_63: 0.0
   art_sys_64: 2.50511092e-06
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
   art_sys_69: -6.54028672e-07
-  art_sys_70: -0.0
+  art_sys_70: 0.0
   art_sys_71: 1.17787458e-07
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: -4.26063451e-08
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 6.37371162e-08
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: -4.03966220e-09
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
   art_sys_90: 3.40611967e-10
   sys_1: 6.90560483e+02
@@ -1895,7 +1895,7 @@ bins:
   sys_3: 5.45179328e+01
   sys_4: -5.45179328e+01
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 3.63452886e+01
   sys_8: -3.63452886e+01
   sys_9: 1.45381154e+02
@@ -1903,7 +1903,7 @@ bins:
   sys_11: 0.0
   sys_12: -1.81726443e+01
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 7.26905771e+01
   sys_16: -7.26905771e+01
   sys_17: 1.81726443e+01
@@ -1933,17 +1933,17 @@ bins:
   sys_41: 3.63452886e+01
   sys_42: -3.63452886e+01
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 1.81726443e+01
   sys_56: -1.81726443e+01
   sys_57: 1.81726443e+01
@@ -1955,17 +1955,17 @@ bins:
   sys_63: 3.63452886e+01
   sys_64: -3.63452886e+01
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
   sys_74: -1.81726443e+01
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
   sys_78: -1.81726443e+01
   sys_79: 1.81726443e+01
@@ -1973,39 +1973,39 @@ bins:
   sys_81: 0.0
   sys_82: -1.81726443e+01
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 5.45179328e+01
   sys_110: -5.45179328e+01
   sys_111: 4.72488751e+02
   sys_112: -4.54316107e+02
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: -9.08632214e+01
   sys_118: 9.08632214e+01
   sys_119: -1.81726443e+02
@@ -2021,98 +2021,98 @@ bins:
   sys_129: 3.63452886e+01
   sys_130: -3.63452886e+01
   sys_131: 0.0
-  sys_132: -0.0
+  sys_132: 0.0
   sys_133: 9.08632214e+01
   sys_134: -9.08632214e+01
   luminosity_uncertainty: 4.62600000e+02
 - art_sys_1: 0.0
   art_sys_2: -5.59880644e-01
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 1.57221880e-03
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: -7.70393233e-01
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: -5.30516357e+00
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: -1.58625879e+00
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
+  art_sys_22: 0.0
   art_sys_23: 7.07597902e+01
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 1.18820891e+00
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: -2.67790339e-01
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: -2.42473600e-02
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
+  art_sys_43: 0.0
   art_sys_44: 1.50349162e-04
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 2.01220583e-04
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: -3.13977714e-05
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 5.25624358e-05
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 4.73347355e-06
   art_sys_62: 0.0
-  art_sys_63: -0.0
+  art_sys_63: 0.0
   art_sys_64: -4.79459747e-06
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
   art_sys_69: 2.74900035e-06
-  art_sys_70: -0.0
+  art_sys_70: 0.0
   art_sys_71: 9.39057694e-07
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 1.08451445e-07
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 1.47385495e-07
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: -1.36169505e-07
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
   art_sys_90: -6.70958864e-10
   sys_1: 3.19612265e+02
@@ -2120,7 +2120,7 @@ bins:
   sys_3: 2.39709199e+01
   sys_4: -2.39709199e+01
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 7.99030663e+00
   sys_8: -7.99030663e+00
   sys_9: 4.79418398e+01
@@ -2128,7 +2128,7 @@ bins:
   sys_11: 0.0
   sys_12: -7.99030663e+00
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 3.19612265e+01
   sys_16: -3.19612265e+01
   sys_17: 7.99030663e+00
@@ -2158,17 +2158,17 @@ bins:
   sys_41: 1.59806133e+01
   sys_42: -1.59806133e+01
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
   sys_56: -7.99030663e+00
   sys_57: 7.99030663e+00
@@ -2180,17 +2180,17 @@ bins:
   sys_63: 1.59806133e+01
   sys_64: -1.59806133e+01
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
   sys_78: -7.99030663e+00
   sys_79: 1.59806133e+01
@@ -2200,37 +2200,37 @@ bins:
   sys_83: 7.99030663e+00
   sys_84: -7.99030663e+00
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 2.39709199e+01
   sys_110: -2.39709199e+01
   sys_111: 1.75786746e+02
   sys_112: -1.75786746e+02
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: -4.79418398e+01
   sys_118: 3.99515331e+01
   sys_119: -8.78933729e+01
@@ -2246,98 +2246,98 @@ bins:
   sys_129: 1.59806133e+01
   sys_130: -1.59806133e+01
   sys_131: 0.0
-  sys_132: -0.0
+  sys_132: 0.0
   sys_133: 3.99515331e+01
   sys_134: -3.99515331e+01
   luminosity_uncertainty: 2.03400000e+02
 - art_sys_1: 0.0
   art_sys_2: -3.40189430e-01
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -6.68262358e-01
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: -7.01607567e-02
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: -5.39138259e-01
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: -3.49927676e+00
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
+  art_sys_22: 0.0
   art_sys_23: -2.64986079e+00
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 3.25491051e+01
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: -6.34601537e-01
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: -1.68143063e-01
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
+  art_sys_43: 0.0
   art_sys_44: -1.30486891e-02
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 1.30308546e-03
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: -3.27163776e-04
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 5.97594369e-05
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 2.39257219e-05
   art_sys_62: 0.0
-  art_sys_63: -0.0
+  art_sys_63: 0.0
   art_sys_64: 3.39099387e-05
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
   art_sys_69: -5.32913752e-06
-  art_sys_70: -0.0
+  art_sys_70: 0.0
   art_sys_71: 2.71306658e-06
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: -7.25244740e-07
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 5.39198882e-07
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 2.22646652e-07
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
   art_sys_90: 4.71488044e-10
   sys_1: 1.51045080e+02
@@ -2345,7 +2345,7 @@ bins:
   sys_3: 7.36805266e+00
   sys_4: -7.36805266e+00
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 3.68402633e+00
   sys_8: -3.68402633e+00
   sys_9: 1.84201316e+01
@@ -2353,7 +2353,7 @@ bins:
   sys_11: 3.68402633e+00
   sys_12: -3.68402633e+00
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 1.10520790e+01
   sys_16: -1.10520790e+01
   sys_17: 3.68402633e+00
@@ -2383,19 +2383,19 @@ bins:
   sys_41: 1.10520790e+01
   sys_42: -1.10520790e+01
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
   sys_48: -3.68402633e+00
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 3.68402633e+00
   sys_58: -3.68402633e+00
   sys_59: 3.68402633e+00
@@ -2405,17 +2405,17 @@ bins:
   sys_63: 7.36805266e+00
   sys_64: -7.36805266e+00
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
   sys_78: -3.68402633e+00
   sys_79: 7.36805266e+00
@@ -2425,37 +2425,37 @@ bins:
   sys_83: 7.36805266e+00
   sys_84: -3.68402633e+00
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 1.10520790e+01
   sys_110: -1.10520790e+01
   sys_111: 6.99965003e+01
   sys_112: -6.99965003e+01
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: -2.21041580e+01
   sys_118: 1.84201316e+01
   sys_119: -3.68402633e+01
@@ -2471,98 +2471,98 @@ bins:
   sys_129: 7.36805266e+00
   sys_130: -7.36805266e+00
   sys_131: 0.0
-  sys_132: -0.0
+  sys_132: 0.0
   sys_133: 1.84201316e+01
   sys_134: -1.84201316e+01
   luminosity_uncertainty: 9.37800000e+01
 - art_sys_1: 0.0
   art_sys_2: 9.23387966e-02
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -5.02852833e-02
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: -1.35259611e-01
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 3.40255235e-02
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: -3.51750100e-01
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
+  art_sys_22: 0.0
   art_sys_23: -1.19370158e+00
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: -1.49352552e+00
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: -1.45575069e+01
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: -5.13965110e-01
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
+  art_sys_43: 0.0
   art_sys_44: -7.07131241e-02
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 7.14714411e-03
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: -1.46476036e-03
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: -1.55464994e-04
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: -6.28948301e-05
   art_sys_62: 0.0
-  art_sys_63: -0.0
+  art_sys_63: 0.0
   art_sys_64: 5.53498030e-05
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
   art_sys_69: -6.73724191e-06
-  art_sys_70: -0.0
+  art_sys_70: 0.0
   art_sys_71: 4.59052397e-06
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: -2.01812845e-06
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: -6.57480973e-07
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 2.07564586e-07
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
   art_sys_90: -1.15028463e-09
   sys_1: 7.27683589e+01
@@ -2570,7 +2570,7 @@ bins:
   sys_3: 3.54967604e+00
   sys_4: -3.54967604e+00
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 1.77483802e+00
   sys_8: -1.77483802e+00
   sys_9: 7.09935208e+00
@@ -2578,7 +2578,7 @@ bins:
   sys_11: 1.77483802e+00
   sys_12: -3.54967604e+00
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 5.32451406e+00
   sys_16: -5.32451406e+00
   sys_17: 1.77483802e+00
@@ -2608,21 +2608,21 @@ bins:
   sys_41: 5.32451406e+00
   sys_42: -5.32451406e+00
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 1.77483802e+00
   sys_60: -1.77483802e+00
   sys_61: 1.77483802e+00
@@ -2630,17 +2630,17 @@ bins:
   sys_63: 3.54967604e+00
   sys_64: -1.77483802e+00
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
   sys_78: -1.77483802e+00
   sys_79: 3.54967604e+00
@@ -2652,35 +2652,35 @@ bins:
   sys_85: 0.0
   sys_86: -1.77483802e+00
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 3.54967604e+00
   sys_110: -5.32451406e+00
   sys_111: 3.01722464e+01
   sys_112: -2.83974083e+01
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: -1.06490281e+01
   sys_118: 7.09935208e+00
   sys_119: -1.59735422e+01
@@ -2696,98 +2696,98 @@ bins:
   sys_129: 3.54967604e+00
   sys_130: -3.54967604e+00
   sys_131: 0.0
-  sys_132: -0.0
+  sys_132: 0.0
   sys_133: 8.87419010e+00
   sys_134: -8.87419010e+00
   luminosity_uncertainty: 4.51800000e+01
 - art_sys_1: 0.0
   art_sys_2: 5.80091660e-02
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 1.94125450e-01
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 1.07567088e-01
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: -1.04484248e-02
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: -1.89766689e-03
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
+  art_sys_22: 0.0
   art_sys_23: -9.06462642e-02
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: -6.72738390e-01
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 1.08843898e+00
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: -7.07546072e+00
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
+  art_sys_43: 0.0
   art_sys_44: -1.95866968e-01
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 3.55592631e-02
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 8.11460358e-05
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 9.47767711e-04
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 2.31004101e-04
   art_sys_62: 0.0
-  art_sys_63: -0.0
+  art_sys_63: 0.0
   art_sys_64: 4.77814218e-05
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
   art_sys_69: 8.70840560e-06
-  art_sys_70: -0.0
+  art_sys_70: 0.0
   art_sys_71: 1.01696338e-05
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: -3.19457414e-06
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 3.71284068e-06
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: -6.54733539e-07
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
   art_sys_90: 8.56908310e-09
   sys_1: 3.68261212e+01
@@ -2795,7 +2795,7 @@ bins:
   sys_3: 1.75362482e+00
   sys_4: -8.76812409e-01
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 8.76812409e-01
   sys_8: -8.76812409e-01
   sys_9: 2.63043723e+00
@@ -2803,7 +2803,7 @@ bins:
   sys_11: 8.76812409e-01
   sys_12: -1.75362482e+00
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 2.63043723e+00
   sys_16: -2.63043723e+00
   sys_17: 8.76812409e-01
@@ -2833,21 +2833,21 @@ bins:
   sys_41: 2.63043723e+00
   sys_42: -2.63043723e+00
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 8.76812409e-01
   sys_60: -8.76812409e-01
   sys_61: 8.76812409e-01
@@ -2855,17 +2855,17 @@ bins:
   sys_63: 8.76812409e-01
   sys_64: -8.76812409e-01
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
   sys_78: -8.76812409e-01
   sys_79: 8.76812409e-01
@@ -2877,35 +2877,35 @@ bins:
   sys_85: 8.76812409e-01
   sys_86: -1.75362482e+00
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 1.75362482e+00
   sys_110: -1.75362482e+00
   sys_111: 1.31521861e+01
   sys_112: -1.22753737e+01
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: -3.50724963e+00
   sys_118: 2.63043723e+00
   sys_119: -5.26087445e+00
@@ -2921,98 +2921,98 @@ bins:
   sys_129: 8.76812409e-01
   sys_130: -8.76812409e-01
   sys_131: 0.0
-  sys_132: -0.0
+  sys_132: 0.0
   sys_133: 4.38406204e+00
   sys_134: -4.38406204e+00
   luminosity_uncertainty: 2.23200000e+01
 - art_sys_1: 0.0
   art_sys_2: 3.56841619e-02
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -3.24320708e-02
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 2.84708301e-02
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 9.48380534e-02
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: -4.90602185e-03
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
+  art_sys_22: 0.0
   art_sys_23: 4.29393443e-02
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: -5.49746356e-02
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 2.42621811e-01
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 4.23950443e-01
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
+  art_sys_43: 0.0
   art_sys_44: -3.42538579e+00
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 1.04010414e-01
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: -1.70034057e-02
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 2.23313283e-03
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 6.97646425e-04
   art_sys_62: 0.0
-  art_sys_63: -0.0
+  art_sys_63: 0.0
   art_sys_64: 1.62980195e-04
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
   art_sys_69: -2.08230958e-05
-  art_sys_70: -0.0
+  art_sys_70: 0.0
   art_sys_71: 9.55312842e-06
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: -4.65891824e-06
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 1.33058018e-06
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 4.62503045e-07
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
   art_sys_90: -1.60785983e-08
   sys_1: 1.86365063e+01
@@ -3020,7 +3020,7 @@ bins:
   sys_3: 4.23556962e-01
   sys_4: -4.23556962e-01
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 4.23556962e-01
   sys_8: -4.23556962e-01
   sys_9: 1.27067089e+00
@@ -3028,7 +3028,7 @@ bins:
   sys_11: 4.23556962e-01
   sys_12: -4.23556962e-01
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 1.27067089e+00
   sys_16: -1.27067089e+00
   sys_17: 4.23556962e-01
@@ -3058,21 +3058,21 @@ bins:
   sys_41: 1.69422785e+00
   sys_42: -1.69422785e+00
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 4.23556962e-01
   sys_60: -4.23556962e-01
   sys_61: 4.23556962e-01
@@ -3080,17 +3080,17 @@ bins:
   sys_63: 4.23556962e-01
   sys_64: -4.23556962e-01
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
   sys_78: -4.23556962e-01
   sys_79: 4.23556962e-01
@@ -3104,33 +3104,33 @@ bins:
   sys_87: 4.23556962e-01
   sys_88: -4.23556962e-01
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
   sys_96: -4.23556962e-01
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 8.47113924e-01
   sys_110: -8.47113924e-01
   sys_111: 5.08268354e+00
   sys_112: -5.08268354e+00
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: -1.27067089e+00
   sys_118: 8.47113924e-01
   sys_119: -1.27067089e+00
@@ -3146,98 +3146,98 @@ bins:
   sys_129: 4.23556962e-01
   sys_130: -4.23556962e-01
   sys_131: 0.0
-  sys_132: -0.0
+  sys_132: 0.0
   sys_133: 2.11778481e+00
   sys_134: -2.11778481e+00
   luminosity_uncertainty: 1.07820000e+01
 - art_sys_1: 0.0
   art_sys_2: -2.20322705e-02
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -5.11195278e-03
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 1.76398223e-03
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: -2.29026537e-02
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 4.83961862e-02
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
+  art_sys_22: 0.0
   art_sys_23: -2.23674578e-03
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: -1.64370589e-03
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 2.51940803e-02
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 1.27765843e-01
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
+  art_sys_43: 0.0
   art_sys_44: 2.22353667e-01
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 1.65201313e+00
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: -2.89783643e-02
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 1.48881977e-02
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 1.36497539e-03
   art_sys_62: 0.0
-  art_sys_63: -0.0
+  art_sys_63: 0.0
   art_sys_64: -4.99751348e-04
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
   art_sys_69: -6.37809257e-05
-  art_sys_70: -0.0
+  art_sys_70: 0.0
   art_sys_71: -8.63674365e-06
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: -1.56419238e-05
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 9.76743155e-06
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: -5.66044411e-07
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
   art_sys_90: 7.19562227e-08
   sys_1: 9.43280446e+00
@@ -3245,7 +3245,7 @@ bins:
   sys_3: 2.05060967e-01
   sys_4: -2.05060967e-01
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 2.05060967e-01
   sys_8: -2.05060967e-01
   sys_9: 4.10121933e-01
@@ -3253,7 +3253,7 @@ bins:
   sys_11: 2.05060967e-01
   sys_12: -2.05060967e-01
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 8.20243866e-01
   sys_16: -6.15182900e-01
   sys_17: 2.05060967e-01
@@ -3283,21 +3283,21 @@ bins:
   sys_41: 1.02530483e+00
   sys_42: -1.02530483e+00
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
   sys_48: -2.05060967e-01
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 2.05060967e-01
   sys_60: -2.05060967e-01
   sys_61: 2.05060967e-01
@@ -3305,17 +3305,17 @@ bins:
   sys_63: 2.05060967e-01
   sys_64: -2.05060967e-01
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
   sys_78: -2.05060967e-01
   sys_79: 2.05060967e-01
@@ -3329,33 +3329,33 @@ bins:
   sys_87: 6.15182900e-01
   sys_88: -6.15182900e-01
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 6.15182900e-01
   sys_110: -6.15182900e-01
   sys_111: 2.25567063e+00
   sys_112: -2.05060967e+00
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: -4.10121933e-01
   sys_118: 2.05060967e-01
   sys_119: -2.05060967e-01
@@ -3371,98 +3371,98 @@ bins:
   sys_129: 2.05060967e-01
   sys_130: -2.05060967e-01
   sys_131: 0.0
-  sys_132: -0.0
+  sys_132: 0.0
   sys_133: 1.02530483e+00
   sys_134: -1.02530483e+00
   luminosity_uncertainty: 5.22000000e+00
 - art_sys_1: 0.0
   art_sys_2: 9.86610479e-03
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -1.45568502e-02
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: -5.91171276e-03
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 3.74820673e-03
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 9.11597314e-03
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
+  art_sys_22: 0.0
   art_sys_23: -3.01618742e-04
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: -8.39904315e-03
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 1.84897828e-02
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: -1.17688968e-02
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
+  art_sys_43: 0.0
   art_sys_44: 5.76594449e-02
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: -5.51521631e-02
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: -9.01414720e-01
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: -1.49158449e-03
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 9.46831670e-03
   art_sys_62: 0.0
-  art_sys_63: -0.0
+  art_sys_63: 0.0
   art_sys_64: -9.07193600e-04
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
   art_sys_69: -2.68164606e-04
-  art_sys_70: -0.0
+  art_sys_70: 0.0
   art_sys_71: 8.18022041e-05
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: -1.42749990e-06
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: -1.09162130e-05
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: -2.82462222e-06
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
   art_sys_90: -1.57577390e-07
   sys_1: 4.75175757e+00
@@ -3470,7 +3470,7 @@ bins:
   sys_3: 9.89949494e-02
   sys_4: -9.89949494e-02
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 9.89949494e-02
   sys_8: -9.89949494e-02
   sys_9: 1.97989899e-01
@@ -3478,7 +3478,7 @@ bins:
   sys_11: 9.89949494e-02
   sys_12: -9.89949494e-02
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 3.95979797e-01
   sys_16: -3.95979797e-01
   sys_17: 9.89949494e-02
@@ -3508,21 +3508,21 @@ bins:
   sys_41: 5.93969696e-01
   sys_42: -5.93969696e-01
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 9.89949494e-02
   sys_48: -9.89949494e-02
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
   sys_60: -9.89949494e-02
   sys_61: 9.89949494e-02
@@ -3530,19 +3530,19 @@ bins:
   sys_63: 9.89949494e-02
   sys_64: -9.89949494e-02
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 9.89949494e-02
   sys_80: -9.89949494e-02
   sys_81: 1.97989899e-01
@@ -3554,37 +3554,37 @@ bins:
   sys_87: 5.93969696e-01
   sys_88: -5.93969696e-01
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
   sys_100: -9.89949494e-02
   sys_101: 0.0
   sys_102: -9.89949494e-02
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 2.96984848e-01
   sys_110: -2.96984848e-01
   sys_111: 8.90954544e-01
   sys_112: -8.90954544e-01
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: -9.89949494e-02
   sys_118: 9.89949494e-02
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: 1.97989899e-01
   sys_122: -1.97989899e-01
   sys_123: 9.89949494e-02
@@ -3596,98 +3596,98 @@ bins:
   sys_129: 9.89949494e-02
   sys_130: -9.89949494e-02
   sys_131: 0.0
-  sys_132: -0.0
+  sys_132: 0.0
   sys_133: 4.94974747e-01
   sys_134: -4.94974747e-01
   luminosity_uncertainty: 2.52000000e+00
 - art_sys_1: 0.0
   art_sys_2: -5.63127896e-03
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 2.48544381e-04
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: -2.38378613e-04
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: -6.78572413e-03
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: -4.23603003e-03
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
+  art_sys_22: 0.0
   art_sys_23: -6.79657670e-03
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: -2.51744701e-03
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: -7.47364840e-03
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 6.70918896e-03
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
+  art_sys_43: 0.0
   art_sys_44: 8.14696942e-03
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: -4.51204560e-02
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: -2.01708171e-03
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 5.51864445e-01
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: -7.66459020e-03
   art_sys_62: 0.0
-  art_sys_63: -0.0
+  art_sys_63: 0.0
   art_sys_64: -5.59610386e-03
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
   art_sys_69: 1.68390971e-04
-  art_sys_70: -0.0
+  art_sys_70: 0.0
   art_sys_71: -7.66965461e-05
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 1.42664030e-04
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 3.06825436e-05
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 3.72320589e-06
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
   art_sys_90: 2.88138736e-07
   sys_1: 2.36569645e+00
@@ -3695,7 +3695,7 @@ bins:
   sys_3: 4.63862048e-02
   sys_4: -4.63862048e-02
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 4.63862048e-02
   sys_8: -4.63862048e-02
   sys_9: 9.27724097e-02
@@ -3703,7 +3703,7 @@ bins:
   sys_11: 4.63862048e-02
   sys_12: -4.63862048e-02
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 1.85544819e-01
   sys_16: -1.85544819e-01
   sys_17: 4.63862048e-02
@@ -3733,21 +3733,21 @@ bins:
   sys_41: 3.24703434e-01
   sys_42: -3.71089639e-01
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 4.63862048e-02
   sys_48: -4.63862048e-02
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
   sys_60: -4.63862048e-02
   sys_61: 4.63862048e-02
@@ -3755,19 +3755,19 @@ bins:
   sys_63: 0.0
   sys_64: -4.63862048e-02
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 4.63862048e-02
   sys_80: -4.63862048e-02
   sys_81: 9.27724097e-02
@@ -3779,15 +3779,15 @@ bins:
   sys_87: 3.71089639e-01
   sys_88: -3.71089639e-01
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 4.63862048e-02
   sys_100: -4.63862048e-02
   sys_101: 4.63862048e-02
@@ -3795,19 +3795,19 @@ bins:
   sys_103: 0.0
   sys_104: -4.63862048e-02
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 1.39158615e-01
   sys_110: -1.39158615e-01
   sys_111: 3.24703434e-01
   sys_112: -3.24703434e-01
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 4.63862048e-02
   sys_120: -4.63862048e-02
   sys_121: 4.63862048e-02
@@ -3821,98 +3821,98 @@ bins:
   sys_129: 4.63862048e-02
   sys_130: -4.63862048e-02
   sys_131: 0.0
-  sys_132: -0.0
+  sys_132: 0.0
   sys_133: 2.31931024e-01
   sys_134: -2.31931024e-01
   luminosity_uncertainty: 1.1808
 - art_sys_1: 0.0
   art_sys_2: -3.67271922e-04
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -2.92790764e-03
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: -7.83460395e-03
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 2.97479134e-03
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: -1.19880779e-02
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
+  art_sys_22: 0.0
   art_sys_23: -9.32768772e-04
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: -2.18413077e-03
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: -4.17107831e-03
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 3.77323538e-03
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
+  art_sys_43: 0.0
   art_sys_44: 4.91183870e-03
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: -5.91482697e-03
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 2.38533248e-02
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 1.30018955e-02
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 3.52977558e-01
   art_sys_62: 0.0
-  art_sys_63: -0.0
+  art_sys_63: 0.0
   art_sys_64: 1.78379506e-02
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
   art_sys_69: -5.61951146e-03
-  art_sys_70: -0.0
+  art_sys_70: 0.0
   art_sys_71: -3.75233618e-05
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: -1.44107323e-05
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 1.42116169e-05
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: -2.92026217e-05
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
   art_sys_90: -3.58813381e-07
   sys_1: 1.21806214e+00
@@ -3920,7 +3920,7 @@ bins:
   sys_3: 2.25567063e-02
   sys_4: -2.25567063e-02
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 2.25567063e-02
   sys_8: -2.25567063e-02
   sys_9: 4.51134126e-02
@@ -3928,7 +3928,7 @@ bins:
   sys_11: 2.25567063e-02
   sys_12: -2.25567063e-02
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 9.02268253e-02
   sys_16: -9.02268253e-02
   sys_17: 2.25567063e-02
@@ -3958,19 +3958,19 @@ bins:
   sys_41: 2.03010357e-01
   sys_42: -2.03010357e-01
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 2.25567063e-02
   sys_48: -2.25567063e-02
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 2.25567063e-02
   sys_58: -2.25567063e-02
   sys_59: 0.0
@@ -3980,19 +3980,19 @@ bins:
   sys_63: 0.0
   sys_64: -2.25567063e-02
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
   sys_80: -2.25567063e-02
   sys_81: 4.51134126e-02
@@ -4004,15 +4004,15 @@ bins:
   sys_87: 2.25567063e-01
   sys_88: -2.48123770e-01
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 2.25567063e-02
   sys_100: -2.25567063e-02
   sys_101: 4.51134126e-02
@@ -4020,23 +4020,23 @@ bins:
   sys_103: 2.25567063e-02
   sys_104: -2.25567063e-02
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 6.76701190e-02
   sys_110: -6.76701190e-02
   sys_111: 1.35340238e-01
   sys_112: -1.35340238e-01
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 2.25567063e-02
   sys_120: -2.25567063e-02
   sys_121: 0.0
-  sys_122: -0.0
+  sys_122: 0.0
   sys_123: 2.25567063e-02
   sys_124: -2.25567063e-02
   sys_125: 2.70680476e-01
@@ -4046,98 +4046,98 @@ bins:
   sys_129: 2.25567063e-02
   sys_130: -2.25567063e-02
   sys_131: 0.0
-  sys_132: -0.0
+  sys_132: 0.0
   sys_133: 1.12783532e-01
   sys_134: -1.12783532e-01
   luminosity_uncertainty: 0.5742
 - art_sys_1: 0.0
   art_sys_2: 1.59903365e-03
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -4.88162348e-04
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 5.07425953e-03
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: -1.14427437e-03
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 6.98922566e-04
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
+  art_sys_22: 0.0
   art_sys_23: -2.22478502e-03
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 4.42147469e-03
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: -3.66366543e-03
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: -1.42404657e-03
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
+  art_sys_43: 0.0
   art_sys_44: -3.11874450e-03
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: -2.67881701e-03
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 5.53810261e-03
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: -1.28019058e-02
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 2.96640044e-02
   art_sys_62: 0.0
-  art_sys_63: -0.0
+  art_sys_63: 0.0
   art_sys_64: -2.21406648e-01
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
   art_sys_69: 1.41042611e-02
-  art_sys_70: -0.0
+  art_sys_70: 0.0
   art_sys_71: -4.29514136e-03
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: -1.08130828e-04
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: -1.02810457e-05
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 1.30791015e-05
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
   art_sys_90: 5.15500715e-07
   sys_1: 5.90009898e-01
@@ -4145,7 +4145,7 @@ bins:
   sys_3: 1.05358910e-02
   sys_4: -1.05358910e-02
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 1.05358910e-02
   sys_8: -1.05358910e-02
   sys_9: 2.10717821e-02
@@ -4153,7 +4153,7 @@ bins:
   sys_11: 1.05358910e-02
   sys_12: -1.05358910e-02
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 5.26794552e-02
   sys_16: -5.26794552e-02
   sys_17: 1.05358910e-02
@@ -4183,17 +4183,17 @@ bins:
   sys_41: 1.15894801e-01
   sys_42: -1.15894801e-01
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 1.05358910e-02
   sys_48: -1.05358910e-02
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
   sys_52: -1.05358910e-02
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
   sys_56: -1.05358910e-02
   sys_57: 1.05358910e-02
@@ -4205,19 +4205,19 @@ bins:
   sys_63: 0.0
   sys_64: -1.05358910e-02
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
   sys_80: -1.05358910e-02
   sys_81: 2.10717821e-02
@@ -4229,15 +4229,15 @@ bins:
   sys_87: 1.26430692e-01
   sys_88: -1.26430692e-01
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 1.05358910e-02
   sys_100: -1.05358910e-02
   sys_101: 3.16076731e-02
@@ -4247,21 +4247,21 @@ bins:
   sys_105: 1.05358910e-02
   sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 4.21435642e-02
   sys_110: -4.21435642e-02
   sys_111: 5.26794552e-02
   sys_112: -5.26794552e-02
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 1.05358910e-02
   sys_120: -1.05358910e-02
   sys_121: 0.0
-  sys_122: -0.0
+  sys_122: 0.0
   sys_123: 1.05358910e-02
   sys_124: -1.05358910e-02
   sys_125: 1.15894801e-01
@@ -4271,98 +4271,98 @@ bins:
   sys_129: 1.05358910e-02
   sys_130: -1.05358910e-02
   sys_131: 0.0
-  sys_132: -0.0
+  sys_132: 0.0
   sys_133: 5.26794552e-02
   sys_134: -5.26794552e-02
   luminosity_uncertainty: 2.68200000e-01
 - art_sys_1: 0.0
   art_sys_2: 1.86630567e-03
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 3.83806142e-04
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 2.00964972e-03
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 3.62178686e-04
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: -3.01797270e-04
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
+  art_sys_22: 0.0
   art_sys_23: 1.24848365e-03
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: -6.64336826e-04
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 5.03706220e-04
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: -7.27098351e-04
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
+  art_sys_43: 0.0
   art_sys_44: -1.98502550e-04
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: -7.13523732e-04
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 1.40810854e-03
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: -1.19428573e-03
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: -1.08710787e-02
   art_sys_62: 0.0
-  art_sys_63: -0.0
+  art_sys_63: 0.0
   art_sys_64: -2.35294277e-02
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
   art_sys_69: -1.41191140e-01
-  art_sys_70: -0.0
+  art_sys_70: 0.0
   art_sys_71: 8.59593556e-03
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 2.16721566e-03
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 1.67789486e-04
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: -3.31225966e-05
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
   art_sys_90: -4.93166581e-07
   sys_1: 2.89135963e-01
@@ -4370,7 +4370,7 @@ bins:
   sys_3: 4.98510281e-03
   sys_4: -4.98510281e-03
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 4.98510281e-03
   sys_8: -4.98510281e-03
   sys_9: 1.49553084e-02
@@ -4378,7 +4378,7 @@ bins:
   sys_11: 4.98510281e-03
   sys_12: -4.98510281e-03
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 2.49255140e-02
   sys_16: -2.49255140e-02
   sys_17: 4.98510281e-03
@@ -4408,17 +4408,17 @@ bins:
   sys_41: 5.98212337e-02
   sys_42: -5.98212337e-02
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 4.98510281e-03
   sys_48: -4.98510281e-03
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
   sys_52: -4.98510281e-03
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 4.98510281e-03
   sys_56: -4.98510281e-03
   sys_57: 4.98510281e-03
@@ -4428,23 +4428,23 @@ bins:
   sys_61: 4.98510281e-03
   sys_62: -4.98510281e-03
   sys_63: 0.0
-  sys_64: -0.0
+  sys_64: 0.0
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 9.97020561e-03
   sys_82: -9.97020561e-03
   sys_83: 2.99106168e-02
@@ -4454,15 +4454,15 @@ bins:
   sys_87: 6.48063365e-02
   sys_88: -6.48063365e-02
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 4.98510281e-03
   sys_100: -4.98510281e-03
   sys_101: 2.49255140e-02
@@ -4472,7 +4472,7 @@ bins:
   sys_105: 4.98510281e-03
   sys_106: -4.98510281e-03
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 1.99404112e-02
   sys_110: -1.99404112e-02
   sys_111: 1.99404112e-02
@@ -4480,13 +4480,13 @@ bins:
   sys_113: -4.98510281e-03
   sys_114: 4.98510281e-03
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 4.98510281e-03
   sys_120: -4.98510281e-03
   sys_121: 0.0
-  sys_122: -0.0
+  sys_122: 0.0
   sys_123: 4.98510281e-03
   sys_124: -4.98510281e-03
   sys_125: 4.98510281e-02
@@ -4496,98 +4496,98 @@ bins:
   sys_129: 4.98510281e-03
   sys_130: -4.98510281e-03
   sys_131: 0.0
-  sys_132: -0.0
+  sys_132: 0.0
   sys_133: 2.49255140e-02
   sys_134: -2.49255140e-02
   luminosity_uncertainty: 0.1269
 - art_sys_1: 0.0
   art_sys_2: 9.45384979e-04
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -8.70290331e-04
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: -8.24770599e-04
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: -1.44122756e-04
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 6.31617950e-05
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
+  art_sys_22: 0.0
   art_sys_23: 7.87719135e-04
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 5.00670262e-04
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: -2.95521635e-04
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: -7.50044230e-04
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
+  art_sys_43: 0.0
   art_sys_44: -2.03205224e-04
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: -1.17004163e-04
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: -8.68435111e-04
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 1.35573286e-04
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: -2.42616255e-03
   art_sys_62: 0.0
-  art_sys_63: -0.0
+  art_sys_63: 0.0
   art_sys_64: 7.63035902e-03
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
   art_sys_69: -1.34883722e-02
-  art_sys_70: -0.0
+  art_sys_70: 0.0
   art_sys_71: -9.68893641e-02
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: -4.47014928e-03
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: -1.31066873e-03
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 3.76798274e-05
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
   art_sys_90: -1.30240207e-06
   sys_1: 1.34753339e-01
@@ -4595,7 +4595,7 @@ bins:
   sys_3: 0.0
   sys_4: -2.28395490e-03
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 2.28395490e-03
   sys_8: -2.28395490e-03
   sys_9: 6.85186471e-03
@@ -4603,7 +4603,7 @@ bins:
   sys_11: 0.0
   sys_12: -2.28395490e-03
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 1.37037294e-02
   sys_16: -1.37037294e-02
   sys_17: 2.28395490e-03
@@ -4633,17 +4633,17 @@ bins:
   sys_41: 3.19753686e-02
   sys_42: -3.19753686e-02
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 2.28395490e-03
   sys_48: -2.28395490e-03
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 2.28395490e-03
   sys_52: -2.28395490e-03
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 2.28395490e-03
   sys_56: -2.28395490e-03
   sys_57: 2.28395490e-03
@@ -4653,23 +4653,23 @@ bins:
   sys_61: 4.56790981e-03
   sys_62: -2.28395490e-03
   sys_63: 0.0
-  sys_64: -0.0
+  sys_64: 0.0
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 4.56790981e-03
   sys_82: -4.56790981e-03
   sys_83: 1.59876843e-02
@@ -4679,15 +4679,15 @@ bins:
   sys_87: 2.96914137e-02
   sys_88: -2.96914137e-02
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 2.28395490e-03
   sys_100: -2.28395490e-03
   sys_101: 1.37037294e-02
@@ -4697,7 +4697,7 @@ bins:
   sys_105: 2.28395490e-03
   sys_106: -2.28395490e-03
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 1.14197745e-02
   sys_110: -1.14197745e-02
   sys_111: 9.13581961e-03
@@ -4705,13 +4705,13 @@ bins:
   sys_113: -2.05555941e-02
   sys_114: 2.05555941e-02
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 2.28395490e-03
   sys_120: -2.28395490e-03
   sys_121: 0.0
-  sys_122: -0.0
+  sys_122: 0.0
   sys_123: 0.0
   sys_124: -2.28395490e-03
   sys_125: 2.28395490e-02
@@ -4721,98 +4721,98 @@ bins:
   sys_129: 2.28395490e-03
   sys_130: -2.28395490e-03
   sys_131: 0.0
-  sys_132: -0.0
+  sys_132: 0.0
   sys_133: 1.14197745e-02
   sys_134: -1.14197745e-02
   luminosity_uncertainty: 5.81400000e-02
 - art_sys_1: 0.0
   art_sys_2: -3.56896050e-04
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 3.63503491e-04
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: -3.17847991e-04
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 2.61995734e-04
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 1.06431135e-04
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
+  art_sys_22: 0.0
   art_sys_23: -1.81061970e-04
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 3.27832275e-04
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: -4.77320533e-04
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: -3.31561633e-04
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
+  art_sys_43: 0.0
   art_sys_44: -2.43172450e-04
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 5.26275394e-04
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: -1.58830117e-04
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: -1.33750885e-03
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 3.76527065e-04
   art_sys_62: 0.0
-  art_sys_63: -0.0
+  art_sys_63: 0.0
   art_sys_64: 1.08396822e-03
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
   art_sys_69: 4.17900353e-03
-  art_sys_70: -0.0
+  art_sys_70: 0.0
   art_sys_71: -7.95431387e-03
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 5.85661451e-02
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 3.70234911e-03
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 1.08560343e-03
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
   art_sys_90: 7.43505189e-07
   sys_1: 6.21122597e-02
@@ -4820,7 +4820,7 @@ bins:
   sys_3: 0.0
   sys_4: -1.01823376e-03
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 1.01823376e-03
   sys_8: -1.01823376e-03
   sys_9: 3.05470129e-03
@@ -4828,7 +4828,7 @@ bins:
   sys_11: 0.0
   sys_12: -1.01823376e-03
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 6.10940259e-03
   sys_16: -6.10940259e-03
   sys_17: 1.01823376e-03
@@ -4858,17 +4858,17 @@ bins:
   sys_41: 1.52735065e-02
   sys_42: -1.52735065e-02
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 2.03646753e-03
   sys_48: -1.01823376e-03
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 1.01823376e-03
   sys_52: -1.01823376e-03
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 1.01823376e-03
   sys_56: -1.01823376e-03
   sys_57: 1.01823376e-03
@@ -4878,23 +4878,23 @@ bins:
   sys_61: 2.03646753e-03
   sys_62: -2.03646753e-03
   sys_63: 0.0
-  sys_64: -0.0
+  sys_64: 0.0
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 1.01823376e-03
   sys_74: -1.01823376e-03
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 2.03646753e-03
   sys_82: -2.03646753e-03
   sys_83: 8.14587012e-03
@@ -4904,15 +4904,15 @@ bins:
   sys_87: 1.42552727e-02
   sys_88: -1.42552727e-02
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 1.01823376e-03
   sys_100: -1.01823376e-03
   sys_101: 6.10940259e-03
@@ -4922,7 +4922,7 @@ bins:
   sys_105: 2.03646753e-03
   sys_106: -1.01823376e-03
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 6.10940259e-03
   sys_110: -6.10940259e-03
   sys_111: 3.05470129e-03
@@ -4930,15 +4930,15 @@ bins:
   sys_113: -1.52735065e-02
   sys_114: 1.62917402e-02
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 1.01823376e-03
   sys_120: -1.01823376e-03
   sys_121: 0.0
-  sys_122: -0.0
+  sys_122: 0.0
   sys_123: 0.0
-  sys_124: -0.0
+  sys_124: 0.0
   sys_125: 9.16410388e-03
   sys_126: -9.16410388e-03
   sys_127: 4.07293506e-03
@@ -4946,114 +4946,114 @@ bins:
   sys_129: 1.01823376e-03
   sys_130: -1.01823376e-03
   sys_131: 0.0
-  sys_132: -0.0
+  sys_132: 0.0
   sys_133: 5.09116882e-03
   sys_134: -5.09116882e-03
   luminosity_uncertainty: 2.59200000e-02
 - art_sys_1: 0.0
   art_sys_2: 2.86758898e-04
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 2.33519970e-04
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 1.04214721e-04
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 1.68795778e-04
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 2.85234691e-04
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
+  art_sys_22: 0.0
   art_sys_23: 1.37763681e-04
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 4.72921381e-04
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 2.84638522e-04
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: -5.97962755e-04
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
+  art_sys_43: 0.0
   art_sys_44: -1.16620506e-04
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 4.51197945e-04
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 2.81990902e-04
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 3.12337233e-04
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 1.27655834e-04
   art_sys_62: 0.0
-  art_sys_63: -0.0
+  art_sys_63: 0.0
   art_sys_64: -2.02533088e-04
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
   art_sys_69: 2.93015810e-04
-  art_sys_70: -0.0
+  art_sys_70: 0.0
   art_sys_71: 2.47588974e-03
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 6.13069375e-03
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: -3.79796250e-02
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: -3.51514731e-03
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
   art_sys_90: -1.64994813e-05
   sys_1: 3.03370022e-02
   sys_2: -2.88923831e-02
   sys_3: 0.0
-  sys_4: -0.0
+  sys_4: 0.0
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 4.81539718e-04
   sys_8: -4.81539718e-04
   sys_9: 1.92615887e-03
   sys_10: -1.44461915e-03
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 3.37077803e-03
   sys_16: -2.88923831e-03
   sys_17: 4.81539718e-04
@@ -5083,17 +5083,17 @@ bins:
   sys_41: 7.70463549e-03
   sys_42: -7.70463549e-03
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 9.63079436e-04
   sys_48: -4.81539718e-04
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 4.81539718e-04
   sys_52: -4.81539718e-04
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 4.81539718e-04
   sys_56: -4.81539718e-04
   sys_57: 4.81539718e-04
@@ -5103,23 +5103,23 @@ bins:
   sys_61: 9.63079436e-04
   sys_62: -9.63079436e-04
   sys_63: 0.0
-  sys_64: -0.0
+  sys_64: 0.0
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 4.81539718e-04
   sys_74: -4.81539718e-04
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 9.63079436e-04
   sys_82: -9.63079436e-04
   sys_83: 3.85231774e-03
@@ -5129,15 +5129,15 @@ bins:
   sys_87: 6.74155605e-03
   sys_88: -6.74155605e-03
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 4.81539718e-04
   sys_100: -4.81539718e-04
   sys_101: 3.37077803e-03
@@ -5147,7 +5147,7 @@ bins:
   sys_105: 9.63079436e-04
   sys_106: -9.63079436e-04
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 3.37077803e-03
   sys_110: -2.88923831e-03
   sys_111: 1.44461915e-03
@@ -5155,130 +5155,130 @@ bins:
   sys_113: 3.37077803e-03
   sys_114: -3.37077803e-03
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 4.81539718e-04
   sys_120: -4.81539718e-04
   sys_121: 0.0
-  sys_122: -0.0
+  sys_122: 0.0
   sys_123: 0.0
-  sys_124: -0.0
+  sys_124: 0.0
   sys_125: 4.33385746e-03
   sys_126: -4.33385746e-03
   sys_127: 1.92615887e-03
   sys_128: -1.92615887e-03
   sys_129: 0.0
-  sys_130: -0.0
+  sys_130: 0.0
   sys_131: 0.0
-  sys_132: -0.0
+  sys_132: 0.0
   sys_133: 2.40769859e-03
   sys_134: -2.40769859e-03
   luminosity_uncertainty: 1.22580000e-02
 - art_sys_1: 0.0
   art_sys_2: -9.89119291e-05
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -4.96248037e-05
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: -4.96220320e-04
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: -2.07463405e-04
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 8.05834636e-05
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
+  art_sys_22: 0.0
   art_sys_23: 4.58438066e-04
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: -2.50109052e-04
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 2.18443117e-04
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: -2.59185077e-04
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
+  art_sys_43: 0.0
   art_sys_44: 7.29630859e-05
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 7.31535374e-05
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: -2.83446159e-05
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 4.10025772e-05
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 4.02513392e-04
   art_sys_62: 0.0
-  art_sys_63: -0.0
+  art_sys_63: 0.0
   art_sys_64: 2.00390623e-05
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
   art_sys_69: -3.31415661e-04
-  art_sys_70: -0.0
+  art_sys_70: 0.0
   art_sys_71: 8.80102295e-04
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: -1.72450427e-03
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: -5.67477883e-03
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 2.42294647e-02
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
   art_sys_90: 1.96414899e-05
   sys_1: 1.28233815e-02
   sys_2: -1.22315331e-02
   sys_3: 0.0
-  sys_4: -0.0
+  sys_4: 0.0
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 1.97282792e-04
   sys_8: -1.97282792e-04
   sys_9: 7.89131168e-04
   sys_10: -5.91848376e-04
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 1.38097954e-03
   sys_16: -1.38097954e-03
   sys_17: 1.97282792e-04
@@ -5308,17 +5308,17 @@ bins:
   sys_41: 3.35380746e-03
   sys_42: -3.15652467e-03
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 3.94565584e-04
   sys_48: -1.97282792e-04
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 1.97282792e-04
   sys_52: -1.97282792e-04
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 1.97282792e-04
   sys_56: -1.97282792e-04
   sys_57: 1.97282792e-04
@@ -5328,23 +5328,23 @@ bins:
   sys_61: 3.94565584e-04
   sys_62: -3.94565584e-04
   sys_63: 0.0
-  sys_64: -0.0
+  sys_64: 0.0
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 1.97282792e-04
   sys_74: -1.97282792e-04
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 3.94565584e-04
   sys_82: -3.94565584e-04
   sys_83: 1.57826234e-03
@@ -5354,15 +5354,15 @@ bins:
   sys_87: 2.76195909e-03
   sys_88: -2.76195909e-03
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 1.97282792e-04
   sys_100: -1.97282792e-04
   sys_101: 1.38097954e-03
@@ -5372,7 +5372,7 @@ bins:
   sys_105: 3.94565584e-04
   sys_106: -3.94565584e-04
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 1.57826234e-03
   sys_110: -1.38097954e-03
   sys_111: 3.94565584e-04
@@ -5380,114 +5380,114 @@ bins:
   sys_113: 1.04559880e-02
   sys_114: -1.26260987e-02
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 1.97282792e-04
   sys_120: -1.97282792e-04
   sys_121: 0.0
-  sys_122: -0.0
+  sys_122: 0.0
   sys_123: 0.0
-  sys_124: -0.0
+  sys_124: 0.0
   sys_125: 1.77554513e-03
   sys_126: -1.57826234e-03
   sys_127: 9.86413960e-04
   sys_128: -9.86413960e-04
   sys_129: 0.0
-  sys_130: -0.0
+  sys_130: 0.0
   sys_131: 0.0
-  sys_132: -0.0
+  sys_132: 0.0
   sys_133: 9.86413960e-04
   sys_134: -9.86413960e-04
   luminosity_uncertainty: 5.02200000e-03
 - art_sys_1: 0.0
   art_sys_2: 3.51192820e-05
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 4.91032841e-05
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: -1.55057942e-05
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: -1.49096125e-05
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 2.26975854e-05
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
+  art_sys_22: 0.0
   art_sys_23: -1.50539349e-05
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 7.50201119e-07
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 5.73578075e-06
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: -1.61928066e-05
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
+  art_sys_43: 0.0
   art_sys_44: 2.03052775e-05
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 3.51266809e-05
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 4.16605593e-05
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 4.65157679e-05
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: -3.24008057e-05
   art_sys_62: 0.0
-  art_sys_63: -0.0
+  art_sys_63: 0.0
   art_sys_64: -3.73927805e-05
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
   art_sys_69: 2.85151249e-05
-  art_sys_70: -0.0
+  art_sys_70: 0.0
   art_sys_71: 2.91284953e-05
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: -2.79996968e-05
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 1.67718168e-04
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 1.72603256e-04
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
   art_sys_90: -3.09782100e-03
   sys_1: 1.44334636e-03
@@ -5495,7 +5495,7 @@ bins:
   sys_3: 1.78190909e-05
   sys_4: 0.0
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 1.78190909e-05
   sys_8: -1.78190909e-05
   sys_9: 8.90954544e-05
@@ -5503,7 +5503,7 @@ bins:
   sys_11: 1.78190909e-05
   sys_12: 0.0
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 1.60371818e-04
   sys_16: -1.60371818e-04
   sys_17: 1.78190909e-05
@@ -5533,17 +5533,17 @@ bins:
   sys_41: 3.92019999e-04
   sys_42: -3.92019999e-04
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 3.56381818e-05
   sys_48: -3.56381818e-05
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 1.78190909e-05
   sys_52: -3.56381818e-05
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 1.78190909e-05
   sys_56: -1.78190909e-05
   sys_57: 1.78190909e-05
@@ -5553,23 +5553,23 @@ bins:
   sys_61: 5.34572727e-05
   sys_62: -5.34572727e-05
   sys_63: 0.0
-  sys_64: -0.0
+  sys_64: 0.0
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 1.78190909e-05
   sys_74: -1.78190909e-05
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 3.56381818e-05
   sys_82: -5.34572727e-05
   sys_83: 1.78190909e-04
@@ -5579,15 +5579,15 @@ bins:
   sys_87: 3.20743636e-04
   sys_88: -3.20743636e-04
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 1.78190909e-05
   sys_100: -1.78190909e-05
   sys_101: 1.60371818e-04
@@ -5597,7 +5597,7 @@ bins:
   sys_105: 3.56381818e-05
   sys_106: -5.34572727e-05
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 3.02924545e-04
   sys_110: -2.85105454e-04
   sys_111: 1.78190909e-05
@@ -5605,23 +5605,23 @@ bins:
   sys_113: 3.56381818e-03
   sys_114: -3.56381818e-03
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: 0.0
-  sys_122: -0.0
+  sys_122: 0.0
   sys_123: 0.0
-  sys_124: -0.0
+  sys_124: 0.0
   sys_125: 1.24733636e-04
   sys_126: -1.24733636e-04
   sys_127: 1.42552727e-04
   sys_128: -1.42552727e-04
   sys_129: 0.0
-  sys_130: -0.0
+  sys_130: 0.0
   sys_131: 0.0
-  sys_132: -0.0
+  sys_132: 0.0
   sys_133: 8.90954544e-05
   sys_134: -8.90954544e-05
   luminosity_uncertainty: 4.53600000e-04
@@ -5629,57 +5629,57 @@ bins:
   art_sys_2: 0.0
   art_sys_3: 9.26298040e+01
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 1.68373855e+01
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 1.32147422e+00
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 2.91699581e-02
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 2.09102772e-02
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
+  art_sys_25: 0.0
   art_sys_26: 2.49685756e-03
-  art_sys_27: -0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 3.45364601e-05
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
   art_sys_37: 1.84619899e-05
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
   art_sys_43: 2.14903160e-05
-  art_sys_44: -0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
   art_sys_46: 3.25400048e-06
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
   art_sys_50: 3.78958112e-07
-  art_sys_51: -0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 1.90510808e-07
   art_sys_57: 0.0
   art_sys_58: 0.0
@@ -5688,20 +5688,20 @@ bins:
   art_sys_61: 0.0
   art_sys_62: 0.0
   art_sys_63: 7.32637398e-08
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
   art_sys_68: 5.94682736e-09
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
   art_sys_72: 1.91383404e-09
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
   art_sys_76: 1.03964175e-09
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
   art_sys_80: 1.08906283e-09
@@ -5710,23 +5710,23 @@ bins:
   art_sys_83: 2.89575025e-10
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 6.90149159e-12
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 2.24244774e+04
   sys_2: -2.10654181e+04
   sys_3: 5.43623693e+03
   sys_4: -5.43623693e+03
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 2.71811847e+03
   sys_8: -2.03858885e+03
   sys_9: 1.15520035e+04
   sys_10: -1.08724739e+04
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 0.0
   sys_14: -6.79529617e+02
   sys_15: 4.07717770e+03
@@ -5742,25 +5742,25 @@ bins:
   sys_25: 4.07717770e+03
   sys_26: -4.07717770e+03
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 0.0
-  sys_30: -0.0
+  sys_30: 0.0
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 0.0
-  sys_38: -0.0
+  sys_38: 0.0
   sys_39: 0.0
-  sys_40: -0.0
+  sys_40: 0.0
   sys_41: 0.0
-  sys_42: -0.0
+  sys_42: 0.0
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 6.79529617e+02
   sys_48: -6.79529617e+02
   sys_49: 6.79529617e+02
@@ -5778,59 +5778,59 @@ bins:
   sys_61: 6.79529617e+02
   sys_62: -6.79529617e+02
   sys_63: 0.0
-  sys_64: -0.0
+  sys_64: 0.0
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
   sys_70: -6.79529617e+02
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 6.79529617e+02
   sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 3.39764808e+03
   sys_110: -3.39764808e+03
   sys_111: 3.26174216e+04
   sys_112: -2.98993031e+04
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: -4.07717770e+03
   sys_118: 3.39764808e+03
   sys_119: -8.15435540e+03
@@ -5854,57 +5854,57 @@ bins:
   art_sys_2: 0.0
   art_sys_3: 3.65139021e+03
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 2.31061640e+01
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 9.70689288e+00
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: -6.80608476e-01
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: -7.02090387e-03
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
+  art_sys_25: 0.0
   art_sys_26: -1.04366041e-02
-  art_sys_27: -0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: -7.44437571e-04
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
   art_sys_37: 9.39701438e-05
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
   art_sys_43: -1.42058685e-05
-  art_sys_44: -0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
   art_sys_46: 1.02961282e-05
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
   art_sys_50: 3.49804795e-07
-  art_sys_51: -0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: -2.15460810e-07
   art_sys_57: 0.0
   art_sys_58: 0.0
@@ -5913,20 +5913,20 @@ bins:
   art_sys_61: 0.0
   art_sys_62: 0.0
   art_sys_63: -1.30477283e-07
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
   art_sys_68: 4.14502348e-09
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
   art_sys_72: 4.93289716e-09
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
   art_sys_76: 4.01447858e-09
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
   art_sys_80: 1.33468720e-09
@@ -5935,25 +5935,25 @@ bins:
   art_sys_83: -6.90948811e-10
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: -2.58828392e-12
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 9.10753534e+03
   sys_2: -8.32688946e+03
   sys_3: 1.82150707e+03
   sys_4: -1.82150707e+03
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 1.04086118e+03
   sys_8: -7.80645886e+02
   sys_9: 3.90322943e+03
   sys_10: -3.90322943e+03
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 1.30107648e+03
   sys_16: -1.56129177e+03
   sys_17: 2.60215295e+02
@@ -5969,27 +5969,27 @@ bins:
   sys_27: 0.0
   sys_28: -2.60215295e+02
   sys_29: 0.0
-  sys_30: -0.0
+  sys_30: 0.0
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 2.60215295e+02
   sys_36: -2.60215295e+02
   sys_37: 0.0
-  sys_38: -0.0
+  sys_38: 0.0
   sys_39: 0.0
   sys_40: -2.60215295e+02
   sys_41: 0.0
-  sys_42: -0.0
+  sys_42: 0.0
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
   sys_48: -2.60215295e+02
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 2.60215295e+02
   sys_52: -2.60215295e+02
   sys_53: 2.60215295e+02
@@ -6003,59 +6003,59 @@ bins:
   sys_61: 5.20430591e+02
   sys_62: -2.60215295e+02
   sys_63: 0.0
-  sys_64: -0.0
+  sys_64: 0.0
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 2.60215295e+02
   sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 1.30107648e+03
   sys_110: -1.30107648e+03
   sys_111: 1.24903342e+04
   sys_112: -1.17096883e+04
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: -1.56129177e+03
   sys_118: 1.04086118e+03
   sys_119: -3.12258355e+03
@@ -6079,57 +6079,57 @@ bins:
   art_sys_2: 0.0
   art_sys_3: -6.10675898e+01
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 1.44672160e+03
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 1.74066184e+01
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: -5.11740677e+00
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 3.25984936e-01
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
+  art_sys_25: 0.0
   art_sys_26: 5.23491103e-02
-  art_sys_27: -0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 9.07658039e-04
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
   art_sys_37: 1.13554253e-04
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
   art_sys_43: 2.15376483e-04
-  art_sys_44: -0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
   art_sys_46: -6.17320859e-05
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
   art_sys_50: -1.46427221e-05
-  art_sys_51: -0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: -2.89415554e-07
   art_sys_57: 0.0
   art_sys_58: 0.0
@@ -6138,20 +6138,20 @@ bins:
   art_sys_61: 0.0
   art_sys_62: 0.0
   art_sys_63: 8.19215976e-07
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
   art_sys_68: -6.30845370e-08
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
   art_sys_72: -2.84417240e-09
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
   art_sys_76: -9.13305396e-10
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
   art_sys_80: -5.54928127e-09
@@ -6160,29 +6160,29 @@ bins:
   art_sys_83: 1.34844779e-09
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: -1.28800958e-11
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 3.71655324e+03
   sys_2: -3.61331565e+03
   sys_3: 6.19425540e+02
   sys_4: -7.22663130e+02
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 3.09712770e+02
   sys_8: -3.09712770e+02
   sys_9: 1.34208867e+03
   sys_10: -1.34208867e+03
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 5.16187950e+02
   sys_16: -5.16187950e+02
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 4.12950360e+02
   sys_20: -4.12950360e+02
   sys_21: 3.09712770e+02
@@ -6194,11 +6194,11 @@ bins:
   sys_27: 0.0
   sys_28: -1.03237590e+02
   sys_29: 0.0
-  sys_30: -0.0
+  sys_30: 0.0
   sys_31: 0.0
   sys_32: -1.03237590e+02
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 1.03237590e+02
   sys_36: -1.03237590e+02
   sys_37: 0.0
@@ -6206,17 +6206,17 @@ bins:
   sys_39: 1.03237590e+02
   sys_40: -1.03237590e+02
   sys_41: 0.0
-  sys_42: -0.0
+  sys_42: 0.0
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 1.03237590e+02
   sys_54: -1.03237590e+02
   sys_55: 2.06475180e+02
@@ -6228,59 +6228,59 @@ bins:
   sys_61: 3.09712770e+02
   sys_62: -2.06475180e+02
   sys_63: 0.0
-  sys_64: -0.0
+  sys_64: 0.0
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 1.03237590e+02
   sys_74: -1.03237590e+02
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 4.12950360e+02
   sys_110: -5.16187950e+02
   sys_111: 4.74892914e+03
   sys_112: -4.64569155e+03
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: -6.19425540e+02
   sys_118: 4.12950360e+02
   sys_119: -1.34208867e+03
@@ -6296,7 +6296,7 @@ bins:
   sys_129: 3.09712770e+02
   sys_130: -3.09712770e+02
   sys_131: 0.0
-  sys_132: -0.0
+  sys_132: 0.0
   sys_133: 5.16187950e+02
   sys_134: -5.16187950e+02
   luminosity_uncertainty: 2.62800000e+03
@@ -6304,57 +6304,57 @@ bins:
   art_sys_2: 0.0
   art_sys_3: -5.52489968e+01
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: -4.17074828e+01
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 6.26769059e+02
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: -1.29573429e+01
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 2.39437533e+00
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
+  art_sys_25: 0.0
   art_sys_26: 6.13805659e-02
-  art_sys_27: -0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 1.12177924e-02
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
   art_sys_37: 2.59363742e-03
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
   art_sys_43: 9.39279509e-04
-  art_sys_44: -0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
   art_sys_46: -1.44880004e-04
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
   art_sys_50: 2.34958238e-05
-  art_sys_51: -0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: -9.12682930e-06
   art_sys_57: 0.0
   art_sys_58: 0.0
@@ -6363,20 +6363,20 @@ bins:
   art_sys_61: 0.0
   art_sys_62: 0.0
   art_sys_63: -1.12036980e-07
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
   art_sys_68: -2.13772792e-07
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
   art_sys_72: -7.60620444e-08
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
   art_sys_76: 1.02583970e-09
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
   art_sys_80: -1.58156715e-09
@@ -6385,17 +6385,17 @@ bins:
   art_sys_83: 1.11134246e-08
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: -6.53689079e-11
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 1.62026448e+03
   sys_2: -1.62026448e+03
   sys_3: 2.13192695e+02
   sys_4: -2.55831233e+02
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 8.52770778e+01
   sys_8: -1.27915617e+02
   sys_9: 4.26385389e+02
@@ -6403,7 +6403,7 @@ bins:
   sys_11: 4.26385389e+01
   sys_12: -4.26385389e+01
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 1.70554156e+02
   sys_16: -2.13192695e+02
   sys_17: 4.26385389e+01
@@ -6419,11 +6419,11 @@ bins:
   sys_27: 0.0
   sys_28: -4.26385389e+01
   sys_29: 0.0
-  sys_30: -0.0
+  sys_30: 0.0
   sys_31: 0.0
   sys_32: -4.26385389e+01
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 8.52770778e+01
   sys_36: -4.26385389e+01
   sys_37: 0.0
@@ -6433,15 +6433,15 @@ bins:
   sys_41: 4.26385389e+01
   sys_42: -4.26385389e+01
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 4.26385389e+01
   sys_54: -4.26385389e+01
   sys_55: 4.26385389e+01
@@ -6455,57 +6455,57 @@ bins:
   sys_63: 4.26385389e+01
   sys_64: 0.0
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 4.26385389e+01
   sys_74: -4.26385389e+01
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 1.70554156e+02
   sys_110: -1.70554156e+02
   sys_111: 1.87609571e+03
   sys_112: -1.87609571e+03
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: -2.13192695e+02
   sys_118: 1.70554156e+02
   sys_119: -5.54301006e+02
@@ -6521,7 +6521,7 @@ bins:
   sys_129: 8.52770778e+01
   sys_130: -8.52770778e+01
   sys_131: 0.0
-  sys_132: -0.0
+  sys_132: 0.0
   sys_133: 2.13192695e+02
   sys_134: -2.13192695e+02
   luminosity_uncertainty: 1085.4
@@ -6529,57 +6529,57 @@ bins:
   art_sys_2: 0.0
   art_sys_3: -4.97759534e+00
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: -2.38505353e+01
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: -2.86626154e+01
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: -2.89238554e+02
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 2.63445182e+00
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
+  art_sys_25: 0.0
   art_sys_26: 1.03045259e+00
-  art_sys_27: -0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 4.83645775e-02
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
   art_sys_37: 1.16659734e-02
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
   art_sys_43: 6.36159664e-04
-  art_sys_44: -0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
   art_sys_46: -2.37469071e-04
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
   art_sys_50: -4.59008783e-05
-  art_sys_51: -0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 7.38957035e-06
   art_sys_57: 0.0
   art_sys_58: 0.0
@@ -6588,20 +6588,20 @@ bins:
   art_sys_61: 0.0
   art_sys_62: 0.0
   art_sys_63: -9.96614505e-07
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
   art_sys_68: -1.62016668e-06
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
   art_sys_72: 9.45842804e-08
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
   art_sys_76: -3.08106821e-08
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
   art_sys_80: -2.71680892e-09
@@ -6610,17 +6610,17 @@ bins:
   art_sys_83: 4.95602545e-09
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 2.12822070e-10
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 7.91464620e+02
   sys_2: -7.33552575e+02
   sys_3: 7.72160605e+01
   sys_4: -9.65200756e+01
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 3.86080303e+01
   sys_8: -5.79120454e+01
   sys_9: 1.54432121e+02
@@ -6628,7 +6628,7 @@ bins:
   sys_11: 1.93040151e+01
   sys_12: -1.93040151e+01
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 7.72160605e+01
   sys_16: -9.65200756e+01
   sys_17: 1.93040151e+01
@@ -6648,7 +6648,7 @@ bins:
   sys_31: 1.93040151e+01
   sys_32: -1.93040151e+01
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 3.86080303e+01
   sys_36: -1.93040151e+01
   sys_37: 1.93040151e+01
@@ -6658,17 +6658,17 @@ bins:
   sys_41: 1.93040151e+01
   sys_42: -1.93040151e+01
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 1.93040151e+01
   sys_56: -1.93040151e+01
   sys_57: 1.93040151e+01
@@ -6680,57 +6680,57 @@ bins:
   sys_63: 1.93040151e+01
   sys_64: 0.0
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
   sys_74: -1.93040151e+01
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 1.93040151e+01
   sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 5.79120454e+01
   sys_110: -7.72160605e+01
   sys_111: 8.30072650e+02
   sys_112: -7.91464620e+02
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: -9.65200756e+01
   sys_118: 7.72160605e+01
   sys_119: -2.50952197e+02
@@ -6746,7 +6746,7 @@ bins:
   sys_129: 3.86080303e+01
   sys_130: -3.86080303e+01
   sys_131: 0.0
-  sys_132: -0.0
+  sys_132: 0.0
   sys_133: 9.65200756e+01
   sys_134: -9.65200756e+01
   luminosity_uncertainty: 4.91400000e+02
@@ -6754,57 +6754,57 @@ bins:
   art_sys_2: 0.0
   art_sys_3: 1.53205129e+00
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: -2.48576786e+00
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: -1.14117652e+01
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 6.48354595e+00
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 1.25361233e+02
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
+  art_sys_25: 0.0
   art_sys_26: 1.44792701e+00
-  art_sys_27: -0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 3.80054092e-01
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
   art_sys_37: 1.71942618e-02
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
   art_sys_43: 2.79005029e-03
-  art_sys_44: -0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
   art_sys_46: -1.01608603e-03
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
   art_sys_50: -1.01982594e-04
-  art_sys_51: -0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: -3.32065169e-05
   art_sys_57: 0.0
   art_sys_58: 0.0
@@ -6813,20 +6813,20 @@ bins:
   art_sys_61: 0.0
   art_sys_62: 0.0
   art_sys_63: -9.41259663e-07
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
   art_sys_68: -2.94607804e-06
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
   art_sys_72: -1.56252706e-07
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
   art_sys_76: 1.94882985e-07
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
   art_sys_80: 1.36754544e-07
@@ -6835,17 +6835,17 @@ bins:
   art_sys_83: -3.91528408e-09
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 4.67796909e-10
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 3.68261212e+02
   sys_2: -3.41956839e+02
   sys_3: 2.63043723e+01
   sys_4: -3.50724963e+01
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 1.75362482e+01
   sys_8: -1.75362482e+01
   sys_9: 6.13768686e+01
@@ -6853,7 +6853,7 @@ bins:
   sys_11: 1.75362482e+01
   sys_12: -8.76812409e+00
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 2.63043723e+01
   sys_16: -3.50724963e+01
   sys_17: 8.76812409e+00
@@ -6883,17 +6883,17 @@ bins:
   sys_41: 1.75362482e+01
   sys_42: -1.75362482e+01
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 8.76812409e+00
   sys_56: -8.76812409e+00
   sys_57: 8.76812409e+00
@@ -6905,57 +6905,57 @@ bins:
   sys_63: 8.76812409e+00
   sys_64: 0.0
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
   sys_74: -8.76812409e+00
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 8.76812409e+00
   sys_80: -8.76812409e+00
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 2.63043723e+01
   sys_110: -2.63043723e+01
   sys_111: 3.50724963e+02
   sys_112: -3.24420591e+02
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: -3.50724963e+01
   sys_118: 3.50724963e+01
   sys_119: -1.05217489e+02
@@ -6971,7 +6971,7 @@ bins:
   sys_129: 1.75362482e+01
   sys_130: -1.75362482e+01
   sys_131: 0.0
-  sys_132: -0.0
+  sys_132: 0.0
   sys_133: 4.38406204e+01
   sys_134: -4.38406204e+01
   luminosity_uncertainty: 2.23200000e+02
@@ -6979,57 +6979,57 @@ bins:
   art_sys_2: 0.0
   art_sys_3: 8.46876719e-01
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: -7.97461045e-01
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 1.17547124e-01
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 5.18134817e+00
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: -3.32918160e+00
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
+  art_sys_25: 0.0
   art_sys_26: 5.60384720e+01
-  art_sys_27: -0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 4.01523101e-01
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
   art_sys_37: 2.30683314e-01
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
   art_sys_43: 7.28439818e-03
-  art_sys_44: -0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
   art_sys_46: -1.11017733e-03
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
   art_sys_50: -2.00617662e-04
-  art_sys_51: -0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 1.25665158e-04
   art_sys_57: 0.0
   art_sys_58: 0.0
@@ -7038,20 +7038,20 @@ bins:
   art_sys_61: 0.0
   art_sys_62: 0.0
   art_sys_63: -6.23072218e-06
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
   art_sys_68: 4.56679298e-06
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
   art_sys_72: -9.64297853e-07
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
   art_sys_76: -2.23790103e-07
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
   art_sys_80: -3.10637309e-07
@@ -7060,17 +7060,17 @@ bins:
   art_sys_83: -7.24158239e-08
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: -2.20717904e-09
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 1.77002969e+02
   sys_2: -1.68574257e+02
   sys_3: 1.26430692e+01
   sys_4: -1.26430692e+01
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 4.21435642e+00
   sys_8: -8.42871283e+00
   sys_9: 2.52861385e+01
@@ -7078,7 +7078,7 @@ bins:
   sys_11: 8.42871283e+00
   sys_12: -4.21435642e+00
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 1.68574257e+01
   sys_16: -1.68574257e+01
   sys_17: 4.21435642e+00
@@ -7108,17 +7108,17 @@ bins:
   sys_41: 8.42871283e+00
   sys_42: -8.42871283e+00
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
   sys_56: -4.21435642e+00
   sys_57: 4.21435642e+00
@@ -7130,19 +7130,19 @@ bins:
   sys_63: 8.42871283e+00
   sys_64: -4.21435642e+00
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
   sys_74: -4.21435642e+00
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 4.21435642e+00
   sys_80: -4.21435642e+00
   sys_81: 4.21435642e+00
@@ -7150,37 +7150,37 @@ bins:
   sys_83: 0.0
   sys_84: -4.21435642e+00
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 1.26430692e+01
   sys_110: -1.26430692e+01
   sys_111: 1.55931187e+02
   sys_112: -1.43288118e+02
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: -1.26430692e+01
   sys_118: 2.10717821e+01
   sys_119: -4.21435642e+01
@@ -7196,7 +7196,7 @@ bins:
   sys_129: 8.42871283e+00
   sys_130: -8.42871283e+00
   sys_131: 0.0
-  sys_132: -0.0
+  sys_132: 0.0
   sys_133: 2.10717821e+01
   sys_134: -2.10717821e+01
   luminosity_uncertainty: 1.07280000e+02
@@ -7204,57 +7204,57 @@ bins:
   art_sys_2: 0.0
   art_sys_3: 1.16344122e-01
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 6.93014776e-02
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: -6.52324941e-02
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 4.23154642e-01
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: -2.01615206e+00
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
+  art_sys_25: 0.0
   art_sys_26: -1.04757992e+00
-  art_sys_27: -0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 2.30745202e+01
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
   art_sys_37: 4.39229675e-01
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
   art_sys_43: 9.77952492e-02
-  art_sys_44: -0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
   art_sys_46: -6.78121465e-03
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
   art_sys_50: -1.60631357e-03
-  art_sys_51: -0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 1.04256662e-04
   art_sys_57: 0.0
   art_sys_58: 0.0
@@ -7263,20 +7263,20 @@ bins:
   art_sys_61: 0.0
   art_sys_62: 0.0
   art_sys_63: -1.42531411e-05
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
   art_sys_68: 8.28494075e-06
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
   art_sys_72: 3.06732482e-06
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
   art_sys_76: -1.49259153e-06
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
   art_sys_80: 5.99125235e-08
@@ -7285,17 +7285,17 @@ bins:
   art_sys_83: 7.91953270e-08
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 3.40346514e-10
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 8.93924393e+01
   sys_2: -8.52346514e+01
   sys_3: 4.15778787e+00
   sys_4: -4.15778787e+00
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 2.07889394e+00
   sys_8: -2.07889394e+00
   sys_9: 1.03944697e+01
@@ -7303,7 +7303,7 @@ bins:
   sys_11: 6.23668181e+00
   sys_12: -4.15778787e+00
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 8.31557575e+00
   sys_16: -6.23668181e+00
   sys_17: 2.07889394e+00
@@ -7333,19 +7333,19 @@ bins:
   sys_41: 6.23668181e+00
   sys_42: -4.15778787e+00
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
   sys_58: -2.07889394e+00
   sys_59: 2.07889394e+00
@@ -7355,19 +7355,19 @@ bins:
   sys_63: 4.15778787e+00
   sys_64: -2.07889394e+00
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 2.07889394e+00
   sys_80: -2.07889394e+00
   sys_81: 2.07889394e+00
@@ -7375,37 +7375,37 @@ bins:
   sys_83: 2.07889394e+00
   sys_84: -2.07889394e+00
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 6.23668181e+00
   sys_110: -6.23668181e+00
   sys_111: 6.86034999e+01
   sys_112: -6.44457120e+01
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: -6.23668181e+00
   sys_118: 8.31557575e+00
   sys_119: -1.66311515e+01
@@ -7421,7 +7421,7 @@ bins:
   sys_129: 4.15778787e+00
   sys_130: -4.15778787e+00
   sys_131: 0.0
-  sys_132: -0.0
+  sys_132: 0.0
   sys_133: 1.03944697e+01
   sys_134: -1.03944697e+01
   luminosity_uncertainty: 5.29200000e+01
@@ -7429,57 +7429,57 @@ bins:
   art_sys_2: 0.0
   art_sys_3: -3.56230445e-02
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 3.46221755e-02
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: -1.03983710e-01
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 1.73891297e-01
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: -5.06369185e-02
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
+  art_sys_25: 0.0
   art_sys_26: -1.12923616e+00
-  art_sys_27: -0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: -9.42629549e-01
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
   art_sys_37: 1.10789527e+01
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
   art_sys_43: 2.09584287e-01
-  art_sys_44: -0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
   art_sys_46: -5.51389492e-02
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
   art_sys_50: -1.97184331e-03
-  art_sys_51: -0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 1.86393536e-05
   art_sys_57: 0.0
   art_sys_58: 0.0
@@ -7488,20 +7488,20 @@ bins:
   art_sys_61: 0.0
   art_sys_62: 0.0
   art_sys_63: -6.95015185e-05
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
   art_sys_68: -1.85458063e-05
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
   art_sys_72: 7.58583947e-06
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
   art_sys_76: -1.66890514e-07
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
   art_sys_80: -1.42506911e-07
@@ -7510,17 +7510,17 @@ bins:
   art_sys_83: -3.54771850e-07
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: -9.65349257e-09
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 4.28718841e+01
   sys_2: -4.18748636e+01
   sys_3: 1.99404112e+00
   sys_4: -1.99404112e+00
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 9.97020561e-01
   sys_8: -9.97020561e-01
   sys_9: 3.98808225e+00
@@ -7528,7 +7528,7 @@ bins:
   sys_11: 1.99404112e+00
   sys_12: -1.99404112e+00
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 2.99106168e+00
   sys_16: -2.99106168e+00
   sys_17: 9.97020561e-01
@@ -7558,19 +7558,19 @@ bins:
   sys_41: 2.99106168e+00
   sys_42: -2.99106168e+00
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
   sys_58: -9.97020561e-01
   sys_59: 9.97020561e-01
@@ -7580,17 +7580,17 @@ bins:
   sys_63: 9.97020561e-01
   sys_64: -9.97020561e-01
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 9.97020561e-01
   sys_78: -9.97020561e-01
   sys_79: 9.97020561e-01
@@ -7602,35 +7602,35 @@ bins:
   sys_85: 9.97020561e-01
   sys_86: -9.97020561e-01
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 2.99106168e+00
   sys_110: -2.99106168e+00
   sys_111: 2.89135963e+01
   sys_112: -2.79165757e+01
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: -1.99404112e+00
   sys_118: 2.99106168e+00
   sys_119: -6.97914393e+00
@@ -7646,7 +7646,7 @@ bins:
   sys_129: 9.97020561e-01
   sys_130: -9.97020561e-01
   sys_131: 0.0
-  sys_132: -0.0
+  sys_132: 0.0
   sys_133: 4.98510281e+00
   sys_134: -4.98510281e+00
   luminosity_uncertainty: 2.53800000e+01
@@ -7654,57 +7654,57 @@ bins:
   art_sys_2: 0.0
   art_sys_3: 2.20671127e-02
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: -5.41995903e-02
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: -1.04787953e-01
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 1.41029359e-02
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: -2.72337984e-02
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
+  art_sys_25: 0.0
   art_sys_26: -1.48874760e-02
-  art_sys_27: -0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: -4.17856240e-01
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
   art_sys_37: -4.91009114e-01
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
   art_sys_43: 4.95403531e+00
-  art_sys_44: -0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
   art_sys_46: -1.55479144e-01
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
   art_sys_50: -2.96485780e-02
-  art_sys_51: -0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 2.34324854e-03
   art_sys_57: 0.0
   art_sys_58: 0.0
@@ -7713,20 +7713,20 @@ bins:
   art_sys_61: 0.0
   art_sys_62: 0.0
   art_sys_63: -8.68262610e-05
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
   art_sys_68: -4.95041606e-05
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
   art_sys_72: 4.59382385e-06
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
   art_sys_76: -5.83798876e-06
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
   art_sys_80: 7.84201589e-07
@@ -7735,17 +7735,17 @@ bins:
   art_sys_83: 5.73288382e-07
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: -1.76751750e-08
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 2.12499730e+01
   sys_2: -2.07670191e+01
   sys_3: 4.82953932e-01
   sys_4: -9.65907863e-01
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 4.82953932e-01
   sys_8: -4.82953932e-01
   sys_9: 1.44886179e+00
@@ -7753,7 +7753,7 @@ bins:
   sys_11: 9.65907863e-01
   sys_12: -9.65907863e-01
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 1.44886179e+00
   sys_16: -1.44886179e+00
   sys_17: 4.82953932e-01
@@ -7783,19 +7783,19 @@ bins:
   sys_41: 1.44886179e+00
   sys_42: -1.44886179e+00
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
   sys_48: -4.82953932e-01
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
   sys_58: -4.82953932e-01
   sys_59: 4.82953932e-01
@@ -7805,17 +7805,17 @@ bins:
   sys_63: 4.82953932e-01
   sys_64: -4.82953932e-01
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 4.82953932e-01
   sys_78: -4.82953932e-01
   sys_79: 4.82953932e-01
@@ -7829,33 +7829,33 @@ bins:
   sys_87: 4.82953932e-01
   sys_88: -4.82953932e-01
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 1.44886179e+00
   sys_110: -1.44886179e+00
   sys_111: 1.25568022e+01
   sys_112: -1.25568022e+01
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: -9.65907863e-01
   sys_118: 9.65907863e-01
   sys_119: -2.41476966e+00
@@ -7871,7 +7871,7 @@ bins:
   sys_129: 4.82953932e-01
   sys_130: -4.82953932e-01
   sys_131: 0.0
-  sys_132: -0.0
+  sys_132: 0.0
   sys_133: 2.41476966e+00
   sys_134: -2.41476966e+00
   luminosity_uncertainty: 1.22940000e+01
@@ -7879,57 +7879,57 @@ bins:
   art_sys_2: 0.0
   art_sys_3: 1.81041225e-02
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: -2.73720267e-02
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: -1.90837606e-02
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 1.76601432e-02
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: -4.10100786e-02
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
+  art_sys_25: 0.0
   art_sys_26: 2.56387568e-03
-  art_sys_27: -0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: -1.68075428e-02
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
   art_sys_37: -2.11470708e-01
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
   art_sys_43: -3.13302816e-01
-  art_sys_44: -0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
   art_sys_46: -2.53953279e+00
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
   art_sys_50: -6.08534883e-02
-  art_sys_51: -0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 1.17720970e-02
   art_sys_57: 0.0
   art_sys_58: 0.0
@@ -7938,20 +7938,20 @@ bins:
   art_sys_61: 0.0
   art_sys_62: 0.0
   art_sys_63: -2.50392673e-04
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
   art_sys_68: -5.90660513e-05
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
   art_sys_72: 3.31712314e-06
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
   art_sys_76: 4.13184789e-06
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
   art_sys_80: -1.27483416e-05
@@ -7960,17 +7960,17 @@ bins:
   art_sys_83: -5.16019090e-07
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 3.00991255e-08
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 1.09290424e+01
   sys_2: -1.06914545e+01
   sys_3: 2.37587878e-01
   sys_4: -2.37587878e-01
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 2.37587878e-01
   sys_8: -2.37587878e-01
   sys_9: 7.12763635e-01
@@ -7978,7 +7978,7 @@ bins:
   sys_11: 4.75175757e-01
   sys_12: -4.75175757e-01
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 7.12763635e-01
   sys_16: -9.50351514e-01
   sys_17: 2.37587878e-01
@@ -8008,21 +8008,21 @@ bins:
   sys_41: 9.50351514e-01
   sys_42: -9.50351514e-01
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
   sys_48: -2.37587878e-01
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 2.37587878e-01
   sys_60: -2.37587878e-01
   sys_61: 2.37587878e-01
@@ -8030,17 +8030,17 @@ bins:
   sys_63: 2.37587878e-01
   sys_64: -2.37587878e-01
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 2.37587878e-01
   sys_78: -2.37587878e-01
   sys_79: 2.37587878e-01
@@ -8054,33 +8054,33 @@ bins:
   sys_87: 2.37587878e-01
   sys_88: -2.37587878e-01
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 7.12763635e-01
   sys_110: -7.12763635e-01
   sys_111: 5.70210908e+00
   sys_112: -5.70210908e+00
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: -4.75175757e-01
   sys_118: 2.37587878e-01
   sys_119: -7.12763635e-01
@@ -8096,7 +8096,7 @@ bins:
   sys_129: 2.37587878e-01
   sys_130: -2.37587878e-01
   sys_131: 0.0
-  sys_132: -0.0
+  sys_132: 0.0
   sys_133: 1.18793939e+00
   sys_134: -1.18793939e+00
   luminosity_uncertainty: 6.04800000e+00
@@ -8104,57 +8104,57 @@ bins:
   art_sys_2: 0.0
   art_sys_3: -8.68512677e-04
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: -1.37465119e-02
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 1.72832139e-02
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 7.00044639e-03
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: -4.10504956e-03
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
+  art_sys_25: 0.0
   art_sys_26: -6.11939284e-03
-  art_sys_27: -0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: -1.74923980e-02
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
   art_sys_37: 4.15894889e-03
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
   art_sys_43: -1.01028631e-01
-  art_sys_44: -0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
   art_sys_46: 1.26479314e-01
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
   art_sys_50: -1.27371770e+00
-  art_sys_51: -0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 1.98615894e-02
   art_sys_57: 0.0
   art_sys_58: 0.0
@@ -8163,20 +8163,20 @@ bins:
   art_sys_61: 0.0
   art_sys_62: 0.0
   art_sys_63: 5.97384564e-04
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
   art_sys_68: -2.60878420e-04
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
   art_sys_72: -1.05940737e-05
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
   art_sys_76: -1.17119672e-05
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
   art_sys_80: -3.66623807e-06
@@ -8185,17 +8185,17 @@ bins:
   art_sys_83: 1.83659760e-06
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 9.80690203e-08
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 5.50906893e+00
   sys_2: -5.28420898e+00
   sys_3: 1.12429978e-01
   sys_4: -1.12429978e-01
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 1.12429978e-01
   sys_8: -1.12429978e-01
   sys_9: 2.24859956e-01
@@ -8203,7 +8203,7 @@ bins:
   sys_11: 1.12429978e-01
   sys_12: -1.12429978e-01
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 3.37289935e-01
   sys_16: -4.49719913e-01
   sys_17: 1.12429978e-01
@@ -8233,21 +8233,21 @@ bins:
   sys_41: 5.62149891e-01
   sys_42: -5.62149891e-01
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
   sys_48: -1.12429978e-01
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 1.12429978e-01
   sys_60: -1.12429978e-01
   sys_61: 1.12429978e-01
@@ -8255,17 +8255,17 @@ bins:
   sys_63: 1.12429978e-01
   sys_64: -1.12429978e-01
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
   sys_78: -1.12429978e-01
   sys_79: 1.12429978e-01
@@ -8279,33 +8279,33 @@ bins:
   sys_87: 3.37289935e-01
   sys_88: -3.37289935e-01
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 3.37289935e-01
   sys_110: -3.37289935e-01
   sys_111: 2.47345952e+00
   sys_112: -2.47345952e+00
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: -1.12429978e-01
   sys_118: 1.12429978e-01
   sys_119: -1.12429978e-01
@@ -8321,7 +8321,7 @@ bins:
   sys_129: 1.12429978e-01
   sys_130: -1.12429978e-01
   sys_131: 0.0
-  sys_132: -0.0
+  sys_132: 0.0
   sys_133: 5.62149891e-01
   sys_134: -5.62149891e-01
   luminosity_uncertainty: 2.86200000e+00
@@ -8329,57 +8329,57 @@ bins:
   art_sys_2: 0.0
   art_sys_3: 4.18314695e-05
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 1.27756784e-03
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 8.64304389e-03
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 1.73308281e-03
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 8.30590092e-03
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
+  art_sys_25: 0.0
   art_sys_26: -1.02347699e-02
-  art_sys_27: -0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: -1.25070612e-03
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
   art_sys_37: 5.02844014e-03
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
   art_sys_43: -9.02975890e-03
-  art_sys_44: -0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
   art_sys_46: 4.23111013e-02
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
   art_sys_50: 3.96382176e-02
-  art_sys_51: -0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 6.52828491e-01
   art_sys_57: 0.0
   art_sys_58: 0.0
@@ -8388,20 +8388,20 @@ bins:
   art_sys_61: 0.0
   art_sys_62: 0.0
   art_sys_63: 7.64390192e-03
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
   art_sys_68: -1.11375996e-04
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
   art_sys_72: 1.64301837e-04
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
   art_sys_76: 6.38669270e-05
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
   art_sys_80: -8.99617612e-06
@@ -8410,17 +8410,17 @@ bins:
   art_sys_83: -6.22023231e-07
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: -1.46032664e-07
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 2.80919382e+00
   sys_2: -2.70114790e+00
   sys_3: 5.40229581e-02
   sys_4: -5.40229581e-02
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 5.40229581e-02
   sys_8: -5.40229581e-02
   sys_9: 1.08045916e-01
@@ -8428,7 +8428,7 @@ bins:
   sys_11: 5.40229581e-02
   sys_12: -5.40229581e-02
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 2.16091832e-01
   sys_16: -2.16091832e-01
   sys_17: 5.40229581e-02
@@ -8458,21 +8458,21 @@ bins:
   sys_41: 3.24137748e-01
   sys_42: -3.24137748e-01
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 5.40229581e-02
   sys_48: -5.40229581e-02
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 5.40229581e-02
   sys_60: -5.40229581e-02
   sys_61: 5.40229581e-02
@@ -8480,19 +8480,19 @@ bins:
   sys_63: 5.40229581e-02
   sys_64: -5.40229581e-02
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 5.40229581e-02
   sys_80: -5.40229581e-02
   sys_81: 1.08045916e-01
@@ -8504,37 +8504,37 @@ bins:
   sys_87: 2.70114790e-01
   sys_88: -2.70114790e-01
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 5.40229581e-02
   sys_102: -5.40229581e-02
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 1.62068874e-01
   sys_110: -1.62068874e-01
   sys_111: 1.08045916e+00
   sys_112: -1.02643620e+00
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: -5.40229581e-02
   sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: 1.62068874e-01
   sys_122: -1.62068874e-01
   sys_123: 1.08045916e-01
@@ -8546,7 +8546,7 @@ bins:
   sys_129: 5.40229581e-02
   sys_130: -5.40229581e-02
   sys_131: 0.0
-  sys_132: -0.0
+  sys_132: 0.0
   sys_133: 2.70114790e-01
   sys_134: -2.70114790e-01
   luminosity_uncertainty: 1.37520000e+00
@@ -8554,57 +8554,57 @@ bins:
   art_sys_2: 0.0
   art_sys_3: -1.46128210e-03
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 7.17719645e-05
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 4.55268371e-03
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 4.72667099e-04
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: -2.96729467e-04
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
+  art_sys_25: 0.0
   art_sys_26: -4.24007919e-03
-  art_sys_27: -0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: -8.89037120e-03
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
   art_sys_37: 7.38496352e-03
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
   art_sys_43: 1.62832626e-03
-  art_sys_44: -0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
   art_sys_46: 4.56089216e-03
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
   art_sys_50: 3.58867605e-02
-  art_sys_51: -0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 7.35385680e-03
   art_sys_57: 0.0
   art_sys_58: 0.0
@@ -8613,20 +8613,20 @@ bins:
   art_sys_61: 0.0
   art_sys_62: 0.0
   art_sys_63: -4.79401607e-03
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
   art_sys_68: -5.04022928e-03
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
   art_sys_72: -3.67723413e-05
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
   art_sys_76: 1.04345188e-04
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
   art_sys_80: 1.71991386e-05
@@ -8635,17 +8635,17 @@ bins:
   art_sys_83: 4.37841240e-06
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: -1.32867506e-07
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 1.41562778e+00
   sys_2: -1.36415040e+00
   sys_3: 2.57386868e-02
   sys_4: -2.57386868e-02
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 2.57386868e-02
   sys_8: -2.57386868e-02
   sys_9: 5.14773737e-02
@@ -8653,7 +8653,7 @@ bins:
   sys_11: 2.57386868e-02
   sys_12: -2.57386868e-02
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 1.02954747e-01
   sys_16: -1.02954747e-01
   sys_17: 2.57386868e-02
@@ -8683,21 +8683,21 @@ bins:
   sys_41: 1.80170808e-01
   sys_42: -1.80170808e-01
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 2.57386868e-02
   sys_48: -2.57386868e-02
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 2.57386868e-02
   sys_60: 0.0
   sys_61: 2.57386868e-02
@@ -8705,19 +8705,19 @@ bins:
   sys_63: 2.57386868e-02
   sys_64: -2.57386868e-02
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 2.57386868e-02
   sys_80: -2.57386868e-02
   sys_81: 5.14773737e-02
@@ -8729,35 +8729,35 @@ bins:
   sys_87: 2.05909495e-01
   sys_88: -1.80170808e-01
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
   sys_100: -2.57386868e-02
   sys_101: 2.57386868e-02
   sys_102: -2.57386868e-02
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 7.72160605e-02
   sys_110: -7.72160605e-02
   sys_111: 4.63296363e-01
   sys_112: -4.37557676e-01
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 2.57386868e-02
   sys_120: -2.57386868e-02
   sys_121: 5.14773737e-02
@@ -8771,7 +8771,7 @@ bins:
   sys_129: 2.57386868e-02
   sys_130: -2.57386868e-02
   sys_131: 0.0
-  sys_132: -0.0
+  sys_132: 0.0
   sys_133: 1.28693434e-01
   sys_134: -1.28693434e-01
   luminosity_uncertainty: 0.6552
@@ -8779,57 +8779,57 @@ bins:
   art_sys_2: 0.0
   art_sys_3: 2.18152173e-03
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: -5.26626015e-03
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: -1.97173830e-04
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: -1.23441144e-03
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 1.61777400e-04
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
+  art_sys_25: 0.0
   art_sys_26: 1.26156351e-03
-  art_sys_27: -0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 7.20949083e-04
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
   art_sys_37: 2.97451271e-03
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
   art_sys_43: 2.26006331e-03
-  art_sys_44: -0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
   art_sys_46: -4.47487527e-03
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
   art_sys_50: 2.55428009e-03
-  art_sys_51: -0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: -2.13235462e-02
   art_sys_57: 0.0
   art_sys_58: 0.0
@@ -8838,20 +8838,20 @@ bins:
   art_sys_61: 0.0
   art_sys_62: 0.0
   art_sys_63: 2.31217805e-01
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
   art_sys_68: 1.03912464e-02
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
   art_sys_72: 3.00561414e-03
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
   art_sys_76: -5.26119197e-05
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
   art_sys_80: 1.33008555e-05
@@ -8860,17 +8860,17 @@ bins:
   art_sys_83: -7.53563100e-06
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 8.93373400e-08
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 6.84903628e-01
   sys_2: -6.49477579e-01
   sys_3: 1.18086832e-02
   sys_4: -1.18086832e-02
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 1.18086832e-02
   sys_8: -1.18086832e-02
   sys_9: 2.36173665e-02
@@ -8878,7 +8878,7 @@ bins:
   sys_11: 1.18086832e-02
   sys_12: -1.18086832e-02
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 5.90434162e-02
   sys_16: -4.72347330e-02
   sys_17: 1.18086832e-02
@@ -8908,21 +8908,21 @@ bins:
   sys_41: 1.06278149e-01
   sys_42: -1.06278149e-01
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 1.18086832e-02
   sys_48: -1.18086832e-02
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 1.18086832e-02
   sys_60: 0.0
   sys_61: 1.18086832e-02
@@ -8930,19 +8930,19 @@ bins:
   sys_63: 1.18086832e-02
   sys_64: -1.18086832e-02
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 1.18086832e-02
   sys_80: -1.18086832e-02
   sys_81: 2.36173665e-02
@@ -8954,15 +8954,15 @@ bins:
   sys_87: 1.18086832e-01
   sys_88: -1.06278149e-01
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 1.18086832e-02
   sys_100: -1.18086832e-02
   sys_101: 2.36173665e-02
@@ -8970,19 +8970,19 @@ bins:
   sys_103: 1.18086832e-02
   sys_104: -1.18086832e-02
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 4.72347330e-02
   sys_110: -4.72347330e-02
   sys_111: 2.00747615e-01
   sys_112: -1.88938932e-01
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 1.18086832e-02
   sys_120: -1.18086832e-02
   sys_121: 1.18086832e-02
@@ -8996,7 +8996,7 @@ bins:
   sys_129: 1.18086832e-02
   sys_130: -1.18086832e-02
   sys_131: 0.0
-  sys_132: -0.0
+  sys_132: 0.0
   sys_133: 5.90434162e-02
   sys_134: -5.90434162e-02
   luminosity_uncertainty: 3.00600000e-01
@@ -9004,57 +9004,57 @@ bins:
   art_sys_2: 0.0
   art_sys_3: 4.70256924e-04
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: -5.95141835e-04
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: -5.55918199e-04
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 3.01154717e-03
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: -2.68235196e-03
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
+  art_sys_25: 0.0
   art_sys_26: 1.94939435e-03
-  art_sys_27: -0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 1.98932700e-03
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
   art_sys_37: -1.06813239e-03
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
   art_sys_43: -1.20136426e-03
-  art_sys_44: -0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
   art_sys_46: 3.34349253e-04
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
   art_sys_50: 1.19741859e-03
-  art_sys_51: -0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: -2.23616367e-03
   art_sys_57: 0.0
   art_sys_58: 0.0
@@ -9063,20 +9063,20 @@ bins:
   art_sys_61: 0.0
   art_sys_62: 0.0
   art_sys_63: 1.67271422e-02
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
   art_sys_68: -1.49266938e-01
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
   art_sys_72: -6.94854252e-03
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
   art_sys_76: 1.77282868e-03
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
   art_sys_80: -7.09836104e-05
@@ -9085,17 +9085,17 @@ bins:
   art_sys_83: 8.02632490e-06
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: -6.98743401e-08
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 3.26520698e-01
   sys_2: -3.10462303e-01
   sys_3: 5.35279833e-03
   sys_4: -5.35279833e-03
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 5.35279833e-03
   sys_8: -5.35279833e-03
   sys_9: 1.07055967e-02
@@ -9103,7 +9103,7 @@ bins:
   sys_11: 5.35279833e-03
   sys_12: -5.35279833e-03
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 2.67639917e-02
   sys_16: -2.67639917e-02
   sys_17: 5.35279833e-03
@@ -9133,17 +9133,17 @@ bins:
   sys_41: 5.88807817e-02
   sys_42: -5.35279833e-02
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 5.35279833e-03
   sys_48: -5.35279833e-03
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 5.35279833e-03
   sys_56: 0.0
   sys_57: 5.35279833e-03
@@ -9155,19 +9155,19 @@ bins:
   sys_63: 5.35279833e-03
   sys_64: -5.35279833e-03
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 5.35279833e-03
   sys_80: -5.35279833e-03
   sys_81: 1.07055967e-02
@@ -9179,15 +9179,15 @@ bins:
   sys_87: 6.42335800e-02
   sys_88: -5.88807817e-02
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 5.35279833e-03
   sys_100: -5.35279833e-03
   sys_101: 1.60583950e-02
@@ -9197,21 +9197,21 @@ bins:
   sys_105: 5.35279833e-03
   sys_106: -5.35279833e-03
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 2.67639917e-02
   sys_110: -2.14111933e-02
   sys_111: 8.56447733e-02
   sys_112: -7.49391767e-02
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 5.35279833e-03
   sys_120: -5.35279833e-03
   sys_121: 0.0
-  sys_122: -0.0
+  sys_122: 0.0
   sys_123: 5.35279833e-03
   sys_124: -5.35279833e-03
   sys_125: 5.88807817e-02
@@ -9221,7 +9221,7 @@ bins:
   sys_129: 5.35279833e-03
   sys_130: -5.35279833e-03
   sys_131: 0.0
-  sys_132: -0.0
+  sys_132: 0.0
   sys_133: 2.67639917e-02
   sys_134: -2.67639917e-02
   luminosity_uncertainty: 1.36260000e-01
@@ -9229,57 +9229,57 @@ bins:
   art_sys_2: 0.0
   art_sys_3: -2.46085850e-04
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 1.47153800e-04
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 4.97699113e-04
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 6.05059961e-04
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 4.76071346e-05
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
+  art_sys_25: 0.0
   art_sys_26: 8.35818202e-04
-  art_sys_27: -0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: -5.85732352e-04
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
   art_sys_37: -1.07114356e-03
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
   art_sys_43: -4.72634953e-04
-  art_sys_44: -0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
   art_sys_46: 1.70478205e-04
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
   art_sys_50: -1.58783756e-04
-  art_sys_51: -0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: -5.56762044e-04
   art_sys_57: 0.0
   art_sys_58: 0.0
@@ -9288,20 +9288,20 @@ bins:
   art_sys_61: 0.0
   art_sys_62: 0.0
   art_sys_63: -6.22142282e-03
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
   art_sys_68: -1.19546130e-02
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
   art_sys_72: 9.20410276e-02
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
   art_sys_76: -4.55292657e-03
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
   art_sys_80: 1.24064517e-03
@@ -9310,17 +9310,17 @@ bins:
   art_sys_83: -5.13397924e-05
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 3.23207248e-06
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 1.52056242e-01
   sys_2: -1.42552727e-01
   sys_3: 2.37587878e-03
   sys_4: -2.37587878e-03
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 2.37587878e-03
   sys_8: -2.37587878e-03
   sys_9: 7.12763635e-03
@@ -9328,7 +9328,7 @@ bins:
   sys_11: 2.37587878e-03
   sys_12: -2.37587878e-03
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 1.42552727e-02
   sys_16: -1.18793939e-02
   sys_17: 2.37587878e-03
@@ -9358,17 +9358,17 @@ bins:
   sys_41: 3.08864242e-02
   sys_42: -2.85105454e-02
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 2.37587878e-03
   sys_48: -2.37587878e-03
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 2.37587878e-03
   sys_56: -2.37587878e-03
   sys_57: 2.37587878e-03
@@ -9378,21 +9378,21 @@ bins:
   sys_61: 2.37587878e-03
   sys_62: -2.37587878e-03
   sys_63: 0.0
-  sys_64: -0.0
+  sys_64: 0.0
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 2.37587878e-03
   sys_80: -2.37587878e-03
   sys_81: 4.75175757e-03
@@ -9404,15 +9404,15 @@ bins:
   sys_87: 3.32623030e-02
   sys_88: -3.08864242e-02
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 2.37587878e-03
   sys_100: -2.37587878e-03
   sys_101: 9.50351514e-03
@@ -9422,7 +9422,7 @@ bins:
   sys_105: 2.37587878e-03
   sys_106: -2.37587878e-03
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 1.18793939e-02
   sys_110: -1.18793939e-02
   sys_111: 3.56381818e-02
@@ -9430,13 +9430,13 @@ bins:
   sys_113: 0.0
   sys_114: -2.37587878e-03
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 2.37587878e-03
   sys_120: -2.37587878e-03
   sys_121: 0.0
-  sys_122: -0.0
+  sys_122: 0.0
   sys_123: 2.37587878e-03
   sys_124: -2.37587878e-03
   sys_125: 2.37587878e-02
@@ -9446,7 +9446,7 @@ bins:
   sys_129: 2.37587878e-03
   sys_130: -2.37587878e-03
   sys_131: 0.0
-  sys_132: -0.0
+  sys_132: 0.0
   sys_133: 1.18793939e-02
   sys_134: -1.18793939e-02
   luminosity_uncertainty: 6.04800000e-02
@@ -9454,57 +9454,57 @@ bins:
   art_sys_2: 0.0
   art_sys_3: -2.88169245e-04
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 1.12439305e-05
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 3.04501558e-05
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: -2.02223515e-04
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: -3.83822047e-04
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
+  art_sys_25: 0.0
   art_sys_26: 1.77777534e-04
-  art_sys_27: -0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 4.94212210e-04
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
   art_sys_37: -5.72344974e-05
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
   art_sys_43: 5.74295647e-04
-  art_sys_44: -0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
   art_sys_46: 2.40080778e-04
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
   art_sys_50: -4.24680898e-04
-  art_sys_51: -0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: -8.03000491e-04
   art_sys_57: 0.0
   art_sys_58: 0.0
@@ -9513,20 +9513,20 @@ bins:
   art_sys_61: 0.0
   art_sys_62: 0.0
   art_sys_63: -8.70524132e-04
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
   art_sys_68: 3.92899790e-03
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
   art_sys_72: 8.40580936e-03
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
   art_sys_76: 5.29940271e-02
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
   art_sys_80: -3.54877870e-03
@@ -9535,17 +9535,17 @@ bins:
   art_sys_83: 4.87573291e-04
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 2.24826071e-06
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 6.02030714e-02
   sys_2: -5.74665681e-02
   sys_3: 9.12167748e-04
   sys_4: -9.12167748e-04
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 9.12167748e-04
   sys_8: -9.12167748e-04
   sys_9: 2.73650324e-03
@@ -9553,7 +9553,7 @@ bins:
   sys_11: 9.12167748e-04
   sys_12: -9.12167748e-04
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 5.47300649e-03
   sys_16: -5.47300649e-03
   sys_17: 9.12167748e-04
@@ -9583,17 +9583,17 @@ bins:
   sys_41: 1.36825162e-02
   sys_42: -1.27703485e-02
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 9.12167748e-04
   sys_48: -9.12167748e-04
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 9.12167748e-04
   sys_52: -9.12167748e-04
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 9.12167748e-04
   sys_56: -9.12167748e-04
   sys_57: 9.12167748e-04
@@ -9603,23 +9603,23 @@ bins:
   sys_61: 9.12167748e-04
   sys_62: -9.12167748e-04
   sys_63: 0.0
-  sys_64: -0.0
+  sys_64: 0.0
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 1.82433550e-03
   sys_82: -1.82433550e-03
   sys_83: 6.38517423e-03
@@ -9629,15 +9629,15 @@ bins:
   sys_87: 1.36825162e-02
   sys_88: -1.27703485e-02
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 9.12167748e-04
   sys_100: -9.12167748e-04
   sys_101: 4.56083874e-03
@@ -9647,7 +9647,7 @@ bins:
   sys_105: 9.12167748e-04
   sys_106: -9.12167748e-04
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 5.47300649e-03
   sys_110: -5.47300649e-03
   sys_111: 1.27703485e-02
@@ -9655,13 +9655,13 @@ bins:
   sys_113: -4.56083874e-03
   sys_114: 4.56083874e-03
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 9.12167748e-04
   sys_120: -9.12167748e-04
   sys_121: 0.0
-  sys_122: -0.0
+  sys_122: 0.0
   sys_123: 9.12167748e-04
   sys_124: -9.12167748e-04
   sys_125: 9.12167748e-03
@@ -9669,9 +9669,9 @@ bins:
   sys_127: 7.29734198e-03
   sys_128: -7.29734198e-03
   sys_129: 0.0
-  sys_130: -0.0
+  sys_130: 0.0
   sys_131: 0.0
-  sys_132: -0.0
+  sys_132: 0.0
   sys_133: 4.56083874e-03
   sys_134: -4.56083874e-03
   luminosity_uncertainty: 2.32200000e-02
@@ -9679,57 +9679,57 @@ bins:
   art_sys_2: 0.0
   art_sys_3: -1.86112779e-04
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 2.23346462e-04
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 9.03836592e-05
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: -4.22132630e-05
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: -5.84248602e-04
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
+  art_sys_25: 0.0
   art_sys_26: 4.68401462e-04
-  art_sys_27: -0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 4.97849826e-05
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
   art_sys_37: -1.26362761e-05
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
   art_sys_43: -1.53132511e-04
-  art_sys_44: -0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
   art_sys_46: -8.81725415e-04
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
   art_sys_50: -2.12504798e-04
-  art_sys_51: -0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 1.11093697e-04
   art_sys_57: 0.0
   art_sys_58: 0.0
@@ -9738,20 +9738,20 @@ bins:
   art_sys_61: 0.0
   art_sys_62: 0.0
   art_sys_63: 7.49741760e-05
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
   art_sys_68: 5.30286564e-04
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
   art_sys_72: -2.45885211e-03
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
   art_sys_76: 5.73510219e-03
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
   art_sys_80: 3.42996232e-02
@@ -9760,17 +9760,17 @@ bins:
   art_sys_83: -1.62729382e-03
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 1.47087510e-05
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 2.61572940e-02
   sys_2: -2.50032958e-02
   sys_3: 0.0
-  sys_4: -0.0
+  sys_4: 0.0
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 3.84666089e-04
   sys_8: -3.84666089e-04
   sys_9: 1.15399827e-03
@@ -9778,7 +9778,7 @@ bins:
   sys_11: 3.84666089e-04
   sys_12: 0.0
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 2.30799653e-03
   sys_16: -2.30799653e-03
   sys_17: 3.84666089e-04
@@ -9808,17 +9808,17 @@ bins:
   sys_41: 6.15465742e-03
   sys_42: -5.76999133e-03
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 3.84666089e-04
   sys_48: -3.84666089e-04
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 3.84666089e-04
   sys_52: -3.84666089e-04
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 3.84666089e-04
   sys_56: -3.84666089e-04
   sys_57: 3.84666089e-04
@@ -9828,23 +9828,23 @@ bins:
   sys_61: 7.69332178e-04
   sys_62: -7.69332178e-04
   sys_63: 0.0
-  sys_64: -0.0
+  sys_64: 0.0
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
   sys_74: -3.84666089e-04
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 7.69332178e-04
   sys_82: -7.69332178e-04
   sys_83: 3.07732871e-03
@@ -9854,15 +9854,15 @@ bins:
   sys_87: 6.15465742e-03
   sys_88: -5.76999133e-03
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 3.84666089e-04
   sys_100: -3.84666089e-04
   sys_101: 2.30799653e-03
@@ -9872,7 +9872,7 @@ bins:
   sys_105: 3.84666089e-04
   sys_106: -3.84666089e-04
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 2.69266262e-03
   sys_110: -2.69266262e-03
   sys_111: 5.38532525e-03
@@ -9880,13 +9880,13 @@ bins:
   sys_113: -2.30799653e-03
   sys_114: 2.30799653e-03
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 3.84666089e-04
   sys_120: -3.84666089e-04
   sys_121: 0.0
-  sys_122: -0.0
+  sys_122: 0.0
   sys_123: 3.84666089e-04
   sys_124: -3.84666089e-04
   sys_125: 3.84666089e-03
@@ -9894,7 +9894,7 @@ bins:
   sys_127: 3.46199480e-03
   sys_128: -3.46199480e-03
   sys_129: 0.0
-  sys_130: -0.0
+  sys_130: 0.0
   sys_131: 3.84666089e-04
   sys_132: -3.84666089e-04
   sys_133: 1.92333044e-03
@@ -9904,57 +9904,57 @@ bins:
   art_sys_2: 0.0
   art_sys_3: 1.69681409e-04
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: -5.71602039e-05
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: -3.68633405e-04
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 1.10705351e-04
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: -2.06184352e-05
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
+  art_sys_25: 0.0
   art_sys_26: 2.45025318e-04
-  art_sys_27: -0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: -1.10969370e-04
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
   art_sys_37: 2.20169510e-04
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
   art_sys_43: -1.79880851e-04
-  art_sys_44: -0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
   art_sys_46: -1.66574526e-04
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
   art_sys_50: 1.12096302e-04
-  art_sys_51: -0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 4.04804083e-05
   art_sys_57: 0.0
   art_sys_58: 0.0
@@ -9963,20 +9963,20 @@ bins:
   art_sys_61: 0.0
   art_sys_62: 0.0
   art_sys_63: 1.01634815e-04
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
   art_sys_68: -2.01066406e-05
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
   art_sys_72: -1.79733766e-04
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
   art_sys_76: -9.15421466e-04
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
   art_sys_80: 3.14922015e-03
@@ -9985,25 +9985,25 @@ bins:
   art_sys_83: 1.82970994e-02
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: -1.26793578e-05
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 9.03682466e-03
   sys_2: -8.52770778e-03
   sys_3: 0.0
-  sys_4: -0.0
+  sys_4: 0.0
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 1.27279221e-04
   sys_8: -1.27279221e-04
   sys_9: 3.81837662e-04
   sys_10: -3.81837662e-04
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 8.90954544e-04
   sys_16: -8.90954544e-04
   sys_17: 1.27279221e-04
@@ -10033,17 +10033,17 @@ bins:
   sys_41: 2.16374675e-03
   sys_42: -2.03646753e-03
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 1.27279221e-04
   sys_48: -1.27279221e-04
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 1.27279221e-04
   sys_52: -1.27279221e-04
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 1.27279221e-04
   sys_56: -1.27279221e-04
   sys_57: 1.27279221e-04
@@ -10053,23 +10053,23 @@ bins:
   sys_61: 2.54558441e-04
   sys_62: -2.54558441e-04
   sys_63: 0.0
-  sys_64: -0.0
+  sys_64: 0.0
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
   sys_74: -1.27279221e-04
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 2.54558441e-04
   sys_82: -2.54558441e-04
   sys_83: 1.01823376e-03
@@ -10079,15 +10079,15 @@ bins:
   sys_87: 2.03646753e-03
   sys_88: -1.90918831e-03
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 1.27279221e-04
   sys_100: -1.27279221e-04
   sys_101: 8.90954544e-04
@@ -10097,7 +10097,7 @@ bins:
   sys_105: 2.54558441e-04
   sys_106: -2.54558441e-04
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 1.01823376e-03
   sys_110: -1.01823376e-03
   sys_111: 1.65462987e-03
@@ -10105,13 +10105,13 @@ bins:
   sys_113: 6.36396103e-04
   sys_114: -1.14551299e-03
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 1.27279221e-04
   sys_120: -1.27279221e-04
   sys_121: 0.0
-  sys_122: -0.0
+  sys_122: 0.0
   sys_123: 1.27279221e-04
   sys_124: -1.27279221e-04
   sys_125: 1.27279221e-03
@@ -10119,7 +10119,7 @@ bins:
   sys_127: 1.14551299e-03
   sys_128: -1.14551299e-03
   sys_129: 0.0
-  sys_130: -0.0
+  sys_130: 0.0
   sys_131: 7.63675324e-04
   sys_132: -7.63675324e-04
   sys_133: 6.36396103e-04
@@ -10129,57 +10129,57 @@ bins:
   art_sys_2: 0.0
   art_sys_3: 3.79588934e-06
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 5.61178365e-06
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 1.34669367e-05
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 2.21024527e-05
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: -1.71852232e-05
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
+  art_sys_25: 0.0
   art_sys_26: 3.23528356e-05
-  art_sys_27: -0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: -7.51576067e-06
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
   art_sys_37: 3.51417643e-05
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
   art_sys_43: 3.36439577e-05
-  art_sys_44: -0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
   art_sys_46: 2.42753463e-05
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
   art_sys_50: 4.45442875e-05
-  art_sys_51: -0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 3.06951183e-05
   art_sys_57: 0.0
   art_sys_58: 0.0
@@ -10188,20 +10188,20 @@ bins:
   art_sys_61: 0.0
   art_sys_62: 0.0
   art_sys_63: 9.96141761e-07
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
   art_sys_68: 3.03943537e-06
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
   art_sys_72: -8.84551020e-05
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
   art_sys_76: -6.25369407e-05
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
   art_sys_80: -1.43853536e-04
@@ -10210,17 +10210,17 @@ bins:
   art_sys_83: 7.96399460e-05
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 3.20193887e-03
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 1.37263568e-03
   sys_2: -1.23835611e-03
   sys_3: 0.0
   sys_4: -1.49199531e-05
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 2.98399062e-05
   sys_8: -1.49199531e-05
   sys_9: 7.45997654e-05
@@ -10228,7 +10228,7 @@ bins:
   sys_11: 0.0
   sys_12: -1.49199531e-05
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 1.34279578e-04
   sys_16: -1.34279578e-04
   sys_17: 1.49199531e-05
@@ -10258,17 +10258,17 @@ bins:
   sys_41: 3.43158921e-04
   sys_42: -3.28238968e-04
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 2.98399062e-05
   sys_48: -2.98399062e-05
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 2.98399062e-05
   sys_52: -2.98399062e-05
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 1.49199531e-05
   sys_56: -1.49199531e-05
   sys_57: 1.49199531e-05
@@ -10278,23 +10278,23 @@ bins:
   sys_61: 4.47598592e-05
   sys_62: -4.47598592e-05
   sys_63: 0.0
-  sys_64: -0.0
+  sys_64: 0.0
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 1.49199531e-05
   sys_74: -1.49199531e-05
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 4.47598592e-05
   sys_82: -4.47598592e-05
   sys_83: 1.79039437e-04
@@ -10304,15 +10304,15 @@ bins:
   sys_87: 2.83479109e-04
   sys_88: -2.68559155e-04
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 1.49199531e-05
   sys_100: -1.49199531e-05
   sys_101: 1.49199531e-04
@@ -10322,7 +10322,7 @@ bins:
   sys_105: 4.47598592e-05
   sys_106: -4.47598592e-05
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 2.23799296e-04
   sys_110: -2.08879343e-04
   sys_111: 1.93959390e-04
@@ -10330,21 +10330,21 @@ bins:
   sys_113: 1.28311597e-03
   sys_114: -1.31295587e-03
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 1.49199531e-05
   sys_120: -1.49199531e-05
   sys_121: 0.0
-  sys_122: -0.0
+  sys_122: 0.0
   sys_123: 0.0
-  sys_124: -0.0
+  sys_124: 0.0
   sys_125: 1.93959390e-04
   sys_126: -1.64119484e-04
   sys_127: 2.83479109e-04
   sys_128: -2.83479109e-04
   sys_129: 0.0
-  sys_130: -0.0
+  sys_130: 0.0
   sys_131: 1.64119484e-04
   sys_132: -1.64119484e-04
   sys_133: 7.45997654e-05
@@ -10352,7 +10352,7 @@ bins:
   luminosity_uncertainty: 3.79800000e-04
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
   art_sys_5: 2.33198035e+03
   art_sys_6: 0.0
@@ -10360,100 +10360,100 @@ bins:
   art_sys_8: 4.11892328e+01
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 1.30479427e+01
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 8.99591665e-01
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 1.51497724e-01
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
   art_sys_25: 2.23487286e-02
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
   art_sys_30: 3.60848773e-04
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 6.21213775e-04
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
   art_sys_40: 9.52007037e-05
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 3.75026894e-05
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
   art_sys_51: 6.17897095e-06
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 1.09362599e-06
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 7.33430682e-07
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
   art_sys_66: 7.34567167e-09
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
   art_sys_70: 3.61209793e-08
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
   art_sys_74: 3.29817357e-08
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 8.33069175e-09
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 3.81855777e-10
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
   art_sys_88: 8.76485834e-11
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 4.20021428e+03
   sys_2: -4.45477272e+03
   sys_3: 1.01823376e+03
   sys_4: -1.01823376e+03
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 3.81837662e+02
   sys_8: -5.09116882e+02
   sys_9: 1.90918831e+03
   sys_10: -1.90918831e+03
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 8.90954544e+02
   sys_16: -7.63675324e+02
   sys_17: 1.27279221e+02
@@ -10467,25 +10467,25 @@ bins:
   sys_25: 8.90954544e+02
   sys_26: -8.90954544e+02
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 0.0
-  sys_30: -0.0
+  sys_30: 0.0
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 0.0
-  sys_38: -0.0
+  sys_38: 0.0
   sys_39: 0.0
-  sys_40: -0.0
+  sys_40: 0.0
   sys_41: 0.0
-  sys_42: -0.0
+  sys_42: 0.0
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
   sys_48: -1.27279221e+02
   sys_49: 0.0
@@ -10503,59 +10503,59 @@ bins:
   sys_61: 2.54558441e+02
   sys_62: -2.54558441e+02
   sys_63: 0.0
-  sys_64: -0.0
+  sys_64: 0.0
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
   sys_72: -1.27279221e+02
   sys_73: 1.27279221e+02
   sys_74: -1.27279221e+02
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 8.90954544e+02
   sys_110: -7.63675324e+02
   sys_111: 8.78226622e+03
   sys_112: -8.65498700e+03
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: -6.36396103e+02
   sys_118: 6.36396103e+02
   sys_119: -2.29102597e+03
@@ -10577,7 +10577,7 @@ bins:
   luminosity_uncertainty: 3.24000000e+03
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
   art_sys_5: 8.95636175e+01
   art_sys_6: 0.0
@@ -10585,100 +10585,100 @@ bins:
   art_sys_8: -1.10508932e+03
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: -2.67216941e+01
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 6.47161044e+00
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 1.65984201e-01
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
   art_sys_25: 4.22713500e-02
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
   art_sys_30: -3.15270604e-03
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: -1.21404034e-03
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
   art_sys_40: 1.49855462e-04
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -9.06258801e-05
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
   art_sys_51: 3.89461332e-06
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 1.91543676e-06
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: -1.05365902e-06
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
   art_sys_66: 3.37162322e-07
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
   art_sys_70: 3.58179579e-08
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
   art_sys_74: -2.42476016e-08
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: -2.39989687e-08
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: -2.09965775e-09
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
   art_sys_88: -2.67708388e-11
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 2.05428662e+03
   sys_2: -2.11135014e+03
   sys_3: 4.56508138e+02
   sys_4: -3.99444621e+02
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 1.71190552e+02
   sys_8: -2.28254069e+02
   sys_9: 8.55952759e+02
   sys_10: -7.98889241e+02
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 3.99444621e+02
   sys_16: -3.42381103e+02
   sys_17: 5.70635172e+01
@@ -10692,29 +10692,29 @@ bins:
   sys_25: 4.56508138e+02
   sys_26: -3.99444621e+02
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 0.0
-  sys_30: -0.0
+  sys_30: 0.0
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 5.70635172e+01
   sys_36: -5.70635172e+01
   sys_37: 0.0
-  sys_38: -0.0
+  sys_38: 0.0
   sys_39: 5.70635172e+01
   sys_40: -5.70635172e+01
   sys_41: 0.0
-  sys_42: -0.0
+  sys_42: 0.0
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 5.70635172e+01
   sys_52: -5.70635172e+01
   sys_53: 5.70635172e+01
@@ -10728,59 +10728,59 @@ bins:
   sys_61: 1.71190552e+02
   sys_62: -1.71190552e+02
   sys_63: 0.0
-  sys_64: -0.0
+  sys_64: 0.0
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 5.70635172e+01
   sys_74: -5.70635172e+01
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 3.99444621e+02
   sys_110: -3.42381103e+02
   sys_111: 4.05150972e+03
   sys_112: -3.93738269e+03
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: -2.85317586e+02
   sys_118: 2.85317586e+02
   sys_119: -9.13016276e+02
@@ -10802,7 +10802,7 @@ bins:
   luminosity_uncertainty: 1.45260000e+03
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
   art_sys_5: -5.45408283e+01
   art_sys_6: 0.0
@@ -10810,92 +10810,92 @@ bins:
   art_sys_8: -5.97903026e+01
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 5.10268361e+02
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: -8.33812508e+00
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 2.66190364e+00
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
   art_sys_25: 8.50333455e-02
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
   art_sys_30: -1.02489061e-03
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: -3.10105237e-03
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
   art_sys_40: 3.91473778e-04
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 8.69866557e-05
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
   art_sys_51: 5.55024174e-05
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: -5.61323138e-06
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 1.28576822e-07
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
   art_sys_66: -1.85599336e-07
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
   art_sys_70: -2.66378264e-07
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
   art_sys_74: -1.45428562e-08
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: -2.24939332e-10
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 1.73963394e-08
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
   art_sys_88: -1.20617826e-11
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 1.00494016e+03
   sys_2: -1.00494016e+03
   sys_3: 1.85120555e+02
   sys_4: -1.58674762e+02
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 7.93373808e+01
   sys_8: -7.93373808e+01
   sys_9: 3.43795317e+02
@@ -10903,7 +10903,7 @@ bins:
   sys_11: 2.64457936e+01
   sys_12: 0.0
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 1.58674762e+02
   sys_16: -1.32228968e+02
   sys_17: 2.64457936e+01
@@ -10917,13 +10917,13 @@ bins:
   sys_25: 1.85120555e+02
   sys_26: -1.85120555e+02
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 0.0
-  sys_30: -0.0
+  sys_30: 0.0
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 2.64457936e+01
   sys_36: -2.64457936e+01
   sys_37: 2.64457936e+01
@@ -10933,13 +10933,13 @@ bins:
   sys_41: 2.64457936e+01
   sys_42: 0.0
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
   sys_52: -2.64457936e+01
   sys_53: 2.64457936e+01
@@ -10955,57 +10955,57 @@ bins:
   sys_63: 2.64457936e+01
   sys_64: 0.0
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 2.64457936e+01
   sys_74: -2.64457936e+01
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 1.58674762e+02
   sys_110: -1.58674762e+02
   sys_111: 1.90409714e+03
   sys_112: -1.82475976e+03
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: -1.05783174e+02
   sys_118: 1.32228968e+02
   sys_119: -3.70241111e+02
@@ -11021,13 +11021,13 @@ bins:
   sys_129: 5.28915872e+01
   sys_130: -5.28915872e+01
   sys_131: 0.0
-  sys_132: -0.0
+  sys_132: 0.0
   sys_133: 1.32228968e+02
   sys_134: -1.32228968e+02
   luminosity_uncertainty: 673.2
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
   art_sys_5: -1.24553514e+01
   art_sys_6: 0.0
@@ -11035,92 +11035,92 @@ bins:
   art_sys_8: 2.63409014e+01
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 1.82092681e+01
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 2.49132069e+02
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: -7.08092036e+00
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
   art_sys_25: 1.58584938e+00
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
   art_sys_30: -3.60811479e-02
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: -1.92201199e-02
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
   art_sys_40: -4.84571565e-05
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -1.62737675e-04
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
   art_sys_51: -8.08997589e-05
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 3.15411999e-06
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: -2.69437490e-06
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
   art_sys_66: -2.77549746e-06
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
   art_sys_70: 2.34617921e-08
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
   art_sys_74: 1.06508888e-07
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: -5.82292265e-09
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 5.11123106e-09
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
   art_sys_88: 5.16173485e-11
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 4.94974747e+02
   sys_2: -4.82600378e+02
   sys_3: 7.42462120e+01
   sys_4: -6.18718434e+01
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 3.71231060e+01
   sys_8: -3.71231060e+01
   sys_9: 1.48492424e+02
@@ -11128,7 +11128,7 @@ bins:
   sys_11: 2.47487373e+01
   sys_12: -1.23743687e+01
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 6.18718434e+01
   sys_16: -6.18718434e+01
   sys_17: 1.23743687e+01
@@ -11144,11 +11144,11 @@ bins:
   sys_27: 1.23743687e+01
   sys_28: 0.0
   sys_29: 0.0
-  sys_30: -0.0
+  sys_30: 0.0
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 2.47487373e+01
   sys_36: -1.23743687e+01
   sys_37: 1.23743687e+01
@@ -11158,15 +11158,15 @@ bins:
   sys_41: 1.23743687e+01
   sys_42: 0.0
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 1.23743687e+01
   sys_54: -1.23743687e+01
   sys_55: 1.23743687e+01
@@ -11180,57 +11180,57 @@ bins:
   sys_63: 1.23743687e+01
   sys_64: 0.0
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 1.23743687e+01
   sys_74: -1.23743687e+01
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 6.18718434e+01
   sys_110: -6.18718434e+01
   sys_111: 8.90954544e+02
   sys_112: -8.41457070e+02
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: -4.94974747e+01
   sys_118: 4.94974747e+01
   sys_119: -1.60866793e+02
@@ -11246,13 +11246,13 @@ bins:
   sys_129: 3.71231060e+01
   sys_130: -3.71231060e+01
   sys_131: 0.0
-  sys_132: -0.0
+  sys_132: 0.0
   sys_133: 6.18718434e+01
   sys_134: -6.18718434e+01
   luminosity_uncertainty: 3.15000000e+02
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
   art_sys_5: -2.35633244e+00
   art_sys_6: 0.0
@@ -11260,92 +11260,92 @@ bins:
   art_sys_8: 3.99082331e+00
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: -9.32852613e+00
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 1.39793874e+01
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 1.30337400e+02
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
   art_sys_25: -2.76328213e+00
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
   art_sys_30: 7.76356933e-01
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: -4.30527930e-04
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
   art_sys_40: -1.02663986e-03
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -5.32648281e-04
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
   art_sys_51: 1.77002357e-04
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: -1.85461896e-06
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: -4.25636772e-06
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
   art_sys_66: -1.43467859e-07
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
   art_sys_70: 3.50941013e-07
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
   art_sys_74: 2.40483565e-08
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 1.35872271e-07
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: -4.03730569e-08
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
   art_sys_88: 5.92681650e-10
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 2.62534606e+02
   sys_2: -2.50032958e+02
   sys_3: 3.12541197e+01
   sys_4: -2.50032958e+01
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 1.25016479e+01
   sys_8: -1.25016479e+01
   sys_9: 6.25082395e+01
@@ -11353,7 +11353,7 @@ bins:
   sys_11: 1.25016479e+01
   sys_12: -6.25082395e+00
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 3.12541197e+01
   sys_16: -2.50032958e+01
   sys_17: 6.25082395e+00
@@ -11369,11 +11369,11 @@ bins:
   sys_27: 6.25082395e+00
   sys_28: 0.0
   sys_29: 0.0
-  sys_30: -0.0
+  sys_30: 0.0
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 1.25016479e+01
   sys_36: -1.25016479e+01
   sys_37: 6.25082395e+00
@@ -11383,17 +11383,17 @@ bins:
   sys_41: 1.25016479e+01
   sys_42: -6.25082395e+00
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 6.25082395e+00
   sys_56: -6.25082395e+00
   sys_57: 6.25082395e+00
@@ -11405,57 +11405,57 @@ bins:
   sys_63: 6.25082395e+00
   sys_64: -6.25082395e+00
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 6.25082395e+00
   sys_74: -6.25082395e+00
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 3.12541197e+01
   sys_110: -2.50032958e+01
   sys_111: 4.43808500e+02
   sys_112: -4.12554380e+02
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: -2.50032958e+01
   sys_118: 1.87524718e+01
   sys_119: -7.50098873e+01
@@ -11471,13 +11471,13 @@ bins:
   sys_129: 1.25016479e+01
   sys_130: -1.25016479e+01
   sys_131: 0.0
-  sys_132: -0.0
+  sys_132: 0.0
   sys_133: 3.12541197e+01
   sys_134: -3.12541197e+01
   luminosity_uncertainty: 159.12
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
   art_sys_5: -6.34567093e-01
   art_sys_6: 0.0
@@ -11485,92 +11485,92 @@ bins:
   art_sys_8: 3.47524300e-01
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: -1.64345245e+00
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: -5.96699599e+00
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 6.36735004e+00
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
   art_sys_25: 5.95698306e+01
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
   art_sys_30: -1.40905539e+00
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: -2.77866576e-01
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
   art_sys_40: -7.92766258e-03
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 3.66278323e-04
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
   art_sys_51: -4.72197729e-05
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 1.58434782e-05
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 9.04300392e-07
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
   art_sys_66: 2.37613082e-06
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
   art_sys_70: 2.50846136e-06
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
   art_sys_74: 1.80489595e-06
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 7.39519526e-08
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: -9.63475484e-09
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
   art_sys_88: 2.36230645e-10
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 1.30984460e+02
   sys_2: -1.25030621e+02
   sys_3: 1.19076782e+01
   sys_4: -1.19076782e+01
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 5.95383910e+00
   sys_8: -5.95383910e+00
   sys_9: 2.67922759e+01
@@ -11578,7 +11578,7 @@ bins:
   sys_11: 8.93075865e+00
   sys_12: -5.95383910e+00
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 1.19076782e+01
   sys_16: -1.19076782e+01
   sys_17: 2.97691955e+00
@@ -11608,17 +11608,17 @@ bins:
   sys_41: 5.95383910e+00
   sys_42: -5.95383910e+00
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 2.97691955e+00
   sys_56: -2.97691955e+00
   sys_57: 2.97691955e+00
@@ -11630,57 +11630,57 @@ bins:
   sys_63: 2.97691955e+00
   sys_64: -2.97691955e+00
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
   sys_74: -2.97691955e+00
   sys_75: 2.97691955e+00
   sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 2.97691955e+00
   sys_80: -2.97691955e+00
   sys_81: 2.97691955e+00
   sys_82: -2.97691955e+00
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 1.19076782e+01
   sys_110: -1.19076782e+01
   sys_111: 2.05407449e+02
   sys_112: -1.93499771e+02
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: -1.19076782e+01
   sys_118: 8.93075865e+00
   sys_119: -3.57230346e+01
@@ -11696,13 +11696,13 @@ bins:
   sys_129: 5.95383910e+00
   sys_130: -5.95383910e+00
   sys_131: 0.0
-  sys_132: -0.0
+  sys_132: 0.0
   sys_133: 1.48845977e+01
   sys_134: -1.48845977e+01
   luminosity_uncertainty: 7.57800000e+01
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
   art_sys_5: -7.95687397e-03
   art_sys_6: 0.0
@@ -11710,92 +11710,92 @@ bins:
   art_sys_8: -1.71563210e-01
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 1.98610325e-01
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: -3.24289379e-01
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: -2.98563643e+00
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
   art_sys_25: 2.82177164e+00
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
   art_sys_30: 3.09001221e+01
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 3.48210070e-01
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
   art_sys_40: -1.03335483e-01
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 8.58417823e-04
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
   art_sys_51: -6.75162723e-04
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 1.71980189e-04
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 3.06180889e-05
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
   art_sys_66: 9.20327718e-06
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
   art_sys_70: -3.79205098e-07
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
   art_sys_74: 1.91291931e-06
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: -2.08081108e-07
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: -1.11835987e-07
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
   art_sys_88: -1.98790364e-09
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 6.76559768e+01
   sys_2: -6.32436305e+01
   sys_3: 4.41234631e+00
   sys_4: -4.41234631e+00
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 2.94156421e+00
   sys_8: -2.94156421e+00
   sys_9: 1.17662568e+01
@@ -11803,7 +11803,7 @@ bins:
   sys_11: 4.41234631e+00
   sys_12: -2.94156421e+00
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 5.88312842e+00
   sys_16: -5.88312842e+00
   sys_17: 1.47078210e+00
@@ -11833,17 +11833,17 @@ bins:
   sys_41: 4.41234631e+00
   sys_42: -2.94156421e+00
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 1.47078210e+00
   sys_56: -1.47078210e+00
   sys_57: 1.47078210e+00
@@ -11855,15 +11855,15 @@ bins:
   sys_63: 1.47078210e+00
   sys_64: -1.47078210e+00
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 1.47078210e+00
   sys_76: 0.0
   sys_77: 0.0
@@ -11875,37 +11875,37 @@ bins:
   sys_83: 1.47078210e+00
   sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 5.88312842e+00
   sys_110: -5.88312842e+00
   sys_111: 9.85424010e+01
   sys_112: -9.11884905e+01
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: -5.88312842e+00
   sys_118: 4.41234631e+00
   sys_119: -1.91201674e+01
@@ -11921,13 +11921,13 @@ bins:
   sys_129: 2.94156421e+00
   sys_130: -2.94156421e+00
   sys_131: 0.0
-  sys_132: -0.0
+  sys_132: 0.0
   sys_133: 7.35391052e+00
   sys_134: -7.35391052e+00
   luminosity_uncertainty: 3.74400000e+01
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
   art_sys_5: 1.52564913e-01
   art_sys_6: 0.0
@@ -11935,92 +11935,92 @@ bins:
   art_sys_8: 7.23789127e-02
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: -1.11637428e-01
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: -2.60344114e-01
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: -2.21037745e-01
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
   art_sys_25: -1.25054374e+00
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
   art_sys_30: 9.24209004e-01
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: -1.23838037e+01
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
   art_sys_40: 2.50324942e-01
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 5.57036350e-02
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
   art_sys_51: -1.81148878e-03
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 2.70935328e-04
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 2.94249444e-05
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
   art_sys_66: 2.68315412e-05
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
   art_sys_70: 1.31564890e-05
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
   art_sys_74: 6.34924848e-07
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: -4.62932059e-07
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 2.69680101e-07
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
   art_sys_88: 6.22427120e-10
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 3.20375940e+01
   sys_2: -2.99926412e+01
   sys_3: 2.04495281e+00
   sys_4: -2.04495281e+00
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 6.81650937e-01
   sys_8: -1.36330187e+00
   sys_9: 4.77155656e+00
@@ -12028,7 +12028,7 @@ bins:
   sys_11: 2.04495281e+00
   sys_12: -2.04495281e+00
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 2.72660375e+00
   sys_16: -2.72660375e+00
   sys_17: 6.81650937e-01
@@ -12058,19 +12058,19 @@ bins:
   sys_41: 2.04495281e+00
   sys_42: -2.04495281e+00
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 6.81650937e-01
   sys_58: -6.81650937e-01
   sys_59: 6.81650937e-01
@@ -12080,15 +12080,15 @@ bins:
   sys_63: 1.36330187e+00
   sys_64: -1.36330187e+00
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 6.81650937e-01
   sys_76: 0.0
   sys_77: 6.81650937e-01
@@ -12100,37 +12100,37 @@ bins:
   sys_83: 6.81650937e-01
   sys_84: -6.81650937e-01
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 2.72660375e+00
   sys_110: -2.72660375e+00
   sys_111: 4.29440090e+01
   sys_112: -4.02174053e+01
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: -2.72660375e+00
   sys_118: 2.72660375e+00
   sys_119: -8.86146218e+00
@@ -12146,13 +12146,13 @@ bins:
   sys_129: 6.81650937e-01
   sys_130: -6.81650937e-01
   sys_131: 0.0
-  sys_132: -0.0
+  sys_132: 0.0
   sys_133: 3.40825469e+00
   sys_134: -3.40825469e+00
   luminosity_uncertainty: 17.352
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
   art_sys_5: 4.83353394e-02
   art_sys_6: 0.0
@@ -12160,92 +12160,92 @@ bins:
   art_sys_8: -2.72779018e-02
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 3.16700332e-02
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: -3.50509083e-03
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 1.21009172e-02
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
   art_sys_25: -1.94002811e-01
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
   art_sys_30: -5.30793968e-01
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: -5.72632250e-01
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
   art_sys_40: -5.54410107e+00
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -1.02990569e-01
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
   art_sys_51: -2.83795870e-02
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 1.29793253e-03
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: -3.07831532e-04
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
   art_sys_66: -9.66556595e-06
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
   art_sys_70: -2.09787115e-05
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
   art_sys_74: 6.81222007e-06
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: -9.85758381e-07
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: -2.84373043e-08
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
   art_sys_88: -8.49427923e-09
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 1.58165645e+01
   sys_2: -1.51575410e+01
   sys_3: 6.59023520e-01
   sys_4: -6.59023520e-01
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 3.29511760e-01
   sys_8: -3.29511760e-01
   sys_9: 1.64755880e+00
@@ -12253,7 +12253,7 @@ bins:
   sys_11: 9.88535280e-01
   sys_12: -9.88535280e-01
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 1.31804704e+00
   sys_16: -1.31804704e+00
   sys_17: 3.29511760e-01
@@ -12283,19 +12283,19 @@ bins:
   sys_41: 9.88535280e-01
   sys_42: -1.31804704e+00
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 3.29511760e-01
   sys_58: -3.29511760e-01
   sys_59: 3.29511760e-01
@@ -12305,15 +12305,15 @@ bins:
   sys_63: 6.59023520e-01
   sys_64: -6.59023520e-01
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 3.29511760e-01
   sys_76: 0.0
   sys_77: 3.29511760e-01
@@ -12327,35 +12327,35 @@ bins:
   sys_85: 3.29511760e-01
   sys_86: -3.29511760e-01
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 1.31804704e+00
   sys_110: -1.31804704e+00
   sys_111: 1.94411938e+01
   sys_112: -1.84526586e+01
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: -1.31804704e+00
   sys_118: 1.31804704e+00
   sys_119: -3.95414112e+00
@@ -12371,13 +12371,13 @@ bins:
   sys_129: 3.29511760e-01
   sys_130: -3.29511760e-01
   sys_131: 0.0
-  sys_132: -0.0
+  sys_132: 0.0
   sys_133: 1.64755880e+00
   sys_134: -1.64755880e+00
   luminosity_uncertainty: 8.38800000e+00
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
   art_sys_5: -2.87994536e-02
   art_sys_6: 0.0
@@ -12385,92 +12385,92 @@ bins:
   art_sys_8: -3.34221706e-02
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: -1.45146040e-02
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 2.35673767e-02
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 2.76255337e-02
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
   art_sys_25: 8.32034240e-03
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
   art_sys_30: -4.58442863e-02
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 2.18568410e-01
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
   art_sys_40: -2.09306604e-01
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 2.86173114e+00
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
   art_sys_51: 5.55053002e-02
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 1.36256733e-02
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 5.16461752e-04
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
   art_sys_66: 2.13637863e-04
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
   art_sys_70: -1.61167031e-05
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
   art_sys_74: -1.25662139e-06
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 3.17236260e-06
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 7.82809980e-07
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
   art_sys_88: 3.02582864e-08
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 7.83050049e+00
   sys_2: -7.67069436e+00
   sys_3: 3.19612265e-01
   sys_4: -3.19612265e-01
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 1.59806133e-01
   sys_8: -1.59806133e-01
   sys_9: 7.99030663e-01
@@ -12478,7 +12478,7 @@ bins:
   sys_11: 3.19612265e-01
   sys_12: -4.79418398e-01
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 6.39224530e-01
   sys_16: -6.39224530e-01
   sys_17: 1.59806133e-01
@@ -12508,19 +12508,19 @@ bins:
   sys_41: 6.39224530e-01
   sys_42: -6.39224530e-01
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 1.59806133e-01
   sys_58: 0.0
   sys_59: 1.59806133e-01
@@ -12530,17 +12530,17 @@ bins:
   sys_63: 3.19612265e-01
   sys_64: -3.19612265e-01
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 1.59806133e-01
   sys_78: -1.59806133e-01
   sys_79: 1.59806133e-01
@@ -12552,35 +12552,35 @@ bins:
   sys_85: 3.19612265e-01
   sys_86: -3.19612265e-01
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 6.39224530e-01
   sys_110: -6.39224530e-01
   sys_111: 8.94914342e+00
   sys_112: -8.62953116e+00
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: -4.79418398e-01
   sys_118: 4.79418398e-01
   sys_119: -1.59806133e+00
@@ -12596,13 +12596,13 @@ bins:
   sys_129: 1.59806133e-01
   sys_130: -1.59806133e-01
   sys_131: 0.0
-  sys_132: -0.0
+  sys_132: 0.0
   sys_133: 7.99030663e-01
   sys_134: -7.99030663e-01
   luminosity_uncertainty: 4.06800000e+00
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
   art_sys_5: 7.63020783e-03
   art_sys_6: 0.0
@@ -12610,92 +12610,92 @@ bins:
   art_sys_8: -8.01336625e-03
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 1.87431147e-02
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: -1.26243875e-02
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 2.16682890e-02
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
   art_sys_25: 2.41152715e-03
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
   art_sys_30: -7.48560387e-03
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 4.05153204e-02
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
   art_sys_40: 1.16049619e-01
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 1.32557395e-01
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
   art_sys_51: -1.24315602e+00
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: -2.51612667e-02
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: -9.22195097e-03
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
   art_sys_66: -1.63779360e-04
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
   art_sys_70: -3.42989315e-05
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
   art_sys_74: -7.69044821e-07
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: -3.93893188e-06
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 1.32559588e-07
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
   art_sys_88: -1.07199328e-07
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 3.85868170e+00
   sys_2: -3.78302128e+00
   sys_3: 1.51320851e-01
   sys_4: -1.51320851e-01
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 7.56604256e-02
   sys_8: -7.56604256e-02
   sys_9: 3.02641702e-01
@@ -12703,7 +12703,7 @@ bins:
   sys_11: 1.51320851e-01
   sys_12: -1.51320851e-01
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 3.02641702e-01
   sys_16: -3.02641702e-01
   sys_17: 7.56604256e-02
@@ -12733,21 +12733,21 @@ bins:
   sys_41: 3.02641702e-01
   sys_42: -3.78302128e-01
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 7.56604256e-02
   sys_60: -7.56604256e-02
   sys_61: 7.56604256e-02
@@ -12755,17 +12755,17 @@ bins:
   sys_63: 7.56604256e-02
   sys_64: -7.56604256e-02
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 7.56604256e-02
   sys_78: -7.56604256e-02
   sys_79: 7.56604256e-02
@@ -12779,33 +12779,33 @@ bins:
   sys_87: 7.56604256e-02
   sys_88: -7.56604256e-02
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 3.02641702e-01
   sys_110: -3.02641702e-01
   sys_111: 4.01000256e+00
   sys_112: -3.85868170e+00
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: -1.51320851e-01
   sys_118: 2.26981277e-01
   sys_119: -5.29622979e-01
@@ -12821,13 +12821,13 @@ bins:
   sys_129: 7.56604256e-02
   sys_130: -7.56604256e-02
   sys_131: 0.0
-  sys_132: -0.0
+  sys_132: 0.0
   sys_133: 3.78302128e-01
   sys_134: -3.78302128e-01
   luminosity_uncertainty: 1.92600000e+00
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
   art_sys_5: -4.34520784e-03
   art_sys_6: 0.0
@@ -12835,92 +12835,92 @@ bins:
   art_sys_8: 3.13573120e-03
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 5.76401978e-03
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: -1.81878371e-03
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 1.60382267e-03
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
   art_sys_25: -1.52634349e-03
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
   art_sys_30: -7.48439983e-03
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 3.53954431e-03
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
   art_sys_40: 2.11968683e-02
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -5.86543323e-02
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
   art_sys_51: -5.42906294e-02
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 6.05612221e-01
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 1.52885159e-02
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
   art_sys_66: 4.92673169e-03
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
   art_sys_70: -1.53704969e-04
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
   art_sys_74: 2.35569710e-05
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: -7.65451259e-06
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: -2.79356350e-06
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
   art_sys_88: 2.12624609e-07
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 1.84010398e+00
   sys_2: -1.84010398e+00
   sys_3: 3.47189430e-02
   sys_4: -3.47189430e-02
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 3.47189430e-02
   sys_8: -3.47189430e-02
   sys_9: 1.04156829e-01
@@ -12928,7 +12928,7 @@ bins:
   sys_11: 6.94378859e-02
   sys_12: -6.94378859e-02
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 1.38875772e-01
   sys_16: -1.38875772e-01
   sys_17: 3.47189430e-02
@@ -12958,21 +12958,21 @@ bins:
   sys_41: 1.73594715e-01
   sys_42: -1.73594715e-01
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
   sys_48: -3.47189430e-02
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 3.47189430e-02
   sys_60: -3.47189430e-02
   sys_61: 3.47189430e-02
@@ -12980,17 +12980,17 @@ bins:
   sys_63: 3.47189430e-02
   sys_64: -3.47189430e-02
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 3.47189430e-02
   sys_78: -3.47189430e-02
   sys_79: 3.47189430e-02
@@ -13004,33 +13004,33 @@ bins:
   sys_87: 6.94378859e-02
   sys_88: -6.94378859e-02
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
   sys_96: -3.47189430e-02
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 1.38875772e-01
   sys_110: -1.38875772e-01
   sys_111: 1.73594715e+00
   sys_112: -1.70122820e+00
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: -3.47189430e-02
   sys_118: 6.94378859e-02
   sys_119: -1.38875772e-01
@@ -13046,13 +13046,13 @@ bins:
   sys_129: 3.47189430e-02
   sys_130: -3.47189430e-02
   sys_131: 0.0
-  sys_132: -0.0
+  sys_132: 0.0
   sys_133: 1.73594715e-01
   sys_134: -1.73594715e-01
   luminosity_uncertainty: 8.83800000e-01
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
   art_sys_5: 4.44328618e-03
   art_sys_6: 0.0
@@ -13060,92 +13060,92 @@ bins:
   art_sys_8: 3.44422933e-03
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: -9.51252728e-05
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: -2.15448156e-03
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: -2.32703303e-03
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
   art_sys_25: 4.52203489e-04
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
   art_sys_30: 3.21855355e-03
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: -1.25044854e-03
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
   art_sys_40: 2.58676170e-03
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -1.71614006e-03
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
   art_sys_51: 3.15078218e-02
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 2.88868612e-02
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: -3.37701525e-01
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
   art_sys_66: -7.81339273e-03
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
   art_sys_70: -2.44957761e-03
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
   art_sys_74: -1.42169631e-05
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: -4.19168303e-05
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: -6.08035069e-06
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
   art_sys_88: 4.28780596e-08
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 8.90742412e-01
   sys_2: -8.75115352e-01
   sys_3: 1.56270599e-02
   sys_4: -1.56270599e-02
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 1.56270599e-02
   sys_8: -1.56270599e-02
   sys_9: 4.68811796e-02
@@ -13153,7 +13153,7 @@ bins:
   sys_11: 1.56270599e-02
   sys_12: -3.12541197e-02
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 6.25082395e-02
   sys_16: -6.25082395e-02
   sys_17: 1.56270599e-02
@@ -13183,21 +13183,21 @@ bins:
   sys_41: 9.37623592e-02
   sys_42: -9.37623592e-02
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
   sys_48: -1.56270599e-02
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 1.56270599e-02
   sys_60: -1.56270599e-02
   sys_61: 1.56270599e-02
@@ -13205,17 +13205,17 @@ bins:
   sys_63: 1.56270599e-02
   sys_64: -1.56270599e-02
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
   sys_78: -1.56270599e-02
   sys_79: 1.56270599e-02
@@ -13229,33 +13229,33 @@ bins:
   sys_87: 6.25082395e-02
   sys_88: -6.25082395e-02
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
   sys_96: -1.56270599e-02
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 1.56270599e-02
   sys_102: -1.56270599e-02
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 6.25082395e-02
   sys_110: -7.81352993e-02
   sys_111: 7.50098873e-01
   sys_112: -7.18844754e-01
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: -1.56270599e-02
   sys_118: 1.56270599e-02
   sys_119: -3.12541197e-02
@@ -13271,13 +13271,13 @@ bins:
   sys_129: 1.56270599e-02
   sys_130: -1.56270599e-02
   sys_131: 0.0
-  sys_132: -0.0
+  sys_132: 0.0
   sys_133: 7.81352993e-02
   sys_134: -7.81352993e-02
   luminosity_uncertainty: 3.97800000e-01
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
   art_sys_5: -3.15755031e-04
   art_sys_6: 0.0
@@ -13285,92 +13285,92 @@ bins:
   art_sys_8: 2.69947459e-03
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 9.53126026e-04
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 4.16705433e-03
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: -1.28111477e-04
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
   art_sys_25: -9.26640812e-04
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
   art_sys_30: -1.47206210e-03
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 1.69056394e-03
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
   art_sys_40: -5.59117852e-04
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -1.85537167e-03
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
   art_sys_51: 1.80713149e-03
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: -1.63781510e-02
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: -1.70246003e-02
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
   art_sys_66: 1.65556806e-01
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
   art_sys_70: 9.41269596e-03
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
   art_sys_74: 2.38387383e-03
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: -3.25726146e-05
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: -2.35283718e-07
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
   art_sys_88: 5.96572547e-07
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 4.32268517e-01
   sys_2: -4.11352299e-01
   sys_3: 6.97207286e-03
   sys_4: -6.97207286e-03
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 6.97207286e-03
   sys_8: -6.97207286e-03
   sys_9: 2.09162186e-02
@@ -13378,7 +13378,7 @@ bins:
   sys_11: 6.97207286e-03
   sys_12: -6.97207286e-03
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 3.48603643e-02
   sys_16: -3.48603643e-02
   sys_17: 6.97207286e-03
@@ -13408,21 +13408,21 @@ bins:
   sys_41: 4.88045100e-02
   sys_42: -5.57765829e-02
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 6.97207286e-03
   sys_48: -6.97207286e-03
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
   sys_60: -6.97207286e-03
   sys_61: 6.97207286e-03
@@ -13430,19 +13430,19 @@ bins:
   sys_63: 6.97207286e-03
   sys_64: -6.97207286e-03
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 6.97207286e-03
   sys_80: -6.97207286e-03
   sys_81: 1.39441457e-02
@@ -13454,33 +13454,33 @@ bins:
   sys_87: 4.88045100e-02
   sys_88: -4.88045100e-02
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
   sys_96: -6.97207286e-03
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
   sys_100: -6.97207286e-03
   sys_101: 6.97207286e-03
   sys_102: -6.97207286e-03
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 3.48603643e-02
   sys_110: -3.48603643e-02
   sys_111: 3.20715352e-01
   sys_112: -3.06771206e-01
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: 0.0
   sys_118: -6.97207286e-03
   sys_119: 0.0
@@ -13496,13 +13496,13 @@ bins:
   sys_129: 6.97207286e-03
   sys_130: -6.97207286e-03
   sys_131: 0.0
-  sys_132: -0.0
+  sys_132: 0.0
   sys_133: 3.48603643e-02
   sys_134: -3.48603643e-02
   luminosity_uncertainty: 0.17748
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
   art_sys_5: 1.00952652e-03
   art_sys_6: 0.0
@@ -13510,92 +13510,92 @@ bins:
   art_sys_8: 8.21971106e-05
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: -1.38787719e-03
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 4.42156732e-04
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 6.47787617e-04
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
   art_sys_25: 1.44060249e-03
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
   art_sys_30: -3.49645490e-05
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: -1.39393151e-03
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
   art_sys_40: 9.82839792e-04
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -5.30998535e-04
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
   art_sys_51: -8.66300821e-05
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: -3.22855254e-03
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 6.61896711e-03
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
   art_sys_66: 1.64656363e-02
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
   art_sys_70: -9.86184257e-02
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
   art_sys_74: -6.26548479e-03
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: -9.77059408e-04
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: -3.79118860e-05
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
   art_sys_88: 1.58890740e-07
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 2.03717464e-01
   sys_2: -1.94595786e-01
   sys_3: 3.04055916e-03
   sys_4: -3.04055916e-03
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 3.04055916e-03
   sys_8: -3.04055916e-03
   sys_9: 9.12167748e-03
@@ -13603,7 +13603,7 @@ bins:
   sys_11: 3.04055916e-03
   sys_12: -3.04055916e-03
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 1.52027958e-02
   sys_16: -1.52027958e-02
   sys_17: 3.04055916e-03
@@ -13633,19 +13633,19 @@ bins:
   sys_41: 2.73650324e-02
   sys_42: -2.73650324e-02
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 3.04055916e-03
   sys_48: -3.04055916e-03
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
   sys_58: -3.04055916e-03
   sys_59: 0.0
@@ -13655,19 +13655,19 @@ bins:
   sys_63: 3.04055916e-03
   sys_64: -3.04055916e-03
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 3.04055916e-03
   sys_80: -3.04055916e-03
   sys_81: 6.08111832e-03
@@ -13679,15 +13679,15 @@ bins:
   sys_87: 2.73650324e-02
   sys_88: -2.73650324e-02
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
   sys_96: -3.04055916e-03
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 3.04055916e-03
   sys_100: -3.04055916e-03
   sys_101: 6.08111832e-03
@@ -13695,19 +13695,19 @@ bins:
   sys_103: 3.04055916e-03
   sys_104: -3.04055916e-03
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 1.52027958e-02
   sys_110: -1.52027958e-02
   sys_111: 1.36825162e-01
   sys_112: -1.30744044e-01
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 3.04055916e-03
   sys_120: 0.0
   sys_121: 6.08111832e-03
@@ -13721,13 +13721,13 @@ bins:
   sys_129: 3.04055916e-03
   sys_130: -3.04055916e-03
   sys_131: 0.0
-  sys_132: -0.0
+  sys_132: 0.0
   sys_133: 1.52027958e-02
   sys_134: -1.52027958e-02
   luminosity_uncertainty: 7.74000000e-02
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
   art_sys_5: -1.09404651e-03
   art_sys_6: 0.0
@@ -13735,92 +13735,92 @@ bins:
   art_sys_8: -6.62646501e-04
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: -7.94570300e-05
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: -3.61668794e-04
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: -8.47706268e-05
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
   art_sys_25: -1.60869026e-03
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
   art_sys_30: -7.91431867e-04
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: -2.49501975e-05
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
   art_sys_40: 7.14736485e-04
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 8.91490945e-05
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
   art_sys_51: -6.86676486e-05
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 8.57951501e-05
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 1.22234131e-03
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
   art_sys_66: -4.66375998e-03
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
   art_sys_70: -1.04944841e-02
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
   art_sys_74: 6.17784824e-02
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 2.07139205e-03
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 4.72630768e-04
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
   art_sys_88: 3.01096465e-06
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 8.80772207e-02
   sys_2: -8.31840417e-02
   sys_3: 1.22329473e-03
   sys_4: -1.22329473e-03
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 1.22329473e-03
   sys_8: -1.22329473e-03
   sys_9: 3.66988419e-03
@@ -13828,7 +13828,7 @@ bins:
   sys_11: 1.22329473e-03
   sys_12: -1.22329473e-03
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 7.33976839e-03
   sys_16: -7.33976839e-03
   sys_17: 1.22329473e-03
@@ -13858,19 +13858,19 @@ bins:
   sys_41: 1.34562420e-02
   sys_42: -1.34562420e-02
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 1.22329473e-03
   sys_48: -1.22329473e-03
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 1.22329473e-03
   sys_58: -1.22329473e-03
   sys_59: 1.22329473e-03
@@ -13880,19 +13880,19 @@ bins:
   sys_63: 1.22329473e-03
   sys_64: -1.22329473e-03
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 1.22329473e-03
   sys_80: -1.22329473e-03
   sys_81: 2.44658946e-03
@@ -13904,15 +13904,15 @@ bins:
   sys_87: 1.46795368e-02
   sys_88: -1.46795368e-02
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 1.22329473e-03
   sys_100: -1.22329473e-03
   sys_101: 3.66988419e-03
@@ -13920,19 +13920,19 @@ bins:
   sys_103: 2.44658946e-03
   sys_104: -1.22329473e-03
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 7.33976839e-03
   sys_110: -7.33976839e-03
   sys_111: 5.38249682e-02
   sys_112: -5.13783787e-02
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 1.22329473e-03
   sys_120: -1.22329473e-03
   sys_121: 1.22329473e-03
@@ -13946,13 +13946,13 @@ bins:
   sys_129: 1.22329473e-03
   sys_130: -1.22329473e-03
   sys_131: 0.0
-  sys_132: -0.0
+  sys_132: 0.0
   sys_133: 6.11647366e-03
   sys_134: -6.11647366e-03
   luminosity_uncertainty: 3.11400000e-02
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
   art_sys_5: 3.75781788e-04
   art_sys_6: 0.0
@@ -13960,92 +13960,92 @@ bins:
   art_sys_8: 7.28712227e-04
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 4.74809621e-05
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: -2.73257032e-05
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 4.92798949e-04
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
   art_sys_25: -2.30799618e-05
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
   art_sys_30: -2.46427648e-04
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 2.12589442e-04
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
   art_sys_40: 1.29647884e-04
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 2.93203289e-04
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
   art_sys_51: 1.15086968e-04
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: -5.98935240e-05
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 3.14330514e-04
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
   art_sys_66: -8.88056712e-04
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
   art_sys_70: 2.10461293e-03
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
   art_sys_74: 3.93965717e-03
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: -3.50112283e-02
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: -1.49379990e-03
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
   art_sys_88: -2.38061588e-05
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 3.31039111e-02
   sys_2: -3.09260222e-02
   sys_3: 4.35577777e-04
   sys_4: -4.35577777e-04
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 4.35577777e-04
   sys_8: -4.35577777e-04
   sys_9: 1.30673333e-03
@@ -14053,7 +14053,7 @@ bins:
   sys_11: 4.35577777e-04
   sys_12: -4.35577777e-04
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 2.61346666e-03
   sys_16: -2.61346666e-03
   sys_17: 4.35577777e-04
@@ -14083,17 +14083,17 @@ bins:
   sys_41: 5.66251110e-03
   sys_42: -5.66251110e-03
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 4.35577777e-04
   sys_48: -4.35577777e-04
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 4.35577777e-04
   sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
   sys_56: -4.35577777e-04
   sys_57: 4.35577777e-04
@@ -14105,19 +14105,19 @@ bins:
   sys_63: 4.35577777e-04
   sys_64: -4.35577777e-04
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 4.35577777e-04
   sys_80: -4.35577777e-04
   sys_81: 8.71155554e-04
@@ -14129,15 +14129,15 @@ bins:
   sys_87: 6.09808888e-03
   sys_88: -6.09808888e-03
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 4.35577777e-04
   sys_100: -4.35577777e-04
   sys_101: 1.74231111e-03
@@ -14147,17 +14147,17 @@ bins:
   sys_105: 4.35577777e-04
   sys_106: -4.35577777e-04
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 3.04904444e-03
   sys_110: -3.04904444e-03
   sys_111: 1.91654222e-02
   sys_112: -1.78586889e-02
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 4.35577777e-04
   sys_120: -4.35577777e-04
   sys_121: 4.35577777e-04
@@ -14177,7 +14177,7 @@ bins:
   luminosity_uncertainty: 0.011088
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
   art_sys_5: 7.30622835e-05
   art_sys_6: 0.0
@@ -14185,92 +14185,92 @@ bins:
   art_sys_8: 8.67752216e-06
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: -5.18515278e-04
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: -2.58460568e-05
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 3.23848987e-04
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
   art_sys_25: 1.04490218e-04
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
   art_sys_30: 1.81578800e-04
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 1.93298848e-04
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
   art_sys_40: -6.84279374e-06
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -1.16004230e-04
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
   art_sys_51: 1.97725129e-05
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 8.90667264e-05
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: -1.04359120e-04
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
   art_sys_66: 8.37153065e-05
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
   art_sys_70: 2.43272098e-04
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
   art_sys_74: -1.31494654e-03
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: -2.97926610e-03
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 1.79118225e-02
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
   art_sys_88: 3.90299005e-05
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 1.07678221e-02
   sys_2: -9.97020561e-03
   sys_3: 1.32936075e-04
   sys_4: -1.32936075e-04
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 1.32936075e-04
   sys_8: -1.32936075e-04
   sys_9: 3.98808225e-04
@@ -14278,7 +14278,7 @@ bins:
   sys_11: 1.32936075e-04
   sys_12: -1.32936075e-04
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 9.30552524e-04
   sys_16: -9.30552524e-04
   sys_17: 1.32936075e-04
@@ -14308,17 +14308,17 @@ bins:
   sys_41: 1.99404112e-03
   sys_42: -1.86110505e-03
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 1.32936075e-04
   sys_48: -1.32936075e-04
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 1.32936075e-04
   sys_52: -1.32936075e-04
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
   sys_56: -1.32936075e-04
   sys_57: 1.32936075e-04
@@ -14330,19 +14330,19 @@ bins:
   sys_63: 1.32936075e-04
   sys_64: -1.32936075e-04
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 1.32936075e-04
   sys_80: -1.32936075e-04
   sys_81: 3.98808225e-04
@@ -14354,15 +14354,15 @@ bins:
   sys_87: 2.12697720e-03
   sys_88: -2.12697720e-03
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 1.32936075e-04
   sys_100: -1.32936075e-04
   sys_101: 6.64680374e-04
@@ -14372,7 +14372,7 @@ bins:
   sys_105: 1.32936075e-04
   sys_106: -1.32936075e-04
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 1.06348860e-03
   sys_110: -1.06348860e-03
   sys_111: 5.84918729e-03
@@ -14380,13 +14380,13 @@ bins:
   sys_113: 0.0
   sys_114: -1.32936075e-04
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 2.65872150e-04
   sys_120: -1.32936075e-04
   sys_121: 0.0
-  sys_122: -0.0
+  sys_122: 0.0
   sys_123: 2.65872150e-04
   sys_124: -2.65872150e-04
   sys_125: 1.72816897e-03
@@ -14402,7 +14402,7 @@ bins:
   luminosity_uncertainty: 3.38400000e-03
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
   art_sys_5: 5.65398720e-05
   art_sys_6: 0.0
@@ -14410,92 +14410,92 @@ bins:
   art_sys_8: 6.49130100e-06
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: -9.75490832e-06
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 6.89014973e-06
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 2.50663143e-05
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
   art_sys_25: 2.07886872e-06
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
   art_sys_30: -1.45812828e-05
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 7.69113733e-07
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
   art_sys_40: 9.58227234e-06
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 1.45046920e-05
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
   art_sys_51: 3.71925535e-05
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 3.84229834e-05
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: -8.16692233e-06
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
   art_sys_66: 3.37707324e-05
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
   art_sys_70: -2.47368030e-05
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
   art_sys_74: 1.24092432e-05
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 2.17139387e-04
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 2.20986029e-04
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
   art_sys_88: -3.33086376e-03
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 2.03010357e-03
   sys_2: -1.80863772e-03
   sys_3: 1.84554870e-05
   sys_4: -1.84554870e-05
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 3.69109740e-05
   sys_8: -1.84554870e-05
   sys_9: 1.10732922e-04
@@ -14503,7 +14503,7 @@ bins:
   sys_11: 1.84554870e-05
   sys_12: -1.84554870e-05
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 2.03010357e-04
   sys_16: -1.84554870e-04
   sys_17: 1.84554870e-05
@@ -14533,17 +14533,17 @@ bins:
   sys_41: 4.79842662e-04
   sys_42: -4.42931688e-04
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 5.53664610e-05
   sys_48: -3.69109740e-05
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 3.69109740e-05
   sys_52: -3.69109740e-05
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 1.84554870e-05
   sys_56: -1.84554870e-05
   sys_57: 3.69109740e-05
@@ -14555,19 +14555,19 @@ bins:
   sys_63: 1.84554870e-05
   sys_64: -1.84554870e-05
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 1.84554870e-05
   sys_74: -1.84554870e-05
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 1.84554870e-05
   sys_80: -1.84554870e-05
   sys_81: 7.38219480e-05
@@ -14579,15 +14579,15 @@ bins:
   sys_87: 4.61387175e-04
   sys_88: -4.24476201e-04
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 1.84554870e-05
   sys_100: -1.84554870e-05
   sys_101: 2.03010357e-04
@@ -14597,7 +14597,7 @@ bins:
   sys_105: 3.69109740e-05
   sys_106: -3.69109740e-05
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 2.58376818e-04
   sys_110: -2.58376818e-04
   sys_111: 9.04318862e-04
@@ -14605,13 +14605,13 @@ bins:
   sys_113: 5.53664610e-05
   sys_114: -7.38219480e-05
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 3.69109740e-05
   sys_120: -1.84554870e-05
   sys_121: 0.0
-  sys_122: -0.0
+  sys_122: 0.0
   sys_123: 3.69109740e-05
   sys_124: -3.69109740e-05
   sys_125: 2.58376818e-04
@@ -14619,7 +14619,7 @@ bins:
   sys_127: 6.27486558e-04
   sys_128: -6.27486558e-04
   sys_129: 0.0
-  sys_130: -0.0
+  sys_130: 0.0
   sys_131: 3.13743279e-04
   sys_132: -3.13743279e-04
   sys_133: 9.22774349e-05
@@ -14627,9 +14627,9 @@ bins:
   luminosity_uncertainty: 4.69800000e-04
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
@@ -14638,95 +14638,95 @@ bins:
   art_sys_11: 1.05822332e+02
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 1.54662983e+01
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 9.68552044e-01
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 1.74252968e-01
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 5.26652034e-04
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
   art_sys_32: 6.13531138e-03
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 1.75138934e-03
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 7.29104001e-04
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
   art_sys_48: 2.48096920e-05
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 2.28006616e-05
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: 3.24912541e-06
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
   art_sys_65: 2.03780513e-07
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
+  art_sys_72: 0.0
   art_sys_73: 1.01661787e-07
-  art_sys_74: -0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
+  art_sys_76: 0.0
   art_sys_77: 5.42627878e-08
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 7.17831092e-09
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 1.33458464e-10
-  art_sys_88: -0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 1.26260987e+03
   sys_2: -1.22753737e+03
   sys_3: 2.80579971e+02
   sys_4: -2.80579971e+02
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 1.40289985e+02
   sys_8: -1.40289985e+02
   sys_9: 5.96232438e+02
   sys_10: -5.96232438e+02
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 3.50724963e+01
   sys_14: -3.50724963e+01
   sys_15: 2.10434978e+02
@@ -14742,25 +14742,25 @@ bins:
   sys_25: 2.45507474e+02
   sys_26: -2.45507474e+02
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 0.0
-  sys_30: -0.0
+  sys_30: 0.0
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
   sys_36: -3.50724963e+01
   sys_37: 0.0
-  sys_38: -0.0
+  sys_38: 0.0
   sys_39: 0.0
-  sys_40: -0.0
+  sys_40: 0.0
   sys_41: 0.0
-  sys_42: -0.0
+  sys_42: 0.0
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 3.50724963e+01
   sys_48: -3.50724963e+01
   sys_49: 3.50724963e+01
@@ -14778,59 +14778,59 @@ bins:
   sys_61: 7.01449927e+01
   sys_62: -7.01449927e+01
   sys_63: 0.0
-  sys_64: -0.0
+  sys_64: 0.0
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 3.50724963e+01
   sys_70: -3.50724963e+01
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 3.50724963e+01
   sys_74: -3.50724963e+01
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 2.45507474e+02
   sys_110: -2.10434978e+02
   sys_111: 3.85797460e+03
   sys_112: -3.50724963e+03
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: -1.40289985e+02
   sys_118: 1.05217489e+02
   sys_119: -4.91014949e+02
@@ -14852,9 +14852,9 @@ bins:
   luminosity_uncertainty: 8.92800000e+02
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
@@ -14863,89 +14863,89 @@ bins:
   art_sys_11: -5.48380604e+02
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: -4.00954459e+01
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: -7.90760820e+00
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: -4.44007650e-01
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: -5.39301823e-02
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
   art_sys_32: -1.87162444e-03
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 2.28485908e-04
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: -4.18398407e-04
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
   art_sys_48: -3.18959075e-05
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: -5.08200322e-06
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: -1.10585096e-06
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
   art_sys_65: 1.05548441e-07
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
+  art_sys_72: 0.0
   art_sys_73: 3.05399083e-08
-  art_sys_74: -0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
+  art_sys_76: 0.0
   art_sys_77: -2.46576399e-08
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: -1.03499634e-08
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: -6.38749618e-11
-  art_sys_88: -0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 6.85186471e+02
   sys_2: -6.67155248e+02
   sys_3: 1.44249783e+02
   sys_4: -1.44249783e+02
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 7.21248917e+01
   sys_8: -7.21248917e+01
   sys_9: 2.88499567e+02
@@ -14967,25 +14967,25 @@ bins:
   sys_25: 1.26218560e+02
   sys_26: -1.26218560e+02
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 0.0
-  sys_30: -0.0
+  sys_30: 0.0
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
   sys_36: -1.80312229e+01
   sys_37: 0.0
-  sys_38: -0.0
+  sys_38: 0.0
   sys_39: 1.80312229e+01
   sys_40: 0.0
   sys_41: 1.80312229e+01
   sys_42: 0.0
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 1.80312229e+01
   sys_48: 0.0
   sys_49: 1.80312229e+01
@@ -15003,59 +15003,59 @@ bins:
   sys_61: 5.40936688e+01
   sys_62: -5.40936688e+01
   sys_63: 0.0
-  sys_64: -0.0
+  sys_64: 0.0
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 1.80312229e+01
   sys_74: -1.80312229e+01
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 1.26218560e+02
   sys_110: -1.08187338e+02
   sys_111: 1.98343452e+03
   sys_112: -1.80312229e+03
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: -7.21248917e+01
   sys_118: 7.21248917e+01
   sys_119: -2.52437121e+02
@@ -15077,9 +15077,9 @@ bins:
   luminosity_uncertainty: 4.59000000e+02
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
@@ -15088,89 +15088,89 @@ bins:
   art_sys_11: -9.17846196e+01
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 2.64335774e+02
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 2.82224968e+01
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 3.37737435e+00
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 2.58525355e-01
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
   art_sys_32: -4.93910361e-02
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 6.41359012e-04
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 1.05304412e-03
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
   art_sys_48: 4.99850286e-05
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 2.38715890e-05
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: -6.36227631e-06
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
   art_sys_65: -2.17630487e-07
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
+  art_sys_72: 0.0
   art_sys_73: 2.74463201e-07
-  art_sys_74: -0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
+  art_sys_76: 0.0
   art_sys_77: 1.66565097e-07
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 1.12107781e-08
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: -2.07223164e-10
-  art_sys_88: -0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 3.45068109e+02
   sys_2: -3.36441406e+02
   sys_3: 6.90136218e+01
   sys_4: -6.03869191e+01
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 3.45068109e+01
   sys_8: -3.45068109e+01
   sys_9: 1.29400541e+02
@@ -15178,7 +15178,7 @@ bins:
   sys_11: 8.62670273e+00
   sys_12: 0.0
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 5.17602164e+01
   sys_16: -5.17602164e+01
   sys_17: 8.62670273e+00
@@ -15196,21 +15196,21 @@ bins:
   sys_29: 0.0
   sys_30: -8.62670273e+00
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 8.62670273e+00
   sys_36: -8.62670273e+00
   sys_37: 0.0
-  sys_38: -0.0
+  sys_38: 0.0
   sys_39: 8.62670273e+00
   sys_40: 0.0
   sys_41: 8.62670273e+00
   sys_42: -8.62670273e+00
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 8.62670273e+00
   sys_48: 0.0
   sys_49: 8.62670273e+00
@@ -15230,57 +15230,57 @@ bins:
   sys_63: 8.62670273e+00
   sys_64: 0.0
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 8.62670273e+00
   sys_74: -8.62670273e+00
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 6.03869191e+01
   sys_110: -5.17602164e+01
   sys_111: 1.03520433e+03
   sys_112: -9.48937300e+02
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: -3.45068109e+01
   sys_118: 3.45068109e+01
   sys_119: -1.20773838e+02
@@ -15296,15 +15296,15 @@ bins:
   sys_129: 2.58801082e+01
   sys_130: -2.58801082e+01
   sys_131: 0.0
-  sys_132: -0.0
+  sys_132: 0.0
   sys_133: 4.31335137e+01
   sys_134: -4.31335137e+01
   luminosity_uncertainty: 2.19600000e+02
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
@@ -15313,89 +15313,89 @@ bins:
   art_sys_11: 1.21576343e+01
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 5.35467638e+01
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: -1.47703546e+02
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: -9.30058149e+00
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: -2.12197547e+00
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
   art_sys_32: 6.27801622e-02
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: -1.07652466e-02
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: -1.17164265e-03
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
   art_sys_48: 2.25238844e-05
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: -5.54662882e-05
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: -2.51878317e-05
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
   art_sys_65: 4.62254240e-06
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
+  art_sys_72: 0.0
   art_sys_73: -3.11603567e-07
-  art_sys_74: -0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
+  art_sys_76: 0.0
   art_sys_77: -2.88768546e-07
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: -1.21574040e-08
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: -6.21697638e-10
-  art_sys_88: -0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 1.82348697e+02
   sys_2: -1.78007061e+02
   sys_3: 3.03914495e+01
   sys_4: -3.03914495e+01
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 1.30249069e+01
   sys_8: -1.73665425e+01
   sys_9: 6.07828989e+01
@@ -15403,7 +15403,7 @@ bins:
   sys_11: 4.34163564e+00
   sys_12: -4.34163564e+00
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 2.60498138e+01
   sys_16: -2.60498138e+01
   sys_17: 4.34163564e+00
@@ -15421,9 +15421,9 @@ bins:
   sys_29: 0.0
   sys_30: -4.34163564e+00
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 4.34163564e+00
   sys_36: -4.34163564e+00
   sys_37: 4.34163564e+00
@@ -15433,13 +15433,13 @@ bins:
   sys_41: 4.34163564e+00
   sys_42: -4.34163564e+00
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 4.34163564e+00
   sys_52: -4.34163564e+00
   sys_53: 4.34163564e+00
@@ -15455,57 +15455,57 @@ bins:
   sys_63: 4.34163564e+00
   sys_64: 0.0
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 4.34163564e+00
   sys_74: -4.34163564e+00
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 3.03914495e+01
   sys_110: -2.60498138e+01
   sys_111: 5.20996276e+02
   sys_112: -4.77579920e+02
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: -1.73665425e+01
   sys_118: 1.73665425e+01
   sys_119: -6.51245345e+01
@@ -15521,15 +15521,15 @@ bins:
   sys_129: 1.30249069e+01
   sys_130: -1.30249069e+01
   sys_131: 0.0
-  sys_132: -0.0
+  sys_132: 0.0
   sys_133: 2.17081782e+01
   sys_134: -2.17081782e+01
   luminosity_uncertainty: 1.10520000e+02
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
@@ -15538,89 +15538,89 @@ bins:
   art_sys_11: 2.37026067e+00
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: -5.67694994e+00
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: -2.21383210e+01
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 6.88004975e+01
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 6.79426548e+00
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
   art_sys_32: -1.08646485e+00
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 5.72672639e-02
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 3.69348743e-03
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
   art_sys_48: -9.81332931e-05
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: -8.25164443e-05
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: -2.91006884e-05
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
   art_sys_65: -8.24371422e-06
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
+  art_sys_72: 0.0
   art_sys_73: 5.55643028e-07
-  art_sys_74: -0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
+  art_sys_76: 0.0
   art_sys_77: 4.38999593e-07
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 7.12822837e-08
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 3.92018610e-09
-  art_sys_88: -0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 8.77378094e+01
   sys_2: -8.57437683e+01
   sys_3: 1.19642467e+01
   sys_4: -1.19642467e+01
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 5.98212337e+00
   sys_8: -5.98212337e+00
   sys_9: 2.59225346e+01
@@ -15628,7 +15628,7 @@ bins:
   sys_11: 3.98808225e+00
   sys_12: -3.98808225e+00
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 1.19642467e+01
   sys_16: -9.97020561e+00
   sys_17: 1.99404112e+00
@@ -15646,9 +15646,9 @@ bins:
   sys_29: 0.0
   sys_30: -1.99404112e+00
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 3.98808225e+00
   sys_36: -3.98808225e+00
   sys_37: 1.99404112e+00
@@ -15658,13 +15658,13 @@ bins:
   sys_41: 3.98808225e+00
   sys_42: -1.99404112e+00
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
   sys_52: -1.99404112e+00
   sys_53: 1.99404112e+00
@@ -15680,57 +15680,57 @@ bins:
   sys_63: 1.99404112e+00
   sys_64: 0.0
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 1.99404112e+00
   sys_74: -1.99404112e+00
   sys_75: 0.0
   sys_76: -1.99404112e+00
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 1.39582879e+01
   sys_110: -1.39582879e+01
   sys_111: 2.39284935e+02
   sys_112: -2.19344524e+02
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: -7.97616449e+00
   sys_118: 9.97020561e+00
   sys_119: -2.79165757e+01
@@ -15746,15 +15746,15 @@ bins:
   sys_129: 3.98808225e+00
   sys_130: -3.98808225e+00
   sys_131: 0.0
-  sys_132: -0.0
+  sys_132: 0.0
   sys_133: 9.97020561e+00
   sys_134: -9.97020561e+00
   luminosity_uncertainty: 5.07600000e+01
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
@@ -15763,89 +15763,89 @@ bins:
   art_sys_11: -1.23682561e-01
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: -2.01230116e+00
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 4.15881071e+00
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 1.26644212e+01
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: -3.93721103e+01
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
   art_sys_32: 2.80465106e+00
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: -4.36143863e-01
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: -1.72570304e-02
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
   art_sys_48: -5.55025645e-04
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: -1.89921974e-04
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: 7.31993643e-05
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
   art_sys_65: 9.33566451e-07
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
+  art_sys_72: 0.0
   art_sys_73: 1.61604621e-06
-  art_sys_74: -0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
+  art_sys_76: 0.0
   art_sys_77: 5.89096510e-07
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: -8.32020540e-08
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: -3.47346911e-09
-  art_sys_88: -0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 4.78569870e+01
   sys_2: -4.58205194e+01
   sys_3: 5.09116882e+00
   sys_4: -5.09116882e+00
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 3.05470129e+00
   sys_8: -3.05470129e+00
   sys_9: 1.12005714e+01
@@ -15853,7 +15853,7 @@ bins:
   sys_11: 2.03646753e+00
   sys_12: -3.05470129e+00
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 5.09116882e+00
   sys_16: -5.09116882e+00
   sys_17: 1.01823376e+00
@@ -15883,15 +15883,15 @@ bins:
   sys_41: 2.03646753e+00
   sys_42: -2.03646753e+00
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 1.01823376e+00
   sys_54: -1.01823376e+00
   sys_55: 1.01823376e+00
@@ -15905,13 +15905,13 @@ bins:
   sys_63: 1.01823376e+00
   sys_64: -1.01823376e+00
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 1.01823376e+00
   sys_74: -1.01823376e+00
   sys_75: 0.0
@@ -15921,41 +15921,41 @@ bins:
   sys_79: 1.01823376e+00
   sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 7.12763635e+00
   sys_110: -7.12763635e+00
   sys_111: 1.22188052e+02
   sys_112: -1.12005714e+02
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: -4.07293506e+00
   sys_118: 5.09116882e+00
   sys_119: -1.42552727e+01
@@ -15971,15 +15971,15 @@ bins:
   sys_129: 2.03646753e+00
   sys_130: -2.03646753e+00
   sys_131: 0.0
-  sys_132: -0.0
+  sys_132: 0.0
   sys_133: 5.09116882e+00
   sys_134: -5.09116882e+00
   luminosity_uncertainty: 25.92
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
@@ -15988,89 +15988,89 @@ bins:
   art_sys_11: 1.89706708e-01
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: -4.29940313e-01
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 1.20519807e+00
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: -1.87521084e+00
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: -5.80882287e+00
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
   art_sys_32: -2.07399830e+01
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 1.33860944e+00
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 1.83095320e-01
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
   art_sys_48: -3.87932213e-04
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 1.32983776e-03
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: -1.19885874e-04
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
   art_sys_65: -3.04898435e-05
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
+  art_sys_72: 0.0
   art_sys_73: 3.71659240e-06
-  art_sys_74: -0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
+  art_sys_76: 0.0
   art_sys_77: -8.22742847e-07
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: -3.78076522e-07
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 6.72876271e-09
-  art_sys_88: -0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 2.38033356e+01
   sys_2: -2.28317709e+01
   sys_3: 2.42891179e+00
   sys_4: -2.42891179e+00
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 9.71564717e-01
   sys_8: -1.45734708e+00
   sys_9: 4.85782359e+00
@@ -16078,7 +16078,7 @@ bins:
   sys_11: 1.45734708e+00
   sys_12: -1.45734708e+00
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 2.42891179e+00
   sys_16: -2.42891179e+00
   sys_17: 4.85782359e-01
@@ -16108,17 +16108,17 @@ bins:
   sys_41: 1.45734708e+00
   sys_42: -1.45734708e+00
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 4.85782359e-01
   sys_56: -4.85782359e-01
   sys_57: 4.85782359e-01
@@ -16130,13 +16130,13 @@ bins:
   sys_63: 9.71564717e-01
   sys_64: -4.85782359e-01
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 4.85782359e-01
   sys_74: -4.85782359e-01
   sys_75: 4.85782359e-01
@@ -16148,39 +16148,39 @@ bins:
   sys_81: 4.85782359e-01
   sys_82: -4.85782359e-01
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 2.91469415e+00
   sys_110: -2.91469415e+00
   sys_111: 5.82938830e+01
   sys_112: -5.34360595e+01
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: -1.94312943e+00
   sys_118: 2.42891179e+00
   sys_119: -7.28673538e+00
@@ -16196,15 +16196,15 @@ bins:
   sys_129: 9.71564717e-01
   sys_130: -9.71564717e-01
   sys_131: 0.0
-  sys_132: -0.0
+  sys_132: 0.0
   sys_133: 2.42891179e+00
   sys_134: -2.42891179e+00
   luminosity_uncertainty: 1.23660000e+01
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
@@ -16213,89 +16213,89 @@ bins:
   art_sys_11: 3.44222239e-02
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: -3.53092675e-02
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 1.83821823e-02
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: -3.82806679e-01
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 9.20211168e-01
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
   art_sys_32: -2.81729485e+00
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: -1.04761471e+01
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: -5.13238656e-01
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
   art_sys_48: -4.20263416e-02
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: -2.36760669e-03
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: -9.22751094e-05
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
   art_sys_65: 2.07729945e-05
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
+  art_sys_72: 0.0
   art_sys_73: 8.21937211e-06
-  art_sys_74: -0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
+  art_sys_76: 0.0
   art_sys_77: 1.10751250e-06
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: -1.01860325e-07
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 8.39216964e-09
-  art_sys_88: -0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 1.25384174e+01
   sys_2: -1.18150472e+01
   sys_3: 9.64493650e-01
   sys_4: -9.64493650e-01
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 4.82246825e-01
   sys_8: -4.82246825e-01
   sys_9: 2.17011071e+00
@@ -16303,7 +16303,7 @@ bins:
   sys_11: 7.23370237e-01
   sys_12: -9.64493650e-01
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 1.20561706e+00
   sys_16: -1.20561706e+00
   sys_17: 2.41123412e-01
@@ -16333,17 +16333,17 @@ bins:
   sys_41: 7.23370237e-01
   sys_42: -7.23370237e-01
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 2.41123412e-01
   sys_56: -2.41123412e-01
   sys_57: 2.41123412e-01
@@ -16355,13 +16355,13 @@ bins:
   sys_63: 4.82246825e-01
   sys_64: -2.41123412e-01
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 2.41123412e-01
   sys_74: -2.41123412e-01
   sys_75: 2.41123412e-01
@@ -16375,37 +16375,37 @@ bins:
   sys_83: 0.0
   sys_84: -2.41123412e-01
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 1.44674047e+00
   sys_110: -1.44674047e+00
   sys_111: 2.89348095e+01
   sys_112: -2.65235754e+01
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: -9.64493650e-01
   sys_118: 1.20561706e+00
   sys_119: -3.85797460e+00
@@ -16421,15 +16421,15 @@ bins:
   sys_129: 4.82246825e-01
   sys_130: -4.82246825e-01
   sys_131: 0.0
-  sys_132: -0.0
+  sys_132: 0.0
   sys_133: 1.20561706e+00
   sys_134: -1.20561706e+00
   luminosity_uncertainty: 6.13800000e+00
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
@@ -16438,89 +16438,89 @@ bins:
   art_sys_11: -4.26261348e-02
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: -3.78322062e-02
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: -4.99806505e-02
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 1.83227932e-02
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 1.56455053e-01
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
   art_sys_32: 4.48493738e-01
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: -1.07499026e+00
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 5.29032997e+00
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
   art_sys_48: 1.13699489e-01
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 3.17628351e-02
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: -7.09890408e-04
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
   art_sys_65: -1.43014484e-04
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
+  art_sys_72: 0.0
   art_sys_73: 1.26575439e-05
-  art_sys_74: -0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
+  art_sys_76: 0.0
   art_sys_77: 4.77472112e-06
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: -1.76815490e-06
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: -2.33251710e-08
-  art_sys_88: -0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 5.72756493e+00
   sys_2: -5.40936688e+00
   sys_3: 3.18198052e-01
   sys_4: -4.24264069e-01
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 2.12132034e-01
   sys_8: -2.12132034e-01
   sys_9: 8.48528137e-01
@@ -16528,7 +16528,7 @@ bins:
   sys_11: 3.18198052e-01
   sys_12: -4.24264069e-01
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 5.30330086e-01
   sys_16: -5.30330086e-01
   sys_17: 1.06066017e-01
@@ -16558,17 +16558,17 @@ bins:
   sys_41: 3.18198052e-01
   sys_42: -3.18198052e-01
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
   sys_56: -1.06066017e-01
   sys_57: 1.06066017e-01
@@ -16580,13 +16580,13 @@ bins:
   sys_63: 2.12132034e-01
   sys_64: -2.12132034e-01
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
   sys_74: -1.06066017e-01
   sys_75: 1.06066017e-01
@@ -16600,37 +16600,37 @@ bins:
   sys_83: 1.06066017e-01
   sys_84: -1.06066017e-01
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 6.36396103e-01
   sys_110: -6.36396103e-01
   sys_111: 1.27279221e+01
   sys_112: -1.16672619e+01
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: -3.18198052e-01
   sys_118: 4.24264069e-01
   sys_119: -1.80312229e+00
@@ -16646,15 +16646,15 @@ bins:
   sys_129: 2.12132034e-01
   sys_130: -2.12132034e-01
   sys_131: 0.0
-  sys_132: -0.0
+  sys_132: 0.0
   sys_133: 5.30330086e-01
   sys_134: -5.30330086e-01
   luminosity_uncertainty: 2.7
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
@@ -16663,89 +16663,89 @@ bins:
   art_sys_11: 5.07072742e-03
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 8.62605994e-03
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: -3.77119608e-03
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 1.83012396e-03
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 1.70692257e-03
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
   art_sys_32: 9.41898568e-02
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 1.70815093e-01
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 3.55861120e-01
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
   art_sys_48: -1.82516318e+00
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: -1.17675942e-01
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: 1.11312913e-02
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
   art_sys_65: 1.40460505e-04
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
+  art_sys_72: 0.0
   art_sys_73: -1.81214163e-05
-  art_sys_74: -0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
+  art_sys_76: 0.0
   art_sys_77: 4.41253808e-06
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 2.95108891e-06
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 4.99886735e-08
-  art_sys_88: -0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 2.55131198e+00
   sys_2: -2.41703240e+00
   sys_3: 1.34279578e-01
   sys_4: -1.34279578e-01
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 8.95197185e-02
   sys_8: -8.95197185e-02
   sys_9: 3.13319015e-01
@@ -16753,7 +16753,7 @@ bins:
   sys_11: 1.34279578e-01
   sys_12: -1.34279578e-01
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 2.23799296e-01
   sys_16: -2.23799296e-01
   sys_17: 4.47598592e-02
@@ -16783,17 +16783,17 @@ bins:
   sys_41: 1.79039437e-01
   sys_42: -1.79039437e-01
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
   sys_56: -4.47598592e-02
   sys_57: 4.47598592e-02
@@ -16805,15 +16805,15 @@ bins:
   sys_63: 8.95197185e-02
   sys_64: -8.95197185e-02
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
   sys_76: -4.47598592e-02
   sys_77: 4.47598592e-02
@@ -16827,35 +16827,35 @@ bins:
   sys_85: 4.47598592e-02
   sys_86: -4.47598592e-02
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 2.68559155e-01
   sys_110: -2.68559155e-01
   sys_111: 5.37118311e+00
   sys_112: -4.92358452e+00
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: -1.34279578e-01
   sys_118: 1.79039437e-01
   sys_119: -7.60917607e-01
@@ -16871,15 +16871,15 @@ bins:
   sys_129: 8.95197185e-02
   sys_130: -8.95197185e-02
   sys_131: 0.0
-  sys_132: -0.0
+  sys_132: 0.0
   sys_133: 2.23799296e-01
   sys_134: -2.23799296e-01
   luminosity_uncertainty: 1.13940000e+00
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
@@ -16888,89 +16888,89 @@ bins:
   art_sys_11: -1.72112671e-04
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: -2.40189713e-03
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: -9.43149334e-03
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 8.29446490e-03
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: -2.25323746e-03
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
   art_sys_32: 1.83356707e-02
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 2.73408436e-02
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: -1.23995592e-01
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
   art_sys_48: -2.15563571e-01
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 1.02220431e+00
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: -4.12383680e-02
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
   art_sys_65: -4.05735515e-03
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
+  art_sys_72: 0.0
   art_sys_73: -9.43846780e-05
-  art_sys_74: -0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
+  art_sys_76: 0.0
   art_sys_77: -2.38666196e-06
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: -2.78743069e-06
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 1.64409273e-07
-  art_sys_88: -0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 1.28976277e+00
   sys_2: -1.22527463e+00
   sys_3: 6.44881384e-02
   sys_4: -6.44881384e-02
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 2.14960461e-02
   sys_8: -2.14960461e-02
   sys_9: 1.28976277e-01
@@ -16978,7 +16978,7 @@ bins:
   sys_11: 6.44881384e-02
   sys_12: -6.44881384e-02
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 1.07480231e-01
   sys_16: -1.07480231e-01
   sys_17: 2.14960461e-02
@@ -17008,19 +17008,19 @@ bins:
   sys_41: 1.07480231e-01
   sys_42: -8.59841846e-02
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 2.14960461e-02
   sys_58: -2.14960461e-02
   sys_59: 2.14960461e-02
@@ -17030,15 +17030,15 @@ bins:
   sys_63: 4.29920923e-02
   sys_64: -4.29920923e-02
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
   sys_76: -2.14960461e-02
   sys_77: 2.14960461e-02
@@ -17052,35 +17052,35 @@ bins:
   sys_85: 2.14960461e-02
   sys_86: -4.29920923e-02
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 1.28976277e-01
   sys_110: -1.28976277e-01
   sys_111: 2.57952554e+00
   sys_112: -2.14960461e+00
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: -6.44881384e-02
   sys_118: 8.59841846e-02
   sys_119: -3.22440692e-01
@@ -17096,15 +17096,15 @@ bins:
   sys_129: 4.29920923e-02
   sys_130: -4.29920923e-02
   sys_131: 0.0
-  sys_132: -0.0
+  sys_132: 0.0
   sys_133: 1.07480231e-01
   sys_134: -1.07480231e-01
   luminosity_uncertainty: 0.5472
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
@@ -17113,89 +17113,89 @@ bins:
   art_sys_11: -2.38809486e-03
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 5.09633103e-03
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: -9.16298949e-03
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 1.98606442e-03
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 4.72702922e-03
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
   art_sys_32: -5.90701995e-03
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: -4.45676358e-03
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: -1.04285455e-02
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
   art_sys_48: 2.23791159e-02
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 8.64339671e-02
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: 5.08482032e-01
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
   art_sys_65: 1.00521977e-02
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
+  art_sys_72: 0.0
   art_sys_73: 1.36673291e-03
-  art_sys_74: -0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
+  art_sys_76: 0.0
   art_sys_77: 9.78069847e-05
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 1.95415916e-06
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 4.76338721e-08
-  art_sys_88: -0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 5.47583491e-01
   sys_2: -5.21915515e-01
   sys_3: 1.71119841e-02
   sys_4: -1.71119841e-02
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 8.55599205e-03
   sys_8: -8.55599205e-03
   sys_9: 4.27799603e-02
@@ -17203,7 +17203,7 @@ bins:
   sys_11: 2.56679762e-02
   sys_12: -2.56679762e-02
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 4.27799603e-02
   sys_16: -4.27799603e-02
   sys_17: 8.55599205e-03
@@ -17233,19 +17233,19 @@ bins:
   sys_41: 4.27799603e-02
   sys_42: -4.27799603e-02
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
   sys_48: -8.55599205e-03
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 8.55599205e-03
   sys_58: -8.55599205e-03
   sys_59: 8.55599205e-03
@@ -17255,17 +17255,17 @@ bins:
   sys_63: 1.71119841e-02
   sys_64: -1.71119841e-02
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 8.55599205e-03
   sys_78: -8.55599205e-03
   sys_79: 1.71119841e-02
@@ -17279,33 +17279,33 @@ bins:
   sys_87: 8.55599205e-03
   sys_88: -8.55599205e-03
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 5.98919444e-02
   sys_110: -5.98919444e-02
   sys_111: 1.02671905e+00
   sys_112: -8.55599205e-01
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: -2.56679762e-02
   sys_118: 2.56679762e-02
   sys_119: -1.11227897e-01
@@ -17321,15 +17321,15 @@ bins:
   sys_129: 1.71119841e-02
   sys_130: -1.71119841e-02
   sys_131: 0.0
-  sys_132: -0.0
+  sys_132: 0.0
   sys_133: 4.27799603e-02
   sys_134: -4.27799603e-02
   luminosity_uncertainty: 2.17800000e-01
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
@@ -17338,89 +17338,89 @@ bins:
   art_sys_11: -2.86526427e-05
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 1.66616724e-03
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: -2.98594765e-03
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: -2.86810562e-03
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 6.16518490e-04
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
   art_sys_32: 2.01777641e-03
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: -1.29831166e-03
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: -1.63067670e-03
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
   art_sys_48: 4.31328982e-03
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: -1.70182880e-02
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: 2.77021220e-02
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
   art_sys_65: -1.93062208e-01
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
+  art_sys_72: 0.0
   art_sys_73: -4.47023141e-03
-  art_sys_74: -0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
+  art_sys_76: 0.0
   art_sys_77: -1.22858535e-03
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 1.69099772e-05
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: -7.79627481e-07
-  art_sys_88: -0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 2.39072803e-01
   sys_2: -2.28678333e-01
   sys_3: 6.92964646e-03
   sys_4: -6.92964646e-03
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 3.46482323e-03
   sys_8: -3.46482323e-03
   sys_9: 1.73241161e-02
@@ -17428,7 +17428,7 @@ bins:
   sys_11: 1.03944697e-02
   sys_12: -1.03944697e-02
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 1.73241161e-02
   sys_16: -1.73241161e-02
   sys_17: 3.46482323e-03
@@ -17458,19 +17458,19 @@ bins:
   sys_41: 2.07889394e-02
   sys_42: -2.07889394e-02
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 3.46482323e-03
   sys_48: -3.46482323e-03
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 3.46482323e-03
   sys_58: 0.0
   sys_59: 3.46482323e-03
@@ -17480,17 +17480,17 @@ bins:
   sys_63: 6.92964646e-03
   sys_64: -6.92964646e-03
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 3.46482323e-03
   sys_78: -3.46482323e-03
   sys_79: 6.92964646e-03
@@ -17504,33 +17504,33 @@ bins:
   sys_87: 6.92964646e-03
   sys_88: -6.92964646e-03
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 3.46482323e-03
   sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 2.42537626e-02
   sys_110: -2.42537626e-02
   sys_111: 4.15778787e-01
   sys_112: -3.46482323e-01
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: -1.03944697e-02
   sys_118: 6.92964646e-03
   sys_119: -3.46482323e-02
@@ -17546,15 +17546,15 @@ bins:
   sys_129: 6.92964646e-03
   sys_130: -6.92964646e-03
   sys_131: 0.0
-  sys_132: -0.0
+  sys_132: 0.0
   sys_133: 1.73241161e-02
   sys_134: -1.73241161e-02
   luminosity_uncertainty: 8.82000000e-02
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
@@ -17563,89 +17563,89 @@ bins:
   art_sys_11: 4.23155727e-04
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: -5.65511840e-04
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: -6.65782519e-04
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: -8.20818411e-04
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 7.91161800e-04
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
   art_sys_32: 1.26254751e-03
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 1.18228895e-03
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: -7.46045385e-04
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
   art_sys_48: -7.45997841e-04
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: -1.18206259e-03
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: -6.59705252e-03
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
   art_sys_65: -1.03250804e-02
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
+  art_sys_72: 0.0
   art_sys_73: 8.70208991e-02
-  art_sys_74: -0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
+  art_sys_76: 0.0
   art_sys_77: 2.84577107e-03
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: -5.32419747e-04
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 3.33221921e-07
-  art_sys_88: -0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 9.52331413e-02
   sys_2: -9.13723383e-02
   sys_3: 2.57386868e-03
   sys_4: -2.57386868e-03
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 1.28693434e-03
   sys_8: -1.28693434e-03
   sys_9: 5.14773737e-03
@@ -17653,7 +17653,7 @@ bins:
   sys_11: 3.86080303e-03
   sys_12: -2.57386868e-03
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 7.72160605e-03
   sys_16: -7.72160605e-03
   sys_17: 2.57386868e-03
@@ -17683,19 +17683,19 @@ bins:
   sys_41: 9.00854039e-03
   sys_42: -9.00854039e-03
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 1.28693434e-03
   sys_48: -1.28693434e-03
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 1.28693434e-03
   sys_58: 0.0
   sys_59: 1.28693434e-03
@@ -17705,17 +17705,17 @@ bins:
   sys_63: 2.57386868e-03
   sys_64: -2.57386868e-03
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 1.28693434e-03
   sys_78: -1.28693434e-03
   sys_79: 2.57386868e-03
@@ -17729,33 +17729,33 @@ bins:
   sys_87: 5.14773737e-03
   sys_88: -5.14773737e-03
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 1.28693434e-03
   sys_96: -1.28693434e-03
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 1.02954747e-02
   sys_110: -1.02954747e-02
   sys_111: 1.54432121e-01
   sys_112: -1.28693434e-01
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: -2.57386868e-03
   sys_118: 2.57386868e-03
   sys_119: -9.00854039e-03
@@ -17771,15 +17771,15 @@ bins:
   sys_129: 2.57386868e-03
   sys_130: -2.57386868e-03
   sys_131: 0.0
-  sys_132: -0.0
+  sys_132: 0.0
   sys_133: 6.43467171e-03
   sys_134: -6.43467171e-03
   luminosity_uncertainty: 3.27600000e-02
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
@@ -17788,89 +17788,89 @@ bins:
   art_sys_11: 3.21937519e-05
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 4.71387127e-04
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 8.05642870e-04
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 8.66219433e-04
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: -2.33297601e-04
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
   art_sys_32: 3.51396400e-04
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: -2.63817757e-04
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 5.24884377e-04
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
   art_sys_48: -2.38103127e-04
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 4.73229993e-04
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: -6.98727479e-05
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
   art_sys_65: 4.20270264e-03
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
+  art_sys_72: 0.0
   art_sys_73: 5.20116947e-03
-  art_sys_74: -0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
+  art_sys_76: 0.0
   art_sys_77: -4.95060369e-02
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 1.16467374e-03
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: -1.50999986e-05
-  art_sys_88: -0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 4.04366084e-02
   sys_2: -3.79405215e-02
   sys_3: 9.98434775e-04
   sys_4: -9.98434775e-04
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 4.99217388e-04
   sys_8: -4.99217388e-04
   sys_9: 1.99686955e-03
@@ -17878,7 +17878,7 @@ bins:
   sys_11: 1.49765216e-03
   sys_12: -9.98434775e-04
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 2.99530433e-03
   sys_16: -2.99530433e-03
   sys_17: 9.98434775e-04
@@ -17908,19 +17908,19 @@ bins:
   sys_41: 3.99373910e-03
   sys_42: -3.99373910e-03
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 4.99217388e-04
   sys_48: -4.99217388e-04
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 4.99217388e-04
   sys_58: 0.0
   sys_59: 4.99217388e-04
@@ -17930,17 +17930,17 @@ bins:
   sys_63: 4.99217388e-04
   sys_64: -4.99217388e-04
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 4.99217388e-04
   sys_78: -4.99217388e-04
   sys_79: 9.98434775e-04
@@ -17954,33 +17954,33 @@ bins:
   sys_87: 2.99530433e-03
   sys_88: -2.99530433e-03
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 4.99217388e-04
   sys_96: -4.99217388e-04
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 4.99217388e-04
   sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 3.99373910e-03
   sys_110: -3.99373910e-03
   sys_111: 5.99060865e-02
   sys_112: -5.49139126e-02
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: -9.98434775e-04
   sys_118: 4.99217388e-04
   sys_119: -2.49608694e-03
@@ -18002,9 +18002,9 @@ bins:
   luminosity_uncertainty: 0.012708
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
@@ -18013,89 +18013,89 @@ bins:
   art_sys_11: 2.21087555e-04
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 1.58138588e-04
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 4.82841032e-05
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 2.56390419e-04
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 2.08041692e-04
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
   art_sys_32: 2.95201005e-04
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 8.26193202e-05
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: -2.94659728e-04
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
   art_sys_48: -1.99308000e-04
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: -9.25225280e-05
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: 2.12072163e-04
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
   art_sys_65: 3.00913493e-04
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
+  art_sys_72: 0.0
   art_sys_73: -1.69677812e-03
-  art_sys_74: -0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
+  art_sys_76: 0.0
   art_sys_77: -2.49111781e-03
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: -2.37758854e-02
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 2.38317378e-05
-  art_sys_88: -0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 1.50104628e-02
   sys_2: -1.41477925e-02
   sys_3: 3.45068109e-04
   sys_4: -3.45068109e-04
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 1.72534055e-04
   sys_8: -1.72534055e-04
   sys_9: 6.90136218e-04
@@ -18103,7 +18103,7 @@ bins:
   sys_11: 3.45068109e-04
   sys_12: -3.45068109e-04
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 1.20773838e-03
   sys_16: -1.03520433e-03
   sys_17: 3.45068109e-04
@@ -18133,17 +18133,17 @@ bins:
   sys_41: 1.72534055e-03
   sys_42: -1.72534055e-03
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 1.72534055e-04
   sys_48: -1.72534055e-04
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 1.72534055e-04
   sys_56: 0.0
   sys_57: 1.72534055e-04
@@ -18155,17 +18155,17 @@ bins:
   sys_63: 1.72534055e-04
   sys_64: -1.72534055e-04
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 1.72534055e-04
   sys_78: -1.72534055e-04
   sys_79: 3.45068109e-04
@@ -18179,33 +18179,33 @@ bins:
   sys_87: 1.38027244e-03
   sys_88: -1.38027244e-03
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 1.72534055e-04
   sys_96: -1.72534055e-04
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 1.72534055e-04
   sys_100: -1.72534055e-04
   sys_101: 1.72534055e-04
   sys_102: -1.72534055e-04
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 1.55280649e-03
   sys_110: -1.55280649e-03
   sys_111: 2.07040866e-02
   sys_112: -1.89787460e-02
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: -1.72534055e-04
   sys_118: 1.72534055e-04
   sys_119: -3.45068109e-04
@@ -18227,9 +18227,9 @@ bins:
   luminosity_uncertainty: 0.004392
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
@@ -18238,89 +18238,89 @@ bins:
   art_sys_11: 2.27773825e-05
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: -3.08479414e-05
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: -4.75510954e-06
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 6.16954980e-05
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 4.02807869e-05
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
   art_sys_32: -5.24997416e-05
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: -9.32401160e-06
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: -4.19067169e-05
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
   art_sys_48: -3.89749968e-05
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 4.94015305e-05
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: 9.51325399e-08
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
   art_sys_65: 2.64759986e-05
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
+  art_sys_72: 0.0
   art_sys_73: -2.52590857e-05
-  art_sys_74: -0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
+  art_sys_76: 0.0
   art_sys_77: 2.01643797e-04
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: -1.70762182e-04
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: -3.42229180e-03
-  art_sys_88: -0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 1.82433550e-03
   sys_2: -1.67230754e-03
   sys_3: 1.52027958e-05
   sys_4: -3.04055916e-05
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 1.52027958e-05
   sys_8: -1.52027958e-05
   sys_9: 6.08111832e-05
@@ -18328,7 +18328,7 @@ bins:
   sys_11: 1.52027958e-05
   sys_12: -3.04055916e-05
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 1.52027958e-04
   sys_16: -1.36825162e-04
   sys_17: 3.04055916e-05
@@ -18358,17 +18358,17 @@ bins:
   sys_41: 2.88853120e-04
   sys_42: -2.73650324e-04
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 1.52027958e-05
   sys_48: -3.04055916e-05
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 1.52027958e-05
   sys_56: -1.52027958e-05
   sys_57: 1.52027958e-05
@@ -18380,17 +18380,17 @@ bins:
   sys_63: 1.52027958e-05
   sys_64: -1.52027958e-05
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
   sys_78: -1.52027958e-05
   sys_79: 1.52027958e-05
@@ -18404,15 +18404,15 @@ bins:
   sys_87: 3.19258712e-04
   sys_88: -3.19258712e-04
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 1.52027958e-05
   sys_96: -1.52027958e-05
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 3.04055916e-05
   sys_100: -3.04055916e-05
   sys_101: 7.60139790e-05
@@ -18422,21 +18422,21 @@ bins:
   sys_105: 0.0
   sys_106: -1.52027958e-05
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 2.12839141e-04
   sys_110: -2.12839141e-04
   sys_111: 1.97636345e-03
   sys_112: -1.82433550e-03
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 3.04055916e-05
   sys_120: -4.56083874e-05
   sys_121: 0.0
-  sys_122: -0.0
+  sys_122: 0.0
   sys_123: 9.12167748e-05
   sys_124: -9.12167748e-05
   sys_125: 2.88853120e-04
@@ -18452,94 +18452,94 @@ bins:
   luminosity_uncertainty: 3.87000000e-04
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
   art_sys_18: 1.49862187e+02
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 2.06764197e+01
-  art_sys_23: -0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
   art_sys_27: 3.71626761e+00
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: 5.06153428e-03
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 9.61911284e-04
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 4.17149953e-05
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
   art_sys_67: 3.07025971e-06
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
   art_sys_86: 3.02921495e-09
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 1.00677864e+02
   sys_2: -1.05472047e+02
   sys_3: 2.15738279e+01
@@ -18551,7 +18551,7 @@ bins:
   sys_9: 4.31476558e+01
   sys_10: -4.79418398e+01
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 2.39709199e+00
   sys_14: -2.39709199e+00
   sys_15: 1.91767359e+01
@@ -18569,23 +18569,23 @@ bins:
   sys_27: 0.0
   sys_28: -2.39709199e+00
   sys_29: 0.0
-  sys_30: -0.0
+  sys_30: 0.0
   sys_31: 0.0
   sys_32: -2.39709199e+00
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 0.0
-  sys_38: -0.0
+  sys_38: 0.0
   sys_39: 0.0
-  sys_40: -0.0
+  sys_40: 0.0
   sys_41: 0.0
-  sys_42: -0.0
+  sys_42: 0.0
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 2.39709199e+00
   sys_48: -2.39709199e+00
   sys_49: 2.39709199e+00
@@ -18603,11 +18603,11 @@ bins:
   sys_61: 7.19127596e+00
   sys_62: -9.58836795e+00
   sys_63: 0.0
-  sys_64: -0.0
+  sys_64: 0.0
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 2.39709199e+00
   sys_70: -2.39709199e+00
   sys_71: 0.0
@@ -18619,43 +18619,43 @@ bins:
   sys_77: 0.0
   sys_78: -2.39709199e+00
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
   sys_90: -2.39709199e+00
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 2.39709199e+01
   sys_110: -2.87651039e+01
   sys_111: 4.31476558e+02
   sys_112: -3.83534718e+02
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: -9.58836795e+00
   sys_118: 9.58836795e+00
   sys_119: -5.03389318e+01
@@ -18677,94 +18677,94 @@ bins:
   luminosity_uncertainty: 6.10200000e+01
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
   art_sys_18: 3.78759431e+01
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: -8.34742434e+01
-  art_sys_23: -0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
   art_sys_27: -1.08242828e+01
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: 5.46364825e-01
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 4.37183375e-03
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 2.54220642e-05
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
   art_sys_67: 5.71071172e-07
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
   art_sys_86: -2.59731501e-08
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 5.41219530e+01
   sys_2: -5.53806031e+01
   sys_3: 1.13278506e+01
@@ -18794,23 +18794,23 @@ bins:
   sys_27: 0.0
   sys_28: -1.25865007e+00
   sys_29: 0.0
-  sys_30: -0.0
+  sys_30: 0.0
   sys_31: 0.0
   sys_32: -1.25865007e+00
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
   sys_36: -1.25865007e+00
   sys_37: 0.0
-  sys_38: -0.0
+  sys_38: 0.0
   sys_39: 0.0
   sys_40: -1.25865007e+00
   sys_41: 1.25865007e+00
   sys_42: 0.0
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 1.25865007e+00
   sys_48: -1.25865007e+00
   sys_49: 1.25865007e+00
@@ -18828,11 +18828,11 @@ bins:
   sys_61: 5.03460028e+00
   sys_62: -5.03460028e+00
   sys_63: 0.0
-  sys_64: -0.0
+  sys_64: 0.0
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
   sys_70: -1.25865007e+00
   sys_71: 0.0
@@ -18844,43 +18844,43 @@ bins:
   sys_77: 0.0
   sys_78: -1.25865007e+00
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
   sys_90: -1.25865007e+00
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 1.13278506e+01
   sys_110: -1.51038008e+01
   sys_111: 2.26557013e+02
   sys_112: -2.01384011e+02
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: -5.03460028e+00
   sys_118: 6.29325035e+00
   sys_119: -2.51730014e+01
@@ -18902,94 +18902,94 @@ bins:
   luminosity_uncertainty: 3.20400000e+01
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
   art_sys_18: -3.07552504e+00
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: -2.11049840e+01
-  art_sys_23: -0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
   art_sys_27: 4.66288056e+01
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: -9.35108289e-01
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 2.92368151e-02
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 6.42178263e-04
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
   art_sys_67: 3.30260184e-06
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
   art_sys_86: -5.33727002e-09
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 2.64740779e+01
   sys_2: -2.64740779e+01
   sys_3: 4.70650274e+00
@@ -19019,11 +19019,11 @@ bins:
   sys_27: 5.88312842e-01
   sys_28: -5.88312842e-01
   sys_29: 0.0
-  sys_30: -0.0
+  sys_30: 0.0
   sys_31: 0.0
   sys_32: -5.88312842e-01
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 5.88312842e-01
   sys_36: -5.88312842e-01
   sys_37: 0.0
@@ -19033,9 +19033,9 @@ bins:
   sys_41: 5.88312842e-01
   sys_42: -5.88312842e-01
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 5.88312842e-01
   sys_48: -5.88312842e-01
   sys_49: 0.0
@@ -19055,9 +19055,9 @@ bins:
   sys_63: 5.88312842e-01
   sys_64: -5.88312842e-01
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
   sys_70: -5.88312842e-01
   sys_71: 0.0
@@ -19069,43 +19069,43 @@ bins:
   sys_77: 5.88312842e-01
   sys_78: -5.88312842e-01
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 5.29481558e+00
   sys_110: -6.47144126e+00
   sys_111: 1.05896312e+02
   sys_112: -9.41300547e+01
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: -1.76493853e+00
   sys_118: 2.94156421e+00
   sys_119: -1.05896312e+01
@@ -19127,100 +19127,100 @@ bins:
   luminosity_uncertainty: 1.49760000e+01
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
   art_sys_18: -1.32147505e+00
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 1.40091930e+00
-  art_sys_23: -0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
   art_sys_27: 2.68546225e+00
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: 1.84140486e+01
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 4.72072270e-02
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 2.51965782e-03
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
   art_sys_67: -1.80518292e-05
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
   art_sys_86: 6.61780487e-08
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 1.03591143e+01
   sys_2: -9.94474977e+00
   sys_3: 1.45027601e+00
   sys_4: -1.65745830e+00
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 8.28729148e-01
   sys_8: -8.28729148e-01
   sys_9: 3.31491659e+00
@@ -19228,7 +19228,7 @@ bins:
   sys_11: 2.07182287e-01
   sys_12: -4.14364574e-01
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 1.24309372e+00
   sys_16: -1.45027601e+00
   sys_17: 2.07182287e-01
@@ -19244,11 +19244,11 @@ bins:
   sys_27: 2.07182287e-01
   sys_28: -2.07182287e-01
   sys_29: 0.0
-  sys_30: -0.0
+  sys_30: 0.0
   sys_31: 0.0
   sys_32: -2.07182287e-01
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 2.07182287e-01
   sys_36: -4.14364574e-01
   sys_37: 2.07182287e-01
@@ -19258,9 +19258,9 @@ bins:
   sys_41: 2.07182287e-01
   sys_42: -2.07182287e-01
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
   sys_48: -2.07182287e-01
   sys_49: 0.0
@@ -19280,13 +19280,13 @@ bins:
   sys_63: 2.07182287e-01
   sys_64: -2.07182287e-01
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 2.07182287e-01
   sys_74: -2.07182287e-01
   sys_75: 2.07182287e-01
@@ -19294,43 +19294,43 @@ bins:
   sys_77: 2.07182287e-01
   sys_78: -2.07182287e-01
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 2.07182287e+00
   sys_110: -2.27900516e+00
   sys_111: 3.93646345e+01
   sys_112: -3.31491659e+01
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: -6.21546861e-01
   sys_118: 1.03591143e+00
   sys_119: -3.72928116e+00
@@ -19346,106 +19346,106 @@ bins:
   sys_129: 1.03591143e+00
   sys_130: -1.03591143e+00
   sys_131: 0.0
-  sys_132: -0.0
+  sys_132: 0.0
   sys_133: 1.03591143e+00
   sys_134: -1.03591143e+00
   luminosity_uncertainty: 5.27400000e+00
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
   art_sys_18: -3.08000966e-02
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 1.75259006e-01
-  art_sys_23: -0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
   art_sys_27: -2.83090956e-01
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: -1.65497567e-01
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 5.11474775e+00
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 1.26924195e-02
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
   art_sys_67: 2.19082476e-04
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
   art_sys_86: 1.09905922e-08
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 2.39885976e+00
   sys_2: -2.23622520e+00
   sys_3: 2.43951840e-01
   sys_4: -2.43951840e-01
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 1.21975920e-01
   sys_8: -1.21975920e-01
   sys_9: 6.09879599e-01
@@ -19453,7 +19453,7 @@ bins:
   sys_11: 1.21975920e-01
   sys_12: -1.21975920e-01
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 2.43951840e-01
   sys_16: -2.43951840e-01
   sys_17: 4.06586399e-02
@@ -19483,15 +19483,15 @@ bins:
   sys_41: 1.21975920e-01
   sys_42: -8.13172798e-02
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
   sys_48: -4.06586399e-02
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 4.06586399e-02
   sys_54: -4.06586399e-02
   sys_55: 4.06586399e-02
@@ -19505,13 +19505,13 @@ bins:
   sys_63: 8.13172798e-02
   sys_64: -8.13172798e-02
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 4.06586399e-02
   sys_74: -4.06586399e-02
   sys_75: 4.06586399e-02
@@ -19523,39 +19523,39 @@ bins:
   sys_81: 4.06586399e-02
   sys_82: -4.06586399e-02
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 4.47245039e-01
   sys_110: -4.06586399e-01
   sys_111: 8.53831438e+00
   sys_112: -7.31855519e+00
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: -1.21975920e-01
   sys_118: 2.03293200e-01
   sys_119: -8.13172798e-01
@@ -19571,106 +19571,106 @@ bins:
   sys_129: 1.21975920e-01
   sys_130: -1.21975920e-01
   sys_131: 0.0
-  sys_132: -0.0
+  sys_132: 0.0
   sys_133: 2.03293200e-01
   sys_134: -2.03293200e-01
   luminosity_uncertainty: 1.03500000e+00
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
   art_sys_18: -1.34277756e-03
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 7.90235306e-03
-  art_sys_23: -0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
   art_sys_27: -2.87818616e-02
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: -3.81100626e-02
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: -5.67834895e-02
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 1.14648575e+00
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
   art_sys_67: 1.01952026e-03
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
   art_sys_86: -6.97139213e-06
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 4.67899628e-01
   sys_2: -4.40775012e-01
   sys_3: 3.39057702e-02
   sys_4: -3.39057702e-02
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 2.03434621e-02
   sys_8: -1.35623081e-02
   sys_9: 8.13738484e-02
@@ -19678,7 +19678,7 @@ bins:
   sys_11: 3.39057702e-02
   sys_12: -3.39057702e-02
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 4.74680782e-02
   sys_16: -4.06869242e-02
   sys_17: 1.35623081e-02
@@ -19708,17 +19708,17 @@ bins:
   sys_41: 3.39057702e-02
   sys_42: -2.71246161e-02
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
   sys_48: -6.78115403e-03
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 6.78115403e-03
   sys_56: -6.78115403e-03
   sys_57: 6.78115403e-03
@@ -19730,13 +19730,13 @@ bins:
   sys_63: 2.03434621e-02
   sys_64: -2.03434621e-02
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 6.78115403e-03
   sys_74: -6.78115403e-03
   sys_75: 6.78115403e-03
@@ -19750,37 +19750,37 @@ bins:
   sys_83: 6.78115403e-03
   sys_84: -6.78115403e-03
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 8.81550024e-02
   sys_110: -8.13738484e-02
   sys_111: 1.55966543e+00
   sys_112: -1.28841927e+00
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: -2.03434621e-02
   sys_118: 3.39057702e-02
   sys_119: -1.55966543e-01
@@ -19796,106 +19796,106 @@ bins:
   sys_129: 2.03434621e-02
   sys_130: -2.03434621e-02
   sys_131: 0.0
-  sys_132: -0.0
+  sys_132: 0.0
   sys_133: 3.39057702e-02
   sys_134: -3.39057702e-02
   luminosity_uncertainty: 1.72620000e-01
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
   art_sys_18: -2.93370846e-03
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 1.97270885e-04
-  art_sys_23: -0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
   art_sys_27: -1.16638320e-04
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: 2.46999396e-03
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: -6.39250230e-03
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: -7.05379139e-03
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
   art_sys_67: 1.66116283e-01
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
   art_sys_86: -1.92373591e-05
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 7.67493700e-02
   sys_2: -7.20117546e-02
   sys_3: 4.73761543e-03
   sys_4: -4.73761543e-03
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 2.84256926e-03
   sys_8: -1.89504617e-03
   sys_9: 9.47523087e-03
@@ -19903,7 +19903,7 @@ bins:
   sys_11: 4.73761543e-03
   sys_12: -5.68513852e-03
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 6.63266161e-03
   sys_16: -7.58018469e-03
   sys_17: 1.89504617e-03
@@ -19933,17 +19933,17 @@ bins:
   sys_41: 5.68513852e-03
   sys_42: -6.63266161e-03
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 9.47523087e-04
   sys_48: -9.47523087e-04
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 9.47523087e-04
   sys_56: -9.47523087e-04
   sys_57: 9.47523087e-04
@@ -19955,13 +19955,13 @@ bins:
   sys_63: 3.79009235e-03
   sys_64: -2.84256926e-03
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 9.47523087e-04
   sys_74: -9.47523087e-04
   sys_75: 9.47523087e-04
@@ -19977,35 +19977,35 @@ bins:
   sys_85: 9.47523087e-04
   sys_86: -9.47523087e-04
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 1.42128463e-02
   sys_110: -1.42128463e-02
   sys_111: 2.36880772e-01
   sys_112: -1.89504617e-01
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: -2.84256926e-03
   sys_118: 4.73761543e-03
   sys_119: -2.36880772e-02
@@ -20027,100 +20027,100 @@ bins:
   luminosity_uncertainty: 2.41200000e-02
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
   art_sys_18: -4.08774582e-05
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 1.81653830e-04
-  art_sys_23: -0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
   art_sys_27: 3.21469826e-05
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: 1.08862236e-04
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 4.41251655e-05
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: -5.99879061e-04
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
   art_sys_67: -2.44540746e-04
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
   art_sys_86: -1.30969784e-02
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 3.81837662e-03
   sys_2: -3.50017857e-03
   sys_3: 9.54594155e-05
   sys_4: -1.90918831e-04
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 6.36396103e-05
   sys_8: -6.36396103e-05
   sys_9: 2.54558441e-04
@@ -20128,7 +20128,7 @@ bins:
   sys_11: 1.59099026e-04
   sys_12: -2.54558441e-04
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 2.86378246e-04
   sys_16: -3.81837662e-04
   sys_17: 9.54594155e-05
@@ -20158,19 +20158,19 @@ bins:
   sys_41: 3.18198052e-04
   sys_42: -4.13657467e-04
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 6.36396103e-05
   sys_48: -3.18198052e-05
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 3.18198052e-05
   sys_58: -3.18198052e-05
   sys_59: 6.36396103e-05
@@ -20180,17 +20180,17 @@ bins:
   sys_63: 1.27279221e-04
   sys_64: -9.54594155e-05
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 6.36396103e-05
   sys_78: -3.18198052e-05
   sys_79: 9.54594155e-05
@@ -20204,35 +20204,35 @@ bins:
   sys_87: 9.54594155e-05
   sys_88: -6.36396103e-05
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 6.36396103e-04
   sys_110: -7.00035713e-04
   sys_111: 9.86413960e-03
   sys_112: -7.95495129e-03
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: -1.05005357e-03
   sys_120: 1.36825162e-03
   sys_121: 1.90918831e-04
@@ -20252,100 +20252,100 @@ bins:
   luminosity_uncertainty: 8.10000000e-04
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
+  art_sys_32: 0.0
   art_sys_33: 1.95703857e+01
-  art_sys_34: -0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 1.17015922e-03
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
   art_sys_55: 1.75380701e-03
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 2.71779798e-08
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 4.08495587e+00
   sys_2: -4.08495587e+00
   sys_3: 8.47821031e-01
   sys_4: -7.70746391e-01
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 4.62447835e-01
   sys_8: -3.85373196e-01
   sys_9: 1.54149278e+00
@@ -20353,7 +20353,7 @@ bins:
   sys_11: 0.0
   sys_12: -7.70746391e-02
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 6.93671752e-01
   sys_16: -6.16597113e-01
   sys_17: 7.70746391e-02
@@ -20371,27 +20371,27 @@ bins:
   sys_29: 0.0
   sys_30: -7.70746391e-02
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 1.54149278e-01
   sys_36: -7.70746391e-02
   sys_37: 0.0
-  sys_38: -0.0
+  sys_38: 0.0
   sys_39: 1.54149278e-01
   sys_40: -7.70746391e-02
   sys_41: 0.0
-  sys_42: -0.0
+  sys_42: 0.0
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 7.70746391e-02
   sys_48: 0.0
   sys_49: 0.0
   sys_50: -7.70746391e-02
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 1.54149278e-01
   sys_54: -7.70746391e-02
   sys_55: 2.31223917e-01
@@ -20403,59 +20403,59 @@ bins:
   sys_61: 3.85373196e-01
   sys_62: -3.85373196e-01
   sys_63: 0.0
-  sys_64: -0.0
+  sys_64: 0.0
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 7.70746391e-02
   sys_74: -7.70746391e-02
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 1.23319423e+00
   sys_110: -1.23319423e+00
   sys_111: 2.00394062e+01
   sys_112: -1.61856742e+01
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: -2.31223917e-01
   sys_118: 2.31223917e-01
   sys_119: -1.92686598e+00
@@ -20477,100 +20477,100 @@ bins:
   luminosity_uncertainty: 1.96200000e+00
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
+  art_sys_32: 0.0
   art_sys_33: -8.42175261e-03
-  art_sys_34: -0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 2.43915516e+00
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
   art_sys_55: -2.12413806e-02
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 2.10810424e-06
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 4.27446049e-01
   sys_2: -4.06763176e-01
   sys_3: 6.89429112e-02
   sys_4: -5.51543289e-02
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 3.44714556e-02
   sys_8: -3.44714556e-02
   sys_9: 1.30991531e-01
@@ -20578,7 +20578,7 @@ bins:
   sys_11: 6.89429112e-03
   sys_12: -2.06828733e-02
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 6.20486200e-02
   sys_16: -5.51543289e-02
   sys_17: 6.89429112e-03
@@ -20598,7 +20598,7 @@ bins:
   sys_31: 6.89429112e-03
   sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 2.06828733e-02
   sys_36: -6.89429112e-03
   sys_37: 6.89429112e-03
@@ -20608,15 +20608,15 @@ bins:
   sys_41: 6.89429112e-03
   sys_42: 0.0
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 6.89429112e-03
   sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 6.89429112e-03
   sys_54: -6.89429112e-03
   sys_55: 1.37885822e-02
@@ -20630,57 +20630,57 @@ bins:
   sys_63: 6.89429112e-03
   sys_64: 0.0
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 6.89429112e-03
   sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 1.24097240e-01
   sys_110: -1.24097240e-01
   sys_111: 2.06828733e+00
   sys_112: -1.58568696e+00
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: -2.06828733e-02
   sys_118: 2.06828733e-02
   sys_119: -1.51674405e-01
@@ -20702,100 +20702,100 @@ bins:
   luminosity_uncertainty: 1.75500000e-01
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
+  art_sys_32: 0.0
   art_sys_33: -3.96311273e-02
-  art_sys_34: -0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 5.95117089e-02
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
   art_sys_55: 8.70567476e-01
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 7.45713266e-07
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 1.36895873e-01
   sys_2: -1.30051079e-01
   sys_3: 1.54007857e-02
   sys_4: -1.02671905e-02
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 6.84479364e-03
   sys_8: -5.13359523e-03
   sys_9: 2.73791746e-02
@@ -20803,7 +20803,7 @@ bins:
   sys_11: 6.84479364e-03
   sys_12: -8.55599205e-03
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 1.54007857e-02
   sys_16: -1.19783889e-02
   sys_17: 1.71119841e-03
@@ -20833,15 +20833,15 @@ bins:
   sys_41: 5.13359523e-03
   sys_42: -5.13359523e-03
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 1.71119841e-03
   sys_54: 0.0
   sys_55: 1.71119841e-03
@@ -20855,17 +20855,17 @@ bins:
   sys_63: 5.13359523e-03
   sys_64: -3.42239682e-03
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 3.42239682e-03
   sys_78: -1.71119841e-03
   sys_79: 3.42239682e-03
@@ -20873,39 +20873,39 @@ bins:
   sys_81: 1.71119841e-03
   sys_82: -1.71119841e-03
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 3.93575634e-02
   sys_110: -3.93575634e-02
   sys_111: 6.33143412e-01
   sys_112: -4.79135555e-01
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: -5.13359523e-03
   sys_118: 5.13359523e-03
   sys_119: -3.93575634e-02
@@ -20927,100 +20927,100 @@ bins:
   luminosity_uncertainty: 0.04356
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
+  art_sys_32: 0.0
   art_sys_33: -3.08397967e-05
-  art_sys_34: -0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: -3.30077403e-04
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
   art_sys_55: -3.84696921e-05
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 1.57126897e-02
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 2.07889394e-03
   sys_2: -1.93040151e-03
   sys_3: 1.33643182e-04
   sys_4: -1.48492424e-04
   sys_5: 0.0
-  sys_6: -0.0
+  sys_6: 0.0
   sys_7: 1.48492424e-05
   sys_8: -1.48492424e-05
   sys_9: 2.37587878e-04
@@ -21028,7 +21028,7 @@ bins:
   sys_11: 1.48492424e-04
   sys_12: -1.78190909e-04
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 1.63341666e-04
   sys_16: -2.07889394e-04
   sys_17: 2.96984848e-05
@@ -21058,21 +21058,21 @@ bins:
   sys_41: 1.48492424e-04
   sys_42: -1.93040151e-04
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 4.45477272e-05
   sys_60: -4.45477272e-05
   sys_61: 1.03944697e-04
@@ -21080,17 +21080,17 @@ bins:
   sys_63: 8.90954544e-05
   sys_64: -1.33643182e-04
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 4.45477272e-05
   sys_78: -8.90954544e-05
   sys_79: 8.90954544e-05
@@ -21100,37 +21100,37 @@ bins:
   sys_83: 4.45477272e-05
   sys_84: -4.45477272e-05
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 6.53366666e-04
   sys_110: -6.38517423e-04
   sys_111: 8.76105302e-03
   sys_112: -5.93969696e-03
   sys_113: 0.0
-  sys_114: -0.0
+  sys_114: 0.0
   sys_115: 0.0
-  sys_116: -0.0
+  sys_116: 0.0
   sys_117: 1.48492424e-05
   sys_118: -1.48492424e-05
   sys_119: -6.68215908e-04

--- a/nnpdf_data/nnpdf_data/commondata/ATLAS_2JET_7TEV_R06/uncertainties_stronger.yaml
+++ b/nnpdf_data/nnpdf_data/commondata/ATLAS_2JET_7TEV_R06/uncertainties_stronger.yaml
@@ -830,92 +830,92 @@ definitions:
 bins:
 - art_sys_1: 0.0
   art_sys_2: 8.66600397e+03
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 1.65603952e+01
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 1.00466592e+01
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 1.26565519e-01
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 3.24886915e-02
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
+  art_sys_22: 0.0
   art_sys_23: 5.12875512e-03
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 1.53888278e-03
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 7.95614472e-05
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 4.88924054e-05
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
+  art_sys_43: 0.0
   art_sys_44: 1.68570003e-05
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 3.46238064e-06
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 9.73326696e-07
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 3.97603562e-07
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 1.98321791e-08
   art_sys_62: 0.0
-  art_sys_63: -0.0
+  art_sys_63: 0.0
   art_sys_64: 5.04287641e-08
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
   art_sys_69: 3.05546432e-08
-  art_sys_70: -0.0
+  art_sys_70: 0.0
   art_sys_71: 8.29975820e-09
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 2.32783123e-09
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 1.54448543e-09
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 5.30147707e-10
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
   art_sys_90: 1.40299436e-11
   sys_1: 2.34547319e+04
@@ -935,17 +935,17 @@ bins:
   sys_15: 7.56604256e+03
   sys_16: -7.56604256e+03
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 0.0
-  sys_20: -0.0
+  sys_20: 0.0
   sys_21: 0.0
-  sys_22: -0.0
+  sys_22: 0.0
   sys_23: 0.0
-  sys_24: -0.0
+  sys_24: 0.0
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 0.0
   sys_30: -7.56604256e+02
   sys_31: 0.0
@@ -963,11 +963,11 @@ bins:
   sys_43: 7.56604256e+02
   sys_44: -7.56604256e+02
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
   sys_52: -7.56604256e+02
   sys_53: 0.0
@@ -975,47 +975,47 @@ bins:
   sys_55: 7.56604256e+02
   sys_56: -7.56604256e+02
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 0.0
-  sys_62: -0.0
+  sys_62: 0.0
   sys_63: 0.0
-  sys_64: -0.0
+  sys_64: 0.0
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 3.78302128e+03
   sys_92: -3.78302128e+03
   sys_93: 2.95075660e+04
   sys_94: -2.72377532e+04
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: -3.02641702e+03
   sys_100: 3.78302128e+03
   sys_101: -9.83585533e+03
@@ -1037,92 +1037,92 @@ bins:
   luminosity_uncertainty: 3210.0
 - art_sys_1: 0.0
   art_sys_2: -4.77033220e+01
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 3.14268214e+03
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 3.50642944e+01
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 6.62067632e+00
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 8.28376346e-02
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
+  art_sys_22: 0.0
   art_sys_23: 1.14440868e-02
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 7.91206859e-03
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: -5.40010282e-04
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 4.01656084e-04
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
+  art_sys_43: 0.0
   art_sys_44: -1.50718011e-05
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 2.16191112e-06
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: -4.46031889e-06
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 8.14636149e-08
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 4.17082996e-07
   art_sys_62: 0.0
-  art_sys_63: -0.0
+  art_sys_63: 0.0
   art_sys_64: 1.05694529e-08
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
   art_sys_69: 1.25633584e-08
-  art_sys_70: -0.0
+  art_sys_70: 0.0
   art_sys_71: -2.95765951e-08
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: -9.14156780e-09
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 1.96642808e-09
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 1.01309289e-09
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
   art_sys_90: 4.60286375e-11
   sys_1: 9.18673130e+03
@@ -1136,27 +1136,27 @@ bins:
   sys_9: 2.00959747e+03
   sys_10: -2.00959747e+03
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 2.87085353e+02
   sys_14: -2.87085353e+02
   sys_15: 2.58376818e+03
   sys_16: -2.58376818e+03
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 0.0
   sys_20: -2.87085353e+02
   sys_21: 0.0
-  sys_22: -0.0
+  sys_22: 0.0
   sys_23: 0.0
   sys_24: -2.87085353e+02
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 0.0
-  sys_30: -0.0
+  sys_30: 0.0
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
   sys_34: -2.87085353e+02
   sys_35: 2.87085353e+02
@@ -1170,59 +1170,59 @@ bins:
   sys_43: 8.61256059e+02
   sys_44: -5.74170706e+02
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 2.87085353e+02
   sys_56: -2.87085353e+02
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 0.0
-  sys_62: -0.0
+  sys_62: 0.0
   sys_63: 0.0
-  sys_64: -0.0
+  sys_64: 0.0
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 1.14834141e+03
   sys_92: -1.14834141e+03
   sys_93: 1.06221581e+04
   sys_94: -9.76090201e+03
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: -1.14834141e+03
   sys_100: 1.43542677e+03
   sys_101: -3.15793888e+03
@@ -1244,92 +1244,92 @@ bins:
   luminosity_uncertainty: 406.0
 - art_sys_1: 0.0
   art_sys_2: -7.00122739e+01
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -9.20257933e+01
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 1.21913825e+03
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 1.80626131e+01
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 2.28059505e+00
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
+  art_sys_22: 0.0
   art_sys_23: 7.90198445e-02
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 1.06746073e-02
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: -2.44464005e-03
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 4.47952792e-04
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
+  art_sys_43: 0.0
   art_sys_44: 1.08646766e-04
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: -9.08624166e-06
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: -3.11648575e-06
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 5.35926874e-07
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 2.29584162e-06
   art_sys_62: 0.0
-  art_sys_63: -0.0
+  art_sys_63: 0.0
   art_sys_64: 1.07006478e-06
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
   art_sys_69: 1.28227265e-07
-  art_sys_70: -0.0
+  art_sys_70: 0.0
   art_sys_71: -6.24732027e-08
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 6.45561067e-09
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 1.59017767e-09
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 1.05553387e-08
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
   art_sys_90: -3.63513279e-11
   sys_1: 3.65432785e+03
@@ -1343,29 +1343,29 @@ bins:
   sys_9: 7.52361615e+02
   sys_10: -6.44881384e+02
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 1.07480231e+02
   sys_14: -1.07480231e+02
   sys_15: 9.67322077e+02
   sys_16: -8.59841846e+02
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 1.07480231e+02
   sys_20: -1.07480231e+02
   sys_21: 0.0
-  sys_22: -0.0
+  sys_22: 0.0
   sys_23: 1.07480231e+02
   sys_24: -1.07480231e+02
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 0.0
-  sys_30: -0.0
+  sys_30: 0.0
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 1.07480231e+02
   sys_36: -1.07480231e+02
   sys_37: 1.07480231e+02
@@ -1379,57 +1379,57 @@ bins:
   sys_45: 1.07480231e+02
   sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 1.07480231e+02
   sys_56: -1.07480231e+02
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 0.0
-  sys_62: -0.0
+  sys_62: 0.0
   sys_63: 0.0
-  sys_64: -0.0
+  sys_64: 0.0
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 4.29920923e+02
   sys_92: -4.29920923e+02
   sys_93: 3.65432785e+03
   sys_94: -3.33188715e+03
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: -4.29920923e+02
   sys_100: 5.37401154e+02
   sys_101: -1.07480231e+03
@@ -1451,92 +1451,92 @@ bins:
   luminosity_uncertainty: 152.0
 - art_sys_1: 0.0
   art_sys_2: 9.77545258e-01
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -3.96231596e+01
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: -4.64375276e+01
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 4.82951674e+02
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 5.44666874e+00
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
+  art_sys_22: 0.0
   art_sys_23: 7.84822573e-01
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 6.48303771e-02
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: -3.61645081e-03
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: -7.83601275e-04
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
+  art_sys_43: 0.0
   art_sys_44: 6.52654718e-04
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 5.20483996e-05
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 9.48094386e-06
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 8.85394144e-06
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: -1.78779821e-06
   art_sys_62: 0.0
-  art_sys_63: -0.0
+  art_sys_63: 0.0
   art_sys_64: -7.30851279e-07
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
   art_sys_69: 1.74720749e-07
-  art_sys_70: -0.0
+  art_sys_70: 0.0
   art_sys_71: -2.62337554e-08
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: -3.64352323e-08
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 1.29471700e-08
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 9.46016641e-09
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
   art_sys_90: -6.30046326e-11
   sys_1: 1.58547482e+03
@@ -1550,7 +1550,7 @@ bins:
   sys_9: 2.14253355e+02
   sys_10: -2.14253355e+02
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 4.28506709e+01
   sys_14: -4.28506709e+01
   sys_15: 3.85656038e+02
@@ -1564,17 +1564,17 @@ bins:
   sys_23: 8.57013419e+01
   sys_24: -8.57013419e+01
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 0.0
-  sys_30: -0.0
+  sys_30: 0.0
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 4.28506709e+01
   sys_38: -4.28506709e+01
   sys_39: 4.28506709e+01
@@ -1586,57 +1586,57 @@ bins:
   sys_45: 4.28506709e+01
   sys_46: -4.28506709e+01
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 4.28506709e+01
   sys_56: -4.28506709e+01
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 4.28506709e+01
   sys_62: -4.28506709e+01
   sys_63: 0.0
-  sys_64: -0.0
+  sys_64: 0.0
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 1.28552013e+02
   sys_92: -1.28552013e+02
   sys_93: 1.28552013e+03
   sys_94: -1.19981879e+03
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: -2.14253355e+02
   sys_100: 2.14253355e+02
   sys_101: -3.85656038e+02
@@ -1658,92 +1658,92 @@ bins:
   luminosity_uncertainty: 0.0
 - art_sys_1: 0.0
   art_sys_2: -6.24445985e-01
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 8.09690516e-01
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: -1.26198742e+01
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: -1.33691170e+01
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 2.00649923e+02
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
+  art_sys_22: 0.0
   art_sys_23: 4.88886178e-01
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 5.72530475e-01
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: -3.85693232e-02
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: -4.09551998e-03
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
+  art_sys_43: 0.0
   art_sys_44: -5.10668135e-04
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: -3.58839834e-04
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 4.01512348e-05
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 9.94951973e-06
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 2.04343429e-05
   art_sys_62: 0.0
-  art_sys_63: -0.0
+  art_sys_63: 0.0
   art_sys_64: 2.50511092e-06
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
   art_sys_69: -6.54028672e-07
-  art_sys_70: -0.0
+  art_sys_70: 0.0
   art_sys_71: 1.17787458e-07
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: -4.26063451e-08
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 6.37371162e-08
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: -4.03966220e-09
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
   art_sys_90: 3.40611967e-10
   sys_1: 6.90560483e+02
@@ -1757,7 +1757,7 @@ bins:
   sys_9: 7.26905771e+01
   sys_10: -7.26905771e+01
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 1.81726443e+01
   sys_14: -1.81726443e+01
   sys_15: 1.45381154e+02
@@ -1771,17 +1771,17 @@ bins:
   sys_23: 5.45179328e+01
   sys_24: -5.45179328e+01
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 0.0
-  sys_30: -0.0
+  sys_30: 0.0
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 1.81726443e+01
   sys_38: -1.81726443e+01
   sys_39: 1.81726443e+01
@@ -1793,17 +1793,17 @@ bins:
   sys_45: 3.63452886e+01
   sys_46: -3.63452886e+01
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
   sys_56: -1.81726443e+01
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
   sys_60: -1.81726443e+01
   sys_61: 1.81726443e+01
@@ -1811,39 +1811,39 @@ bins:
   sys_63: 0.0
   sys_64: -1.81726443e+01
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 5.45179328e+01
   sys_92: -5.45179328e+01
   sys_93: 4.72488751e+02
   sys_94: -4.54316107e+02
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: -9.08632214e+01
   sys_100: 1.09035866e+02
   sys_101: -1.81726443e+02
@@ -1865,92 +1865,92 @@ bins:
   luminosity_uncertainty: 0.0
 - art_sys_1: 0.0
   art_sys_2: -5.59880644e-01
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 1.57221880e-03
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: -7.70393233e-01
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: -5.30516357e+00
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: -1.58625879e+00
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
+  art_sys_22: 0.0
   art_sys_23: 7.07597902e+01
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 1.18820891e+00
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: -2.67790339e-01
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: -2.42473600e-02
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
+  art_sys_43: 0.0
   art_sys_44: 1.50349162e-04
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 2.01220583e-04
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: -3.13977714e-05
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 5.25624358e-05
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 4.73347355e-06
   art_sys_62: 0.0
-  art_sys_63: -0.0
+  art_sys_63: 0.0
   art_sys_64: -4.79459747e-06
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
   art_sys_69: 2.74900035e-06
-  art_sys_70: -0.0
+  art_sys_70: 0.0
   art_sys_71: 9.39057694e-07
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 1.08451445e-07
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 1.47385495e-07
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: -1.36169505e-07
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
   art_sys_90: -6.70958864e-10
   sys_1: 3.19612265e+02
@@ -1964,7 +1964,7 @@ bins:
   sys_9: 2.39709199e+01
   sys_10: -2.39709199e+01
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 7.99030663e+00
   sys_14: -7.99030663e+00
   sys_15: 6.39224530e+01
@@ -1978,17 +1978,17 @@ bins:
   sys_23: 2.39709199e+01
   sys_24: -2.39709199e+01
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 0.0
-  sys_30: -0.0
+  sys_30: 0.0
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 0.0
   sys_38: -7.99030663e+00
   sys_39: 7.99030663e+00
@@ -2000,17 +2000,17 @@ bins:
   sys_45: 1.59806133e+01
   sys_46: -1.59806133e+01
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
   sys_60: -7.99030663e+00
   sys_61: 1.59806133e+01
@@ -2020,37 +2020,37 @@ bins:
   sys_65: 7.99030663e+00
   sys_66: -7.99030663e+00
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 2.39709199e+01
   sys_92: -2.39709199e+01
   sys_93: 1.75786746e+02
   sys_94: -1.75786746e+02
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: -4.79418398e+01
   sys_100: 4.79418398e+01
   sys_101: -8.78933729e+01
@@ -2072,92 +2072,92 @@ bins:
   luminosity_uncertainty: 0.0
 - art_sys_1: 0.0
   art_sys_2: -3.40189430e-01
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -6.68262358e-01
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: -7.01607567e-02
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: -5.39138259e-01
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: -3.49927676e+00
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
+  art_sys_22: 0.0
   art_sys_23: -2.64986079e+00
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 3.25491051e+01
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: -6.34601537e-01
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: -1.68143063e-01
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
+  art_sys_43: 0.0
   art_sys_44: -1.30486891e-02
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 1.30308546e-03
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: -3.27163776e-04
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 5.97594369e-05
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 2.39257219e-05
   art_sys_62: 0.0
-  art_sys_63: -0.0
+  art_sys_63: 0.0
   art_sys_64: 3.39099387e-05
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
   art_sys_69: -5.32913752e-06
-  art_sys_70: -0.0
+  art_sys_70: 0.0
   art_sys_71: 2.71306658e-06
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: -7.25244740e-07
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 5.39198882e-07
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 2.22646652e-07
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
   art_sys_90: 4.71488044e-10
   sys_1: 1.51045080e+02
@@ -2171,7 +2171,7 @@ bins:
   sys_9: 1.10520790e+01
   sys_10: -1.10520790e+01
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 3.68402633e+00
   sys_14: -3.68402633e+00
   sys_15: 2.94722106e+01
@@ -2185,19 +2185,19 @@ bins:
   sys_23: 1.47361053e+01
   sys_24: -1.47361053e+01
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 0.0
   sys_30: -3.68402633e+00
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 0.0
-  sys_38: -0.0
+  sys_38: 0.0
   sys_39: 3.68402633e+00
   sys_40: -3.68402633e+00
   sys_41: 3.68402633e+00
@@ -2207,17 +2207,17 @@ bins:
   sys_45: 7.36805266e+00
   sys_46: -7.36805266e+00
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
   sys_60: -3.68402633e+00
   sys_61: 7.36805266e+00
@@ -2227,37 +2227,37 @@ bins:
   sys_65: 7.36805266e+00
   sys_66: -3.68402633e+00
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 1.10520790e+01
   sys_92: -1.10520790e+01
   sys_93: 6.99965003e+01
   sys_94: -6.99965003e+01
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: -2.21041580e+01
   sys_100: 2.21041580e+01
   sys_101: -4.05242896e+01
@@ -2279,92 +2279,92 @@ bins:
   luminosity_uncertainty: 0.0
 - art_sys_1: 0.0
   art_sys_2: 9.23387966e-02
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -5.02852833e-02
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: -1.35259611e-01
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 3.40255235e-02
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: -3.51750100e-01
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
+  art_sys_22: 0.0
   art_sys_23: -1.19370158e+00
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: -1.49352552e+00
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: -1.45575069e+01
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: -5.13965110e-01
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
+  art_sys_43: 0.0
   art_sys_44: -7.07131241e-02
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 7.14714411e-03
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: -1.46476036e-03
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: -1.55464994e-04
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: -6.28948301e-05
   art_sys_62: 0.0
-  art_sys_63: -0.0
+  art_sys_63: 0.0
   art_sys_64: 5.53498030e-05
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
   art_sys_69: -6.73724191e-06
-  art_sys_70: -0.0
+  art_sys_70: 0.0
   art_sys_71: 4.59052397e-06
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: -2.01812845e-06
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: -6.57480973e-07
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 2.07564586e-07
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
   art_sys_90: -1.15028463e-09
   sys_1: 7.27683589e+01
@@ -2378,7 +2378,7 @@ bins:
   sys_9: 3.54967604e+00
   sys_10: -3.54967604e+00
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 1.77483802e+00
   sys_14: -1.77483802e+00
   sys_15: 1.59735422e+01
@@ -2392,21 +2392,21 @@ bins:
   sys_23: 8.87419010e+00
   sys_24: -8.87419010e+00
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 0.0
-  sys_30: -0.0
+  sys_30: 0.0
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 0.0
-  sys_38: -0.0
+  sys_38: 0.0
   sys_39: 0.0
-  sys_40: -0.0
+  sys_40: 0.0
   sys_41: 1.77483802e+00
   sys_42: -1.77483802e+00
   sys_43: 1.77483802e+00
@@ -2414,17 +2414,17 @@ bins:
   sys_45: 3.54967604e+00
   sys_46: -1.77483802e+00
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
   sys_60: -1.77483802e+00
   sys_61: 3.54967604e+00
@@ -2436,35 +2436,35 @@ bins:
   sys_67: 0.0
   sys_68: -1.77483802e+00
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 3.54967604e+00
   sys_92: -5.32451406e+00
   sys_93: 3.01722464e+01
   sys_94: -2.83974083e+01
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: -1.06490281e+01
   sys_100: 8.87419010e+00
   sys_101: -1.59735422e+01
@@ -2486,92 +2486,92 @@ bins:
   luminosity_uncertainty: 0.0
 - art_sys_1: 0.0
   art_sys_2: 5.80091660e-02
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 1.94125450e-01
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 1.07567088e-01
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: -1.04484248e-02
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: -1.89766689e-03
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
+  art_sys_22: 0.0
   art_sys_23: -9.06462642e-02
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: -6.72738390e-01
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 1.08843898e+00
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: -7.07546072e+00
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
+  art_sys_43: 0.0
   art_sys_44: -1.95866968e-01
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 3.55592631e-02
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 8.11460358e-05
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 9.47767711e-04
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 2.31004101e-04
   art_sys_62: 0.0
-  art_sys_63: -0.0
+  art_sys_63: 0.0
   art_sys_64: 4.77814218e-05
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
   art_sys_69: 8.70840560e-06
-  art_sys_70: -0.0
+  art_sys_70: 0.0
   art_sys_71: 1.01696338e-05
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: -3.19457414e-06
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 3.71284068e-06
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: -6.54733539e-07
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
   art_sys_90: 8.56908310e-09
   sys_1: 3.68261212e+01
@@ -2585,7 +2585,7 @@ bins:
   sys_9: 1.75362482e+00
   sys_10: -1.75362482e+00
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 8.76812409e-01
   sys_14: -8.76812409e-01
   sys_15: 7.89131168e+00
@@ -2599,21 +2599,21 @@ bins:
   sys_23: 5.26087445e+00
   sys_24: -4.38406204e+00
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 0.0
-  sys_30: -0.0
+  sys_30: 0.0
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 0.0
-  sys_38: -0.0
+  sys_38: 0.0
   sys_39: 0.0
-  sys_40: -0.0
+  sys_40: 0.0
   sys_41: 8.76812409e-01
   sys_42: -8.76812409e-01
   sys_43: 8.76812409e-01
@@ -2621,17 +2621,17 @@ bins:
   sys_45: 8.76812409e-01
   sys_46: -8.76812409e-01
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
   sys_60: -8.76812409e-01
   sys_61: 8.76812409e-01
@@ -2643,35 +2643,35 @@ bins:
   sys_67: 8.76812409e-01
   sys_68: -1.75362482e+00
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 1.75362482e+00
   sys_92: -1.75362482e+00
   sys_93: 1.31521861e+01
   sys_94: -1.22753737e+01
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: -4.38406204e+00
   sys_100: 3.50724963e+00
   sys_101: -6.13768686e+00
@@ -2693,92 +2693,92 @@ bins:
   luminosity_uncertainty: 0.0
 - art_sys_1: 0.0
   art_sys_2: 3.56841619e-02
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -3.24320708e-02
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 2.84708301e-02
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 9.48380534e-02
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: -4.90602185e-03
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
+  art_sys_22: 0.0
   art_sys_23: 4.29393443e-02
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: -5.49746356e-02
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 2.42621811e-01
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 4.23950443e-01
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
+  art_sys_43: 0.0
   art_sys_44: -3.42538579e+00
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 1.04010414e-01
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: -1.70034057e-02
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 2.23313283e-03
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 6.97646425e-04
   art_sys_62: 0.0
-  art_sys_63: -0.0
+  art_sys_63: 0.0
   art_sys_64: 1.62980195e-04
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
   art_sys_69: -2.08230958e-05
-  art_sys_70: -0.0
+  art_sys_70: 0.0
   art_sys_71: 9.55312842e-06
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: -4.65891824e-06
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 1.33058018e-06
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 4.62503045e-07
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
   art_sys_90: -1.60785983e-08
   sys_1: 1.86365063e+01
@@ -2792,7 +2792,7 @@ bins:
   sys_9: 8.47113924e-01
   sys_10: -4.23556962e-01
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 4.23556962e-01
   sys_14: -4.23556962e-01
   sys_15: 3.81201266e+00
@@ -2806,21 +2806,21 @@ bins:
   sys_23: 3.38845570e+00
   sys_24: -2.96489873e+00
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 0.0
-  sys_30: -0.0
+  sys_30: 0.0
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 0.0
-  sys_38: -0.0
+  sys_38: 0.0
   sys_39: 0.0
-  sys_40: -0.0
+  sys_40: 0.0
   sys_41: 4.23556962e-01
   sys_42: -4.23556962e-01
   sys_43: 4.23556962e-01
@@ -2828,17 +2828,17 @@ bins:
   sys_45: 4.23556962e-01
   sys_46: -4.23556962e-01
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
   sys_60: -4.23556962e-01
   sys_61: 4.23556962e-01
@@ -2852,33 +2852,33 @@ bins:
   sys_69: 4.23556962e-01
   sys_70: -4.23556962e-01
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
   sys_78: -4.23556962e-01
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 8.47113924e-01
   sys_92: -8.47113924e-01
   sys_93: 5.08268354e+00
   sys_94: -5.08268354e+00
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: -1.27067089e+00
   sys_100: 8.47113924e-01
   sys_101: -1.69422785e+00
@@ -2900,92 +2900,92 @@ bins:
   luminosity_uncertainty: 0.0
 - art_sys_1: 0.0
   art_sys_2: -2.20322705e-02
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -5.11195278e-03
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 1.76398223e-03
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: -2.29026537e-02
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 4.83961862e-02
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
+  art_sys_22: 0.0
   art_sys_23: -2.23674578e-03
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: -1.64370589e-03
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 2.51940803e-02
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 1.27765843e-01
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
+  art_sys_43: 0.0
   art_sys_44: 2.22353667e-01
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 1.65201313e+00
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: -2.89783643e-02
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 1.48881977e-02
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 1.36497539e-03
   art_sys_62: 0.0
-  art_sys_63: -0.0
+  art_sys_63: 0.0
   art_sys_64: -4.99751348e-04
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
   art_sys_69: -6.37809257e-05
-  art_sys_70: -0.0
+  art_sys_70: 0.0
   art_sys_71: -8.63674365e-06
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: -1.56419238e-05
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 9.76743155e-06
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: -5.66044411e-07
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
   art_sys_90: 7.19562227e-08
   sys_1: 9.43280446e+00
@@ -2999,7 +2999,7 @@ bins:
   sys_9: 2.05060967e-01
   sys_10: -2.05060967e-01
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 2.05060967e-01
   sys_14: -2.05060967e-01
   sys_15: 1.84554870e+00
@@ -3013,21 +3013,21 @@ bins:
   sys_23: 2.25567063e+00
   sys_24: -2.25567063e+00
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 0.0
   sys_30: -2.05060967e-01
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 0.0
-  sys_38: -0.0
+  sys_38: 0.0
   sys_39: 0.0
-  sys_40: -0.0
+  sys_40: 0.0
   sys_41: 2.05060967e-01
   sys_42: -2.05060967e-01
   sys_43: 2.05060967e-01
@@ -3035,17 +3035,17 @@ bins:
   sys_45: 2.05060967e-01
   sys_46: -2.05060967e-01
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
   sys_60: -2.05060967e-01
   sys_61: 2.05060967e-01
@@ -3059,33 +3059,33 @@ bins:
   sys_69: 6.15182900e-01
   sys_70: -6.15182900e-01
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 6.15182900e-01
   sys_92: -6.15182900e-01
   sys_93: 2.25567063e+00
   sys_94: -2.05060967e+00
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: -4.10121933e-01
   sys_100: 2.05060967e-01
   sys_101: -4.10121933e-01
@@ -3107,92 +3107,92 @@ bins:
   luminosity_uncertainty: 0.0
 - art_sys_1: 0.0
   art_sys_2: 9.86610479e-03
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -1.45568502e-02
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: -5.91171276e-03
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 3.74820673e-03
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 9.11597314e-03
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
+  art_sys_22: 0.0
   art_sys_23: -3.01618742e-04
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: -8.39904315e-03
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 1.84897828e-02
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: -1.17688968e-02
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
+  art_sys_43: 0.0
   art_sys_44: 5.76594449e-02
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: -5.51521631e-02
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: -9.01414720e-01
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: -1.49158449e-03
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 9.46831670e-03
   art_sys_62: 0.0
-  art_sys_63: -0.0
+  art_sys_63: 0.0
   art_sys_64: -9.07193600e-04
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
   art_sys_69: -2.68164606e-04
-  art_sys_70: -0.0
+  art_sys_70: 0.0
   art_sys_71: 8.18022041e-05
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: -1.42749990e-06
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: -1.09162130e-05
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: -2.82462222e-06
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
   art_sys_90: -1.57577390e-07
   sys_1: 4.75175757e+00
@@ -3206,7 +3206,7 @@ bins:
   sys_9: 9.89949494e-02
   sys_10: -9.89949494e-02
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 9.89949494e-02
   sys_14: -9.89949494e-02
   sys_15: 7.91959595e-01
@@ -3220,21 +3220,21 @@ bins:
   sys_23: 1.68291414e+00
   sys_24: -1.68291414e+00
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 9.89949494e-02
   sys_30: -9.89949494e-02
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 0.0
-  sys_38: -0.0
+  sys_38: 0.0
   sys_39: 0.0
-  sys_40: -0.0
+  sys_40: 0.0
   sys_41: 0.0
   sys_42: -9.89949494e-02
   sys_43: 9.89949494e-02
@@ -3242,19 +3242,19 @@ bins:
   sys_45: 9.89949494e-02
   sys_46: -9.89949494e-02
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 9.89949494e-02
   sys_62: -9.89949494e-02
   sys_63: 1.97989899e-01
@@ -3266,37 +3266,37 @@ bins:
   sys_69: 5.93969696e-01
   sys_70: -5.93969696e-01
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
   sys_82: -9.89949494e-02
   sys_83: 0.0
   sys_84: -9.89949494e-02
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 2.96984848e-01
   sys_92: -2.96984848e-01
   sys_93: 8.90954544e-01
   sys_94: -8.90954544e-01
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: -9.89949494e-02
   sys_100: 9.89949494e-02
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 1.97989899e-01
   sys_104: -1.97989899e-01
   sys_105: 9.89949494e-02
@@ -3314,92 +3314,92 @@ bins:
   luminosity_uncertainty: 0.0
 - art_sys_1: 0.0
   art_sys_2: -5.63127896e-03
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 2.48544381e-04
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: -2.38378613e-04
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: -6.78572413e-03
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: -4.23603003e-03
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
+  art_sys_22: 0.0
   art_sys_23: -6.79657670e-03
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: -2.51744701e-03
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: -7.47364840e-03
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 6.70918896e-03
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
+  art_sys_43: 0.0
   art_sys_44: 8.14696942e-03
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: -4.51204560e-02
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: -2.01708171e-03
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 5.51864445e-01
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: -7.66459020e-03
   art_sys_62: 0.0
-  art_sys_63: -0.0
+  art_sys_63: 0.0
   art_sys_64: -5.59610386e-03
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
   art_sys_69: 1.68390971e-04
-  art_sys_70: -0.0
+  art_sys_70: 0.0
   art_sys_71: -7.66965461e-05
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 1.42664030e-04
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 3.06825436e-05
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 3.72320589e-06
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
   art_sys_90: 2.88138736e-07
   sys_1: 2.36569645e+00
@@ -3413,7 +3413,7 @@ bins:
   sys_9: 4.63862048e-02
   sys_10: -4.63862048e-02
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 4.63862048e-02
   sys_14: -4.63862048e-02
   sys_15: 3.24703434e-01
@@ -3427,21 +3427,21 @@ bins:
   sys_23: 1.15965512e+00
   sys_24: -1.15965512e+00
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 4.63862048e-02
   sys_30: -4.63862048e-02
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 0.0
-  sys_38: -0.0
+  sys_38: 0.0
   sys_39: 0.0
-  sys_40: -0.0
+  sys_40: 0.0
   sys_41: 0.0
   sys_42: -4.63862048e-02
   sys_43: 4.63862048e-02
@@ -3449,19 +3449,19 @@ bins:
   sys_45: 0.0
   sys_46: -4.63862048e-02
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 4.63862048e-02
   sys_62: -4.63862048e-02
   sys_63: 9.27724097e-02
@@ -3473,15 +3473,15 @@ bins:
   sys_69: 3.71089639e-01
   sys_70: -3.71089639e-01
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 4.63862048e-02
   sys_82: -4.63862048e-02
   sys_83: 4.63862048e-02
@@ -3489,17 +3489,17 @@ bins:
   sys_85: 0.0
   sys_86: -4.63862048e-02
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 1.39158615e-01
   sys_92: -1.39158615e-01
   sys_93: 3.24703434e-01
   sys_94: -3.24703434e-01
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: -4.63862048e-02
   sys_100: 0.0
   sys_101: 0.0
@@ -3521,92 +3521,92 @@ bins:
   luminosity_uncertainty: 0.0
 - art_sys_1: 0.0
   art_sys_2: -3.67271922e-04
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -2.92790764e-03
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: -7.83460395e-03
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 2.97479134e-03
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: -1.19880779e-02
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
+  art_sys_22: 0.0
   art_sys_23: -9.32768772e-04
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: -2.18413077e-03
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: -4.17107831e-03
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 3.77323538e-03
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
+  art_sys_43: 0.0
   art_sys_44: 4.91183870e-03
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: -5.91482697e-03
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 2.38533248e-02
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 1.30018955e-02
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 3.52977558e-01
   art_sys_62: 0.0
-  art_sys_63: -0.0
+  art_sys_63: 0.0
   art_sys_64: 1.78379506e-02
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
   art_sys_69: -5.61951146e-03
-  art_sys_70: -0.0
+  art_sys_70: 0.0
   art_sys_71: -3.75233618e-05
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: -1.44107323e-05
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 1.42116169e-05
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: -2.92026217e-05
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
   art_sys_90: -3.58813381e-07
   sys_1: 1.21806214e+00
@@ -3620,7 +3620,7 @@ bins:
   sys_9: 2.25567063e-02
   sys_10: -2.25567063e-02
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 2.25567063e-02
   sys_14: -2.25567063e-02
   sys_15: 1.57896944e-01
@@ -3634,19 +3634,19 @@ bins:
   sys_23: 7.66928015e-01
   sys_24: -7.66928015e-01
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 2.25567063e-02
   sys_30: -2.25567063e-02
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 0.0
-  sys_38: -0.0
+  sys_38: 0.0
   sys_39: 2.25567063e-02
   sys_40: -2.25567063e-02
   sys_41: 0.0
@@ -3656,19 +3656,19 @@ bins:
   sys_45: 0.0
   sys_46: -2.25567063e-02
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 0.0
   sys_62: -2.25567063e-02
   sys_63: 4.51134126e-02
@@ -3680,15 +3680,15 @@ bins:
   sys_69: 2.25567063e-01
   sys_70: -2.48123770e-01
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 2.25567063e-02
   sys_82: -2.25567063e-02
   sys_83: 4.51134126e-02
@@ -3696,23 +3696,23 @@ bins:
   sys_85: 2.25567063e-02
   sys_86: -2.25567063e-02
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 6.76701190e-02
   sys_92: -6.76701190e-02
   sys_93: 1.35340238e-01
   sys_94: -1.35340238e-01
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 2.25567063e-02
   sys_102: -2.25567063e-02
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 2.25567063e-02
   sys_106: -2.25567063e-02
   sys_107: 2.70680476e-01
@@ -3728,92 +3728,92 @@ bins:
   luminosity_uncertainty: 0.0
 - art_sys_1: 0.0
   art_sys_2: 1.59903365e-03
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -4.88162348e-04
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 5.07425953e-03
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: -1.14427437e-03
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 6.98922566e-04
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
+  art_sys_22: 0.0
   art_sys_23: -2.22478502e-03
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 4.42147469e-03
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: -3.66366543e-03
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: -1.42404657e-03
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
+  art_sys_43: 0.0
   art_sys_44: -3.11874450e-03
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: -2.67881701e-03
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 5.53810261e-03
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: -1.28019058e-02
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 2.96640044e-02
   art_sys_62: 0.0
-  art_sys_63: -0.0
+  art_sys_63: 0.0
   art_sys_64: -2.21406648e-01
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
   art_sys_69: 1.41042611e-02
-  art_sys_70: -0.0
+  art_sys_70: 0.0
   art_sys_71: -4.29514136e-03
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: -1.08130828e-04
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: -1.02810457e-05
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 1.30791015e-05
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
   art_sys_90: 5.15500715e-07
   sys_1: 5.90009898e-01
@@ -3827,7 +3827,7 @@ bins:
   sys_9: 2.10717821e-02
   sys_10: -2.10717821e-02
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 1.05358910e-02
   sys_14: -1.05358910e-02
   sys_15: 7.37512373e-02
@@ -3841,17 +3841,17 @@ bins:
   sys_23: 4.53043315e-01
   sys_24: -4.63579206e-01
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 1.05358910e-02
   sys_30: -1.05358910e-02
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
   sys_34: -1.05358910e-02
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 0.0
   sys_38: -1.05358910e-02
   sys_39: 1.05358910e-02
@@ -3863,19 +3863,19 @@ bins:
   sys_45: 0.0
   sys_46: -1.05358910e-02
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 0.0
   sys_62: -1.05358910e-02
   sys_63: 2.10717821e-02
@@ -3887,15 +3887,15 @@ bins:
   sys_69: 1.26430692e-01
   sys_70: -1.26430692e-01
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 1.05358910e-02
   sys_82: -1.05358910e-02
   sys_83: 3.16076731e-02
@@ -3905,21 +3905,21 @@ bins:
   sys_87: 1.05358910e-02
   sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 4.21435642e-02
   sys_92: -4.21435642e-02
   sys_93: 5.26794552e-02
   sys_94: -5.26794552e-02
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 1.05358910e-02
   sys_102: -1.05358910e-02
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 1.05358910e-02
   sys_106: -1.05358910e-02
   sys_107: 1.15894801e-01
@@ -3935,92 +3935,92 @@ bins:
   luminosity_uncertainty: 0.0
 - art_sys_1: 0.0
   art_sys_2: 1.86630567e-03
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 3.83806142e-04
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 2.00964972e-03
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 3.62178686e-04
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: -3.01797270e-04
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
+  art_sys_22: 0.0
   art_sys_23: 1.24848365e-03
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: -6.64336826e-04
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 5.03706220e-04
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: -7.27098351e-04
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
+  art_sys_43: 0.0
   art_sys_44: -1.98502550e-04
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: -7.13523732e-04
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 1.40810854e-03
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: -1.19428573e-03
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: -1.08710787e-02
   art_sys_62: 0.0
-  art_sys_63: -0.0
+  art_sys_63: 0.0
   art_sys_64: -2.35294277e-02
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
   art_sys_69: -1.41191140e-01
-  art_sys_70: -0.0
+  art_sys_70: 0.0
   art_sys_71: 8.59593556e-03
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 2.16721566e-03
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 1.67789486e-04
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: -3.31225966e-05
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
   art_sys_90: -4.93166581e-07
   sys_1: 2.89135963e-01
@@ -4034,7 +4034,7 @@ bins:
   sys_9: 9.97020561e-03
   sys_10: -9.97020561e-03
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 4.98510281e-03
   sys_14: -4.98510281e-03
   sys_15: 2.99106168e-02
@@ -4048,17 +4048,17 @@ bins:
   sys_23: 2.64210449e-01
   sys_24: -2.64210449e-01
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 4.98510281e-03
   sys_30: -4.98510281e-03
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
   sys_34: -4.98510281e-03
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 4.98510281e-03
   sys_38: -4.98510281e-03
   sys_39: 4.98510281e-03
@@ -4068,23 +4068,23 @@ bins:
   sys_43: 4.98510281e-03
   sys_44: -4.98510281e-03
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 0.0
-  sys_62: -0.0
+  sys_62: 0.0
   sys_63: 9.97020561e-03
   sys_64: -9.97020561e-03
   sys_65: 2.99106168e-02
@@ -4094,15 +4094,15 @@ bins:
   sys_69: 6.48063365e-02
   sys_70: -6.48063365e-02
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 4.98510281e-03
   sys_82: -4.98510281e-03
   sys_83: 2.49255140e-02
@@ -4112,7 +4112,7 @@ bins:
   sys_87: 4.98510281e-03
   sys_88: -4.98510281e-03
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 1.99404112e-02
   sys_92: -1.99404112e-02
   sys_93: 1.99404112e-02
@@ -4120,13 +4120,13 @@ bins:
   sys_95: -4.98510281e-03
   sys_96: 4.98510281e-03
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 4.98510281e-03
   sys_102: -4.98510281e-03
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 4.98510281e-03
   sys_106: -4.98510281e-03
   sys_107: 4.98510281e-02
@@ -4142,92 +4142,92 @@ bins:
   luminosity_uncertainty: 0.0
 - art_sys_1: 0.0
   art_sys_2: 9.45384979e-04
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -8.70290331e-04
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: -8.24770599e-04
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: -1.44122756e-04
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 6.31617950e-05
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
+  art_sys_22: 0.0
   art_sys_23: 7.87719135e-04
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 5.00670262e-04
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: -2.95521635e-04
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: -7.50044230e-04
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
+  art_sys_43: 0.0
   art_sys_44: -2.03205224e-04
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: -1.17004163e-04
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: -8.68435111e-04
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 1.35573286e-04
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: -2.42616255e-03
   art_sys_62: 0.0
-  art_sys_63: -0.0
+  art_sys_63: 0.0
   art_sys_64: 7.63035902e-03
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
   art_sys_69: -1.34883722e-02
-  art_sys_70: -0.0
+  art_sys_70: 0.0
   art_sys_71: -9.68893641e-02
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: -4.47014928e-03
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: -1.31066873e-03
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 3.76798274e-05
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
   art_sys_90: -1.30240207e-06
   sys_1: 1.34753339e-01
@@ -4241,7 +4241,7 @@ bins:
   sys_9: 4.56790981e-03
   sys_10: -4.56790981e-03
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 2.28395490e-03
   sys_14: -2.28395490e-03
   sys_15: 1.37037294e-02
@@ -4255,17 +4255,17 @@ bins:
   sys_23: 1.41605204e-01
   sys_24: -1.39321249e-01
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 2.28395490e-03
   sys_30: -2.28395490e-03
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 2.28395490e-03
   sys_34: -2.28395490e-03
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 2.28395490e-03
   sys_38: -2.28395490e-03
   sys_39: 2.28395490e-03
@@ -4275,23 +4275,23 @@ bins:
   sys_43: 4.56790981e-03
   sys_44: -2.28395490e-03
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 0.0
-  sys_62: -0.0
+  sys_62: 0.0
   sys_63: 4.56790981e-03
   sys_64: -4.56790981e-03
   sys_65: 1.59876843e-02
@@ -4301,15 +4301,15 @@ bins:
   sys_69: 2.96914137e-02
   sys_70: -2.96914137e-02
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 2.28395490e-03
   sys_82: -2.28395490e-03
   sys_83: 1.37037294e-02
@@ -4319,7 +4319,7 @@ bins:
   sys_87: 2.28395490e-03
   sys_88: -2.28395490e-03
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 1.14197745e-02
   sys_92: -1.14197745e-02
   sys_93: 9.13581961e-03
@@ -4327,13 +4327,13 @@ bins:
   sys_95: -2.05555941e-02
   sys_96: 2.05555941e-02
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 2.28395490e-03
   sys_102: -2.28395490e-03
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
   sys_106: -2.28395490e-03
   sys_107: 2.28395490e-02
@@ -4349,92 +4349,92 @@ bins:
   luminosity_uncertainty: 0.0
 - art_sys_1: 0.0
   art_sys_2: -3.56896050e-04
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 3.63503491e-04
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: -3.17847991e-04
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 2.61995734e-04
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 1.06431135e-04
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
+  art_sys_22: 0.0
   art_sys_23: -1.81061970e-04
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 3.27832275e-04
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: -4.77320533e-04
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: -3.31561633e-04
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
+  art_sys_43: 0.0
   art_sys_44: -2.43172450e-04
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 5.26275394e-04
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: -1.58830117e-04
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: -1.33750885e-03
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 3.76527065e-04
   art_sys_62: 0.0
-  art_sys_63: -0.0
+  art_sys_63: 0.0
   art_sys_64: 1.08396822e-03
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
   art_sys_69: 4.17900353e-03
-  art_sys_70: -0.0
+  art_sys_70: 0.0
   art_sys_71: -7.95431387e-03
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 5.85661451e-02
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 3.70234911e-03
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 1.08560343e-03
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
   art_sys_90: 7.43505189e-07
   sys_1: 6.21122597e-02
@@ -4448,7 +4448,7 @@ bins:
   sys_9: 2.03646753e-03
   sys_10: -2.03646753e-03
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 1.01823376e-03
   sys_14: -1.01823376e-03
   sys_15: 7.12763635e-03
@@ -4462,17 +4462,17 @@ bins:
   sys_23: 7.12763635e-02
   sys_24: -6.82216622e-02
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 2.03646753e-03
   sys_30: -1.01823376e-03
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 1.01823376e-03
   sys_34: -1.01823376e-03
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 1.01823376e-03
   sys_38: -1.01823376e-03
   sys_39: 1.01823376e-03
@@ -4482,23 +4482,23 @@ bins:
   sys_43: 2.03646753e-03
   sys_44: -2.03646753e-03
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 1.01823376e-03
   sys_56: -1.01823376e-03
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 0.0
-  sys_62: -0.0
+  sys_62: 0.0
   sys_63: 2.03646753e-03
   sys_64: -2.03646753e-03
   sys_65: 8.14587012e-03
@@ -4508,15 +4508,15 @@ bins:
   sys_69: 1.42552727e-02
   sys_70: -1.42552727e-02
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 1.01823376e-03
   sys_82: -1.01823376e-03
   sys_83: 6.10940259e-03
@@ -4526,7 +4526,7 @@ bins:
   sys_87: 2.03646753e-03
   sys_88: -1.01823376e-03
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 6.10940259e-03
   sys_92: -6.10940259e-03
   sys_93: 3.05470129e-03
@@ -4534,15 +4534,15 @@ bins:
   sys_95: -1.52735065e-02
   sys_96: 1.62917402e-02
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 1.01823376e-03
   sys_102: -1.01823376e-03
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 9.16410388e-03
   sys_108: -9.16410388e-03
   sys_109: 4.07293506e-03
@@ -4556,92 +4556,92 @@ bins:
   luminosity_uncertainty: 0.0
 - art_sys_1: 0.0
   art_sys_2: 2.86758898e-04
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 2.33519970e-04
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 1.04214721e-04
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 1.68795778e-04
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 2.85234691e-04
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
+  art_sys_22: 0.0
   art_sys_23: 1.37763681e-04
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 4.72921381e-04
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 2.84638522e-04
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: -5.97962755e-04
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
+  art_sys_43: 0.0
   art_sys_44: -1.16620506e-04
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 4.51197945e-04
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 2.81990902e-04
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 3.12337233e-04
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 1.27655834e-04
   art_sys_62: 0.0
-  art_sys_63: -0.0
+  art_sys_63: 0.0
   art_sys_64: -2.02533088e-04
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
   art_sys_69: 2.93015810e-04
-  art_sys_70: -0.0
+  art_sys_70: 0.0
   art_sys_71: 2.47588974e-03
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 6.13069375e-03
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: -3.79796250e-02
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: -3.51514731e-03
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
   art_sys_90: -1.64994813e-05
   sys_1: 3.03370022e-02
@@ -4655,7 +4655,7 @@ bins:
   sys_9: 9.63079436e-04
   sys_10: -9.63079436e-04
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 4.81539718e-04
   sys_14: -4.81539718e-04
   sys_15: 3.37077803e-03
@@ -4669,17 +4669,17 @@ bins:
   sys_23: 3.65970186e-02
   sys_24: -3.46708597e-02
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 9.63079436e-04
   sys_30: -4.81539718e-04
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 4.81539718e-04
   sys_34: -4.81539718e-04
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 4.81539718e-04
   sys_38: -4.81539718e-04
   sys_39: 4.81539718e-04
@@ -4689,23 +4689,23 @@ bins:
   sys_43: 9.63079436e-04
   sys_44: -9.63079436e-04
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 4.81539718e-04
   sys_56: -4.81539718e-04
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 0.0
-  sys_62: -0.0
+  sys_62: 0.0
   sys_63: 9.63079436e-04
   sys_64: -9.63079436e-04
   sys_65: 3.85231774e-03
@@ -4715,15 +4715,15 @@ bins:
   sys_69: 6.74155605e-03
   sys_70: -6.74155605e-03
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 4.81539718e-04
   sys_82: -4.81539718e-04
   sys_83: 3.37077803e-03
@@ -4733,7 +4733,7 @@ bins:
   sys_87: 9.63079436e-04
   sys_88: -9.63079436e-04
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 3.37077803e-03
   sys_92: -2.88923831e-03
   sys_93: 1.44461915e-03
@@ -4741,21 +4741,21 @@ bins:
   sys_95: 3.37077803e-03
   sys_96: -3.37077803e-03
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 4.81539718e-04
   sys_102: -4.81539718e-04
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 4.33385746e-03
   sys_108: -4.33385746e-03
   sys_109: 1.92615887e-03
   sys_110: -1.92615887e-03
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 8.66771492e-03
   sys_114: -8.66771492e-03
   sys_115: 2.40769859e-03
@@ -4763,92 +4763,92 @@ bins:
   luminosity_uncertainty: 0.0
 - art_sys_1: 0.0
   art_sys_2: -9.89119291e-05
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -4.96248037e-05
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: -4.96220320e-04
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: -2.07463405e-04
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 8.05834636e-05
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
+  art_sys_22: 0.0
   art_sys_23: 4.58438066e-04
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: -2.50109052e-04
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 2.18443117e-04
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: -2.59185077e-04
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
+  art_sys_43: 0.0
   art_sys_44: 7.29630859e-05
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 7.31535374e-05
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: -2.83446159e-05
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 4.10025772e-05
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 4.02513392e-04
   art_sys_62: 0.0
-  art_sys_63: -0.0
+  art_sys_63: 0.0
   art_sys_64: 2.00390623e-05
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
   art_sys_69: -3.31415661e-04
-  art_sys_70: -0.0
+  art_sys_70: 0.0
   art_sys_71: 8.80102295e-04
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: -1.72450427e-03
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: -5.67477883e-03
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 2.42294647e-02
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
   art_sys_90: 1.96414899e-05
   sys_1: 1.28233815e-02
@@ -4862,7 +4862,7 @@ bins:
   sys_9: 3.94565584e-04
   sys_10: -3.94565584e-04
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 1.97282792e-04
   sys_14: -1.97282792e-04
   sys_15: 1.38097954e-03
@@ -4876,17 +4876,17 @@ bins:
   sys_23: 1.59799061e-02
   sys_24: -1.49934922e-02
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 3.94565584e-04
   sys_30: -1.97282792e-04
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 1.97282792e-04
   sys_34: -1.97282792e-04
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 1.97282792e-04
   sys_38: -1.97282792e-04
   sys_39: 1.97282792e-04
@@ -4896,23 +4896,23 @@ bins:
   sys_43: 3.94565584e-04
   sys_44: -3.94565584e-04
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 1.97282792e-04
   sys_56: -1.97282792e-04
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 0.0
-  sys_62: -0.0
+  sys_62: 0.0
   sys_63: 3.94565584e-04
   sys_64: -3.94565584e-04
   sys_65: 1.57826234e-03
@@ -4922,15 +4922,15 @@ bins:
   sys_69: 2.76195909e-03
   sys_70: -2.76195909e-03
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 1.97282792e-04
   sys_82: -1.97282792e-04
   sys_83: 1.38097954e-03
@@ -4940,7 +4940,7 @@ bins:
   sys_87: 3.94565584e-04
   sys_88: -3.94565584e-04
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 1.57826234e-03
   sys_92: -1.38097954e-03
   sys_93: 3.94565584e-04
@@ -4948,21 +4948,21 @@ bins:
   sys_95: 1.04559880e-02
   sys_96: -1.26260987e-02
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 1.97282792e-04
   sys_102: -1.97282792e-04
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 1.77554513e-03
   sys_108: -1.57826234e-03
   sys_109: 9.86413960e-04
   sys_110: -9.86413960e-04
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 3.55109026e-03
   sys_114: -3.55109026e-03
   sys_115: 9.86413960e-04
@@ -4970,92 +4970,92 @@ bins:
   luminosity_uncertainty: 0.0
 - art_sys_1: 0.0
   art_sys_2: 3.51192820e-05
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 4.91032841e-05
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: -1.55057942e-05
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: -1.49096125e-05
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 2.26975854e-05
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
+  art_sys_22: 0.0
   art_sys_23: -1.50539349e-05
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 7.50201119e-07
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 5.73578075e-06
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: -1.61928066e-05
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
+  art_sys_43: 0.0
   art_sys_44: 2.03052775e-05
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 3.51266809e-05
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 4.16605593e-05
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 4.65157679e-05
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: -3.24008057e-05
   art_sys_62: 0.0
-  art_sys_63: -0.0
+  art_sys_63: 0.0
   art_sys_64: -3.73927805e-05
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
   art_sys_69: 2.85151249e-05
-  art_sys_70: -0.0
+  art_sys_70: 0.0
   art_sys_71: 2.91284953e-05
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: -2.79996968e-05
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 1.67718168e-04
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 1.72603256e-04
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
   art_sys_90: -3.09782100e-03
   sys_1: 1.44334636e-03
@@ -5069,7 +5069,7 @@ bins:
   sys_9: 5.34572727e-05
   sys_10: -5.34572727e-05
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 1.78190909e-05
   sys_14: -1.78190909e-05
   sys_15: 1.42552727e-04
@@ -5083,17 +5083,17 @@ bins:
   sys_23: 1.96010000e-03
   sys_24: -1.74627091e-03
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 3.56381818e-05
   sys_30: -3.56381818e-05
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 1.78190909e-05
   sys_34: -3.56381818e-05
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 1.78190909e-05
   sys_38: -1.78190909e-05
   sys_39: 1.78190909e-05
@@ -5103,23 +5103,23 @@ bins:
   sys_43: 5.34572727e-05
   sys_44: -5.34572727e-05
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 1.78190909e-05
   sys_56: -1.78190909e-05
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 0.0
-  sys_62: -0.0
+  sys_62: 0.0
   sys_63: 3.56381818e-05
   sys_64: -5.34572727e-05
   sys_65: 1.78190909e-04
@@ -5129,15 +5129,15 @@ bins:
   sys_69: 3.20743636e-04
   sys_70: -3.20743636e-04
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 1.78190909e-05
   sys_82: -1.78190909e-05
   sys_83: 1.60371818e-04
@@ -5147,7 +5147,7 @@ bins:
   sys_87: 3.56381818e-05
   sys_88: -5.34572727e-05
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 3.02924545e-04
   sys_92: -2.85105454e-04
   sys_93: 1.78190909e-05
@@ -5155,21 +5155,21 @@ bins:
   sys_95: 3.56381818e-03
   sys_96: -3.56381818e-03
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 1.24733636e-04
   sys_108: -1.24733636e-04
   sys_109: 1.42552727e-04
   sys_110: -1.42552727e-04
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 3.20743636e-04
   sys_114: -3.20743636e-04
   sys_115: 8.90954544e-05
@@ -5179,57 +5179,57 @@ bins:
   art_sys_2: 0.0
   art_sys_3: 9.26298040e+01
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 1.68373855e+01
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 1.32147422e+00
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 2.91699581e-02
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 2.09102772e-02
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
+  art_sys_25: 0.0
   art_sys_26: 2.49685756e-03
-  art_sys_27: -0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 3.45364601e-05
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
   art_sys_37: 1.84619899e-05
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
   art_sys_43: 2.14903160e-05
-  art_sys_44: -0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
   art_sys_46: 3.25400048e-06
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
   art_sys_50: 3.78958112e-07
-  art_sys_51: -0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 1.90510808e-07
   art_sys_57: 0.0
   art_sys_58: 0.0
@@ -5238,20 +5238,20 @@ bins:
   art_sys_61: 0.0
   art_sys_62: 0.0
   art_sys_63: 7.32637398e-08
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
   art_sys_68: 5.94682736e-09
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
   art_sys_72: 1.91383404e-09
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
   art_sys_76: 1.03964175e-09
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
   art_sys_80: 1.08906283e-09
@@ -5260,11 +5260,11 @@ bins:
   art_sys_83: 2.89575025e-10
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 6.90149159e-12
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 2.24244774e+04
   sys_2: -2.10654181e+04
   sys_3: 1.63087108e+04
@@ -5282,17 +5282,17 @@ bins:
   sys_15: 6.79529617e+03
   sys_16: -6.79529617e+03
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 0.0
-  sys_20: -0.0
+  sys_20: 0.0
   sys_21: 0.0
-  sys_22: -0.0
+  sys_22: 0.0
   sys_23: 0.0
-  sys_24: -0.0
+  sys_24: 0.0
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 6.79529617e+02
   sys_30: -6.79529617e+02
   sys_31: 6.79529617e+02
@@ -5310,59 +5310,59 @@ bins:
   sys_43: 6.79529617e+02
   sys_44: -6.79529617e+02
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
   sys_52: -6.79529617e+02
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 6.79529617e+02
   sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 0.0
-  sys_62: -0.0
+  sys_62: 0.0
   sys_63: 0.0
-  sys_64: -0.0
+  sys_64: 0.0
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 3.39764808e+03
   sys_92: -3.39764808e+03
   sys_93: 3.26174216e+04
   sys_94: -2.98993031e+04
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: -4.07717770e+03
   sys_100: 2.03858885e+03
   sys_101: -8.15435540e+03
@@ -5386,57 +5386,57 @@ bins:
   art_sys_2: 0.0
   art_sys_3: 3.65139021e+03
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 2.31061640e+01
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 9.70689288e+00
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: -6.80608476e-01
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: -7.02090387e-03
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
+  art_sys_25: 0.0
   art_sys_26: -1.04366041e-02
-  art_sys_27: -0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: -7.44437571e-04
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
   art_sys_37: 9.39701438e-05
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
   art_sys_43: -1.42058685e-05
-  art_sys_44: -0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
   art_sys_46: 1.02961282e-05
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
   art_sys_50: 3.49804795e-07
-  art_sys_51: -0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: -2.15460810e-07
   art_sys_57: 0.0
   art_sys_58: 0.0
@@ -5445,20 +5445,20 @@ bins:
   art_sys_61: 0.0
   art_sys_62: 0.0
   art_sys_63: -1.30477283e-07
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
   art_sys_68: 4.14502348e-09
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
   art_sys_72: 4.93289716e-09
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
   art_sys_76: 4.01447858e-09
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
   art_sys_80: 1.33468720e-09
@@ -5467,11 +5467,11 @@ bins:
   art_sys_83: -6.90948811e-10
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: -2.58828392e-12
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 9.10753534e+03
   sys_2: -8.32688946e+03
   sys_3: 5.46452121e+03
@@ -5483,27 +5483,27 @@ bins:
   sys_9: 2.08172236e+03
   sys_10: -2.08172236e+03
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 2.60215295e+02
   sys_14: -2.60215295e+02
   sys_15: 2.60215295e+03
   sys_16: -2.60215295e+03
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 2.60215295e+02
   sys_20: -2.60215295e+02
   sys_21: 0.0
-  sys_22: -0.0
+  sys_22: 0.0
   sys_23: 0.0
   sys_24: -2.60215295e+02
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 0.0
   sys_30: -2.60215295e+02
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 2.60215295e+02
   sys_34: -2.60215295e+02
   sys_35: 2.60215295e+02
@@ -5517,59 +5517,59 @@ bins:
   sys_43: 5.20430591e+02
   sys_44: -2.60215295e+02
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 2.60215295e+02
   sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 0.0
-  sys_62: -0.0
+  sys_62: 0.0
   sys_63: 0.0
-  sys_64: -0.0
+  sys_64: 0.0
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 1.30107648e+03
   sys_92: -1.30107648e+03
   sys_93: 1.24903342e+04
   sys_94: -1.17096883e+04
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: -1.56129177e+03
   sys_100: 7.80645886e+02
   sys_101: -3.12258355e+03
@@ -5593,57 +5593,57 @@ bins:
   art_sys_2: 0.0
   art_sys_3: -6.10675898e+01
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 1.44672160e+03
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 1.74066184e+01
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: -5.11740677e+00
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 3.25984936e-01
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
+  art_sys_25: 0.0
   art_sys_26: 5.23491103e-02
-  art_sys_27: -0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 9.07658039e-04
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
   art_sys_37: 1.13554253e-04
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
   art_sys_43: 2.15376483e-04
-  art_sys_44: -0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
   art_sys_46: -6.17320859e-05
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
   art_sys_50: -1.46427221e-05
-  art_sys_51: -0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: -2.89415554e-07
   art_sys_57: 0.0
   art_sys_58: 0.0
@@ -5652,20 +5652,20 @@ bins:
   art_sys_61: 0.0
   art_sys_62: 0.0
   art_sys_63: 8.19215976e-07
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
   art_sys_68: -6.30845370e-08
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
   art_sys_72: -2.84417240e-09
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
   art_sys_76: -9.13305396e-10
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
   art_sys_80: -5.54928127e-09
@@ -5674,11 +5674,11 @@ bins:
   art_sys_83: 1.34844779e-09
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: -1.28800958e-11
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 3.71655324e+03
   sys_2: -3.61331565e+03
   sys_3: 1.85827662e+03
@@ -5690,9 +5690,9 @@ bins:
   sys_9: 7.22663130e+02
   sys_10: -8.25900720e+02
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 0.0
-  sys_14: -0.0
+  sys_14: 0.0
   sys_15: 9.29138310e+02
   sys_16: -1.03237590e+03
   sys_17: 0.0
@@ -5704,15 +5704,15 @@ bins:
   sys_23: 1.03237590e+02
   sys_24: -1.03237590e+02
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 0.0
-  sys_30: -0.0
+  sys_30: 0.0
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 1.03237590e+02
   sys_36: -1.03237590e+02
   sys_37: 2.06475180e+02
@@ -5724,59 +5724,59 @@ bins:
   sys_43: 3.09712770e+02
   sys_44: -2.06475180e+02
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 1.03237590e+02
   sys_56: -1.03237590e+02
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 0.0
-  sys_62: -0.0
+  sys_62: 0.0
   sys_63: 0.0
-  sys_64: -0.0
+  sys_64: 0.0
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 4.12950360e+02
   sys_92: -5.16187950e+02
   sys_93: 4.74892914e+03
   sys_94: -4.64569155e+03
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: -6.19425540e+02
   sys_100: 3.09712770e+02
   sys_101: -1.34208867e+03
@@ -5800,57 +5800,57 @@ bins:
   art_sys_2: 0.0
   art_sys_3: -5.52489968e+01
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: -4.17074828e+01
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 6.26769059e+02
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: -1.29573429e+01
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 2.39437533e+00
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
+  art_sys_25: 0.0
   art_sys_26: 6.13805659e-02
-  art_sys_27: -0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 1.12177924e-02
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
   art_sys_37: 2.59363742e-03
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
   art_sys_43: 9.39279509e-04
-  art_sys_44: -0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
   art_sys_46: -1.44880004e-04
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
   art_sys_50: 2.34958238e-05
-  art_sys_51: -0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: -9.12682930e-06
   art_sys_57: 0.0
   art_sys_58: 0.0
@@ -5859,20 +5859,20 @@ bins:
   art_sys_61: 0.0
   art_sys_62: 0.0
   art_sys_63: -1.12036980e-07
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
   art_sys_68: -2.13772792e-07
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
   art_sys_72: -7.60620444e-08
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
   art_sys_76: 1.02583970e-09
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
   art_sys_80: -1.58156715e-09
@@ -5881,11 +5881,11 @@ bins:
   art_sys_83: 1.11134246e-08
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: -6.53689079e-11
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 1.62026448e+03
   sys_2: -1.62026448e+03
   sys_3: 7.24855161e+02
@@ -5897,7 +5897,7 @@ bins:
   sys_9: 2.55831233e+02
   sys_10: -2.98469772e+02
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 4.26385389e+01
   sys_14: -4.26385389e+01
   sys_15: 3.83746850e+02
@@ -5911,15 +5911,15 @@ bins:
   sys_23: 4.26385389e+01
   sys_24: -4.26385389e+01
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 0.0
-  sys_30: -0.0
+  sys_30: 0.0
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 4.26385389e+01
   sys_36: -4.26385389e+01
   sys_37: 4.26385389e+01
@@ -5933,57 +5933,57 @@ bins:
   sys_45: 4.26385389e+01
   sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 4.26385389e+01
   sys_56: -4.26385389e+01
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 0.0
-  sys_62: -0.0
+  sys_62: 0.0
   sys_63: 0.0
-  sys_64: -0.0
+  sys_64: 0.0
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 1.70554156e+02
   sys_92: -1.70554156e+02
   sys_93: 1.87609571e+03
   sys_94: -1.87609571e+03
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: -2.13192695e+02
   sys_100: 1.27915617e+02
   sys_101: -5.96939545e+02
@@ -6007,57 +6007,57 @@ bins:
   art_sys_2: 0.0
   art_sys_3: -4.97759534e+00
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: -2.38505353e+01
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: -2.86626154e+01
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: -2.89238554e+02
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 2.63445182e+00
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
+  art_sys_25: 0.0
   art_sys_26: 1.03045259e+00
-  art_sys_27: -0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 4.83645775e-02
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
   art_sys_37: 1.16659734e-02
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
   art_sys_43: 6.36159664e-04
-  art_sys_44: -0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
   art_sys_46: -2.37469071e-04
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
   art_sys_50: -4.59008783e-05
-  art_sys_51: -0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 7.38957035e-06
   art_sys_57: 0.0
   art_sys_58: 0.0
@@ -6066,20 +6066,20 @@ bins:
   art_sys_61: 0.0
   art_sys_62: 0.0
   art_sys_63: -9.96614505e-07
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
   art_sys_68: -1.62016668e-06
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
   art_sys_72: 9.45842804e-08
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
   art_sys_76: -3.08106821e-08
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
   art_sys_80: -2.71680892e-09
@@ -6088,11 +6088,11 @@ bins:
   art_sys_83: 4.95602545e-09
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 2.12822070e-10
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 7.91464620e+02
   sys_2: -7.33552575e+02
   sys_3: 3.08864242e+02
@@ -6104,7 +6104,7 @@ bins:
   sys_9: 9.65200756e+01
   sys_10: -9.65200756e+01
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 1.93040151e+01
   sys_14: -1.93040151e+01
   sys_15: 1.54432121e+02
@@ -6118,17 +6118,17 @@ bins:
   sys_23: 3.86080303e+01
   sys_24: -1.93040151e+01
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 0.0
-  sys_30: -0.0
+  sys_30: 0.0
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 1.93040151e+01
   sys_38: -1.93040151e+01
   sys_39: 1.93040151e+01
@@ -6140,57 +6140,57 @@ bins:
   sys_45: 1.93040151e+01
   sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
   sys_56: -1.93040151e+01
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 1.93040151e+01
   sys_62: 0.0
   sys_63: 0.0
-  sys_64: -0.0
+  sys_64: 0.0
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 5.79120454e+01
   sys_92: -7.72160605e+01
   sys_93: 8.30072650e+02
   sys_94: -7.91464620e+02
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: -9.65200756e+01
   sys_100: 7.72160605e+01
   sys_101: -2.50952197e+02
@@ -6214,57 +6214,57 @@ bins:
   art_sys_2: 0.0
   art_sys_3: 1.53205129e+00
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: -2.48576786e+00
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: -1.14117652e+01
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 6.48354595e+00
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 1.25361233e+02
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
+  art_sys_25: 0.0
   art_sys_26: 1.44792701e+00
-  art_sys_27: -0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 3.80054092e-01
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
   art_sys_37: 1.71942618e-02
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
   art_sys_43: 2.79005029e-03
-  art_sys_44: -0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
   art_sys_46: -1.01608603e-03
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
   art_sys_50: -1.01982594e-04
-  art_sys_51: -0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: -3.32065169e-05
   art_sys_57: 0.0
   art_sys_58: 0.0
@@ -6273,20 +6273,20 @@ bins:
   art_sys_61: 0.0
   art_sys_62: 0.0
   art_sys_63: -9.41259663e-07
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
   art_sys_68: -2.94607804e-06
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
   art_sys_72: -1.56252706e-07
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
   art_sys_76: 1.94882985e-07
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
   art_sys_80: 1.36754544e-07
@@ -6295,11 +6295,11 @@ bins:
   art_sys_83: -3.91528408e-09
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 4.67796909e-10
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 3.68261212e+02
   sys_2: -3.41956839e+02
   sys_3: 1.31521861e+02
@@ -6311,7 +6311,7 @@ bins:
   sys_9: 3.50724963e+01
   sys_10: -3.50724963e+01
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 8.76812409e+00
   sys_14: -8.76812409e+00
   sys_15: 7.01449927e+01
@@ -6325,17 +6325,17 @@ bins:
   sys_23: 2.63043723e+01
   sys_24: -8.76812409e+00
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 0.0
-  sys_30: -0.0
+  sys_30: 0.0
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 8.76812409e+00
   sys_38: -8.76812409e+00
   sys_39: 8.76812409e+00
@@ -6347,57 +6347,57 @@ bins:
   sys_45: 8.76812409e+00
   sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
   sys_56: -8.76812409e+00
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 8.76812409e+00
   sys_62: -8.76812409e+00
   sys_63: 0.0
-  sys_64: -0.0
+  sys_64: 0.0
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 2.63043723e+01
   sys_92: -2.63043723e+01
   sys_93: 3.50724963e+02
   sys_94: -3.24420591e+02
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: -3.50724963e+01
   sys_100: 3.50724963e+01
   sys_101: -1.05217489e+02
@@ -6421,57 +6421,57 @@ bins:
   art_sys_2: 0.0
   art_sys_3: 8.46876719e-01
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: -7.97461045e-01
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 1.17547124e-01
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 5.18134817e+00
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: -3.32918160e+00
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
+  art_sys_25: 0.0
   art_sys_26: 5.60384720e+01
-  art_sys_27: -0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 4.01523101e-01
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
   art_sys_37: 2.30683314e-01
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
   art_sys_43: 7.28439818e-03
-  art_sys_44: -0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
   art_sys_46: -1.11017733e-03
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
   art_sys_50: -2.00617662e-04
-  art_sys_51: -0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 1.25665158e-04
   art_sys_57: 0.0
   art_sys_58: 0.0
@@ -6480,20 +6480,20 @@ bins:
   art_sys_61: 0.0
   art_sys_62: 0.0
   art_sys_63: -6.23072218e-06
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
   art_sys_68: 4.56679298e-06
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
   art_sys_72: -9.64297853e-07
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
   art_sys_76: -2.23790103e-07
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
   art_sys_80: -3.10637309e-07
@@ -6502,11 +6502,11 @@ bins:
   art_sys_83: -7.24158239e-08
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: -2.20717904e-09
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 1.77002969e+02
   sys_2: -1.68574257e+02
   sys_3: 6.32153462e+01
@@ -6518,7 +6518,7 @@ bins:
   sys_9: 1.26430692e+01
   sys_10: -1.26430692e+01
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 4.21435642e+00
   sys_14: -4.21435642e+00
   sys_15: 3.79292077e+01
@@ -6532,17 +6532,17 @@ bins:
   sys_23: 1.68574257e+01
   sys_24: -8.42871283e+00
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 0.0
-  sys_30: -0.0
+  sys_30: 0.0
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 0.0
   sys_38: -4.21435642e+00
   sys_39: 4.21435642e+00
@@ -6554,19 +6554,19 @@ bins:
   sys_45: 8.42871283e+00
   sys_46: -4.21435642e+00
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
   sys_56: -4.21435642e+00
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 4.21435642e+00
   sys_62: -4.21435642e+00
   sys_63: 4.21435642e+00
@@ -6574,37 +6574,37 @@ bins:
   sys_65: 0.0
   sys_66: -4.21435642e+00
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 1.26430692e+01
   sys_92: -1.26430692e+01
   sys_93: 1.55931187e+02
   sys_94: -1.43288118e+02
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: -1.26430692e+01
   sys_100: 2.10717821e+01
   sys_101: -4.21435642e+01
@@ -6628,57 +6628,57 @@ bins:
   art_sys_2: 0.0
   art_sys_3: 1.16344122e-01
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 6.93014776e-02
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: -6.52324941e-02
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 4.23154642e-01
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: -2.01615206e+00
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
+  art_sys_25: 0.0
   art_sys_26: -1.04757992e+00
-  art_sys_27: -0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 2.30745202e+01
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
   art_sys_37: 4.39229675e-01
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
   art_sys_43: 9.77952492e-02
-  art_sys_44: -0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
   art_sys_46: -6.78121465e-03
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
   art_sys_50: -1.60631357e-03
-  art_sys_51: -0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 1.04256662e-04
   art_sys_57: 0.0
   art_sys_58: 0.0
@@ -6687,20 +6687,20 @@ bins:
   art_sys_61: 0.0
   art_sys_62: 0.0
   art_sys_63: -1.42531411e-05
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
   art_sys_68: 8.28494075e-06
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
   art_sys_72: 3.06732482e-06
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
   art_sys_76: -1.49259153e-06
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
   art_sys_80: 5.99125235e-08
@@ -6709,11 +6709,11 @@ bins:
   art_sys_83: 7.91953270e-08
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 3.40346514e-10
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 8.93924393e+01
   sys_2: -8.52346514e+01
   sys_3: 2.91045151e+01
@@ -6725,7 +6725,7 @@ bins:
   sys_9: 6.23668181e+00
   sys_10: -6.23668181e+00
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 2.07889394e+00
   sys_14: -2.07889394e+00
   sys_15: 1.87100454e+01
@@ -6739,19 +6739,19 @@ bins:
   sys_23: 8.31557575e+00
   sys_24: -6.23668181e+00
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 0.0
-  sys_30: -0.0
+  sys_30: 0.0
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 0.0
-  sys_38: -0.0
+  sys_38: 0.0
   sys_39: 0.0
   sys_40: -2.07889394e+00
   sys_41: 2.07889394e+00
@@ -6761,19 +6761,19 @@ bins:
   sys_45: 4.15778787e+00
   sys_46: -2.07889394e+00
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 2.07889394e+00
   sys_62: -2.07889394e+00
   sys_63: 2.07889394e+00
@@ -6781,37 +6781,37 @@ bins:
   sys_65: 2.07889394e+00
   sys_66: -2.07889394e+00
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 6.23668181e+00
   sys_92: -6.23668181e+00
   sys_93: 6.86034999e+01
   sys_94: -6.44457120e+01
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: -6.23668181e+00
   sys_100: 1.03944697e+01
   sys_101: -1.66311515e+01
@@ -6835,57 +6835,57 @@ bins:
   art_sys_2: 0.0
   art_sys_3: -3.56230445e-02
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 3.46221755e-02
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: -1.03983710e-01
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 1.73891297e-01
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: -5.06369185e-02
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
+  art_sys_25: 0.0
   art_sys_26: -1.12923616e+00
-  art_sys_27: -0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: -9.42629549e-01
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
   art_sys_37: 1.10789527e+01
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
   art_sys_43: 2.09584287e-01
-  art_sys_44: -0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
   art_sys_46: -5.51389492e-02
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
   art_sys_50: -1.97184331e-03
-  art_sys_51: -0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 1.86393536e-05
   art_sys_57: 0.0
   art_sys_58: 0.0
@@ -6894,20 +6894,20 @@ bins:
   art_sys_61: 0.0
   art_sys_62: 0.0
   art_sys_63: -6.95015185e-05
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
   art_sys_68: -1.85458063e-05
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
   art_sys_72: 7.58583947e-06
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
   art_sys_76: -1.66890514e-07
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
   art_sys_80: -1.42506911e-07
@@ -6916,11 +6916,11 @@ bins:
   art_sys_83: -3.54771850e-07
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: -9.65349257e-09
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 4.28718841e+01
   sys_2: -4.18748636e+01
   sys_3: 1.39582879e+01
@@ -6932,7 +6932,7 @@ bins:
   sys_9: 1.99404112e+00
   sys_10: -1.99404112e+00
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 9.97020561e-01
   sys_14: -9.97020561e-01
   sys_15: 8.97318505e+00
@@ -6946,19 +6946,19 @@ bins:
   sys_23: 4.98510281e+00
   sys_24: -3.98808225e+00
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 0.0
-  sys_30: -0.0
+  sys_30: 0.0
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 0.0
-  sys_38: -0.0
+  sys_38: 0.0
   sys_39: 0.0
   sys_40: -9.97020561e-01
   sys_41: 9.97020561e-01
@@ -6968,17 +6968,17 @@ bins:
   sys_45: 9.97020561e-01
   sys_46: -9.97020561e-01
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 9.97020561e-01
   sys_60: -9.97020561e-01
   sys_61: 9.97020561e-01
@@ -6990,35 +6990,35 @@ bins:
   sys_67: 9.97020561e-01
   sys_68: -9.97020561e-01
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 2.99106168e+00
   sys_92: -2.99106168e+00
   sys_93: 2.89135963e+01
   sys_94: -2.79165757e+01
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: -2.99106168e+00
   sys_100: 3.98808225e+00
   sys_101: -6.97914393e+00
@@ -7042,57 +7042,57 @@ bins:
   art_sys_2: 0.0
   art_sys_3: 2.20671127e-02
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: -5.41995903e-02
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: -1.04787953e-01
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 1.41029359e-02
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: -2.72337984e-02
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
+  art_sys_25: 0.0
   art_sys_26: -1.48874760e-02
-  art_sys_27: -0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: -4.17856240e-01
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
   art_sys_37: -4.91009114e-01
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
   art_sys_43: 4.95403531e+00
-  art_sys_44: -0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
   art_sys_46: -1.55479144e-01
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
   art_sys_50: -2.96485780e-02
-  art_sys_51: -0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 2.34324854e-03
   art_sys_57: 0.0
   art_sys_58: 0.0
@@ -7101,20 +7101,20 @@ bins:
   art_sys_61: 0.0
   art_sys_62: 0.0
   art_sys_63: -8.68262610e-05
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
   art_sys_68: -4.95041606e-05
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
   art_sys_72: 4.59382385e-06
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
   art_sys_76: -5.83798876e-06
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
   art_sys_80: 7.84201589e-07
@@ -7123,11 +7123,11 @@ bins:
   art_sys_83: 5.73288382e-07
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: -1.76751750e-08
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 2.12499730e+01
   sys_2: -2.07670191e+01
   sys_3: 6.76135504e+00
@@ -7139,7 +7139,7 @@ bins:
   sys_9: 9.65907863e-01
   sys_10: -9.65907863e-01
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 4.82953932e-01
   sys_14: -4.82953932e-01
   sys_15: 4.34658538e+00
@@ -7153,19 +7153,19 @@ bins:
   sys_23: 2.89772359e+00
   sys_24: -2.89772359e+00
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 0.0
   sys_30: -4.82953932e-01
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 0.0
-  sys_38: -0.0
+  sys_38: 0.0
   sys_39: 0.0
   sys_40: -4.82953932e-01
   sys_41: 4.82953932e-01
@@ -7175,17 +7175,17 @@ bins:
   sys_45: 4.82953932e-01
   sys_46: -4.82953932e-01
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 4.82953932e-01
   sys_60: -4.82953932e-01
   sys_61: 4.82953932e-01
@@ -7199,33 +7199,33 @@ bins:
   sys_69: 4.82953932e-01
   sys_70: -4.82953932e-01
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 1.44886179e+00
   sys_92: -1.44886179e+00
   sys_93: 1.25568022e+01
   sys_94: -1.25568022e+01
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: -1.44886179e+00
   sys_100: 9.65907863e-01
   sys_101: -2.89772359e+00
@@ -7249,57 +7249,57 @@ bins:
   art_sys_2: 0.0
   art_sys_3: 1.81041225e-02
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: -2.73720267e-02
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: -1.90837606e-02
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 1.76601432e-02
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: -4.10100786e-02
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
+  art_sys_25: 0.0
   art_sys_26: 2.56387568e-03
-  art_sys_27: -0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: -1.68075428e-02
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
   art_sys_37: -2.11470708e-01
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
   art_sys_43: -3.13302816e-01
-  art_sys_44: -0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
   art_sys_46: -2.53953279e+00
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
   art_sys_50: -6.08534883e-02
-  art_sys_51: -0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 1.17720970e-02
   art_sys_57: 0.0
   art_sys_58: 0.0
@@ -7308,20 +7308,20 @@ bins:
   art_sys_61: 0.0
   art_sys_62: 0.0
   art_sys_63: -2.50392673e-04
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
   art_sys_68: -5.90660513e-05
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
   art_sys_72: 3.31712314e-06
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
   art_sys_76: 4.13184789e-06
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
   art_sys_80: -1.27483416e-05
@@ -7330,11 +7330,11 @@ bins:
   art_sys_83: -5.16019090e-07
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 3.00991255e-08
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 1.09290424e+01
   sys_2: -1.06914545e+01
   sys_3: 3.56381818e+00
@@ -7346,7 +7346,7 @@ bins:
   sys_9: 2.37587878e-01
   sys_10: -4.75175757e-01
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 2.37587878e-01
   sys_14: -2.37587878e-01
   sys_15: 1.90070303e+00
@@ -7360,21 +7360,21 @@ bins:
   sys_23: 1.66311515e+00
   sys_24: -1.90070303e+00
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 0.0
   sys_30: -2.37587878e-01
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 0.0
-  sys_38: -0.0
+  sys_38: 0.0
   sys_39: 0.0
-  sys_40: -0.0
+  sys_40: 0.0
   sys_41: 2.37587878e-01
   sys_42: -2.37587878e-01
   sys_43: 2.37587878e-01
@@ -7382,17 +7382,17 @@ bins:
   sys_45: 2.37587878e-01
   sys_46: -2.37587878e-01
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 2.37587878e-01
   sys_60: -2.37587878e-01
   sys_61: 2.37587878e-01
@@ -7406,33 +7406,33 @@ bins:
   sys_69: 2.37587878e-01
   sys_70: -2.37587878e-01
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 7.12763635e-01
   sys_92: -7.12763635e-01
   sys_93: 5.70210908e+00
   sys_94: -5.70210908e+00
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: -4.75175757e-01
   sys_100: 2.37587878e-01
   sys_101: -7.12763635e-01
@@ -7456,57 +7456,57 @@ bins:
   art_sys_2: 0.0
   art_sys_3: -8.68512677e-04
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: -1.37465119e-02
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 1.72832139e-02
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 7.00044639e-03
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: -4.10504956e-03
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
+  art_sys_25: 0.0
   art_sys_26: -6.11939284e-03
-  art_sys_27: -0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: -1.74923980e-02
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
   art_sys_37: 4.15894889e-03
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
   art_sys_43: -1.01028631e-01
-  art_sys_44: -0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
   art_sys_46: 1.26479314e-01
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
   art_sys_50: -1.27371770e+00
-  art_sys_51: -0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 1.98615894e-02
   art_sys_57: 0.0
   art_sys_58: 0.0
@@ -7515,20 +7515,20 @@ bins:
   art_sys_61: 0.0
   art_sys_62: 0.0
   art_sys_63: 5.97384564e-04
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
   art_sys_68: -2.60878420e-04
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
   art_sys_72: -1.05940737e-05
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
   art_sys_76: -1.17119672e-05
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
   art_sys_80: -3.66623807e-06
@@ -7537,11 +7537,11 @@ bins:
   art_sys_83: 1.83659760e-06
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 9.80690203e-08
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 5.50906893e+00
   sys_2: -5.28420898e+00
   sys_3: 1.91130963e+00
@@ -7553,7 +7553,7 @@ bins:
   sys_9: 1.12429978e-01
   sys_10: -1.12429978e-01
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 1.12429978e-01
   sys_14: -1.12429978e-01
   sys_15: 8.99439826e-01
@@ -7567,21 +7567,21 @@ bins:
   sys_23: 1.23672976e+00
   sys_24: -1.23672976e+00
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 0.0
   sys_30: -1.12429978e-01
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 0.0
-  sys_38: -0.0
+  sys_38: 0.0
   sys_39: 0.0
-  sys_40: -0.0
+  sys_40: 0.0
   sys_41: 1.12429978e-01
   sys_42: -1.12429978e-01
   sys_43: 1.12429978e-01
@@ -7589,17 +7589,17 @@ bins:
   sys_45: 1.12429978e-01
   sys_46: -1.12429978e-01
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
   sys_60: -1.12429978e-01
   sys_61: 1.12429978e-01
@@ -7613,33 +7613,33 @@ bins:
   sys_69: 3.37289935e-01
   sys_70: -3.37289935e-01
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 3.37289935e-01
   sys_92: -3.37289935e-01
   sys_93: 2.47345952e+00
   sys_94: -2.47345952e+00
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: -1.12429978e-01
   sys_100: 1.12429978e-01
   sys_101: -2.24859956e-01
@@ -7663,57 +7663,57 @@ bins:
   art_sys_2: 0.0
   art_sys_3: 4.18314695e-05
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 1.27756784e-03
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 8.64304389e-03
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 1.73308281e-03
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 8.30590092e-03
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
+  art_sys_25: 0.0
   art_sys_26: -1.02347699e-02
-  art_sys_27: -0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: -1.25070612e-03
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
   art_sys_37: 5.02844014e-03
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
   art_sys_43: -9.02975890e-03
-  art_sys_44: -0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
   art_sys_46: 4.23111013e-02
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
   art_sys_50: 3.96382176e-02
-  art_sys_51: -0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 6.52828491e-01
   art_sys_57: 0.0
   art_sys_58: 0.0
@@ -7722,20 +7722,20 @@ bins:
   art_sys_61: 0.0
   art_sys_62: 0.0
   art_sys_63: 7.64390192e-03
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
   art_sys_68: -1.11375996e-04
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
   art_sys_72: 1.64301837e-04
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
   art_sys_76: 6.38669270e-05
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
   art_sys_80: -8.99617612e-06
@@ -7744,11 +7744,11 @@ bins:
   art_sys_83: -6.22023231e-07
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: -1.46032664e-07
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 2.80919382e+00
   sys_2: -2.70114790e+00
   sys_3: 1.13448212e+00
@@ -7760,7 +7760,7 @@ bins:
   sys_9: 5.40229581e-02
   sys_10: -5.40229581e-02
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 5.40229581e-02
   sys_14: -5.40229581e-02
   sys_15: 4.32183665e-01
@@ -7774,21 +7774,21 @@ bins:
   sys_23: 8.64367329e-01
   sys_24: -8.64367329e-01
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 5.40229581e-02
   sys_30: -5.40229581e-02
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 0.0
-  sys_38: -0.0
+  sys_38: 0.0
   sys_39: 0.0
-  sys_40: -0.0
+  sys_40: 0.0
   sys_41: 5.40229581e-02
   sys_42: -5.40229581e-02
   sys_43: 5.40229581e-02
@@ -7796,19 +7796,19 @@ bins:
   sys_45: 5.40229581e-02
   sys_46: -5.40229581e-02
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 5.40229581e-02
   sys_62: -5.40229581e-02
   sys_63: 1.08045916e-01
@@ -7820,37 +7820,37 @@ bins:
   sys_69: 2.70114790e-01
   sys_70: -2.70114790e-01
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 5.40229581e-02
   sys_84: -5.40229581e-02
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 1.62068874e-01
   sys_92: -1.62068874e-01
   sys_93: 1.08045916e+00
   sys_94: -1.02643620e+00
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: -5.40229581e-02
   sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 1.62068874e-01
   sys_104: -1.62068874e-01
   sys_105: 1.08045916e-01
@@ -7870,57 +7870,57 @@ bins:
   art_sys_2: 0.0
   art_sys_3: -1.46128210e-03
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 7.17719645e-05
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 4.55268371e-03
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 4.72667099e-04
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: -2.96729467e-04
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
+  art_sys_25: 0.0
   art_sys_26: -4.24007919e-03
-  art_sys_27: -0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: -8.89037120e-03
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
   art_sys_37: 7.38496352e-03
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
   art_sys_43: 1.62832626e-03
-  art_sys_44: -0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
   art_sys_46: 4.56089216e-03
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
   art_sys_50: 3.58867605e-02
-  art_sys_51: -0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 7.35385680e-03
   art_sys_57: 0.0
   art_sys_58: 0.0
@@ -7929,20 +7929,20 @@ bins:
   art_sys_61: 0.0
   art_sys_62: 0.0
   art_sys_63: -4.79401607e-03
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
   art_sys_68: -5.04022928e-03
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
   art_sys_72: -3.67723413e-05
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
   art_sys_76: 1.04345188e-04
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
   art_sys_80: 1.71991386e-05
@@ -7951,11 +7951,11 @@ bins:
   art_sys_83: 4.37841240e-06
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: -1.32867506e-07
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 1.41562778e+00
   sys_2: -1.36415040e+00
   sys_3: 6.69205858e-01
@@ -7967,7 +7967,7 @@ bins:
   sys_9: 5.14773737e-02
   sys_10: -2.57386868e-02
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 2.57386868e-02
   sys_14: -2.57386868e-02
   sys_15: 2.05909495e-01
@@ -7981,21 +7981,21 @@ bins:
   sys_23: 6.17728484e-01
   sys_24: -5.91989797e-01
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 2.57386868e-02
   sys_30: -2.57386868e-02
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 0.0
-  sys_38: -0.0
+  sys_38: 0.0
   sys_39: 0.0
-  sys_40: -0.0
+  sys_40: 0.0
   sys_41: 2.57386868e-02
   sys_42: 0.0
   sys_43: 2.57386868e-02
@@ -8003,19 +8003,19 @@ bins:
   sys_45: 2.57386868e-02
   sys_46: -2.57386868e-02
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 2.57386868e-02
   sys_62: -2.57386868e-02
   sys_63: 5.14773737e-02
@@ -8027,35 +8027,35 @@ bins:
   sys_69: 2.05909495e-01
   sys_70: -1.80170808e-01
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
   sys_82: -2.57386868e-02
   sys_83: 2.57386868e-02
   sys_84: -2.57386868e-02
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 7.72160605e-02
   sys_92: -7.72160605e-02
   sys_93: 4.63296363e-01
   sys_94: -4.37557676e-01
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 2.57386868e-02
   sys_102: -2.57386868e-02
   sys_103: 5.14773737e-02
@@ -8077,57 +8077,57 @@ bins:
   art_sys_2: 0.0
   art_sys_3: 2.18152173e-03
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: -5.26626015e-03
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: -1.97173830e-04
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: -1.23441144e-03
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 1.61777400e-04
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
+  art_sys_25: 0.0
   art_sys_26: 1.26156351e-03
-  art_sys_27: -0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 7.20949083e-04
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
   art_sys_37: 2.97451271e-03
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
   art_sys_43: 2.26006331e-03
-  art_sys_44: -0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
   art_sys_46: -4.47487527e-03
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
   art_sys_50: 2.55428009e-03
-  art_sys_51: -0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: -2.13235462e-02
   art_sys_57: 0.0
   art_sys_58: 0.0
@@ -8136,20 +8136,20 @@ bins:
   art_sys_61: 0.0
   art_sys_62: 0.0
   art_sys_63: 2.31217805e-01
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
   art_sys_68: 1.03912464e-02
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
   art_sys_72: 3.00561414e-03
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
   art_sys_76: -5.26119197e-05
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
   art_sys_80: 1.33008555e-05
@@ -8158,11 +8158,11 @@ bins:
   art_sys_83: -7.53563100e-06
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 8.93373400e-08
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 6.84903628e-01
   sys_2: -6.49477579e-01
   sys_3: 3.89686547e-01
@@ -8174,7 +8174,7 @@ bins:
   sys_9: 2.36173665e-02
   sys_10: -1.18086832e-02
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 1.18086832e-02
   sys_14: -1.18086832e-02
   sys_15: 9.44694660e-02
@@ -8188,21 +8188,21 @@ bins:
   sys_23: 3.89686547e-01
   sys_24: -3.77877864e-01
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 1.18086832e-02
   sys_30: -1.18086832e-02
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 0.0
-  sys_38: -0.0
+  sys_38: 0.0
   sys_39: 0.0
-  sys_40: -0.0
+  sys_40: 0.0
   sys_41: 1.18086832e-02
   sys_42: 0.0
   sys_43: 1.18086832e-02
@@ -8210,19 +8210,19 @@ bins:
   sys_45: 1.18086832e-02
   sys_46: -1.18086832e-02
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 1.18086832e-02
   sys_62: -1.18086832e-02
   sys_63: 2.36173665e-02
@@ -8234,15 +8234,15 @@ bins:
   sys_69: 1.18086832e-01
   sys_70: -1.06278149e-01
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 1.18086832e-02
   sys_82: -1.18086832e-02
   sys_83: 2.36173665e-02
@@ -8250,19 +8250,19 @@ bins:
   sys_85: 1.18086832e-02
   sys_86: -1.18086832e-02
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 4.72347330e-02
   sys_92: -4.72347330e-02
   sys_93: 2.00747615e-01
   sys_94: -1.88938932e-01
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 1.18086832e-02
   sys_102: -1.18086832e-02
   sys_103: 1.18086832e-02
@@ -8284,57 +8284,57 @@ bins:
   art_sys_2: 0.0
   art_sys_3: 4.70256924e-04
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: -5.95141835e-04
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: -5.55918199e-04
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 3.01154717e-03
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: -2.68235196e-03
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
+  art_sys_25: 0.0
   art_sys_26: 1.94939435e-03
-  art_sys_27: -0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 1.98932700e-03
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
   art_sys_37: -1.06813239e-03
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
   art_sys_43: -1.20136426e-03
-  art_sys_44: -0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
   art_sys_46: 3.34349253e-04
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
   art_sys_50: 1.19741859e-03
-  art_sys_51: -0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: -2.23616367e-03
   art_sys_57: 0.0
   art_sys_58: 0.0
@@ -8343,20 +8343,20 @@ bins:
   art_sys_61: 0.0
   art_sys_62: 0.0
   art_sys_63: 1.67271422e-02
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
   art_sys_68: -1.49266938e-01
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
   art_sys_72: -6.94854252e-03
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
   art_sys_76: 1.77282868e-03
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
   art_sys_80: -7.09836104e-05
@@ -8365,11 +8365,11 @@ bins:
   art_sys_83: 8.02632490e-06
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: -6.98743401e-08
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 3.26520698e-01
   sys_2: -3.10462303e-01
   sys_3: 2.24817530e-01
@@ -8381,7 +8381,7 @@ bins:
   sys_9: 1.07055967e-02
   sys_10: -1.07055967e-02
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 5.35279833e-03
   sys_14: -5.35279833e-03
   sys_15: 4.28223867e-02
@@ -8395,17 +8395,17 @@ bins:
   sys_23: 2.35523127e-01
   sys_24: -2.19464732e-01
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 5.35279833e-03
   sys_30: -5.35279833e-03
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 5.35279833e-03
   sys_38: 0.0
   sys_39: 5.35279833e-03
@@ -8417,19 +8417,19 @@ bins:
   sys_45: 5.35279833e-03
   sys_46: -5.35279833e-03
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 5.35279833e-03
   sys_62: -5.35279833e-03
   sys_63: 1.07055967e-02
@@ -8441,15 +8441,15 @@ bins:
   sys_69: 6.42335800e-02
   sys_70: -5.88807817e-02
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 5.35279833e-03
   sys_82: -5.35279833e-03
   sys_83: 1.60583950e-02
@@ -8459,21 +8459,21 @@ bins:
   sys_87: 5.35279833e-03
   sys_88: -5.35279833e-03
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 2.67639917e-02
   sys_92: -2.14111933e-02
   sys_93: 8.56447733e-02
   sys_94: -7.49391767e-02
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 5.35279833e-03
   sys_102: -5.35279833e-03
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 5.35279833e-03
   sys_106: -5.35279833e-03
   sys_107: 5.88807817e-02
@@ -8491,57 +8491,57 @@ bins:
   art_sys_2: 0.0
   art_sys_3: -2.46085850e-04
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 1.47153800e-04
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 4.97699113e-04
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 6.05059961e-04
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 4.76071346e-05
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
+  art_sys_25: 0.0
   art_sys_26: 8.35818202e-04
-  art_sys_27: -0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: -5.85732352e-04
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
   art_sys_37: -1.07114356e-03
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
   art_sys_43: -4.72634953e-04
-  art_sys_44: -0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
   art_sys_46: 1.70478205e-04
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
   art_sys_50: -1.58783756e-04
-  art_sys_51: -0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: -5.56762044e-04
   art_sys_57: 0.0
   art_sys_58: 0.0
@@ -8550,20 +8550,20 @@ bins:
   art_sys_61: 0.0
   art_sys_62: 0.0
   art_sys_63: -6.22142282e-03
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
   art_sys_68: -1.19546130e-02
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
   art_sys_72: 9.20410276e-02
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
   art_sys_76: -4.55292657e-03
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
   art_sys_80: 1.24064517e-03
@@ -8572,11 +8572,11 @@ bins:
   art_sys_83: -5.13397924e-05
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 3.23207248e-06
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 1.52056242e-01
   sys_2: -1.42552727e-01
   sys_3: 1.18793939e-01
@@ -8588,7 +8588,7 @@ bins:
   sys_9: 4.75175757e-03
   sys_10: -4.75175757e-03
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 2.37587878e-03
   sys_14: -2.37587878e-03
   sys_15: 1.66311515e-02
@@ -8602,17 +8602,17 @@ bins:
   sys_23: 1.28297454e-01
   sys_24: -1.21169818e-01
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 2.37587878e-03
   sys_30: -2.37587878e-03
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 2.37587878e-03
   sys_38: -2.37587878e-03
   sys_39: 2.37587878e-03
@@ -8622,21 +8622,21 @@ bins:
   sys_43: 2.37587878e-03
   sys_44: -2.37587878e-03
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 2.37587878e-03
   sys_62: -2.37587878e-03
   sys_63: 4.75175757e-03
@@ -8648,15 +8648,15 @@ bins:
   sys_69: 3.32623030e-02
   sys_70: -3.08864242e-02
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 2.37587878e-03
   sys_82: -2.37587878e-03
   sys_83: 9.50351514e-03
@@ -8666,7 +8666,7 @@ bins:
   sys_87: 2.37587878e-03
   sys_88: -2.37587878e-03
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 1.18793939e-02
   sys_92: -1.18793939e-02
   sys_93: 3.56381818e-02
@@ -8674,13 +8674,13 @@ bins:
   sys_95: 0.0
   sys_96: -2.37587878e-03
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 2.37587878e-03
   sys_102: -2.37587878e-03
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 2.37587878e-03
   sys_106: -2.37587878e-03
   sys_107: 2.37587878e-02
@@ -8698,57 +8698,57 @@ bins:
   art_sys_2: 0.0
   art_sys_3: -2.88169245e-04
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 1.12439305e-05
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 3.04501558e-05
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: -2.02223515e-04
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: -3.83822047e-04
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
+  art_sys_25: 0.0
   art_sys_26: 1.77777534e-04
-  art_sys_27: -0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 4.94212210e-04
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
   art_sys_37: -5.72344974e-05
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
   art_sys_43: 5.74295647e-04
-  art_sys_44: -0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
   art_sys_46: 2.40080778e-04
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
   art_sys_50: -4.24680898e-04
-  art_sys_51: -0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: -8.03000491e-04
   art_sys_57: 0.0
   art_sys_58: 0.0
@@ -8757,20 +8757,20 @@ bins:
   art_sys_61: 0.0
   art_sys_62: 0.0
   art_sys_63: -8.70524132e-04
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
   art_sys_68: 3.92899790e-03
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
   art_sys_72: 8.40580936e-03
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
   art_sys_76: 5.29940271e-02
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
   art_sys_80: -3.54877870e-03
@@ -8779,11 +8779,11 @@ bins:
   art_sys_83: 4.87573291e-04
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 2.24826071e-06
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 6.02030714e-02
   sys_2: -5.74665681e-02
   sys_3: 5.29057294e-02
@@ -8795,7 +8795,7 @@ bins:
   sys_9: 1.82433550e-03
   sys_10: -1.82433550e-03
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 9.12167748e-04
   sys_14: -9.12167748e-04
   sys_15: 6.38517423e-03
@@ -8809,17 +8809,17 @@ bins:
   sys_23: 5.83787359e-02
   sys_24: -5.56422326e-02
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 9.12167748e-04
   sys_30: -9.12167748e-04
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 9.12167748e-04
   sys_34: -9.12167748e-04
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 9.12167748e-04
   sys_38: -9.12167748e-04
   sys_39: 9.12167748e-04
@@ -8829,23 +8829,23 @@ bins:
   sys_43: 9.12167748e-04
   sys_44: -9.12167748e-04
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 0.0
-  sys_62: -0.0
+  sys_62: 0.0
   sys_63: 1.82433550e-03
   sys_64: -1.82433550e-03
   sys_65: 6.38517423e-03
@@ -8855,15 +8855,15 @@ bins:
   sys_69: 1.36825162e-02
   sys_70: -1.27703485e-02
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 9.12167748e-04
   sys_82: -9.12167748e-04
   sys_83: 4.56083874e-03
@@ -8873,7 +8873,7 @@ bins:
   sys_87: 9.12167748e-04
   sys_88: -9.12167748e-04
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 5.47300649e-03
   sys_92: -5.47300649e-03
   sys_93: 1.27703485e-02
@@ -8881,13 +8881,13 @@ bins:
   sys_95: -4.56083874e-03
   sys_96: 4.56083874e-03
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 9.12167748e-04
   sys_102: -9.12167748e-04
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 9.12167748e-04
   sys_106: -9.12167748e-04
   sys_107: 9.12167748e-03
@@ -8895,7 +8895,7 @@ bins:
   sys_109: 7.29734198e-03
   sys_110: -7.29734198e-03
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 1.64190195e-02
   sys_114: -1.64190195e-02
   sys_115: 4.56083874e-03
@@ -8905,57 +8905,57 @@ bins:
   art_sys_2: 0.0
   art_sys_3: -1.86112779e-04
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 2.23346462e-04
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 9.03836592e-05
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: -4.22132630e-05
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: -5.84248602e-04
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
+  art_sys_25: 0.0
   art_sys_26: 4.68401462e-04
-  art_sys_27: -0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 4.97849826e-05
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
   art_sys_37: -1.26362761e-05
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
   art_sys_43: -1.53132511e-04
-  art_sys_44: -0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
   art_sys_46: -8.81725415e-04
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
   art_sys_50: -2.12504798e-04
-  art_sys_51: -0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 1.11093697e-04
   art_sys_57: 0.0
   art_sys_58: 0.0
@@ -8964,20 +8964,20 @@ bins:
   art_sys_61: 0.0
   art_sys_62: 0.0
   art_sys_63: 7.49741760e-05
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
   art_sys_68: 5.30286564e-04
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
   art_sys_72: -2.45885211e-03
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
   art_sys_76: 5.73510219e-03
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
   art_sys_80: 3.42996232e-02
@@ -8986,11 +8986,11 @@ bins:
   art_sys_83: -1.62729382e-03
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 1.47087510e-05
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 2.61572940e-02
   sys_2: -2.50032958e-02
   sys_3: 2.46186297e-02
@@ -9002,7 +9002,7 @@ bins:
   sys_9: 7.69332178e-04
   sys_10: -7.69332178e-04
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 3.84666089e-04
   sys_14: -3.84666089e-04
   sys_15: 2.69266262e-03
@@ -9016,17 +9016,17 @@ bins:
   sys_23: 2.76959584e-02
   sys_24: -2.61572940e-02
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 3.84666089e-04
   sys_30: -3.84666089e-04
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 3.84666089e-04
   sys_34: -3.84666089e-04
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 3.84666089e-04
   sys_38: -3.84666089e-04
   sys_39: 3.84666089e-04
@@ -9036,23 +9036,23 @@ bins:
   sys_43: 7.69332178e-04
   sys_44: -7.69332178e-04
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
   sys_56: -3.84666089e-04
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 0.0
-  sys_62: -0.0
+  sys_62: 0.0
   sys_63: 7.69332178e-04
   sys_64: -7.69332178e-04
   sys_65: 3.07732871e-03
@@ -9062,15 +9062,15 @@ bins:
   sys_69: 6.15465742e-03
   sys_70: -5.76999133e-03
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 3.84666089e-04
   sys_82: -3.84666089e-04
   sys_83: 2.30799653e-03
@@ -9080,7 +9080,7 @@ bins:
   sys_87: 3.84666089e-04
   sys_88: -3.84666089e-04
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 2.69266262e-03
   sys_92: -2.69266262e-03
   sys_93: 5.38532525e-03
@@ -9088,13 +9088,13 @@ bins:
   sys_95: -2.30799653e-03
   sys_96: 2.30799653e-03
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 3.84666089e-04
   sys_102: -3.84666089e-04
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 3.84666089e-04
   sys_106: -3.84666089e-04
   sys_107: 3.84666089e-03
@@ -9102,7 +9102,7 @@ bins:
   sys_109: 3.46199480e-03
   sys_110: -3.46199480e-03
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 6.92398960e-03
   sys_114: -6.92398960e-03
   sys_115: 1.92333044e-03
@@ -9112,57 +9112,57 @@ bins:
   art_sys_2: 0.0
   art_sys_3: 1.69681409e-04
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: -5.71602039e-05
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: -3.68633405e-04
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 1.10705351e-04
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: -2.06184352e-05
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
+  art_sys_25: 0.0
   art_sys_26: 2.45025318e-04
-  art_sys_27: -0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: -1.10969370e-04
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
   art_sys_37: 2.20169510e-04
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
   art_sys_43: -1.79880851e-04
-  art_sys_44: -0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
   art_sys_46: -1.66574526e-04
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
   art_sys_50: 1.12096302e-04
-  art_sys_51: -0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 4.04804083e-05
   art_sys_57: 0.0
   art_sys_58: 0.0
@@ -9171,20 +9171,20 @@ bins:
   art_sys_61: 0.0
   art_sys_62: 0.0
   art_sys_63: 1.01634815e-04
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
   art_sys_68: -2.01066406e-05
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
   art_sys_72: -1.79733766e-04
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
   art_sys_76: -9.15421466e-04
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
   art_sys_80: 3.14922015e-03
@@ -9193,11 +9193,11 @@ bins:
   art_sys_83: 1.82970994e-02
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: -1.26793578e-05
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 9.03682466e-03
   sys_2: -8.52770778e-03
   sys_3: 9.03682466e-03
@@ -9209,7 +9209,7 @@ bins:
   sys_9: 2.54558441e-04
   sys_10: -2.54558441e-04
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 1.27279221e-04
   sys_14: -1.27279221e-04
   sys_15: 8.90954544e-04
@@ -9223,17 +9223,17 @@ bins:
   sys_23: 1.01823376e-02
   sys_24: -9.54594155e-03
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 1.27279221e-04
   sys_30: -1.27279221e-04
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 1.27279221e-04
   sys_34: -1.27279221e-04
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 1.27279221e-04
   sys_38: -1.27279221e-04
   sys_39: 1.27279221e-04
@@ -9243,23 +9243,23 @@ bins:
   sys_43: 2.54558441e-04
   sys_44: -2.54558441e-04
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
   sys_56: -1.27279221e-04
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 0.0
-  sys_62: -0.0
+  sys_62: 0.0
   sys_63: 2.54558441e-04
   sys_64: -2.54558441e-04
   sys_65: 1.01823376e-03
@@ -9269,15 +9269,15 @@ bins:
   sys_69: 2.03646753e-03
   sys_70: -1.90918831e-03
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 1.27279221e-04
   sys_82: -1.27279221e-04
   sys_83: 8.90954544e-04
@@ -9287,7 +9287,7 @@ bins:
   sys_87: 2.54558441e-04
   sys_88: -2.54558441e-04
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 1.01823376e-03
   sys_92: -1.01823376e-03
   sys_93: 1.65462987e-03
@@ -9295,13 +9295,13 @@ bins:
   sys_95: 6.36396103e-04
   sys_96: -1.14551299e-03
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 1.27279221e-04
   sys_102: -1.27279221e-04
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 1.27279221e-04
   sys_106: -1.27279221e-04
   sys_107: 1.27279221e-03
@@ -9309,7 +9309,7 @@ bins:
   sys_109: 1.14551299e-03
   sys_110: -1.14551299e-03
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 2.29102597e-03
   sys_114: -2.29102597e-03
   sys_115: 6.36396103e-04
@@ -9319,57 +9319,57 @@ bins:
   art_sys_2: 0.0
   art_sys_3: 3.79588934e-06
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 5.61178365e-06
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 1.34669367e-05
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 2.21024527e-05
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: -1.71852232e-05
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
+  art_sys_25: 0.0
   art_sys_26: 3.23528356e-05
-  art_sys_27: -0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: -7.51576067e-06
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
   art_sys_37: 3.51417643e-05
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
   art_sys_43: 3.36439577e-05
-  art_sys_44: -0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
   art_sys_46: 2.42753463e-05
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
   art_sys_50: 4.45442875e-05
-  art_sys_51: -0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 3.06951183e-05
   art_sys_57: 0.0
   art_sys_58: 0.0
@@ -9378,20 +9378,20 @@ bins:
   art_sys_61: 0.0
   art_sys_62: 0.0
   art_sys_63: 9.96141761e-07
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
   art_sys_68: 3.03943537e-06
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
   art_sys_72: -8.84551020e-05
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
   art_sys_76: -6.25369407e-05
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
   art_sys_80: -1.43853536e-04
@@ -9400,11 +9400,11 @@ bins:
   art_sys_83: 7.96399460e-05
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 3.20193887e-03
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 1.37263568e-03
   sys_2: -1.23835611e-03
   sys_3: 1.64119484e-03
@@ -9416,7 +9416,7 @@ bins:
   sys_9: 4.47598592e-05
   sys_10: -4.47598592e-05
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 1.49199531e-05
   sys_14: -1.49199531e-05
   sys_15: 1.19359625e-04
@@ -9430,17 +9430,17 @@ bins:
   sys_23: 1.79039437e-03
   sys_24: -1.64119484e-03
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 2.98399062e-05
   sys_30: -2.98399062e-05
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 2.98399062e-05
   sys_34: -2.98399062e-05
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 1.49199531e-05
   sys_38: -1.49199531e-05
   sys_39: 1.49199531e-05
@@ -9450,23 +9450,23 @@ bins:
   sys_43: 4.47598592e-05
   sys_44: -4.47598592e-05
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 1.49199531e-05
   sys_56: -1.49199531e-05
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 0.0
-  sys_62: -0.0
+  sys_62: 0.0
   sys_63: 4.47598592e-05
   sys_64: -4.47598592e-05
   sys_65: 1.79039437e-04
@@ -9476,15 +9476,15 @@ bins:
   sys_69: 2.83479109e-04
   sys_70: -2.68559155e-04
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 1.49199531e-05
   sys_82: -1.49199531e-05
   sys_83: 1.49199531e-04
@@ -9494,7 +9494,7 @@ bins:
   sys_87: 4.47598592e-05
   sys_88: -4.47598592e-05
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 2.23799296e-04
   sys_92: -2.08879343e-04
   sys_93: 1.93959390e-04
@@ -9502,21 +9502,21 @@ bins:
   sys_95: 1.28311597e-03
   sys_96: -1.31295587e-03
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 1.49199531e-05
   sys_102: -1.49199531e-05
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 1.93959390e-04
   sys_108: -1.64119484e-04
   sys_109: 2.83479109e-04
   sys_110: -2.83479109e-04
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 2.68559155e-04
   sys_114: -2.68559155e-04
   sys_115: 7.45997654e-05
@@ -9524,7 +9524,7 @@ bins:
   luminosity_uncertainty: 2.32100000e-04
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
   art_sys_5: 2.33198035e+03
   art_sys_6: 0.0
@@ -9532,86 +9532,86 @@ bins:
   art_sys_8: 4.11892328e+01
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 1.30479427e+01
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 8.99591665e-01
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 1.51497724e-01
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
   art_sys_25: 2.23487286e-02
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
   art_sys_30: 3.60848773e-04
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 6.21213775e-04
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
   art_sys_40: 9.52007037e-05
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 3.75026894e-05
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
   art_sys_51: 6.17897095e-06
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 1.09362599e-06
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 7.33430682e-07
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
   art_sys_66: 7.34567167e-09
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
   art_sys_70: 3.61209793e-08
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
   art_sys_74: 3.29817357e-08
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 8.33069175e-09
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 3.81855777e-10
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
   art_sys_88: 8.76485834e-11
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 4.20021428e+03
   sys_2: -4.45477272e+03
   sys_3: 2.67286363e+03
@@ -9623,23 +9623,23 @@ bins:
   sys_9: 1.14551299e+03
   sys_10: -1.14551299e+03
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 1.27279221e+02
   sys_14: -1.27279221e+02
   sys_15: 1.40007143e+03
   sys_16: -1.40007143e+03
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 0.0
-  sys_20: -0.0
+  sys_20: 0.0
   sys_21: 0.0
-  sys_22: -0.0
+  sys_22: 0.0
   sys_23: 0.0
-  sys_24: -0.0
+  sys_24: 0.0
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 0.0
   sys_30: -1.27279221e+02
   sys_31: 0.0
@@ -9657,59 +9657,59 @@ bins:
   sys_43: 2.54558441e+02
   sys_44: -2.54558441e+02
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
   sys_54: -1.27279221e+02
   sys_55: 1.27279221e+02
   sys_56: -1.27279221e+02
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 0.0
-  sys_62: -0.0
+  sys_62: 0.0
   sys_63: 0.0
-  sys_64: -0.0
+  sys_64: 0.0
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 8.90954544e+02
   sys_92: -7.63675324e+02
   sys_93: 8.78226622e+03
   sys_94: -8.65498700e+03
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: -6.36396103e+02
   sys_100: 6.36396103e+02
   sys_101: -2.29102597e+03
@@ -9731,7 +9731,7 @@ bins:
   luminosity_uncertainty: 720.0
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
   art_sys_5: 8.95636175e+01
   art_sys_6: 0.0
@@ -9739,86 +9739,86 @@ bins:
   art_sys_8: -1.10508932e+03
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: -2.67216941e+01
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 6.47161044e+00
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 1.65984201e-01
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
   art_sys_25: 4.22713500e-02
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
   art_sys_30: -3.15270604e-03
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: -1.21404034e-03
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
   art_sys_40: 1.49855462e-04
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -9.06258801e-05
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
   art_sys_51: 3.89461332e-06
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 1.91543676e-06
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: -1.05365902e-06
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
   art_sys_66: 3.37162322e-07
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
   art_sys_70: 3.58179579e-08
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
   art_sys_74: -2.42476016e-08
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: -2.39989687e-08
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: -2.09965775e-09
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
   art_sys_88: -2.67708388e-11
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 2.05428662e+03
   sys_2: -2.11135014e+03
   sys_3: 1.19833386e+03
@@ -9830,27 +9830,27 @@ bins:
   sys_9: 5.13571655e+02
   sys_10: -4.56508138e+02
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 5.70635172e+01
   sys_14: -5.70635172e+01
   sys_15: 6.27698690e+02
   sys_16: -5.70635172e+02
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 5.70635172e+01
   sys_20: -5.70635172e+01
   sys_21: 0.0
-  sys_22: -0.0
+  sys_22: 0.0
   sys_23: 5.70635172e+01
   sys_24: -5.70635172e+01
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 0.0
-  sys_30: -0.0
+  sys_30: 0.0
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 5.70635172e+01
   sys_34: -5.70635172e+01
   sys_35: 5.70635172e+01
@@ -9864,59 +9864,59 @@ bins:
   sys_43: 1.71190552e+02
   sys_44: -1.71190552e+02
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 5.70635172e+01
   sys_56: -5.70635172e+01
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 0.0
-  sys_62: -0.0
+  sys_62: 0.0
   sys_63: 0.0
-  sys_64: -0.0
+  sys_64: 0.0
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 3.99444621e+02
   sys_92: -3.42381103e+02
   sys_93: 4.05150972e+03
   sys_94: -3.93738269e+03
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: -2.85317586e+02
   sys_100: 2.85317586e+02
   sys_101: -9.13016276e+02
@@ -9938,7 +9938,7 @@ bins:
   luminosity_uncertainty: 161.4
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
   art_sys_5: -5.45408283e+01
   art_sys_6: 0.0
@@ -9946,86 +9946,86 @@ bins:
   art_sys_8: -5.97903026e+01
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 5.10268361e+02
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: -8.33812508e+00
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 2.66190364e+00
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
   art_sys_25: 8.50333455e-02
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
   art_sys_30: -1.02489061e-03
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: -3.10105237e-03
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
   art_sys_40: 3.91473778e-04
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 8.69866557e-05
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
   art_sys_51: 5.55024174e-05
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: -5.61323138e-06
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 1.28576822e-07
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
   art_sys_66: -1.85599336e-07
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
   art_sys_70: -2.66378264e-07
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
   art_sys_74: -1.45428562e-08
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: -2.24939332e-10
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 1.73963394e-08
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
   art_sys_88: -1.20617826e-11
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 1.00494016e+03
   sys_2: -1.00494016e+03
   sys_3: 5.28915872e+02
@@ -10037,13 +10037,13 @@ bins:
   sys_9: 2.11566349e+02
   sys_10: -1.85120555e+02
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 2.64457936e+01
   sys_14: -2.64457936e+01
   sys_15: 2.64457936e+02
   sys_16: -2.64457936e+02
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 2.64457936e+01
   sys_20: -2.64457936e+01
   sys_21: 2.64457936e+01
@@ -10051,13 +10051,13 @@ bins:
   sys_23: 2.64457936e+01
   sys_24: -2.64457936e+01
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 0.0
-  sys_30: -0.0
+  sys_30: 0.0
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
   sys_34: -2.64457936e+01
   sys_35: 2.64457936e+01
@@ -10073,57 +10073,57 @@ bins:
   sys_45: 2.64457936e+01
   sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 2.64457936e+01
   sys_56: -2.64457936e+01
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 0.0
-  sys_62: -0.0
+  sys_62: 0.0
   sys_63: 0.0
-  sys_64: -0.0
+  sys_64: 0.0
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 1.58674762e+02
   sys_92: -1.58674762e+02
   sys_93: 1.90409714e+03
   sys_94: -1.82475976e+03
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: -1.32228968e+02
   sys_100: 1.32228968e+02
   sys_101: -3.70241111e+02
@@ -10145,7 +10145,7 @@ bins:
   luminosity_uncertainty: 0.0
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
   art_sys_5: -1.24553514e+01
   art_sys_6: 0.0
@@ -10153,86 +10153,86 @@ bins:
   art_sys_8: 2.63409014e+01
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 1.82092681e+01
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 2.49132069e+02
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: -7.08092036e+00
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
   art_sys_25: 1.58584938e+00
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
   art_sys_30: -3.60811479e-02
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: -1.92201199e-02
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
   art_sys_40: -4.84571565e-05
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -1.62737675e-04
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
   art_sys_51: -8.08997589e-05
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 3.15411999e-06
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: -2.69437490e-06
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
   art_sys_66: -2.77549746e-06
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
   art_sys_70: 2.34617921e-08
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
   art_sys_74: 1.06508888e-07
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: -5.82292265e-09
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 5.11123106e-09
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
   art_sys_88: 5.16173485e-11
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 4.94974747e+02
   sys_2: -4.82600378e+02
   sys_3: 2.22738636e+02
@@ -10244,13 +10244,13 @@ bins:
   sys_9: 8.66205807e+01
   sys_10: -7.42462120e+01
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 1.23743687e+01
   sys_14: -1.23743687e+01
   sys_15: 1.23743687e+02
   sys_16: -1.11369318e+02
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 2.47487373e+01
   sys_20: -1.23743687e+01
   sys_21: 1.23743687e+01
@@ -10258,15 +10258,15 @@ bins:
   sys_23: 2.47487373e+01
   sys_24: -2.47487373e+01
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 0.0
-  sys_30: -0.0
+  sys_30: 0.0
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 1.23743687e+01
   sys_36: -1.23743687e+01
   sys_37: 1.23743687e+01
@@ -10280,57 +10280,57 @@ bins:
   sys_45: 1.23743687e+01
   sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 1.23743687e+01
   sys_56: -1.23743687e+01
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 0.0
-  sys_62: -0.0
+  sys_62: 0.0
   sys_63: 0.0
-  sys_64: -0.0
+  sys_64: 0.0
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 6.18718434e+01
   sys_92: -6.18718434e+01
   sys_93: 8.90954544e+02
   sys_94: -8.41457070e+02
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: -4.94974747e+01
   sys_100: 4.94974747e+01
   sys_101: -1.48492424e+02
@@ -10352,7 +10352,7 @@ bins:
   luminosity_uncertainty: 0.0
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
   art_sys_5: -2.35633244e+00
   art_sys_6: 0.0
@@ -10360,86 +10360,86 @@ bins:
   art_sys_8: 3.99082331e+00
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: -9.32852613e+00
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 1.39793874e+01
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 1.30337400e+02
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
   art_sys_25: -2.76328213e+00
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
   art_sys_30: 7.76356933e-01
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: -4.30527930e-04
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
   art_sys_40: -1.02663986e-03
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -5.32648281e-04
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
   art_sys_51: 1.77002357e-04
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: -1.85461896e-06
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: -4.25636772e-06
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
   art_sys_66: -1.43467859e-07
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
   art_sys_70: 3.50941013e-07
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
   art_sys_74: 2.40483565e-08
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 1.35872271e-07
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: -4.03730569e-08
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
   art_sys_88: 5.92681650e-10
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 2.62534606e+02
   sys_2: -2.50032958e+02
   sys_3: 1.06264007e+02
@@ -10451,13 +10451,13 @@ bins:
   sys_9: 3.75049437e+01
   sys_10: -3.12541197e+01
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 6.25082395e+00
   sys_14: -6.25082395e+00
   sys_15: 5.62574155e+01
   sys_16: -5.62574155e+01
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 1.25016479e+01
   sys_20: -1.25016479e+01
   sys_21: 6.25082395e+00
@@ -10465,17 +10465,17 @@ bins:
   sys_23: 1.87524718e+01
   sys_24: -1.25016479e+01
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 0.0
-  sys_30: -0.0
+  sys_30: 0.0
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 6.25082395e+00
   sys_38: -6.25082395e+00
   sys_39: 6.25082395e+00
@@ -10487,57 +10487,57 @@ bins:
   sys_45: 6.25082395e+00
   sys_46: -6.25082395e+00
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 6.25082395e+00
   sys_56: -6.25082395e+00
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 0.0
-  sys_62: -0.0
+  sys_62: 0.0
   sys_63: 0.0
-  sys_64: -0.0
+  sys_64: 0.0
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 3.12541197e+01
   sys_92: -2.50032958e+01
   sys_93: 4.43808500e+02
   sys_94: -4.12554380e+02
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: -2.50032958e+01
   sys_100: 2.50032958e+01
   sys_101: -7.50098873e+01
@@ -10559,7 +10559,7 @@ bins:
   luminosity_uncertainty: 0.0
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
   art_sys_5: -6.34567093e-01
   art_sys_6: 0.0
@@ -10567,86 +10567,86 @@ bins:
   art_sys_8: 3.47524300e-01
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: -1.64345245e+00
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: -5.96699599e+00
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 6.36735004e+00
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
   art_sys_25: 5.95698306e+01
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
   art_sys_30: -1.40905539e+00
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: -2.77866576e-01
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
   art_sys_40: -7.92766258e-03
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 3.66278323e-04
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
   art_sys_51: -4.72197729e-05
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 1.58434782e-05
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 9.04300392e-07
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
   art_sys_66: 2.37613082e-06
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
   art_sys_70: 2.50846136e-06
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
   art_sys_74: 1.80489595e-06
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 7.39519526e-08
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: -9.63475484e-09
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
   art_sys_88: 2.36230645e-10
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 1.30984460e+02
   sys_2: -1.25030621e+02
   sys_3: 5.06076323e+01
@@ -10658,7 +10658,7 @@ bins:
   sys_9: 1.48845977e+01
   sys_10: -1.19076782e+01
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 2.97691955e+00
   sys_14: -2.97691955e+00
   sys_15: 2.67922759e+01
@@ -10672,17 +10672,17 @@ bins:
   sys_23: 8.93075865e+00
   sys_24: -8.93075865e+00
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 0.0
-  sys_30: -0.0
+  sys_30: 0.0
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 2.97691955e+00
   sys_38: -2.97691955e+00
   sys_39: 2.97691955e+00
@@ -10694,57 +10694,57 @@ bins:
   sys_45: 2.97691955e+00
   sys_46: -2.97691955e+00
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
   sys_56: -2.97691955e+00
   sys_57: 2.97691955e+00
   sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 2.97691955e+00
   sys_62: -2.97691955e+00
   sys_63: 2.97691955e+00
   sys_64: -2.97691955e+00
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 1.19076782e+01
   sys_92: -1.19076782e+01
   sys_93: 2.05407449e+02
   sys_94: -1.93499771e+02
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: -1.48845977e+01
   sys_100: 8.93075865e+00
   sys_101: -3.57230346e+01
@@ -10766,7 +10766,7 @@ bins:
   luminosity_uncertainty: 0.0
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
   art_sys_5: -7.95687397e-03
   art_sys_6: 0.0
@@ -10774,86 +10774,86 @@ bins:
   art_sys_8: -1.71563210e-01
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 1.98610325e-01
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: -3.24289379e-01
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: -2.98563643e+00
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
   art_sys_25: 2.82177164e+00
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
   art_sys_30: 3.09001221e+01
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 3.48210070e-01
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
   art_sys_40: -1.03335483e-01
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 8.58417823e-04
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
   art_sys_51: -6.75162723e-04
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 1.71980189e-04
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 3.06180889e-05
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
   art_sys_66: 9.20327718e-06
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
   art_sys_70: -3.79205098e-07
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
   art_sys_74: 1.91291931e-06
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: -2.08081108e-07
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: -1.11835987e-07
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
   art_sys_88: -1.98790364e-09
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 6.76559768e+01
   sys_2: -6.32436305e+01
   sys_3: 2.50032958e+01
@@ -10865,7 +10865,7 @@ bins:
   sys_9: 5.88312842e+00
   sys_10: -5.88312842e+00
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 1.47078210e+00
   sys_14: -1.47078210e+00
   sys_15: 1.47078210e+01
@@ -10879,17 +10879,17 @@ bins:
   sys_23: 5.88312842e+00
   sys_24: -5.88312842e+00
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 0.0
-  sys_30: -0.0
+  sys_30: 0.0
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 1.47078210e+00
   sys_38: -1.47078210e+00
   sys_39: 1.47078210e+00
@@ -10901,15 +10901,15 @@ bins:
   sys_45: 1.47078210e+00
   sys_46: -1.47078210e+00
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 1.47078210e+00
   sys_58: 0.0
   sys_59: 0.0
@@ -10921,37 +10921,37 @@ bins:
   sys_65: 1.47078210e+00
   sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 5.88312842e+00
   sys_92: -5.88312842e+00
   sys_93: 9.85424010e+01
   sys_94: -9.11884905e+01
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: -7.35391052e+00
   sys_100: 4.41234631e+00
   sys_101: -1.91201674e+01
@@ -10973,7 +10973,7 @@ bins:
   luminosity_uncertainty: 0.0
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
   art_sys_5: 1.52564913e-01
   art_sys_6: 0.0
@@ -10981,86 +10981,86 @@ bins:
   art_sys_8: 7.23789127e-02
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: -1.11637428e-01
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: -2.60344114e-01
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: -2.21037745e-01
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
   art_sys_25: -1.25054374e+00
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
   art_sys_30: 9.24209004e-01
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: -1.23838037e+01
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
   art_sys_40: 2.50324942e-01
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 5.57036350e-02
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
   art_sys_51: -1.81148878e-03
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 2.70935328e-04
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 2.94249444e-05
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
   art_sys_66: 2.68315412e-05
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
   art_sys_70: 1.31564890e-05
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
   art_sys_74: 6.34924848e-07
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: -4.62932059e-07
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 2.69680101e-07
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
   art_sys_88: 6.22427120e-10
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 3.20375940e+01
   sys_2: -2.99926412e+01
   sys_3: 1.09064150e+01
@@ -11072,7 +11072,7 @@ bins:
   sys_9: 2.04495281e+00
   sys_10: -2.04495281e+00
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 6.81650937e-01
   sys_14: -6.81650937e-01
   sys_15: 6.81650937e+00
@@ -11086,19 +11086,19 @@ bins:
   sys_23: 3.40825469e+00
   sys_24: -3.40825469e+00
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 0.0
-  sys_30: -0.0
+  sys_30: 0.0
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 0.0
-  sys_38: -0.0
+  sys_38: 0.0
   sys_39: 6.81650937e-01
   sys_40: -6.81650937e-01
   sys_41: 6.81650937e-01
@@ -11108,15 +11108,15 @@ bins:
   sys_45: 1.36330187e+00
   sys_46: -1.36330187e+00
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 6.81650937e-01
   sys_58: 0.0
   sys_59: 6.81650937e-01
@@ -11128,37 +11128,37 @@ bins:
   sys_65: 6.81650937e-01
   sys_66: -6.81650937e-01
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 2.72660375e+00
   sys_92: -2.72660375e+00
   sys_93: 4.29440090e+01
   sys_94: -4.02174053e+01
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: -3.40825469e+00
   sys_100: 2.72660375e+00
   sys_101: -8.86146218e+00
@@ -11180,7 +11180,7 @@ bins:
   luminosity_uncertainty: 0.0
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
   art_sys_5: 4.83353394e-02
   art_sys_6: 0.0
@@ -11188,86 +11188,86 @@ bins:
   art_sys_8: -2.72779018e-02
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 3.16700332e-02
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: -3.50509083e-03
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 1.21009172e-02
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
   art_sys_25: -1.94002811e-01
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
   art_sys_30: -5.30793968e-01
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: -5.72632250e-01
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
   art_sys_40: -5.54410107e+00
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -1.02990569e-01
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
   art_sys_51: -2.83795870e-02
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 1.29793253e-03
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: -3.07831532e-04
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
   art_sys_66: -9.66556595e-06
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
   art_sys_70: -2.09787115e-05
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
   art_sys_74: 6.81222007e-06
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: -9.85758381e-07
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: -2.84373043e-08
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
   art_sys_88: -8.49427923e-09
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 1.58165645e+01
   sys_2: -1.51575410e+01
   sys_3: 5.27218816e+00
@@ -11279,7 +11279,7 @@ bins:
   sys_9: 9.88535280e-01
   sys_10: -9.88535280e-01
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 3.29511760e-01
   sys_14: -3.29511760e-01
   sys_15: 3.29511760e+00
@@ -11293,19 +11293,19 @@ bins:
   sys_23: 1.64755880e+00
   sys_24: -1.97707056e+00
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 0.0
-  sys_30: -0.0
+  sys_30: 0.0
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 0.0
-  sys_38: -0.0
+  sys_38: 0.0
   sys_39: 3.29511760e-01
   sys_40: -3.29511760e-01
   sys_41: 3.29511760e-01
@@ -11315,15 +11315,15 @@ bins:
   sys_45: 6.59023520e-01
   sys_46: -6.59023520e-01
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 3.29511760e-01
   sys_58: 0.0
   sys_59: 3.29511760e-01
@@ -11337,35 +11337,35 @@ bins:
   sys_67: 3.29511760e-01
   sys_68: -3.29511760e-01
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 1.31804704e+00
   sys_92: -1.31804704e+00
   sys_93: 1.94411938e+01
   sys_94: -1.84526586e+01
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: -1.64755880e+00
   sys_100: 1.31804704e+00
   sys_101: -4.28365288e+00
@@ -11387,7 +11387,7 @@ bins:
   luminosity_uncertainty: 0.0
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
   art_sys_5: -2.87994536e-02
   art_sys_6: 0.0
@@ -11395,86 +11395,86 @@ bins:
   art_sys_8: -3.34221706e-02
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: -1.45146040e-02
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 2.35673767e-02
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 2.76255337e-02
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
   art_sys_25: 8.32034240e-03
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
   art_sys_30: -4.58442863e-02
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 2.18568410e-01
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
   art_sys_40: -2.09306604e-01
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 2.86173114e+00
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
   art_sys_51: 5.55053002e-02
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 1.36256733e-02
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 5.16461752e-04
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
   art_sys_66: 2.13637863e-04
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
   art_sys_70: -1.61167031e-05
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
   art_sys_74: -1.25662139e-06
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 3.17236260e-06
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 7.82809980e-07
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
   art_sys_88: 3.02582864e-08
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 7.83050049e+00
   sys_2: -7.67069436e+00
   sys_3: 2.55689812e+00
@@ -11486,7 +11486,7 @@ bins:
   sys_9: 3.19612265e-01
   sys_10: -3.19612265e-01
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 1.59806133e-01
   sys_14: -1.59806133e-01
   sys_15: 1.59806133e+00
@@ -11500,19 +11500,19 @@ bins:
   sys_23: 9.58836795e-01
   sys_24: -1.11864293e+00
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 0.0
-  sys_30: -0.0
+  sys_30: 0.0
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 0.0
-  sys_38: -0.0
+  sys_38: 0.0
   sys_39: 1.59806133e-01
   sys_40: 0.0
   sys_41: 1.59806133e-01
@@ -11522,17 +11522,17 @@ bins:
   sys_45: 3.19612265e-01
   sys_46: -3.19612265e-01
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 1.59806133e-01
   sys_60: -1.59806133e-01
   sys_61: 1.59806133e-01
@@ -11544,35 +11544,35 @@ bins:
   sys_67: 3.19612265e-01
   sys_68: -3.19612265e-01
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 6.39224530e-01
   sys_92: -6.39224530e-01
   sys_93: 8.94914342e+00
   sys_94: -8.62953116e+00
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: -6.39224530e-01
   sys_100: 4.79418398e-01
   sys_101: -1.91767359e+00
@@ -11594,7 +11594,7 @@ bins:
   luminosity_uncertainty: 0.0
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
   art_sys_5: 7.63020783e-03
   art_sys_6: 0.0
@@ -11602,86 +11602,86 @@ bins:
   art_sys_8: -8.01336625e-03
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 1.87431147e-02
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: -1.26243875e-02
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 2.16682890e-02
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
   art_sys_25: 2.41152715e-03
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
   art_sys_30: -7.48560387e-03
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 4.05153204e-02
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
   art_sys_40: 1.16049619e-01
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 1.32557395e-01
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
   art_sys_51: -1.24315602e+00
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: -2.51612667e-02
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: -9.22195097e-03
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
   art_sys_66: -1.63779360e-04
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
   art_sys_70: -3.42989315e-05
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
   art_sys_74: -7.69044821e-07
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: -3.93893188e-06
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 1.32559588e-07
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
   art_sys_88: -1.07199328e-07
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 3.85868170e+00
   sys_2: -3.78302128e+00
   sys_3: 1.28622723e+00
@@ -11693,7 +11693,7 @@ bins:
   sys_9: 1.51320851e-01
   sys_10: -1.51320851e-01
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 7.56604256e-02
   sys_14: -7.56604256e-02
   sys_15: 7.56604256e-01
@@ -11707,21 +11707,21 @@ bins:
   sys_23: 6.05283405e-01
   sys_24: -6.05283405e-01
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 0.0
-  sys_30: -0.0
+  sys_30: 0.0
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 0.0
-  sys_38: -0.0
+  sys_38: 0.0
   sys_39: 0.0
-  sys_40: -0.0
+  sys_40: 0.0
   sys_41: 7.56604256e-02
   sys_42: -7.56604256e-02
   sys_43: 7.56604256e-02
@@ -11729,17 +11729,17 @@ bins:
   sys_45: 7.56604256e-02
   sys_46: -7.56604256e-02
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 7.56604256e-02
   sys_60: -7.56604256e-02
   sys_61: 7.56604256e-02
@@ -11753,33 +11753,33 @@ bins:
   sys_69: 7.56604256e-02
   sys_70: -7.56604256e-02
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 3.02641702e-01
   sys_92: -3.02641702e-01
   sys_93: 4.01000256e+00
   sys_94: -3.85868170e+00
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: -2.26981277e-01
   sys_100: 1.51320851e-01
   sys_101: -6.80943830e-01
@@ -11801,7 +11801,7 @@ bins:
   luminosity_uncertainty: 0.0
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
   art_sys_5: -4.34520784e-03
   art_sys_6: 0.0
@@ -11809,86 +11809,86 @@ bins:
   art_sys_8: 3.13573120e-03
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 5.76401978e-03
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: -1.81878371e-03
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 1.60382267e-03
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
   art_sys_25: -1.52634349e-03
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
   art_sys_30: -7.48439983e-03
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 3.53954431e-03
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
   art_sys_40: 2.11968683e-02
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -5.86543323e-02
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
   art_sys_51: -5.42906294e-02
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 6.05612221e-01
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 1.52885159e-02
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
   art_sys_66: 4.92673169e-03
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
   art_sys_70: -1.53704969e-04
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
   art_sys_74: 2.35569710e-05
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: -7.65451259e-06
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: -2.79356350e-06
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
   art_sys_88: 2.12624609e-07
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 1.84010398e+00
   sys_2: -1.84010398e+00
   sys_3: 6.59659916e-01
@@ -11900,7 +11900,7 @@ bins:
   sys_9: 6.94378859e-02
   sys_10: -6.94378859e-02
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 3.47189430e-02
   sys_14: -3.47189430e-02
   sys_15: 3.47189430e-01
@@ -11914,21 +11914,21 @@ bins:
   sys_23: 3.81908373e-01
   sys_24: -3.81908373e-01
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 0.0
   sys_30: -3.47189430e-02
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 0.0
-  sys_38: -0.0
+  sys_38: 0.0
   sys_39: 0.0
-  sys_40: -0.0
+  sys_40: 0.0
   sys_41: 3.47189430e-02
   sys_42: -3.47189430e-02
   sys_43: 3.47189430e-02
@@ -11936,17 +11936,17 @@ bins:
   sys_45: 3.47189430e-02
   sys_46: -3.47189430e-02
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 3.47189430e-02
   sys_60: -3.47189430e-02
   sys_61: 3.47189430e-02
@@ -11960,33 +11960,33 @@ bins:
   sys_69: 6.94378859e-02
   sys_70: -6.94378859e-02
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
   sys_78: -3.47189430e-02
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 1.38875772e-01
   sys_92: -1.38875772e-01
   sys_93: 1.73594715e+00
   sys_94: -1.70122820e+00
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: -6.94378859e-02
   sys_100: 6.94378859e-02
   sys_101: -2.08313658e-01
@@ -12008,7 +12008,7 @@ bins:
   luminosity_uncertainty: 0.0
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
   art_sys_5: 4.44328618e-03
   art_sys_6: 0.0
@@ -12016,86 +12016,86 @@ bins:
   art_sys_8: 3.44422933e-03
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: -9.51252728e-05
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: -2.15448156e-03
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: -2.32703303e-03
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
   art_sys_25: 4.52203489e-04
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
   art_sys_30: 3.21855355e-03
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: -1.25044854e-03
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
   art_sys_40: 2.58676170e-03
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -1.71614006e-03
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
   art_sys_51: 3.15078218e-02
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 2.88868612e-02
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: -3.37701525e-01
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
   art_sys_66: -7.81339273e-03
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
   art_sys_70: -2.44957761e-03
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
   art_sys_74: -1.42169631e-05
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: -4.19168303e-05
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: -6.08035069e-06
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
   art_sys_88: 4.28780596e-08
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 8.90742412e-01
   sys_2: -8.75115352e-01
   sys_3: 3.43795317e-01
@@ -12107,7 +12107,7 @@ bins:
   sys_9: 3.12541197e-02
   sys_10: -3.12541197e-02
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 1.56270599e-02
   sys_14: -1.56270599e-02
   sys_15: 1.56270599e-01
@@ -12121,21 +12121,21 @@ bins:
   sys_23: 2.34405898e-01
   sys_24: -2.50032958e-01
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 0.0
   sys_30: -1.56270599e-02
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 0.0
-  sys_38: -0.0
+  sys_38: 0.0
   sys_39: 0.0
-  sys_40: -0.0
+  sys_40: 0.0
   sys_41: 1.56270599e-02
   sys_42: -1.56270599e-02
   sys_43: 1.56270599e-02
@@ -12143,17 +12143,17 @@ bins:
   sys_45: 1.56270599e-02
   sys_46: -1.56270599e-02
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
   sys_60: -1.56270599e-02
   sys_61: 1.56270599e-02
@@ -12167,33 +12167,33 @@ bins:
   sys_69: 6.25082395e-02
   sys_70: -6.25082395e-02
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
   sys_78: -1.56270599e-02
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 1.56270599e-02
   sys_84: -1.56270599e-02
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 6.25082395e-02
   sys_92: -7.81352993e-02
   sys_93: 7.50098873e-01
   sys_94: -7.18844754e-01
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: -3.12541197e-02
   sys_100: 1.56270599e-02
   sys_101: -4.68811796e-02
@@ -12215,7 +12215,7 @@ bins:
   luminosity_uncertainty: 0.0
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
   art_sys_5: -3.15755031e-04
   art_sys_6: 0.0
@@ -12223,86 +12223,86 @@ bins:
   art_sys_8: 2.69947459e-03
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 9.53126026e-04
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 4.16705433e-03
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: -1.28111477e-04
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
   art_sys_25: -9.26640812e-04
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
   art_sys_30: -1.47206210e-03
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 1.69056394e-03
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
   art_sys_40: -5.59117852e-04
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -1.85537167e-03
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
   art_sys_51: 1.80713149e-03
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: -1.63781510e-02
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: -1.70246003e-02
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
   art_sys_66: 1.65556806e-01
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
   art_sys_70: 9.41269596e-03
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
   art_sys_74: 2.38387383e-03
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: -3.25726146e-05
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: -2.35283718e-07
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
   art_sys_88: 5.96572547e-07
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 4.32268517e-01
   sys_2: -4.11352299e-01
   sys_3: 1.88245967e-01
@@ -12314,7 +12314,7 @@ bins:
   sys_9: 1.39441457e-02
   sys_10: -1.39441457e-02
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 6.97207286e-03
   sys_14: -6.97207286e-03
   sys_15: 6.97207286e-02
@@ -12328,21 +12328,21 @@ bins:
   sys_23: 1.53385603e-01
   sys_24: -1.53385603e-01
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 6.97207286e-03
   sys_30: -6.97207286e-03
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 0.0
-  sys_38: -0.0
+  sys_38: 0.0
   sys_39: 0.0
-  sys_40: -0.0
+  sys_40: 0.0
   sys_41: 0.0
   sys_42: -6.97207286e-03
   sys_43: 6.97207286e-03
@@ -12350,19 +12350,19 @@ bins:
   sys_45: 6.97207286e-03
   sys_46: -6.97207286e-03
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 6.97207286e-03
   sys_62: -6.97207286e-03
   sys_63: 1.39441457e-02
@@ -12374,33 +12374,33 @@ bins:
   sys_69: 4.88045100e-02
   sys_70: -4.88045100e-02
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
   sys_78: -6.97207286e-03
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
   sys_82: -6.97207286e-03
   sys_83: 6.97207286e-03
   sys_84: -6.97207286e-03
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 3.48603643e-02
   sys_92: -3.48603643e-02
   sys_93: 3.20715352e-01
   sys_94: -3.06771206e-01
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: -6.97207286e-03
   sys_100: 0.0
   sys_101: -6.97207286e-03
@@ -12422,7 +12422,7 @@ bins:
   luminosity_uncertainty: 0.0
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
   art_sys_5: 1.00952652e-03
   art_sys_6: 0.0
@@ -12430,86 +12430,86 @@ bins:
   art_sys_8: 8.21971106e-05
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: -1.38787719e-03
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 4.42156732e-04
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 6.47787617e-04
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
   art_sys_25: 1.44060249e-03
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
   art_sys_30: -3.49645490e-05
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: -1.39393151e-03
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
   art_sys_40: 9.82839792e-04
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -5.30998535e-04
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
   art_sys_51: -8.66300821e-05
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: -3.22855254e-03
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 6.61896711e-03
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
   art_sys_66: 1.64656363e-02
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
   art_sys_70: -9.86184257e-02
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
   art_sys_74: -6.26548479e-03
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: -9.77059408e-04
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: -3.79118860e-05
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
   art_sys_88: 1.58890740e-07
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 2.03717464e-01
   sys_2: -1.94595786e-01
   sys_3: 1.03379011e-01
@@ -12521,7 +12521,7 @@ bins:
   sys_9: 6.08111832e-03
   sys_10: -6.08111832e-03
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 3.04055916e-03
   sys_14: -3.04055916e-03
   sys_15: 3.04055916e-02
@@ -12535,19 +12535,19 @@ bins:
   sys_23: 9.42573339e-02
   sys_24: -9.42573339e-02
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 3.04055916e-03
   sys_30: -3.04055916e-03
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 0.0
-  sys_38: -0.0
+  sys_38: 0.0
   sys_39: 0.0
   sys_40: -3.04055916e-03
   sys_41: 0.0
@@ -12557,19 +12557,19 @@ bins:
   sys_45: 3.04055916e-03
   sys_46: -3.04055916e-03
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 3.04055916e-03
   sys_62: -3.04055916e-03
   sys_63: 6.08111832e-03
@@ -12581,15 +12581,15 @@ bins:
   sys_69: 2.73650324e-02
   sys_70: -2.73650324e-02
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
   sys_78: -3.04055916e-03
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 3.04055916e-03
   sys_82: -3.04055916e-03
   sys_83: 6.08111832e-03
@@ -12597,21 +12597,21 @@ bins:
   sys_85: 3.04055916e-03
   sys_86: -3.04055916e-03
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 1.52027958e-02
   sys_92: -1.52027958e-02
   sys_93: 1.36825162e-01
   sys_94: -1.30744044e-01
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: -3.04055916e-03
   sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 6.08111832e-03
   sys_104: -6.08111832e-03
   sys_105: 6.08111832e-03
@@ -12629,7 +12629,7 @@ bins:
   luminosity_uncertainty: 0.0
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
   art_sys_5: -1.09404651e-03
   art_sys_6: 0.0
@@ -12637,86 +12637,86 @@ bins:
   art_sys_8: -6.62646501e-04
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: -7.94570300e-05
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: -3.61668794e-04
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: -8.47706268e-05
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
   art_sys_25: -1.60869026e-03
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
   art_sys_30: -7.91431867e-04
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: -2.49501975e-05
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
   art_sys_40: 7.14736485e-04
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 8.91490945e-05
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
   art_sys_51: -6.86676486e-05
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 8.57951501e-05
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 1.22234131e-03
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
   art_sys_66: -4.66375998e-03
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
   art_sys_70: -1.04944841e-02
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
   art_sys_74: 6.17784824e-02
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 2.07139205e-03
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 4.72630768e-04
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
   art_sys_88: 3.01096465e-06
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 8.80772207e-02
   sys_2: -8.31840417e-02
   sys_3: 5.01550840e-02
@@ -12728,7 +12728,7 @@ bins:
   sys_9: 2.44658946e-03
   sys_10: -2.44658946e-03
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 1.22329473e-03
   sys_14: -1.22329473e-03
   sys_15: 1.22329473e-02
@@ -12742,19 +12742,19 @@ bins:
   sys_23: 4.89317893e-02
   sys_24: -4.77084945e-02
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 1.22329473e-03
   sys_30: -1.22329473e-03
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 0.0
-  sys_38: -0.0
+  sys_38: 0.0
   sys_39: 1.22329473e-03
   sys_40: -1.22329473e-03
   sys_41: 1.22329473e-03
@@ -12764,19 +12764,19 @@ bins:
   sys_45: 1.22329473e-03
   sys_46: -1.22329473e-03
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 1.22329473e-03
   sys_62: -1.22329473e-03
   sys_63: 2.44658946e-03
@@ -12788,15 +12788,15 @@ bins:
   sys_69: 1.46795368e-02
   sys_70: -1.46795368e-02
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 1.22329473e-03
   sys_82: -1.22329473e-03
   sys_83: 3.66988419e-03
@@ -12804,19 +12804,19 @@ bins:
   sys_85: 2.44658946e-03
   sys_86: -1.22329473e-03
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 7.33976839e-03
   sys_92: -7.33976839e-03
   sys_93: 5.38249682e-02
   sys_94: -5.13783787e-02
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 1.22329473e-03
   sys_102: 0.0
   sys_103: 1.22329473e-03
@@ -12836,7 +12836,7 @@ bins:
   luminosity_uncertainty: 0.0
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
   art_sys_5: 3.75781788e-04
   art_sys_6: 0.0
@@ -12844,86 +12844,86 @@ bins:
   art_sys_8: 7.28712227e-04
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 4.74809621e-05
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: -2.73257032e-05
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 4.92798949e-04
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
   art_sys_25: -2.30799618e-05
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
   art_sys_30: -2.46427648e-04
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 2.12589442e-04
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
   art_sys_40: 1.29647884e-04
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 2.93203289e-04
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
   art_sys_51: 1.15086968e-04
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: -5.98935240e-05
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 3.14330514e-04
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
   art_sys_66: -8.88056712e-04
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
   art_sys_70: 2.10461293e-03
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
   art_sys_74: 3.93965717e-03
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: -3.50112283e-02
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: -1.49379990e-03
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
   art_sys_88: -2.38061588e-05
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 3.31039111e-02
   sys_2: -3.09260222e-02
   sys_3: 2.09077333e-02
@@ -12935,7 +12935,7 @@ bins:
   sys_9: 8.71155554e-04
   sys_10: -8.71155554e-04
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 4.35577777e-04
   sys_14: -4.35577777e-04
   sys_15: 4.35577777e-03
@@ -12949,17 +12949,17 @@ bins:
   sys_23: 2.13433111e-02
   sys_24: -2.04721555e-02
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 4.35577777e-04
   sys_30: -4.35577777e-04
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 4.35577777e-04
   sys_34: 0.0
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 0.0
   sys_38: -4.35577777e-04
   sys_39: 4.35577777e-04
@@ -12971,19 +12971,19 @@ bins:
   sys_45: 4.35577777e-04
   sys_46: -4.35577777e-04
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 4.35577777e-04
   sys_62: -4.35577777e-04
   sys_63: 8.71155554e-04
@@ -12995,15 +12995,15 @@ bins:
   sys_69: 6.09808888e-03
   sys_70: -6.09808888e-03
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 4.35577777e-04
   sys_82: -4.35577777e-04
   sys_83: 1.74231111e-03
@@ -13013,17 +13013,17 @@ bins:
   sys_87: 4.35577777e-04
   sys_88: -4.35577777e-04
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 3.04904444e-03
   sys_92: -3.04904444e-03
   sys_93: 1.91654222e-02
   sys_94: -1.78586889e-02
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 4.35577777e-04
   sys_102: -4.35577777e-04
   sys_103: 4.35577777e-04
@@ -13043,7 +13043,7 @@ bins:
   luminosity_uncertainty: 0.000616
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
   art_sys_5: 7.30622835e-05
   art_sys_6: 0.0
@@ -13051,86 +13051,86 @@ bins:
   art_sys_8: 8.67752216e-06
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: -5.18515278e-04
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: -2.58460568e-05
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 3.23848987e-04
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
   art_sys_25: 1.04490218e-04
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
   art_sys_30: 1.81578800e-04
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 1.93298848e-04
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
   art_sys_40: -6.84279374e-06
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -1.16004230e-04
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
   art_sys_51: 1.97725129e-05
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 8.90667264e-05
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: -1.04359120e-04
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
   art_sys_66: 8.37153065e-05
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
   art_sys_70: 2.43272098e-04
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
   art_sys_74: -1.31494654e-03
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: -2.97926610e-03
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 1.79118225e-02
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
   art_sys_88: 3.90299005e-05
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 1.07678221e-02
   sys_2: -9.97020561e-03
   sys_3: 7.44442019e-03
@@ -13142,7 +13142,7 @@ bins:
   sys_9: 2.65872150e-04
   sys_10: -2.65872150e-04
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 1.32936075e-04
   sys_14: -1.32936075e-04
   sys_15: 1.32936075e-03
@@ -13156,17 +13156,17 @@ bins:
   sys_23: 7.84322842e-03
   sys_24: -7.57735627e-03
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 1.32936075e-04
   sys_30: -1.32936075e-04
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 1.32936075e-04
   sys_34: -1.32936075e-04
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 0.0
   sys_38: -1.32936075e-04
   sys_39: 1.32936075e-04
@@ -13178,19 +13178,19 @@ bins:
   sys_45: 1.32936075e-04
   sys_46: -1.32936075e-04
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 1.32936075e-04
   sys_62: -1.32936075e-04
   sys_63: 3.98808225e-04
@@ -13202,15 +13202,15 @@ bins:
   sys_69: 2.12697720e-03
   sys_70: -2.12697720e-03
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 1.32936075e-04
   sys_82: -1.32936075e-04
   sys_83: 6.64680374e-04
@@ -13220,7 +13220,7 @@ bins:
   sys_87: 1.32936075e-04
   sys_88: -1.32936075e-04
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 1.06348860e-03
   sys_92: -1.06348860e-03
   sys_93: 5.84918729e-03
@@ -13228,13 +13228,13 @@ bins:
   sys_95: 0.0
   sys_96: -1.32936075e-04
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 1.32936075e-04
   sys_102: -1.32936075e-04
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 2.65872150e-04
   sys_106: -2.65872150e-04
   sys_107: 1.72816897e-03
@@ -13250,7 +13250,7 @@ bins:
   luminosity_uncertainty: 1.69200000e-03
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
   art_sys_5: 5.65398720e-05
   art_sys_6: 0.0
@@ -13258,86 +13258,86 @@ bins:
   art_sys_8: 6.49130100e-06
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: -9.75490832e-06
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 6.89014973e-06
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 2.50663143e-05
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
   art_sys_25: 2.07886872e-06
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
   art_sys_30: -1.45812828e-05
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 7.69113733e-07
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
   art_sys_40: 9.58227234e-06
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 1.45046920e-05
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
   art_sys_51: 3.71925535e-05
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 3.84229834e-05
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: -8.16692233e-06
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
   art_sys_66: 3.37707324e-05
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
   art_sys_70: -2.47368030e-05
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
   art_sys_74: 1.24092432e-05
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 2.17139387e-04
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 2.20986029e-04
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
   art_sys_88: -3.33086376e-03
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 2.03010357e-03
   sys_2: -1.80863772e-03
   sys_3: 1.84554870e-03
@@ -13349,7 +13349,7 @@ bins:
   sys_9: 7.38219480e-05
   sys_10: -5.53664610e-05
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 1.84554870e-05
   sys_14: -1.84554870e-05
   sys_15: 2.03010357e-04
@@ -13363,17 +13363,17 @@ bins:
   sys_23: 2.21465844e-03
   sys_24: -2.03010357e-03
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 5.53664610e-05
   sys_30: -3.69109740e-05
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 3.69109740e-05
   sys_34: -3.69109740e-05
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 1.84554870e-05
   sys_38: -1.84554870e-05
   sys_39: 3.69109740e-05
@@ -13385,19 +13385,19 @@ bins:
   sys_45: 1.84554870e-05
   sys_46: -1.84554870e-05
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 1.84554870e-05
   sys_56: -1.84554870e-05
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 1.84554870e-05
   sys_62: -1.84554870e-05
   sys_63: 7.38219480e-05
@@ -13409,15 +13409,15 @@ bins:
   sys_69: 4.61387175e-04
   sys_70: -4.24476201e-04
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 1.84554870e-05
   sys_82: -1.84554870e-05
   sys_83: 2.03010357e-04
@@ -13427,7 +13427,7 @@ bins:
   sys_87: 3.69109740e-05
   sys_88: -3.69109740e-05
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 2.58376818e-04
   sys_92: -2.58376818e-04
   sys_93: 9.04318862e-04
@@ -13435,13 +13435,13 @@ bins:
   sys_95: 5.53664610e-05
   sys_96: -7.38219480e-05
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 3.69109740e-05
   sys_102: -1.84554870e-05
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 3.69109740e-05
   sys_106: -3.69109740e-05
   sys_107: 2.58376818e-04
@@ -13449,7 +13449,7 @@ bins:
   sys_109: 6.27486558e-04
   sys_110: -6.27486558e-04
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 3.32198766e-04
   sys_114: -3.32198766e-04
   sys_115: 9.22774349e-05
@@ -13457,9 +13457,9 @@ bins:
   luminosity_uncertainty: 4.43700000e-04
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
@@ -13468,83 +13468,83 @@ bins:
   art_sys_11: 1.05822332e+02
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 1.54662983e+01
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 9.68552044e-01
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 1.74252968e-01
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 5.26652034e-04
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
   art_sys_32: 6.13531138e-03
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 1.75138934e-03
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 7.29104001e-04
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
   art_sys_48: 2.48096920e-05
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 2.28006616e-05
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: 3.24912541e-06
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
   art_sys_65: 2.03780513e-07
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
+  art_sys_72: 0.0
   art_sys_73: 1.01661787e-07
-  art_sys_74: -0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
+  art_sys_76: 0.0
   art_sys_77: 5.42627878e-08
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 7.17831092e-09
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 1.33458464e-10
-  art_sys_88: -0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 1.26260987e+03
   sys_2: -1.22753737e+03
   sys_3: 8.41739912e+02
@@ -13562,17 +13562,17 @@ bins:
   sys_15: 3.50724963e+02
   sys_16: -3.50724963e+02
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 0.0
   sys_20: -3.50724963e+01
   sys_21: 0.0
-  sys_22: -0.0
+  sys_22: 0.0
   sys_23: 0.0
-  sys_24: -0.0
+  sys_24: 0.0
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 3.50724963e+01
   sys_30: -3.50724963e+01
   sys_31: 3.50724963e+01
@@ -13590,59 +13590,59 @@ bins:
   sys_43: 7.01449927e+01
   sys_44: -7.01449927e+01
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 3.50724963e+01
   sys_52: -3.50724963e+01
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 3.50724963e+01
   sys_56: -3.50724963e+01
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 0.0
-  sys_62: -0.0
+  sys_62: 0.0
   sys_63: 0.0
-  sys_64: -0.0
+  sys_64: 0.0
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 2.45507474e+02
   sys_92: -2.10434978e+02
   sys_93: 3.85797460e+03
   sys_94: -3.50724963e+03
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: -1.40289985e+02
   sys_100: 1.05217489e+02
   sys_101: -4.91014949e+02
@@ -13664,9 +13664,9 @@ bins:
   luminosity_uncertainty: 99.2
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
@@ -13675,83 +13675,83 @@ bins:
   art_sys_11: -5.48380604e+02
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: -4.00954459e+01
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: -7.90760820e+00
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: -4.44007650e-01
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: -5.39301823e-02
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
   art_sys_32: -1.87162444e-03
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 2.28485908e-04
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: -4.18398407e-04
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
   art_sys_48: -3.18959075e-05
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: -5.08200322e-06
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: -1.10585096e-06
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
   art_sys_65: 1.05548441e-07
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
+  art_sys_72: 0.0
   art_sys_73: 3.05399083e-08
-  art_sys_74: -0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
+  art_sys_76: 0.0
   art_sys_77: -2.46576399e-08
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: -1.03499634e-08
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: -6.38749618e-11
-  art_sys_88: -0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 6.85186471e+02
   sys_2: -6.67155248e+02
   sys_3: 4.14718127e+02
@@ -13769,17 +13769,17 @@ bins:
   sys_15: 1.98343452e+02
   sys_16: -1.98343452e+02
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 0.0
   sys_20: -1.80312229e+01
   sys_21: 0.0
-  sys_22: -0.0
+  sys_22: 0.0
   sys_23: 1.80312229e+01
   sys_24: 0.0
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 1.80312229e+01
   sys_30: 0.0
   sys_31: 1.80312229e+01
@@ -13797,59 +13797,59 @@ bins:
   sys_43: 5.40936688e+01
   sys_44: -5.40936688e+01
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 1.80312229e+01
   sys_56: -1.80312229e+01
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 0.0
-  sys_62: -0.0
+  sys_62: 0.0
   sys_63: 0.0
-  sys_64: -0.0
+  sys_64: 0.0
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 1.26218560e+02
   sys_92: -1.08187338e+02
   sys_93: 1.98343452e+03
   sys_94: -1.80312229e+03
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: -7.21248917e+01
   sys_100: 7.21248917e+01
   sys_101: -2.52437121e+02
@@ -13871,9 +13871,9 @@ bins:
   luminosity_uncertainty: 25.5
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
@@ -13882,83 +13882,83 @@ bins:
   art_sys_11: -9.17846196e+01
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 2.64335774e+02
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 2.82224968e+01
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 3.37737435e+00
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 2.58525355e-01
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
   art_sys_32: -4.93910361e-02
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 6.41359012e-04
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 1.05304412e-03
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
   art_sys_48: 4.99850286e-05
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 2.38715890e-05
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: -6.36227631e-06
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
   art_sys_65: -2.17630487e-07
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
+  art_sys_72: 0.0
   art_sys_73: 2.74463201e-07
-  art_sys_74: -0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
+  art_sys_76: 0.0
   art_sys_77: 1.66565097e-07
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 1.12107781e-08
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: -2.07223164e-10
-  art_sys_88: -0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 3.45068109e+02
   sys_2: -3.36441406e+02
   sys_3: 1.89787460e+02
@@ -13970,23 +13970,23 @@ bins:
   sys_9: 7.76403246e+01
   sys_10: -6.90136218e+01
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 8.62670273e+00
   sys_14: -8.62670273e+00
   sys_15: 9.48937300e+01
   sys_16: -9.48937300e+01
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 8.62670273e+00
   sys_20: -8.62670273e+00
   sys_21: 0.0
-  sys_22: -0.0
+  sys_22: 0.0
   sys_23: 8.62670273e+00
   sys_24: 0.0
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 8.62670273e+00
   sys_30: 0.0
   sys_31: 8.62670273e+00
@@ -14006,57 +14006,57 @@ bins:
   sys_45: 8.62670273e+00
   sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 8.62670273e+00
   sys_56: -8.62670273e+00
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 0.0
-  sys_62: -0.0
+  sys_62: 0.0
   sys_63: 0.0
-  sys_64: -0.0
+  sys_64: 0.0
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 6.03869191e+01
   sys_92: -5.17602164e+01
   sys_93: 1.03520433e+03
   sys_94: -9.48937300e+02
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: -3.45068109e+01
   sys_100: 3.45068109e+01
   sys_101: -1.20773838e+02
@@ -14078,9 +14078,9 @@ bins:
   luminosity_uncertainty: 0.0
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
@@ -14089,83 +14089,83 @@ bins:
   art_sys_11: 1.21576343e+01
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 5.35467638e+01
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: -1.47703546e+02
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: -9.30058149e+00
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: -2.12197547e+00
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
   art_sys_32: 6.27801622e-02
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: -1.07652466e-02
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: -1.17164265e-03
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
   art_sys_48: 2.25238844e-05
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: -5.54662882e-05
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: -2.51878317e-05
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
   art_sys_65: 4.62254240e-06
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
+  art_sys_72: 0.0
   art_sys_73: -3.11603567e-07
-  art_sys_74: -0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
+  art_sys_76: 0.0
   art_sys_77: -2.88768546e-07
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: -1.21574040e-08
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: -6.21697638e-10
-  art_sys_88: -0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 1.82348697e+02
   sys_2: -1.78007061e+02
   sys_3: 9.11743484e+01
@@ -14177,13 +14177,13 @@ bins:
   sys_9: 3.47330851e+01
   sys_10: -3.47330851e+01
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 4.34163564e+00
   sys_14: -4.34163564e+00
   sys_15: 4.77579920e+01
   sys_16: -4.77579920e+01
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 4.34163564e+00
   sys_20: -4.34163564e+00
   sys_21: 4.34163564e+00
@@ -14191,13 +14191,13 @@ bins:
   sys_23: 4.34163564e+00
   sys_24: -4.34163564e+00
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 0.0
-  sys_30: -0.0
+  sys_30: 0.0
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 4.34163564e+00
   sys_34: -4.34163564e+00
   sys_35: 4.34163564e+00
@@ -14213,57 +14213,57 @@ bins:
   sys_45: 4.34163564e+00
   sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 4.34163564e+00
   sys_56: -4.34163564e+00
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 0.0
-  sys_62: -0.0
+  sys_62: 0.0
   sys_63: 0.0
-  sys_64: -0.0
+  sys_64: 0.0
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 3.03914495e+01
   sys_92: -2.60498138e+01
   sys_93: 5.20996276e+02
   sys_94: -4.77579920e+02
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: -1.73665425e+01
   sys_100: 2.17081782e+01
   sys_101: -6.07828989e+01
@@ -14285,9 +14285,9 @@ bins:
   luminosity_uncertainty: 0.0
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
@@ -14296,83 +14296,83 @@ bins:
   art_sys_11: 2.37026067e+00
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: -5.67694994e+00
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: -2.21383210e+01
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 6.88004975e+01
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 6.79426548e+00
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
   art_sys_32: -1.08646485e+00
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 5.72672639e-02
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 3.69348743e-03
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
   art_sys_48: -9.81332931e-05
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: -8.25164443e-05
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: -2.91006884e-05
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
   art_sys_65: -8.24371422e-06
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
+  art_sys_72: 0.0
   art_sys_73: 5.55643028e-07
-  art_sys_74: -0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
+  art_sys_76: 0.0
   art_sys_77: 4.38999593e-07
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 7.12822837e-08
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 3.92018610e-09
-  art_sys_88: -0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 8.77378094e+01
   sys_2: -8.57437683e+01
   sys_3: 3.98808225e+01
@@ -14384,13 +14384,13 @@ bins:
   sys_9: 1.39582879e+01
   sys_10: -1.39582879e+01
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 1.99404112e+00
   sys_14: -1.99404112e+00
   sys_15: 2.19344524e+01
   sys_16: -1.99404112e+01
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 3.98808225e+00
   sys_20: -3.98808225e+00
   sys_21: 1.99404112e+00
@@ -14398,13 +14398,13 @@ bins:
   sys_23: 3.98808225e+00
   sys_24: -3.98808225e+00
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 0.0
-  sys_30: -0.0
+  sys_30: 0.0
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
   sys_34: -1.99404112e+00
   sys_35: 1.99404112e+00
@@ -14420,57 +14420,57 @@ bins:
   sys_45: 1.99404112e+00
   sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 1.99404112e+00
   sys_56: -1.99404112e+00
   sys_57: 0.0
   sys_58: -1.99404112e+00
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 0.0
-  sys_62: -0.0
+  sys_62: 0.0
   sys_63: 0.0
-  sys_64: -0.0
+  sys_64: 0.0
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 1.39582879e+01
   sys_92: -1.39582879e+01
   sys_93: 2.39284935e+02
   sys_94: -2.19344524e+02
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: -7.97616449e+00
   sys_100: 9.97020561e+00
   sys_101: -2.79165757e+01
@@ -14492,9 +14492,9 @@ bins:
   luminosity_uncertainty: 0.0
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
@@ -14503,83 +14503,83 @@ bins:
   art_sys_11: -1.23682561e-01
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: -2.01230116e+00
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 4.15881071e+00
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 1.26644212e+01
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: -3.93721103e+01
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
   art_sys_32: 2.80465106e+00
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: -4.36143863e-01
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: -1.72570304e-02
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
   art_sys_48: -5.55025645e-04
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: -1.89921974e-04
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: 7.31993643e-05
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
   art_sys_65: 9.33566451e-07
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
+  art_sys_72: 0.0
   art_sys_73: 1.61604621e-06
-  art_sys_74: -0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
+  art_sys_76: 0.0
   art_sys_77: 5.89096510e-07
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: -8.32020540e-08
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: -3.47346911e-09
-  art_sys_88: -0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 4.78569870e+01
   sys_2: -4.58205194e+01
   sys_3: 2.03646753e+01
@@ -14591,7 +14591,7 @@ bins:
   sys_9: 6.10940259e+00
   sys_10: -6.10940259e+00
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 1.01823376e+00
   sys_14: -1.01823376e+00
   sys_15: 1.12005714e+01
@@ -14605,15 +14605,15 @@ bins:
   sys_23: 3.05470129e+00
   sys_24: -3.05470129e+00
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 0.0
-  sys_30: -0.0
+  sys_30: 0.0
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 1.01823376e+00
   sys_36: -1.01823376e+00
   sys_37: 1.01823376e+00
@@ -14627,13 +14627,13 @@ bins:
   sys_45: 1.01823376e+00
   sys_46: -1.01823376e+00
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 1.01823376e+00
   sys_56: -1.01823376e+00
   sys_57: 0.0
@@ -14643,41 +14643,41 @@ bins:
   sys_61: 1.01823376e+00
   sys_62: 0.0
   sys_63: 0.0
-  sys_64: -0.0
+  sys_64: 0.0
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 7.12763635e+00
   sys_92: -7.12763635e+00
   sys_93: 1.22188052e+02
   sys_94: -1.12005714e+02
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: -4.07293506e+00
   sys_100: 5.09116882e+00
   sys_101: -1.42552727e+01
@@ -14699,9 +14699,9 @@ bins:
   luminosity_uncertainty: 0.0
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
@@ -14710,83 +14710,83 @@ bins:
   art_sys_11: 1.89706708e-01
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: -4.29940313e-01
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 1.20519807e+00
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: -1.87521084e+00
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: -5.80882287e+00
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
   art_sys_32: -2.07399830e+01
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 1.33860944e+00
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 1.83095320e-01
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
   art_sys_48: -3.87932213e-04
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 1.32983776e-03
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: -1.19885874e-04
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
   art_sys_65: -3.04898435e-05
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
+  art_sys_72: 0.0
   art_sys_73: 3.71659240e-06
-  art_sys_74: -0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
+  art_sys_76: 0.0
   art_sys_77: -8.22742847e-07
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: -3.78076522e-07
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 6.72876271e-09
-  art_sys_88: -0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 2.38033356e+01
   sys_2: -2.28317709e+01
   sys_3: 9.22986481e+00
@@ -14798,7 +14798,7 @@ bins:
   sys_9: 2.91469415e+00
   sys_10: -2.91469415e+00
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 4.85782359e-01
   sys_14: -4.85782359e-01
   sys_15: 5.34360595e+00
@@ -14812,17 +14812,17 @@ bins:
   sys_23: 1.45734708e+00
   sys_24: -1.94312943e+00
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 0.0
-  sys_30: -0.0
+  sys_30: 0.0
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 4.85782359e-01
   sys_38: -4.85782359e-01
   sys_39: 4.85782359e-01
@@ -14834,13 +14834,13 @@ bins:
   sys_45: 9.71564717e-01
   sys_46: -4.85782359e-01
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 4.85782359e-01
   sys_56: -4.85782359e-01
   sys_57: 4.85782359e-01
@@ -14852,39 +14852,39 @@ bins:
   sys_63: 4.85782359e-01
   sys_64: -4.85782359e-01
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 2.91469415e+00
   sys_92: -2.91469415e+00
   sys_93: 5.82938830e+01
   sys_94: -5.34360595e+01
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: -1.94312943e+00
   sys_100: 2.42891179e+00
   sys_101: -7.28673538e+00
@@ -14906,9 +14906,9 @@ bins:
   luminosity_uncertainty: 0.0
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
@@ -14917,83 +14917,83 @@ bins:
   art_sys_11: 3.44222239e-02
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: -3.53092675e-02
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 1.83821823e-02
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: -3.82806679e-01
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 9.20211168e-01
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
   art_sys_32: -2.81729485e+00
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: -1.04761471e+01
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: -5.13238656e-01
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
   art_sys_48: -4.20263416e-02
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: -2.36760669e-03
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: -9.22751094e-05
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
   art_sys_65: 2.07729945e-05
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
+  art_sys_72: 0.0
   art_sys_73: 8.21937211e-06
-  art_sys_74: -0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
+  art_sys_76: 0.0
   art_sys_77: 1.10751250e-06
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: -1.01860325e-07
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 8.39216964e-09
-  art_sys_88: -0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 1.25384174e+01
   sys_2: -1.18150472e+01
   sys_3: 4.34022142e+00
@@ -15005,7 +15005,7 @@ bins:
   sys_9: 1.20561706e+00
   sys_10: -1.20561706e+00
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 2.41123412e-01
   sys_14: -2.41123412e-01
   sys_15: 2.65235754e+00
@@ -15019,17 +15019,17 @@ bins:
   sys_23: 9.64493650e-01
   sys_24: -1.20561706e+00
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 0.0
-  sys_30: -0.0
+  sys_30: 0.0
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 2.41123412e-01
   sys_38: -2.41123412e-01
   sys_39: 2.41123412e-01
@@ -15041,13 +15041,13 @@ bins:
   sys_45: 4.82246825e-01
   sys_46: -2.41123412e-01
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 2.41123412e-01
   sys_56: -2.41123412e-01
   sys_57: 2.41123412e-01
@@ -15061,37 +15061,37 @@ bins:
   sys_65: 0.0
   sys_66: -2.41123412e-01
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 1.44674047e+00
   sys_92: -1.44674047e+00
   sys_93: 2.89348095e+01
   sys_94: -2.65235754e+01
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: -7.23370237e-01
   sys_100: 1.20561706e+00
   sys_101: -3.85797460e+00
@@ -15113,9 +15113,9 @@ bins:
   luminosity_uncertainty: 0.0
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
@@ -15124,83 +15124,83 @@ bins:
   art_sys_11: -4.26261348e-02
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: -3.78322062e-02
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: -4.99806505e-02
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 1.83227932e-02
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 1.56455053e-01
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
   art_sys_32: 4.48493738e-01
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: -1.07499026e+00
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 5.29032997e+00
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
   art_sys_48: 1.13699489e-01
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 3.17628351e-02
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: -7.09890408e-04
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
   art_sys_65: -1.43014484e-04
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
+  art_sys_72: 0.0
   art_sys_73: 1.26575439e-05
-  art_sys_74: -0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
+  art_sys_76: 0.0
   art_sys_77: 4.77472112e-06
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: -1.76815490e-06
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: -2.33251710e-08
-  art_sys_88: -0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 5.72756493e+00
   sys_2: -5.40936688e+00
   sys_3: 1.90918831e+00
@@ -15212,7 +15212,7 @@ bins:
   sys_9: 4.24264069e-01
   sys_10: -4.24264069e-01
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 1.06066017e-01
   sys_14: -1.06066017e-01
   sys_15: 1.16672619e+00
@@ -15226,17 +15226,17 @@ bins:
   sys_23: 5.30330086e-01
   sys_24: -5.30330086e-01
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 0.0
-  sys_30: -0.0
+  sys_30: 0.0
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 0.0
   sys_38: -1.06066017e-01
   sys_39: 1.06066017e-01
@@ -15248,13 +15248,13 @@ bins:
   sys_45: 2.12132034e-01
   sys_46: -2.12132034e-01
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
   sys_56: -1.06066017e-01
   sys_57: 1.06066017e-01
@@ -15268,37 +15268,37 @@ bins:
   sys_65: 1.06066017e-01
   sys_66: -1.06066017e-01
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 6.36396103e-01
   sys_92: -6.36396103e-01
   sys_93: 1.27279221e+01
   sys_94: -1.16672619e+01
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: -3.18198052e-01
   sys_100: 4.24264069e-01
   sys_101: -1.69705627e+00
@@ -15320,9 +15320,9 @@ bins:
   luminosity_uncertainty: 0.0
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
@@ -15331,83 +15331,83 @@ bins:
   art_sys_11: 5.07072742e-03
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 8.62605994e-03
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: -3.77119608e-03
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 1.83012396e-03
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 1.70692257e-03
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
   art_sys_32: 9.41898568e-02
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 1.70815093e-01
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 3.55861120e-01
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
   art_sys_48: -1.82516318e+00
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: -1.17675942e-01
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: 1.11312913e-02
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
   art_sys_65: 1.40460505e-04
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
+  art_sys_72: 0.0
   art_sys_73: -1.81214163e-05
-  art_sys_74: -0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
+  art_sys_76: 0.0
   art_sys_77: 4.41253808e-06
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 2.95108891e-06
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 4.99886735e-08
-  art_sys_88: -0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 2.55131198e+00
   sys_2: -2.41703240e+00
   sys_3: 8.50437326e-01
@@ -15419,7 +15419,7 @@ bins:
   sys_9: 1.34279578e-01
   sys_10: -1.79039437e-01
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 4.47598592e-02
   sys_14: -4.47598592e-02
   sys_15: 5.37118311e-01
@@ -15433,17 +15433,17 @@ bins:
   sys_23: 2.68559155e-01
   sys_24: -2.68559155e-01
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 0.0
-  sys_30: -0.0
+  sys_30: 0.0
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 0.0
   sys_38: -4.47598592e-02
   sys_39: 4.47598592e-02
@@ -15455,15 +15455,15 @@ bins:
   sys_45: 8.95197185e-02
   sys_46: -8.95197185e-02
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
   sys_58: -4.47598592e-02
   sys_59: 4.47598592e-02
@@ -15477,35 +15477,35 @@ bins:
   sys_67: 4.47598592e-02
   sys_68: -4.47598592e-02
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 2.68559155e-01
   sys_92: -2.68559155e-01
   sys_93: 5.37118311e+00
   sys_94: -4.92358452e+00
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: -1.34279578e-01
   sys_100: 1.79039437e-01
   sys_101: -6.71397889e-01
@@ -15527,9 +15527,9 @@ bins:
   luminosity_uncertainty: 0.0
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
@@ -15538,83 +15538,83 @@ bins:
   art_sys_11: -1.72112671e-04
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: -2.40189713e-03
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: -9.43149334e-03
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 8.29446490e-03
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: -2.25323746e-03
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
   art_sys_32: 1.83356707e-02
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 2.73408436e-02
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: -1.23995592e-01
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
   art_sys_48: -2.15563571e-01
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 1.02220431e+00
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: -4.12383680e-02
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
   art_sys_65: -4.05735515e-03
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
+  art_sys_72: 0.0
   art_sys_73: -9.43846780e-05
-  art_sys_74: -0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
+  art_sys_76: 0.0
   art_sys_77: -2.38666196e-06
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: -2.78743069e-06
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 1.64409273e-07
-  art_sys_88: -0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 1.28976277e+00
   sys_2: -1.22527463e+00
   sys_3: 4.29920923e-01
@@ -15626,7 +15626,7 @@ bins:
   sys_9: 6.44881384e-02
   sys_10: -6.44881384e-02
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 2.14960461e-02
   sys_14: -2.14960461e-02
   sys_15: 2.57952554e-01
@@ -15640,19 +15640,19 @@ bins:
   sys_23: 1.71968369e-01
   sys_24: -1.50472323e-01
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 0.0
-  sys_30: -0.0
+  sys_30: 0.0
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 0.0
-  sys_38: -0.0
+  sys_38: 0.0
   sys_39: 2.14960461e-02
   sys_40: -2.14960461e-02
   sys_41: 2.14960461e-02
@@ -15662,15 +15662,15 @@ bins:
   sys_45: 4.29920923e-02
   sys_46: -4.29920923e-02
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
   sys_58: -2.14960461e-02
   sys_59: 2.14960461e-02
@@ -15684,35 +15684,35 @@ bins:
   sys_67: 2.14960461e-02
   sys_68: -4.29920923e-02
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 1.28976277e-01
   sys_92: -1.28976277e-01
   sys_93: 2.57952554e+00
   sys_94: -2.14960461e+00
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: -6.44881384e-02
   sys_100: 6.44881384e-02
   sys_101: -3.00944646e-01
@@ -15734,9 +15734,9 @@ bins:
   luminosity_uncertainty: 0.0
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
@@ -15745,83 +15745,83 @@ bins:
   art_sys_11: -2.38809486e-03
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 5.09633103e-03
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: -9.16298949e-03
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 1.98606442e-03
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 4.72702922e-03
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
   art_sys_32: -5.90701995e-03
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: -4.45676358e-03
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: -1.04285455e-02
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
   art_sys_48: 2.23791159e-02
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 8.64339671e-02
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: 5.08482032e-01
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
   art_sys_65: 1.00521977e-02
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
+  art_sys_72: 0.0
   art_sys_73: 1.36673291e-03
-  art_sys_74: -0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
+  art_sys_76: 0.0
   art_sys_77: 9.78069847e-05
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 1.95415916e-06
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 4.76338721e-08
-  art_sys_88: -0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 5.47583491e-01
   sys_2: -5.21915515e-01
   sys_3: 1.79675833e-01
@@ -15833,7 +15833,7 @@ bins:
   sys_9: 2.56679762e-02
   sys_10: -2.56679762e-02
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 8.55599205e-03
   sys_14: -1.71119841e-02
   sys_15: 1.11227897e-01
@@ -15847,19 +15847,19 @@ bins:
   sys_23: 8.55599205e-02
   sys_24: -8.55599205e-02
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 0.0
   sys_30: -8.55599205e-03
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 0.0
-  sys_38: -0.0
+  sys_38: 0.0
   sys_39: 8.55599205e-03
   sys_40: -8.55599205e-03
   sys_41: 8.55599205e-03
@@ -15869,17 +15869,17 @@ bins:
   sys_45: 1.71119841e-02
   sys_46: -1.71119841e-02
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 8.55599205e-03
   sys_60: -8.55599205e-03
   sys_61: 1.71119841e-02
@@ -15893,33 +15893,33 @@ bins:
   sys_69: 8.55599205e-03
   sys_70: -8.55599205e-03
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 5.98919444e-02
   sys_92: -5.98919444e-02
   sys_93: 1.02671905e+00
   sys_94: -8.55599205e-01
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: -2.56679762e-02
   sys_100: 2.56679762e-02
   sys_101: -1.11227897e-01
@@ -15941,9 +15941,9 @@ bins:
   luminosity_uncertainty: 0.0
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
@@ -15952,83 +15952,83 @@ bins:
   art_sys_11: -2.86526427e-05
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 1.66616724e-03
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: -2.98594765e-03
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: -2.86810562e-03
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 6.16518490e-04
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
   art_sys_32: 2.01777641e-03
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: -1.29831166e-03
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: -1.63067670e-03
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
   art_sys_48: 4.31328982e-03
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: -1.70182880e-02
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: 2.77021220e-02
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
   art_sys_65: -1.93062208e-01
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
+  art_sys_72: 0.0
   art_sys_73: -4.47023141e-03
-  art_sys_74: -0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
+  art_sys_76: 0.0
   art_sys_77: -1.22858535e-03
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 1.69099772e-05
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: -7.79627481e-07
-  art_sys_88: -0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 2.39072803e-01
   sys_2: -2.28678333e-01
   sys_3: 8.31557575e-02
@@ -16040,7 +16040,7 @@ bins:
   sys_9: 1.03944697e-02
   sys_10: -1.03944697e-02
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 3.46482323e-03
   sys_14: -6.92964646e-03
   sys_15: 4.50427020e-02
@@ -16054,19 +16054,19 @@ bins:
   sys_23: 4.50427020e-02
   sys_24: -4.50427020e-02
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 3.46482323e-03
   sys_30: -3.46482323e-03
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 0.0
-  sys_38: -0.0
+  sys_38: 0.0
   sys_39: 3.46482323e-03
   sys_40: 0.0
   sys_41: 3.46482323e-03
@@ -16076,17 +16076,17 @@ bins:
   sys_45: 6.92964646e-03
   sys_46: -6.92964646e-03
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 3.46482323e-03
   sys_60: -3.46482323e-03
   sys_61: 6.92964646e-03
@@ -16100,33 +16100,33 @@ bins:
   sys_69: 6.92964646e-03
   sys_70: -6.92964646e-03
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 3.46482323e-03
   sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 2.42537626e-02
   sys_92: -2.42537626e-02
   sys_93: 4.15778787e-01
   sys_94: -3.46482323e-01
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: -6.92964646e-03
   sys_100: 1.03944697e-02
   sys_101: -3.81130555e-02
@@ -16148,9 +16148,9 @@ bins:
   luminosity_uncertainty: 0.0
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
@@ -16159,83 +16159,83 @@ bins:
   art_sys_11: 4.23155727e-04
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: -5.65511840e-04
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: -6.65782519e-04
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: -8.20818411e-04
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 7.91161800e-04
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
   art_sys_32: 1.26254751e-03
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 1.18228895e-03
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: -7.46045385e-04
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
   art_sys_48: -7.45997841e-04
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: -1.18206259e-03
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: -6.59705252e-03
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
   art_sys_65: -1.03250804e-02
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
+  art_sys_72: 0.0
   art_sys_73: 8.70208991e-02
-  art_sys_74: -0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
+  art_sys_76: 0.0
   art_sys_77: 2.84577107e-03
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: -5.32419747e-04
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 3.33221921e-07
-  art_sys_88: -0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 9.52331413e-02
   sys_2: -9.13723383e-02
   sys_3: 3.47472272e-02
@@ -16247,7 +16247,7 @@ bins:
   sys_9: 3.86080303e-03
   sys_10: -2.57386868e-03
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 2.57386868e-03
   sys_14: -2.57386868e-03
   sys_15: 1.80170808e-02
@@ -16261,19 +16261,19 @@ bins:
   sys_23: 2.18778838e-02
   sys_24: -2.18778838e-02
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 1.28693434e-03
   sys_30: -1.28693434e-03
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 0.0
-  sys_38: -0.0
+  sys_38: 0.0
   sys_39: 1.28693434e-03
   sys_40: 0.0
   sys_41: 1.28693434e-03
@@ -16283,17 +16283,17 @@ bins:
   sys_45: 2.57386868e-03
   sys_46: -2.57386868e-03
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 1.28693434e-03
   sys_60: -1.28693434e-03
   sys_61: 2.57386868e-03
@@ -16307,33 +16307,33 @@ bins:
   sys_69: 5.14773737e-03
   sys_70: -5.14773737e-03
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 1.28693434e-03
   sys_78: -1.28693434e-03
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 1.02954747e-02
   sys_92: -1.02954747e-02
   sys_93: 1.54432121e-01
   sys_94: -1.28693434e-01
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: -2.57386868e-03
   sys_100: 2.57386868e-03
   sys_101: -1.15824091e-02
@@ -16355,9 +16355,9 @@ bins:
   luminosity_uncertainty: 0.0
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
@@ -16366,83 +16366,83 @@ bins:
   art_sys_11: 3.21937519e-05
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 4.71387127e-04
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 8.05642870e-04
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 8.66219433e-04
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: -2.33297601e-04
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
   art_sys_32: 3.51396400e-04
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: -2.63817757e-04
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 5.24884377e-04
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
   art_sys_48: -2.38103127e-04
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 4.73229993e-04
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: -6.98727479e-05
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
   art_sys_65: 4.20270264e-03
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
+  art_sys_72: 0.0
   art_sys_73: 5.20116947e-03
-  art_sys_74: -0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
+  art_sys_76: 0.0
   art_sys_77: -4.95060369e-02
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 1.16467374e-03
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: -1.50999986e-05
-  art_sys_88: -0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 4.04366084e-02
   sys_2: -3.79405215e-02
   sys_3: 1.54757390e-02
@@ -16454,7 +16454,7 @@ bins:
   sys_9: 9.98434775e-04
   sys_10: -9.98434775e-04
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 9.98434775e-04
   sys_14: -9.98434775e-04
   sys_15: 6.98904343e-03
@@ -16468,19 +16468,19 @@ bins:
   sys_23: 1.04835651e-02
   sys_24: -1.09827825e-02
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 4.99217388e-04
   sys_30: -4.99217388e-04
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 0.0
-  sys_38: -0.0
+  sys_38: 0.0
   sys_39: 4.99217388e-04
   sys_40: 0.0
   sys_41: 4.99217388e-04
@@ -16490,17 +16490,17 @@ bins:
   sys_45: 4.99217388e-04
   sys_46: -4.99217388e-04
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 4.99217388e-04
   sys_60: -4.99217388e-04
   sys_61: 9.98434775e-04
@@ -16514,33 +16514,33 @@ bins:
   sys_69: 2.99530433e-03
   sys_70: -2.99530433e-03
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 4.99217388e-04
   sys_78: -4.99217388e-04
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 4.99217388e-04
   sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 3.99373910e-03
   sys_92: -3.99373910e-03
   sys_93: 5.99060865e-02
   sys_94: -5.49139126e-02
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: -4.99217388e-04
   sys_100: 9.98434775e-04
   sys_101: -3.49452171e-03
@@ -16562,9 +16562,9 @@ bins:
   luminosity_uncertainty: 7.06000000e-04
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
@@ -16573,83 +16573,83 @@ bins:
   art_sys_11: 2.21087555e-04
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 1.58138588e-04
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 4.82841032e-05
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 2.56390419e-04
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 2.08041692e-04
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
   art_sys_32: 2.95201005e-04
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 8.26193202e-05
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: -2.94659728e-04
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
   art_sys_48: -1.99308000e-04
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: -9.25225280e-05
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: 2.12072163e-04
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
   art_sys_65: 3.00913493e-04
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
+  art_sys_72: 0.0
   art_sys_73: -1.69677812e-03
-  art_sys_74: -0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
+  art_sys_76: 0.0
   art_sys_77: -2.49111781e-03
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: -2.37758854e-02
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 2.38317378e-05
-  art_sys_88: -0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 1.50104628e-02
   sys_2: -1.41477925e-02
   sys_3: 6.21122597e-03
@@ -16661,7 +16661,7 @@ bins:
   sys_9: 5.17602164e-04
   sys_10: -3.45068109e-04
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 3.45068109e-04
   sys_14: -3.45068109e-04
   sys_15: 2.41547676e-03
@@ -16675,17 +16675,17 @@ bins:
   sys_23: 4.83095353e-03
   sys_24: -4.83095353e-03
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 1.72534055e-04
   sys_30: -1.72534055e-04
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 1.72534055e-04
   sys_38: 0.0
   sys_39: 1.72534055e-04
@@ -16697,17 +16697,17 @@ bins:
   sys_45: 1.72534055e-04
   sys_46: -1.72534055e-04
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 1.72534055e-04
   sys_60: -1.72534055e-04
   sys_61: 3.45068109e-04
@@ -16721,33 +16721,33 @@ bins:
   sys_69: 1.38027244e-03
   sys_70: -1.38027244e-03
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 1.72534055e-04
   sys_78: -1.72534055e-04
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 1.72534055e-04
   sys_82: -1.72534055e-04
   sys_83: 1.72534055e-04
   sys_84: -1.72534055e-04
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 1.55280649e-03
   sys_92: -1.55280649e-03
   sys_93: 2.07040866e-02
   sys_94: -1.89787460e-02
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: -1.72534055e-04
   sys_100: 1.72534055e-04
   sys_101: -8.62670273e-04
@@ -16769,9 +16769,9 @@ bins:
   luminosity_uncertainty: 0.000976
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
@@ -16780,83 +16780,83 @@ bins:
   art_sys_11: 2.27773825e-05
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: -3.08479414e-05
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: -4.75510954e-06
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 6.16954980e-05
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 4.02807869e-05
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
   art_sys_32: -5.24997416e-05
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: -9.32401160e-06
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: -4.19067169e-05
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
   art_sys_48: -3.89749968e-05
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 4.94015305e-05
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: 9.51325399e-08
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
   art_sys_65: 2.64759986e-05
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
+  art_sys_72: 0.0
   art_sys_73: -2.52590857e-05
-  art_sys_74: -0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
+  art_sys_76: 0.0
   art_sys_77: 2.01643797e-04
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: -1.70762182e-04
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: -3.42229180e-03
-  art_sys_88: -0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 1.82433550e-03
   sys_2: -1.67230754e-03
   sys_3: 1.00338452e-03
@@ -16868,7 +16868,7 @@ bins:
   sys_9: 4.56083874e-05
   sys_10: -4.56083874e-05
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 3.04055916e-05
   sys_14: -4.56083874e-05
   sys_15: 2.43244733e-04
@@ -16882,17 +16882,17 @@ bins:
   sys_23: 1.00338452e-03
   sys_24: -9.57776135e-04
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 1.52027958e-05
   sys_30: -3.04055916e-05
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 1.52027958e-05
   sys_38: -1.52027958e-05
   sys_39: 1.52027958e-05
@@ -16904,17 +16904,17 @@ bins:
   sys_45: 1.52027958e-05
   sys_46: -1.52027958e-05
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
   sys_60: -1.52027958e-05
   sys_61: 1.52027958e-05
@@ -16928,15 +16928,15 @@ bins:
   sys_69: 3.19258712e-04
   sys_70: -3.19258712e-04
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 1.52027958e-05
   sys_78: -1.52027958e-05
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 3.04055916e-05
   sys_82: -3.04055916e-05
   sys_83: 7.60139790e-05
@@ -16946,21 +16946,21 @@ bins:
   sys_87: 0.0
   sys_88: -1.52027958e-05
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 2.12839141e-04
   sys_92: -2.12839141e-04
   sys_93: 1.97636345e-03
   sys_94: -1.82433550e-03
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 3.04055916e-05
   sys_102: -6.08111832e-05
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 9.12167748e-05
   sys_106: -9.12167748e-05
   sys_107: 2.88853120e-04
@@ -16976,94 +16976,94 @@ bins:
   luminosity_uncertainty: 0.000258
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
   art_sys_18: 1.49862187e+02
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 2.06764197e+01
-  art_sys_23: -0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
   art_sys_27: 3.71626761e+00
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: 5.06153428e-03
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 9.61911284e-04
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 4.17149953e-05
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
   art_sys_67: 3.07025971e-06
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
   art_sys_86: 3.02921495e-09
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 1.00677864e+02
   sys_2: -1.05472047e+02
   sys_3: 5.99272997e+01
@@ -17083,15 +17083,15 @@ bins:
   sys_17: 0.0
   sys_18: -2.39709199e+00
   sys_19: 0.0
-  sys_20: -0.0
+  sys_20: 0.0
   sys_21: 0.0
-  sys_22: -0.0
+  sys_22: 0.0
   sys_23: 0.0
-  sys_24: -0.0
+  sys_24: 0.0
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 2.39709199e+00
   sys_30: -2.39709199e+00
   sys_31: 2.39709199e+00
@@ -17109,11 +17109,11 @@ bins:
   sys_43: 7.19127596e+00
   sys_44: -9.58836795e+00
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 2.39709199e+00
   sys_52: -2.39709199e+00
   sys_53: 0.0
@@ -17125,43 +17125,43 @@ bins:
   sys_59: 0.0
   sys_60: -2.39709199e+00
   sys_61: 0.0
-  sys_62: -0.0
+  sys_62: 0.0
   sys_63: 0.0
-  sys_64: -0.0
+  sys_64: 0.0
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
   sys_72: -2.39709199e+00
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 2.39709199e+01
   sys_92: -2.87651039e+01
   sys_93: 4.31476558e+02
   sys_94: -3.83534718e+02
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: -9.58836795e+00
   sys_100: 1.19854599e+01
   sys_101: -5.03389318e+01
@@ -17183,94 +17183,94 @@ bins:
   luminosity_uncertainty: 3.39
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
   art_sys_18: 3.78759431e+01
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: -8.34742434e+01
-  art_sys_23: -0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
   art_sys_27: -1.08242828e+01
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: 5.46364825e-01
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 4.37183375e-03
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 2.54220642e-05
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
   art_sys_67: 5.71071172e-07
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
   art_sys_86: -2.59731501e-08
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 5.41219530e+01
   sys_2: -5.53806031e+01
   sys_3: 3.02076017e+01
@@ -17292,13 +17292,13 @@ bins:
   sys_19: 0.0
   sys_20: -1.25865007e+00
   sys_21: 0.0
-  sys_22: -0.0
+  sys_22: 0.0
   sys_23: 0.0
   sys_24: -1.25865007e+00
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 1.25865007e+00
   sys_30: -1.25865007e+00
   sys_31: 1.25865007e+00
@@ -17316,11 +17316,11 @@ bins:
   sys_43: 5.03460028e+00
   sys_44: -5.03460028e+00
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
   sys_52: -1.25865007e+00
   sys_53: 0.0
@@ -17332,43 +17332,43 @@ bins:
   sys_59: 0.0
   sys_60: -1.25865007e+00
   sys_61: 0.0
-  sys_62: -0.0
+  sys_62: 0.0
   sys_63: 0.0
-  sys_64: -0.0
+  sys_64: 0.0
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
   sys_72: -1.25865007e+00
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 1.13278506e+01
   sys_92: -1.51038008e+01
   sys_93: 2.26557013e+02
   sys_94: -2.01384011e+02
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: -5.03460028e+00
   sys_100: 6.29325035e+00
   sys_101: -2.51730014e+01
@@ -17390,94 +17390,94 @@ bins:
   luminosity_uncertainty: 1.78
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
   art_sys_18: -3.07552504e+00
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: -2.11049840e+01
-  art_sys_23: -0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
   art_sys_27: 4.66288056e+01
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: -9.35108289e-01
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 2.92368151e-02
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 6.42178263e-04
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
   art_sys_67: 3.30260184e-06
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
   art_sys_86: -5.33727002e-09
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 2.64740779e+01
   sys_2: -2.64740779e+01
   sys_3: 1.35311954e+01
@@ -17503,9 +17503,9 @@ bins:
   sys_23: 5.88312842e-01
   sys_24: -5.88312842e-01
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 5.88312842e-01
   sys_30: -5.88312842e-01
   sys_31: 0.0
@@ -17525,9 +17525,9 @@ bins:
   sys_45: 5.88312842e-01
   sys_46: -5.88312842e-01
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
   sys_52: -5.88312842e-01
   sys_53: 0.0
@@ -17539,43 +17539,43 @@ bins:
   sys_59: 5.88312842e-01
   sys_60: -5.88312842e-01
   sys_61: 0.0
-  sys_62: -0.0
+  sys_62: 0.0
   sys_63: 0.0
-  sys_64: -0.0
+  sys_64: 0.0
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 5.29481558e+00
   sys_92: -6.47144126e+00
   sys_93: 1.05896312e+02
   sys_94: -9.41300547e+01
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: -1.76493853e+00
   sys_100: 2.94156421e+00
   sys_101: -1.05896312e+01
@@ -17597,94 +17597,94 @@ bins:
   luminosity_uncertainty: 8.32000000e-01
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
   art_sys_18: -1.32147505e+00
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 1.40091930e+00
-  art_sys_23: -0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
   art_sys_27: 2.68546225e+00
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: 1.84140486e+01
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 4.72072270e-02
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 2.51965782e-03
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
   art_sys_67: -1.80518292e-05
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
   art_sys_86: 6.61780487e-08
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 1.03591143e+01
   sys_2: -9.94474977e+00
   sys_3: 4.97237489e+00
@@ -17696,7 +17696,7 @@ bins:
   sys_9: 1.65745830e+00
   sys_10: -1.86464058e+00
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 2.07182287e-01
   sys_14: -2.07182287e-01
   sys_15: 2.69336973e+00
@@ -17710,9 +17710,9 @@ bins:
   sys_23: 4.14364574e-01
   sys_24: -4.14364574e-01
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 0.0
   sys_30: -2.07182287e-01
   sys_31: 0.0
@@ -17732,13 +17732,13 @@ bins:
   sys_45: 2.07182287e-01
   sys_46: -2.07182287e-01
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 2.07182287e-01
   sys_56: -2.07182287e-01
   sys_57: 2.07182287e-01
@@ -17746,43 +17746,43 @@ bins:
   sys_59: 2.07182287e-01
   sys_60: -2.07182287e-01
   sys_61: 0.0
-  sys_62: -0.0
+  sys_62: 0.0
   sys_63: 0.0
-  sys_64: -0.0
+  sys_64: 0.0
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 2.07182287e+00
   sys_92: -2.27900516e+00
   sys_93: 3.93646345e+01
   sys_94: -3.31491659e+01
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: -6.21546861e-01
   sys_100: 1.03591143e+00
   sys_101: -3.72928116e+00
@@ -17804,94 +17804,94 @@ bins:
   luminosity_uncertainty: 0.0
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
   art_sys_18: -3.08000966e-02
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 1.75259006e-01
-  art_sys_23: -0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
   art_sys_27: -2.83090956e-01
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: -1.65497567e-01
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 5.11474775e+00
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 1.26924195e-02
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
   art_sys_67: 2.19082476e-04
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
   art_sys_86: 1.09905922e-08
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 2.39885976e+00
   sys_2: -2.23622520e+00
   sys_3: 9.75807358e-01
@@ -17903,7 +17903,7 @@ bins:
   sys_9: 3.25269119e-01
   sys_10: -2.84610479e-01
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 4.06586399e-02
   sys_14: -4.06586399e-02
   sys_15: 5.69220959e-01
@@ -17917,15 +17917,15 @@ bins:
   sys_23: 1.62634560e-01
   sys_24: -1.62634560e-01
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 0.0
   sys_30: -4.06586399e-02
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 4.06586399e-02
   sys_36: -4.06586399e-02
   sys_37: 4.06586399e-02
@@ -17939,13 +17939,13 @@ bins:
   sys_45: 8.13172798e-02
   sys_46: -8.13172798e-02
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 4.06586399e-02
   sys_56: -4.06586399e-02
   sys_57: 4.06586399e-02
@@ -17957,39 +17957,39 @@ bins:
   sys_63: 4.06586399e-02
   sys_64: -4.06586399e-02
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 4.47245039e-01
   sys_92: -4.06586399e-01
   sys_93: 8.53831438e+00
   sys_94: -7.31855519e+00
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: -1.21975920e-01
   sys_100: 2.03293200e-01
   sys_101: -8.13172798e-01
@@ -18011,94 +18011,94 @@ bins:
   luminosity_uncertainty: 0.0
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
   art_sys_18: -1.34277756e-03
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 7.90235306e-03
-  art_sys_23: -0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
   art_sys_27: -2.87818616e-02
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: -3.81100626e-02
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: -5.67834895e-02
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 1.14648575e+00
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
   art_sys_67: 1.01952026e-03
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
   art_sys_86: -6.97139213e-06
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 4.67899628e-01
   sys_2: -4.40775012e-01
   sys_3: 1.76310005e-01
@@ -18110,7 +18110,7 @@ bins:
   sys_9: 4.06869242e-02
   sys_10: -4.06869242e-02
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 1.35623081e-02
   sys_14: -6.78115403e-03
   sys_15: 1.08498465e-01
@@ -18124,17 +18124,17 @@ bins:
   sys_23: 4.74680782e-02
   sys_24: -4.74680782e-02
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 0.0
   sys_30: -6.78115403e-03
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 6.78115403e-03
   sys_38: -6.78115403e-03
   sys_39: 6.78115403e-03
@@ -18146,13 +18146,13 @@ bins:
   sys_45: 2.03434621e-02
   sys_46: -2.03434621e-02
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 6.78115403e-03
   sys_56: -6.78115403e-03
   sys_57: 6.78115403e-03
@@ -18166,37 +18166,37 @@ bins:
   sys_65: 6.78115403e-03
   sys_66: -6.78115403e-03
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 8.81550024e-02
   sys_92: -8.13738484e-02
   sys_93: 1.55966543e+00
   sys_94: -1.28841927e+00
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: -2.03434621e-02
   sys_100: 3.39057702e-02
   sys_101: -1.42404235e-01
@@ -18218,94 +18218,94 @@ bins:
   luminosity_uncertainty: 0.0
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
   art_sys_18: -2.93370846e-03
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 1.97270885e-04
-  art_sys_23: -0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
   art_sys_27: -1.16638320e-04
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: 2.46999396e-03
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: -6.39250230e-03
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: -7.05379139e-03
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
   art_sys_67: 1.66116283e-01
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
   art_sys_86: -1.92373591e-05
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 7.67493700e-02
   sys_2: -7.20117546e-02
   sys_3: 2.65306464e-02
@@ -18317,7 +18317,7 @@ bins:
   sys_9: 5.68513852e-03
   sys_10: -5.68513852e-03
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 1.89504617e-03
   sys_14: -1.89504617e-03
   sys_15: 1.70554156e-02
@@ -18331,17 +18331,17 @@ bins:
   sys_23: 8.52770778e-03
   sys_24: -9.47523087e-03
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 9.47523087e-04
   sys_30: -9.47523087e-04
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 9.47523087e-04
   sys_38: -9.47523087e-04
   sys_39: 9.47523087e-04
@@ -18353,13 +18353,13 @@ bins:
   sys_45: 3.79009235e-03
   sys_46: -2.84256926e-03
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 9.47523087e-04
   sys_56: -9.47523087e-04
   sys_57: 9.47523087e-04
@@ -18375,35 +18375,35 @@ bins:
   sys_67: 9.47523087e-04
   sys_68: -9.47523087e-04
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 1.42128463e-02
   sys_92: -1.42128463e-02
   sys_93: 2.36880772e-01
   sys_94: -1.89504617e-01
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: -2.84256926e-03
   sys_100: 4.73761543e-03
   sys_101: -2.17930310e-02
@@ -18425,94 +18425,94 @@ bins:
   luminosity_uncertainty: 0.00134
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
   art_sys_18: -4.08774582e-05
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 1.81653830e-04
-  art_sys_23: -0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
   art_sys_27: 3.21469826e-05
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: 1.08862236e-04
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 4.41251655e-05
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: -5.99879061e-04
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
   art_sys_67: -2.44540746e-04
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
   art_sys_86: -1.30969784e-02
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 3.81837662e-03
   sys_2: -3.50017857e-03
   sys_3: 1.17733279e-03
@@ -18524,7 +18524,7 @@ bins:
   sys_9: 1.27279221e-04
   sys_10: -2.54558441e-04
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 9.54594155e-05
   sys_14: -9.54594155e-05
   sys_15: 6.68215908e-04
@@ -18538,19 +18538,19 @@ bins:
   sys_23: 5.72756493e-04
   sys_24: -6.68215908e-04
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 6.36396103e-05
   sys_30: -3.18198052e-05
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 0.0
-  sys_38: -0.0
+  sys_38: 0.0
   sys_39: 3.18198052e-05
   sys_40: -3.18198052e-05
   sys_41: 6.36396103e-05
@@ -18560,17 +18560,17 @@ bins:
   sys_45: 1.27279221e-04
   sys_46: -9.54594155e-05
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 6.36396103e-05
   sys_60: -3.18198052e-05
   sys_61: 9.54594155e-05
@@ -18584,35 +18584,35 @@ bins:
   sys_69: 9.54594155e-05
   sys_70: -6.36396103e-05
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 6.36396103e-04
   sys_92: -7.00035713e-04
   sys_93: 9.86413960e-03
   sys_94: -7.95495129e-03
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: -9.86413960e-04
   sys_102: 1.40007143e-03
   sys_103: 8.90954544e-04
@@ -18632,94 +18632,94 @@ bins:
   luminosity_uncertainty: 7.20000000e-04
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
+  art_sys_32: 0.0
   art_sys_33: 1.95703857e+01
-  art_sys_34: -0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 1.17015922e-03
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
   art_sys_55: 1.75380701e-03
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 2.71779798e-08
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 4.08495587e+00
   sys_2: -4.08495587e+00
   sys_3: 2.15808990e+00
@@ -18731,29 +18731,29 @@ bins:
   sys_9: 9.24895670e-01
   sys_10: -8.47821031e-01
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 7.70746391e-02
   sys_14: -7.70746391e-02
   sys_15: 1.15611959e+00
   sys_16: -1.15611959e+00
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 1.54149278e-01
   sys_20: -7.70746391e-02
   sys_21: 0.0
-  sys_22: -0.0
+  sys_22: 0.0
   sys_23: 1.54149278e-01
   sys_24: -7.70746391e-02
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 7.70746391e-02
   sys_30: 0.0
   sys_31: 0.0
   sys_32: -7.70746391e-02
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 1.54149278e-01
   sys_36: -7.70746391e-02
   sys_37: 2.31223917e-01
@@ -18765,59 +18765,59 @@ bins:
   sys_43: 3.85373196e-01
   sys_44: -3.85373196e-01
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 7.70746391e-02
   sys_56: -7.70746391e-02
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 0.0
-  sys_62: -0.0
+  sys_62: 0.0
   sys_63: 0.0
-  sys_64: -0.0
+  sys_64: 0.0
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 1.23319423e+00
   sys_92: -1.23319423e+00
   sys_93: 2.00394062e+01
   sys_94: -1.61856742e+01
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: -2.31223917e-01
   sys_100: 2.31223917e-01
   sys_101: -1.92686598e+00
@@ -18839,94 +18839,94 @@ bins:
   luminosity_uncertainty: 0.327
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
+  art_sys_32: 0.0
   art_sys_33: -8.42175261e-03
-  art_sys_34: -0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 2.43915516e+00
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
   art_sys_55: -2.12413806e-02
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 2.10810424e-06
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 4.27446049e-01
   sys_2: -4.06763176e-01
   sys_3: 2.06828733e-01
@@ -18938,7 +18938,7 @@ bins:
   sys_9: 7.58372023e-02
   sys_10: -6.89429112e-02
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 6.89429112e-03
   sys_14: -6.89429112e-03
   sys_15: 1.10308658e-01
@@ -18952,15 +18952,15 @@ bins:
   sys_23: 2.06828733e-02
   sys_24: -2.06828733e-02
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 6.89429112e-03
   sys_30: 0.0
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 6.89429112e-03
   sys_36: -6.89429112e-03
   sys_37: 1.37885822e-02
@@ -18974,57 +18974,57 @@ bins:
   sys_45: 6.89429112e-03
   sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 6.89429112e-03
   sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 0.0
-  sys_62: -0.0
+  sys_62: 0.0
   sys_63: 0.0
-  sys_64: -0.0
+  sys_64: 0.0
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 1.24097240e-01
   sys_92: -1.24097240e-01
   sys_93: 2.06828733e+00
   sys_94: -1.58568696e+00
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: -2.06828733e-02
   sys_100: 2.06828733e-02
   sys_101: -1.51674405e-01
@@ -19046,94 +19046,94 @@ bins:
   luminosity_uncertainty: 0.00975
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
+  art_sys_32: 0.0
   art_sys_33: -3.96311273e-02
-  art_sys_34: -0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 5.95117089e-02
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
   art_sys_55: 8.70567476e-01
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 7.45713266e-07
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 1.36895873e-01
   sys_2: -1.30051079e-01
   sys_3: 5.47583491e-02
@@ -19145,7 +19145,7 @@ bins:
   sys_9: 1.71119841e-02
   sys_10: -1.36895873e-02
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 1.71119841e-03
   sys_14: -1.71119841e-03
   sys_15: 2.90903730e-02
@@ -19159,15 +19159,15 @@ bins:
   sys_23: 8.55599205e-03
   sys_24: -8.55599205e-03
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 0.0
-  sys_30: -0.0
+  sys_30: 0.0
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 1.71119841e-03
   sys_36: 0.0
   sys_37: 1.71119841e-03
@@ -19181,17 +19181,17 @@ bins:
   sys_45: 5.13359523e-03
   sys_46: -3.42239682e-03
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 3.42239682e-03
   sys_60: -1.71119841e-03
   sys_61: 3.42239682e-03
@@ -19199,39 +19199,39 @@ bins:
   sys_63: 1.71119841e-03
   sys_64: -1.71119841e-03
   sys_65: 0.0
-  sys_66: -0.0
+  sys_66: 0.0
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 3.93575634e-02
   sys_92: -3.93575634e-02
   sys_93: 6.33143412e-01
   sys_94: -4.79135555e-01
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: -5.13359523e-03
   sys_100: 5.13359523e-03
   sys_101: -4.10687619e-02
@@ -19253,94 +19253,94 @@ bins:
   luminosity_uncertainty: 0.00242
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
+  art_sys_32: 0.0
   art_sys_33: -3.08397967e-05
-  art_sys_34: -0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: -3.30077403e-04
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
   art_sys_55: -3.84696921e-05
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 1.57126897e-02
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 2.07889394e-03
   sys_2: -1.93040151e-03
   sys_3: 6.83065151e-04
@@ -19352,7 +19352,7 @@ bins:
   sys_9: 1.33643182e-04
   sys_10: -1.48492424e-04
   sys_11: 0.0
-  sys_12: -0.0
+  sys_12: 0.0
   sys_13: 2.96984848e-05
   sys_14: -7.42462120e-05
   sys_15: 3.86080303e-04
@@ -19366,21 +19366,21 @@ bins:
   sys_23: 1.93040151e-04
   sys_24: -2.22738636e-04
   sys_25: 0.0
-  sys_26: -0.0
+  sys_26: 0.0
   sys_27: 0.0
-  sys_28: -0.0
+  sys_28: 0.0
   sys_29: 0.0
-  sys_30: -0.0
+  sys_30: 0.0
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 0.0
-  sys_38: -0.0
+  sys_38: 0.0
   sys_39: 0.0
-  sys_40: -0.0
+  sys_40: 0.0
   sys_41: 4.45477272e-05
   sys_42: -4.45477272e-05
   sys_43: 1.03944697e-04
@@ -19388,17 +19388,17 @@ bins:
   sys_45: 8.90954544e-05
   sys_46: -1.33643182e-04
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 4.45477272e-05
   sys_60: -8.90954544e-05
   sys_61: 8.90954544e-05
@@ -19408,37 +19408,37 @@ bins:
   sys_65: 4.45477272e-05
   sys_66: -4.45477272e-05
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 6.53366666e-04
   sys_92: -6.38517423e-04
   sys_93: 8.76105302e-03
   sys_94: -5.93969696e-03
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 1.48492424e-05
   sys_100: -1.48492424e-05
   sys_101: -7.57311363e-04

--- a/nnpdf_data/nnpdf_data/commondata/ATLAS_2JET_7TEV_R06/uncertainties_weaker.yaml
+++ b/nnpdf_data/nnpdf_data/commondata/ATLAS_2JET_7TEV_R06/uncertainties_weaker.yaml
@@ -918,92 +918,92 @@ definitions:
 bins:
 - art_sys_1: 0.0
   art_sys_2: 8.66600397e+03
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 1.65603952e+01
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 1.00466592e+01
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 1.26565519e-01
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 3.24886915e-02
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
+  art_sys_22: 0.0
   art_sys_23: 5.12875512e-03
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 1.53888278e-03
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 7.95614472e-05
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 4.88924054e-05
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
+  art_sys_43: 0.0
   art_sys_44: 1.68570003e-05
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 3.46238064e-06
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 9.73326696e-07
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 3.97603562e-07
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 1.98321791e-08
   art_sys_62: 0.0
-  art_sys_63: -0.0
+  art_sys_63: 0.0
   art_sys_64: 5.04287641e-08
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
   art_sys_69: 3.05546432e-08
-  art_sys_70: -0.0
+  art_sys_70: 0.0
   art_sys_71: 8.29975820e-09
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 2.32783123e-09
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 1.54448543e-09
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 5.30147707e-10
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
   art_sys_90: 1.40299436e-11
   sys_1: 6.05283405e+03
@@ -1015,13 +1015,13 @@ bins:
   sys_7: 6.05283405e+03
   sys_8: -6.05283405e+03
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 2.26981277e+03
   sys_12: -3.02641702e+03
   sys_13: 1.13490638e+04
   sys_14: -1.13490638e+04
   sys_15: 0.0
-  sys_16: -0.0
+  sys_16: 0.0
   sys_17: 0.0
   sys_18: -7.56604256e+02
   sys_19: 4.53962554e+03
@@ -1037,25 +1037,25 @@ bins:
   sys_29: 4.53962554e+03
   sys_30: -4.53962554e+03
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 0.0
-  sys_38: -0.0
+  sys_38: 0.0
   sys_39: 0.0
-  sys_40: -0.0
+  sys_40: 0.0
   sys_41: 0.0
-  sys_42: -0.0
+  sys_42: 0.0
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
   sys_52: -7.56604256e+02
   sys_53: 0.0
@@ -1073,11 +1073,11 @@ bins:
   sys_65: 7.56604256e+02
   sys_66: -7.56604256e+02
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
   sys_74: -7.56604256e+02
   sys_75: 0.0
@@ -1085,47 +1085,47 @@ bins:
   sys_77: 7.56604256e+02
   sys_78: -7.56604256e+02
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 3.78302128e+03
   sys_114: -3.78302128e+03
   sys_115: 2.95075660e+04
   sys_116: -2.72377532e+04
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: -3.02641702e+03
   sys_122: 3.78302128e+03
   sys_123: -9.83585533e+03
@@ -1147,92 +1147,92 @@ bins:
   luminosity_uncertainty: 1.92600000e+04
 - art_sys_1: 0.0
   art_sys_2: -4.77033220e+01
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 3.14268214e+03
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 3.50642944e+01
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 6.62067632e+00
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 8.28376346e-02
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
+  art_sys_22: 0.0
   art_sys_23: 1.14440868e-02
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 7.91206859e-03
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: -5.40010282e-04
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 4.01656084e-04
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
+  art_sys_43: 0.0
   art_sys_44: -1.50718011e-05
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 2.16191112e-06
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: -4.46031889e-06
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 8.14636149e-08
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 4.17082996e-07
   art_sys_62: 0.0
-  art_sys_63: -0.0
+  art_sys_63: 0.0
   art_sys_64: 1.05694529e-08
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
   art_sys_69: 1.25633584e-08
-  art_sys_70: -0.0
+  art_sys_70: 0.0
   art_sys_71: -2.95765951e-08
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: -9.14156780e-09
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 1.96642808e-09
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 1.01309289e-09
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
   art_sys_90: 4.60286375e-11
   sys_1: 2.00959747e+03
@@ -1244,15 +1244,15 @@ bins:
   sys_7: 1.72251212e+03
   sys_8: -1.72251212e+03
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 8.61256059e+02
   sys_12: -8.61256059e+02
   sys_13: 3.73210959e+03
   sys_14: -3.44502424e+03
   sys_15: 0.0
-  sys_16: -0.0
+  sys_16: 0.0
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 1.43542677e+03
   sys_20: -1.43542677e+03
   sys_21: 2.87085353e+02
@@ -1268,27 +1268,27 @@ bins:
   sys_31: 0.0
   sys_32: -2.87085353e+02
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 0.0
-  sys_38: -0.0
+  sys_38: 0.0
   sys_39: 0.0
   sys_40: -2.87085353e+02
   sys_41: 0.0
-  sys_42: -0.0
+  sys_42: 0.0
   sys_43: 0.0
   sys_44: -2.87085353e+02
   sys_45: 0.0
   sys_46: -2.87085353e+02
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
   sys_56: -2.87085353e+02
   sys_57: 2.87085353e+02
@@ -1302,59 +1302,59 @@ bins:
   sys_65: 8.61256059e+02
   sys_66: -5.74170706e+02
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 2.87085353e+02
   sys_78: -2.87085353e+02
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 1.14834141e+03
   sys_114: -1.14834141e+03
   sys_115: 1.06221581e+04
   sys_116: -9.76090201e+03
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: -1.14834141e+03
   sys_122: 1.43542677e+03
   sys_123: -3.15793888e+03
@@ -1376,92 +1376,92 @@ bins:
   luminosity_uncertainty: 7.30800000e+03
 - art_sys_1: 0.0
   art_sys_2: -7.00122739e+01
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -9.20257933e+01
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 1.21913825e+03
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 1.80626131e+01
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 2.28059505e+00
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
+  art_sys_22: 0.0
   art_sys_23: 7.90198445e-02
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 1.06746073e-02
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: -2.44464005e-03
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 4.47952792e-04
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
+  art_sys_43: 0.0
   art_sys_44: 1.08646766e-04
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: -9.08624166e-06
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: -3.11648575e-06
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 5.35926874e-07
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 2.29584162e-06
   art_sys_62: 0.0
-  art_sys_63: -0.0
+  art_sys_63: 0.0
   art_sys_64: 1.07006478e-06
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
   art_sys_69: 1.28227265e-07
-  art_sys_70: -0.0
+  art_sys_70: 0.0
   art_sys_71: -6.24732027e-08
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 6.45561067e-09
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 1.59017767e-09
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 1.05553387e-08
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
   art_sys_90: -3.63513279e-11
   sys_1: 7.52361615e+02
@@ -1473,15 +1473,15 @@ bins:
   sys_7: 5.37401154e+02
   sys_8: -5.37401154e+02
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 2.14960461e+02
   sys_12: -3.22440692e+02
   sys_13: 1.18228254e+03
   sys_14: -1.07480231e+03
   sys_15: 0.0
-  sys_16: -0.0
+  sys_16: 0.0
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 5.37401154e+02
   sys_20: -4.29920923e+02
   sys_21: 1.07480231e+02
@@ -1497,29 +1497,29 @@ bins:
   sys_31: 0.0
   sys_32: -1.07480231e+02
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 0.0
-  sys_38: -0.0
+  sys_38: 0.0
   sys_39: 1.07480231e+02
   sys_40: -1.07480231e+02
   sys_41: 0.0
-  sys_42: -0.0
+  sys_42: 0.0
   sys_43: 1.07480231e+02
   sys_44: -1.07480231e+02
   sys_45: 1.07480231e+02
   sys_46: -1.07480231e+02
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 1.07480231e+02
   sys_58: -1.07480231e+02
   sys_59: 1.07480231e+02
@@ -1533,57 +1533,57 @@ bins:
   sys_67: 1.07480231e+02
   sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 1.07480231e+02
   sys_78: -1.07480231e+02
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 4.29920923e+02
   sys_114: -4.29920923e+02
   sys_115: 3.65432785e+03
   sys_116: -3.33188715e+03
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: -4.29920923e+02
   sys_122: 5.37401154e+02
   sys_123: -1.07480231e+03
@@ -1605,92 +1605,92 @@ bins:
   luminosity_uncertainty: 2.73600000e+03
 - art_sys_1: 0.0
   art_sys_2: 9.77545258e-01
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -3.96231596e+01
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: -4.64375276e+01
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 4.82951674e+02
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 5.44666874e+00
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
+  art_sys_22: 0.0
   art_sys_23: 7.84822573e-01
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 6.48303771e-02
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: -3.61645081e-03
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: -7.83601275e-04
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
+  art_sys_43: 0.0
   art_sys_44: 6.52654718e-04
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 5.20483996e-05
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 9.48094386e-06
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 8.85394144e-06
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: -1.78779821e-06
   art_sys_62: 0.0
-  art_sys_63: -0.0
+  art_sys_63: 0.0
   art_sys_64: -7.30851279e-07
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
   art_sys_69: 1.74720749e-07
-  art_sys_70: -0.0
+  art_sys_70: 0.0
   art_sys_71: -2.62337554e-08
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: -3.64352323e-08
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 1.29471700e-08
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 9.46016641e-09
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
   art_sys_90: -6.30046326e-11
   sys_1: 2.57104026e+02
@@ -1702,15 +1702,15 @@ bins:
   sys_7: 2.14253355e+02
   sys_8: -1.71402684e+02
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 8.57013419e+01
   sys_12: -8.57013419e+01
   sys_13: 3.85656038e+02
   sys_14: -3.85656038e+02
   sys_15: 0.0
-  sys_16: -0.0
+  sys_16: 0.0
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 1.71402684e+02
   sys_20: -1.71402684e+02
   sys_21: 4.28506709e+01
@@ -1740,17 +1740,17 @@ bins:
   sys_45: 8.57013419e+01
   sys_46: -8.57013419e+01
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 4.28506709e+01
   sys_60: -4.28506709e+01
   sys_61: 4.28506709e+01
@@ -1762,57 +1762,57 @@ bins:
   sys_67: 4.28506709e+01
   sys_68: -4.28506709e+01
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 4.28506709e+01
   sys_78: -4.28506709e+01
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 4.28506709e+01
   sys_84: -4.28506709e+01
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 1.28552013e+02
   sys_114: -1.28552013e+02
   sys_115: 1.28552013e+03
   sys_116: -1.19981879e+03
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: -2.14253355e+02
   sys_122: 2.14253355e+02
   sys_123: -3.85656038e+02
@@ -1828,98 +1828,98 @@ bins:
   sys_133: 8.57013419e+01
   sys_134: -8.57013419e+01
   sys_135: 0.0
-  sys_136: -0.0
+  sys_136: 0.0
   sys_137: 2.14253355e+02
   sys_138: -2.14253355e+02
   luminosity_uncertainty: 1.09080000e+03
 - art_sys_1: 0.0
   art_sys_2: -6.24445985e-01
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 8.09690516e-01
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: -1.26198742e+01
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: -1.33691170e+01
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 2.00649923e+02
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
+  art_sys_22: 0.0
   art_sys_23: 4.88886178e-01
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 5.72530475e-01
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: -3.85693232e-02
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: -4.09551998e-03
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
+  art_sys_43: 0.0
   art_sys_44: -5.10668135e-04
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: -3.58839834e-04
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 4.01512348e-05
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 9.94951973e-06
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 2.04343429e-05
   art_sys_62: 0.0
-  art_sys_63: -0.0
+  art_sys_63: 0.0
   art_sys_64: 2.50511092e-06
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
   art_sys_69: -6.54028672e-07
-  art_sys_70: -0.0
+  art_sys_70: 0.0
   art_sys_71: 1.17787458e-07
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: -4.26063451e-08
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 6.37371162e-08
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: -4.03966220e-09
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
   art_sys_90: 3.40611967e-10
   sys_1: 9.08632214e+01
@@ -1931,7 +1931,7 @@ bins:
   sys_7: 5.45179328e+01
   sys_8: -5.45179328e+01
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 3.63452886e+01
   sys_12: -3.63452886e+01
   sys_13: 1.45381154e+02
@@ -1939,7 +1939,7 @@ bins:
   sys_15: 0.0
   sys_16: -1.81726443e+01
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 7.26905771e+01
   sys_20: -7.26905771e+01
   sys_21: 1.81726443e+01
@@ -1969,17 +1969,17 @@ bins:
   sys_45: 3.63452886e+01
   sys_46: -3.63452886e+01
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 1.81726443e+01
   sys_60: -1.81726443e+01
   sys_61: 1.81726443e+01
@@ -1991,17 +1991,17 @@ bins:
   sys_67: 3.63452886e+01
   sys_68: -3.63452886e+01
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
   sys_78: -1.81726443e+01
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
   sys_82: -1.81726443e+01
   sys_83: 1.81726443e+01
@@ -2009,39 +2009,39 @@ bins:
   sys_85: 0.0
   sys_86: -1.81726443e+01
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 5.45179328e+01
   sys_114: -5.45179328e+01
   sys_115: 4.72488751e+02
   sys_116: -4.54316107e+02
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: -9.08632214e+01
   sys_122: 1.09035866e+02
   sys_123: -1.81726443e+02
@@ -2057,98 +2057,98 @@ bins:
   sys_133: 3.63452886e+01
   sys_134: -3.63452886e+01
   sys_135: 0.0
-  sys_136: -0.0
+  sys_136: 0.0
   sys_137: 9.08632214e+01
   sys_138: -9.08632214e+01
   luminosity_uncertainty: 4.62600000e+02
 - art_sys_1: 0.0
   art_sys_2: -5.59880644e-01
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 1.57221880e-03
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: -7.70393233e-01
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: -5.30516357e+00
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: -1.58625879e+00
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
+  art_sys_22: 0.0
   art_sys_23: 7.07597902e+01
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 1.18820891e+00
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: -2.67790339e-01
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: -2.42473600e-02
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
+  art_sys_43: 0.0
   art_sys_44: 1.50349162e-04
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 2.01220583e-04
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: -3.13977714e-05
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 5.25624358e-05
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 4.73347355e-06
   art_sys_62: 0.0
-  art_sys_63: -0.0
+  art_sys_63: 0.0
   art_sys_64: -4.79459747e-06
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
   art_sys_69: 2.74900035e-06
-  art_sys_70: -0.0
+  art_sys_70: 0.0
   art_sys_71: 9.39057694e-07
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 1.08451445e-07
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 1.47385495e-07
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: -1.36169505e-07
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
   art_sys_90: -6.70958864e-10
   sys_1: 3.19612265e+01
@@ -2160,7 +2160,7 @@ bins:
   sys_7: 2.39709199e+01
   sys_8: -2.39709199e+01
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 7.99030663e+00
   sys_12: -7.99030663e+00
   sys_13: 4.79418398e+01
@@ -2168,7 +2168,7 @@ bins:
   sys_15: 0.0
   sys_16: -7.99030663e+00
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 3.19612265e+01
   sys_20: -3.19612265e+01
   sys_21: 7.99030663e+00
@@ -2198,17 +2198,17 @@ bins:
   sys_45: 1.59806133e+01
   sys_46: -1.59806133e+01
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
   sys_60: -7.99030663e+00
   sys_61: 7.99030663e+00
@@ -2220,17 +2220,17 @@ bins:
   sys_67: 1.59806133e+01
   sys_68: -1.59806133e+01
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
   sys_82: -7.99030663e+00
   sys_83: 1.59806133e+01
@@ -2240,37 +2240,37 @@ bins:
   sys_87: 7.99030663e+00
   sys_88: -7.99030663e+00
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 2.39709199e+01
   sys_114: -2.39709199e+01
   sys_115: 1.75786746e+02
   sys_116: -1.75786746e+02
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: -4.79418398e+01
   sys_122: 4.79418398e+01
   sys_123: -8.78933729e+01
@@ -2286,98 +2286,98 @@ bins:
   sys_133: 1.59806133e+01
   sys_134: -1.59806133e+01
   sys_135: 0.0
-  sys_136: -0.0
+  sys_136: 0.0
   sys_137: 3.99515331e+01
   sys_138: -3.99515331e+01
   luminosity_uncertainty: 2.03400000e+02
 - art_sys_1: 0.0
   art_sys_2: -3.40189430e-01
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -6.68262358e-01
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: -7.01607567e-02
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: -5.39138259e-01
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: -3.49927676e+00
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
+  art_sys_22: 0.0
   art_sys_23: -2.64986079e+00
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 3.25491051e+01
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: -6.34601537e-01
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: -1.68143063e-01
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
+  art_sys_43: 0.0
   art_sys_44: -1.30486891e-02
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 1.30308546e-03
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: -3.27163776e-04
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 5.97594369e-05
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 2.39257219e-05
   art_sys_62: 0.0
-  art_sys_63: -0.0
+  art_sys_63: 0.0
   art_sys_64: 3.39099387e-05
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
   art_sys_69: -5.32913752e-06
-  art_sys_70: -0.0
+  art_sys_70: 0.0
   art_sys_71: 2.71306658e-06
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: -7.25244740e-07
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 5.39198882e-07
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 2.22646652e-07
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
   art_sys_90: 4.71488044e-10
   sys_1: 1.10520790e+01
@@ -2389,7 +2389,7 @@ bins:
   sys_7: 7.36805266e+00
   sys_8: -7.36805266e+00
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 3.68402633e+00
   sys_12: -3.68402633e+00
   sys_13: 1.84201316e+01
@@ -2397,7 +2397,7 @@ bins:
   sys_15: 3.68402633e+00
   sys_16: -3.68402633e+00
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 1.10520790e+01
   sys_20: -1.10520790e+01
   sys_21: 3.68402633e+00
@@ -2427,19 +2427,19 @@ bins:
   sys_45: 1.10520790e+01
   sys_46: -1.10520790e+01
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
   sys_52: -3.68402633e+00
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 3.68402633e+00
   sys_62: -3.68402633e+00
   sys_63: 3.68402633e+00
@@ -2449,17 +2449,17 @@ bins:
   sys_67: 7.36805266e+00
   sys_68: -7.36805266e+00
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
   sys_82: -3.68402633e+00
   sys_83: 7.36805266e+00
@@ -2469,37 +2469,37 @@ bins:
   sys_87: 7.36805266e+00
   sys_88: -3.68402633e+00
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 1.10520790e+01
   sys_114: -1.10520790e+01
   sys_115: 6.99965003e+01
   sys_116: -6.99965003e+01
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: -2.21041580e+01
   sys_122: 2.21041580e+01
   sys_123: -4.05242896e+01
@@ -2515,98 +2515,98 @@ bins:
   sys_133: 7.36805266e+00
   sys_134: -7.36805266e+00
   sys_135: 0.0
-  sys_136: -0.0
+  sys_136: 0.0
   sys_137: 1.84201316e+01
   sys_138: -1.84201316e+01
   luminosity_uncertainty: 9.37800000e+01
 - art_sys_1: 0.0
   art_sys_2: 9.23387966e-02
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -5.02852833e-02
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: -1.35259611e-01
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 3.40255235e-02
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: -3.51750100e-01
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
+  art_sys_22: 0.0
   art_sys_23: -1.19370158e+00
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: -1.49352552e+00
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: -1.45575069e+01
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: -5.13965110e-01
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
+  art_sys_43: 0.0
   art_sys_44: -7.07131241e-02
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 7.14714411e-03
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: -1.46476036e-03
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: -1.55464994e-04
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: -6.28948301e-05
   art_sys_62: 0.0
-  art_sys_63: -0.0
+  art_sys_63: 0.0
   art_sys_64: 5.53498030e-05
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
   art_sys_69: -6.73724191e-06
-  art_sys_70: -0.0
+  art_sys_70: 0.0
   art_sys_71: 4.59052397e-06
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: -2.01812845e-06
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: -6.57480973e-07
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 2.07564586e-07
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
   art_sys_90: -1.15028463e-09
   sys_1: 3.54967604e+00
@@ -2618,7 +2618,7 @@ bins:
   sys_7: 3.54967604e+00
   sys_8: -3.54967604e+00
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 1.77483802e+00
   sys_12: -1.77483802e+00
   sys_13: 7.09935208e+00
@@ -2626,7 +2626,7 @@ bins:
   sys_15: 1.77483802e+00
   sys_16: -3.54967604e+00
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 5.32451406e+00
   sys_20: -5.32451406e+00
   sys_21: 1.77483802e+00
@@ -2656,21 +2656,21 @@ bins:
   sys_45: 5.32451406e+00
   sys_46: -5.32451406e+00
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 0.0
-  sys_62: -0.0
+  sys_62: 0.0
   sys_63: 1.77483802e+00
   sys_64: -1.77483802e+00
   sys_65: 1.77483802e+00
@@ -2678,17 +2678,17 @@ bins:
   sys_67: 3.54967604e+00
   sys_68: -1.77483802e+00
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
   sys_82: -1.77483802e+00
   sys_83: 3.54967604e+00
@@ -2700,35 +2700,35 @@ bins:
   sys_89: 0.0
   sys_90: -1.77483802e+00
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 3.54967604e+00
   sys_114: -5.32451406e+00
   sys_115: 3.01722464e+01
   sys_116: -2.83974083e+01
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: -1.06490281e+01
   sys_122: 8.87419010e+00
   sys_123: -1.59735422e+01
@@ -2744,98 +2744,98 @@ bins:
   sys_133: 3.54967604e+00
   sys_134: -3.54967604e+00
   sys_135: 0.0
-  sys_136: -0.0
+  sys_136: 0.0
   sys_137: 8.87419010e+00
   sys_138: -8.87419010e+00
   luminosity_uncertainty: 4.51800000e+01
 - art_sys_1: 0.0
   art_sys_2: 5.80091660e-02
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 1.94125450e-01
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 1.07567088e-01
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: -1.04484248e-02
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: -1.89766689e-03
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
+  art_sys_22: 0.0
   art_sys_23: -9.06462642e-02
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: -6.72738390e-01
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 1.08843898e+00
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: -7.07546072e+00
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
+  art_sys_43: 0.0
   art_sys_44: -1.95866968e-01
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 3.55592631e-02
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 8.11460358e-05
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 9.47767711e-04
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 2.31004101e-04
   art_sys_62: 0.0
-  art_sys_63: -0.0
+  art_sys_63: 0.0
   art_sys_64: 4.77814218e-05
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
   art_sys_69: 8.70840560e-06
-  art_sys_70: -0.0
+  art_sys_70: 0.0
   art_sys_71: 1.01696338e-05
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: -3.19457414e-06
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 3.71284068e-06
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: -6.54733539e-07
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
   art_sys_90: 8.56908310e-09
   sys_1: 1.75362482e+00
@@ -2847,7 +2847,7 @@ bins:
   sys_7: 1.75362482e+00
   sys_8: -8.76812409e-01
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 8.76812409e-01
   sys_12: -8.76812409e-01
   sys_13: 2.63043723e+00
@@ -2855,7 +2855,7 @@ bins:
   sys_15: 8.76812409e-01
   sys_16: -1.75362482e+00
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 2.63043723e+00
   sys_20: -2.63043723e+00
   sys_21: 8.76812409e-01
@@ -2885,21 +2885,21 @@ bins:
   sys_45: 2.63043723e+00
   sys_46: -2.63043723e+00
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 0.0
-  sys_62: -0.0
+  sys_62: 0.0
   sys_63: 8.76812409e-01
   sys_64: -8.76812409e-01
   sys_65: 8.76812409e-01
@@ -2907,17 +2907,17 @@ bins:
   sys_67: 8.76812409e-01
   sys_68: -8.76812409e-01
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
   sys_82: -8.76812409e-01
   sys_83: 8.76812409e-01
@@ -2929,35 +2929,35 @@ bins:
   sys_89: 8.76812409e-01
   sys_90: -1.75362482e+00
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 1.75362482e+00
   sys_114: -1.75362482e+00
   sys_115: 1.31521861e+01
   sys_116: -1.22753737e+01
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: -4.38406204e+00
   sys_122: 3.50724963e+00
   sys_123: -6.13768686e+00
@@ -2973,98 +2973,98 @@ bins:
   sys_133: 8.76812409e-01
   sys_134: -8.76812409e-01
   sys_135: 0.0
-  sys_136: -0.0
+  sys_136: 0.0
   sys_137: 4.38406204e+00
   sys_138: -4.38406204e+00
   luminosity_uncertainty: 2.23200000e+01
 - art_sys_1: 0.0
   art_sys_2: 3.56841619e-02
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -3.24320708e-02
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 2.84708301e-02
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 9.48380534e-02
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: -4.90602185e-03
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
+  art_sys_22: 0.0
   art_sys_23: 4.29393443e-02
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: -5.49746356e-02
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 2.42621811e-01
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 4.23950443e-01
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
+  art_sys_43: 0.0
   art_sys_44: -3.42538579e+00
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 1.04010414e-01
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: -1.70034057e-02
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 2.23313283e-03
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 6.97646425e-04
   art_sys_62: 0.0
-  art_sys_63: -0.0
+  art_sys_63: 0.0
   art_sys_64: 1.62980195e-04
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
   art_sys_69: -2.08230958e-05
-  art_sys_70: -0.0
+  art_sys_70: 0.0
   art_sys_71: 9.55312842e-06
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: -4.65891824e-06
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 1.33058018e-06
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 4.62503045e-07
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
   art_sys_90: -1.60785983e-08
   sys_1: 8.47113924e-01
@@ -3076,7 +3076,7 @@ bins:
   sys_7: 4.23556962e-01
   sys_8: -4.23556962e-01
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 4.23556962e-01
   sys_12: -4.23556962e-01
   sys_13: 1.27067089e+00
@@ -3084,7 +3084,7 @@ bins:
   sys_15: 4.23556962e-01
   sys_16: -4.23556962e-01
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 1.27067089e+00
   sys_20: -1.27067089e+00
   sys_21: 4.23556962e-01
@@ -3114,21 +3114,21 @@ bins:
   sys_45: 1.69422785e+00
   sys_46: -1.69422785e+00
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 0.0
-  sys_62: -0.0
+  sys_62: 0.0
   sys_63: 4.23556962e-01
   sys_64: -4.23556962e-01
   sys_65: 4.23556962e-01
@@ -3136,17 +3136,17 @@ bins:
   sys_67: 4.23556962e-01
   sys_68: -4.23556962e-01
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
   sys_82: -4.23556962e-01
   sys_83: 4.23556962e-01
@@ -3160,33 +3160,33 @@ bins:
   sys_91: 4.23556962e-01
   sys_92: -4.23556962e-01
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
   sys_100: -4.23556962e-01
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 8.47113924e-01
   sys_114: -8.47113924e-01
   sys_115: 5.08268354e+00
   sys_116: -5.08268354e+00
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: -1.27067089e+00
   sys_122: 8.47113924e-01
   sys_123: -1.69422785e+00
@@ -3202,98 +3202,98 @@ bins:
   sys_133: 4.23556962e-01
   sys_134: -4.23556962e-01
   sys_135: 0.0
-  sys_136: -0.0
+  sys_136: 0.0
   sys_137: 2.11778481e+00
   sys_138: -2.11778481e+00
   luminosity_uncertainty: 1.07820000e+01
 - art_sys_1: 0.0
   art_sys_2: -2.20322705e-02
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -5.11195278e-03
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 1.76398223e-03
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: -2.29026537e-02
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 4.83961862e-02
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
+  art_sys_22: 0.0
   art_sys_23: -2.23674578e-03
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: -1.64370589e-03
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 2.51940803e-02
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 1.27765843e-01
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
+  art_sys_43: 0.0
   art_sys_44: 2.22353667e-01
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 1.65201313e+00
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: -2.89783643e-02
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 1.48881977e-02
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 1.36497539e-03
   art_sys_62: 0.0
-  art_sys_63: -0.0
+  art_sys_63: 0.0
   art_sys_64: -4.99751348e-04
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
   art_sys_69: -6.37809257e-05
-  art_sys_70: -0.0
+  art_sys_70: 0.0
   art_sys_71: -8.63674365e-06
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: -1.56419238e-05
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 9.76743155e-06
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: -5.66044411e-07
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
   art_sys_90: 7.19562227e-08
   sys_1: 4.10121933e-01
@@ -3305,7 +3305,7 @@ bins:
   sys_7: 2.05060967e-01
   sys_8: -2.05060967e-01
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 2.05060967e-01
   sys_12: -2.05060967e-01
   sys_13: 4.10121933e-01
@@ -3313,7 +3313,7 @@ bins:
   sys_15: 2.05060967e-01
   sys_16: -2.05060967e-01
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 8.20243866e-01
   sys_20: -6.15182900e-01
   sys_21: 2.05060967e-01
@@ -3343,21 +3343,21 @@ bins:
   sys_45: 1.02530483e+00
   sys_46: -1.02530483e+00
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
   sys_52: -2.05060967e-01
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 0.0
-  sys_62: -0.0
+  sys_62: 0.0
   sys_63: 2.05060967e-01
   sys_64: -2.05060967e-01
   sys_65: 2.05060967e-01
@@ -3365,17 +3365,17 @@ bins:
   sys_67: 2.05060967e-01
   sys_68: -2.05060967e-01
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
   sys_82: -2.05060967e-01
   sys_83: 2.05060967e-01
@@ -3389,33 +3389,33 @@ bins:
   sys_91: 6.15182900e-01
   sys_92: -6.15182900e-01
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 6.15182900e-01
   sys_114: -6.15182900e-01
   sys_115: 2.25567063e+00
   sys_116: -2.05060967e+00
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: -4.10121933e-01
   sys_122: 2.05060967e-01
   sys_123: -4.10121933e-01
@@ -3431,98 +3431,98 @@ bins:
   sys_133: 2.05060967e-01
   sys_134: -2.05060967e-01
   sys_135: 0.0
-  sys_136: -0.0
+  sys_136: 0.0
   sys_137: 1.02530483e+00
   sys_138: -1.02530483e+00
   luminosity_uncertainty: 5.22000000e+00
 - art_sys_1: 0.0
   art_sys_2: 9.86610479e-03
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -1.45568502e-02
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: -5.91171276e-03
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 3.74820673e-03
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 9.11597314e-03
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
+  art_sys_22: 0.0
   art_sys_23: -3.01618742e-04
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: -8.39904315e-03
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 1.84897828e-02
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: -1.17688968e-02
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
+  art_sys_43: 0.0
   art_sys_44: 5.76594449e-02
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: -5.51521631e-02
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: -9.01414720e-01
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: -1.49158449e-03
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 9.46831670e-03
   art_sys_62: 0.0
-  art_sys_63: -0.0
+  art_sys_63: 0.0
   art_sys_64: -9.07193600e-04
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
   art_sys_69: -2.68164606e-04
-  art_sys_70: -0.0
+  art_sys_70: 0.0
   art_sys_71: 8.18022041e-05
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: -1.42749990e-06
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: -1.09162130e-05
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: -2.82462222e-06
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
   art_sys_90: -1.57577390e-07
   sys_1: 9.89949494e-02
@@ -3534,7 +3534,7 @@ bins:
   sys_7: 9.89949494e-02
   sys_8: -9.89949494e-02
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 9.89949494e-02
   sys_12: -9.89949494e-02
   sys_13: 1.97989899e-01
@@ -3542,7 +3542,7 @@ bins:
   sys_15: 9.89949494e-02
   sys_16: -9.89949494e-02
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 3.95979797e-01
   sys_20: -3.95979797e-01
   sys_21: 9.89949494e-02
@@ -3572,21 +3572,21 @@ bins:
   sys_45: 5.93969696e-01
   sys_46: -5.93969696e-01
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 9.89949494e-02
   sys_52: -9.89949494e-02
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 0.0
-  sys_62: -0.0
+  sys_62: 0.0
   sys_63: 0.0
   sys_64: -9.89949494e-02
   sys_65: 9.89949494e-02
@@ -3594,19 +3594,19 @@ bins:
   sys_67: 9.89949494e-02
   sys_68: -9.89949494e-02
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 9.89949494e-02
   sys_84: -9.89949494e-02
   sys_85: 1.97989899e-01
@@ -3618,37 +3618,37 @@ bins:
   sys_91: 5.93969696e-01
   sys_92: -5.93969696e-01
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
   sys_104: -9.89949494e-02
   sys_105: 0.0
   sys_106: -9.89949494e-02
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 2.96984848e-01
   sys_114: -2.96984848e-01
   sys_115: 8.90954544e-01
   sys_116: -8.90954544e-01
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: -9.89949494e-02
   sys_122: 9.89949494e-02
   sys_123: 0.0
-  sys_124: -0.0
+  sys_124: 0.0
   sys_125: 1.97989899e-01
   sys_126: -1.97989899e-01
   sys_127: 9.89949494e-02
@@ -3660,98 +3660,98 @@ bins:
   sys_133: 9.89949494e-02
   sys_134: -9.89949494e-02
   sys_135: 0.0
-  sys_136: -0.0
+  sys_136: 0.0
   sys_137: 4.94974747e-01
   sys_138: -4.94974747e-01
   luminosity_uncertainty: 2.52000000e+00
 - art_sys_1: 0.0
   art_sys_2: -5.63127896e-03
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 2.48544381e-04
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: -2.38378613e-04
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: -6.78572413e-03
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: -4.23603003e-03
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
+  art_sys_22: 0.0
   art_sys_23: -6.79657670e-03
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: -2.51744701e-03
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: -7.47364840e-03
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 6.70918896e-03
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
+  art_sys_43: 0.0
   art_sys_44: 8.14696942e-03
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: -4.51204560e-02
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: -2.01708171e-03
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 5.51864445e-01
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: -7.66459020e-03
   art_sys_62: 0.0
-  art_sys_63: -0.0
+  art_sys_63: 0.0
   art_sys_64: -5.59610386e-03
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
   art_sys_69: 1.68390971e-04
-  art_sys_70: -0.0
+  art_sys_70: 0.0
   art_sys_71: -7.66965461e-05
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 1.42664030e-04
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 3.06825436e-05
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 3.72320589e-06
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
   art_sys_90: 2.88138736e-07
   sys_1: 4.63862048e-02
@@ -3763,7 +3763,7 @@ bins:
   sys_7: 4.63862048e-02
   sys_8: -4.63862048e-02
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 4.63862048e-02
   sys_12: -4.63862048e-02
   sys_13: 9.27724097e-02
@@ -3771,7 +3771,7 @@ bins:
   sys_15: 4.63862048e-02
   sys_16: -4.63862048e-02
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 1.85544819e-01
   sys_20: -1.85544819e-01
   sys_21: 4.63862048e-02
@@ -3801,21 +3801,21 @@ bins:
   sys_45: 3.24703434e-01
   sys_46: -3.71089639e-01
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 4.63862048e-02
   sys_52: -4.63862048e-02
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 0.0
-  sys_62: -0.0
+  sys_62: 0.0
   sys_63: 0.0
   sys_64: -4.63862048e-02
   sys_65: 4.63862048e-02
@@ -3823,19 +3823,19 @@ bins:
   sys_67: 0.0
   sys_68: -4.63862048e-02
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 4.63862048e-02
   sys_84: -4.63862048e-02
   sys_85: 9.27724097e-02
@@ -3847,15 +3847,15 @@ bins:
   sys_91: 3.71089639e-01
   sys_92: -3.71089639e-01
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 4.63862048e-02
   sys_104: -4.63862048e-02
   sys_105: 4.63862048e-02
@@ -3863,17 +3863,17 @@ bins:
   sys_107: 0.0
   sys_108: -4.63862048e-02
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 1.39158615e-01
   sys_114: -1.39158615e-01
   sys_115: 3.24703434e-01
   sys_116: -3.24703434e-01
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: -4.63862048e-02
   sys_122: 0.0
   sys_123: 0.0
@@ -3889,98 +3889,98 @@ bins:
   sys_133: 4.63862048e-02
   sys_134: -4.63862048e-02
   sys_135: 0.0
-  sys_136: -0.0
+  sys_136: 0.0
   sys_137: 2.31931024e-01
   sys_138: -2.31931024e-01
   luminosity_uncertainty: 1.1808
 - art_sys_1: 0.0
   art_sys_2: -3.67271922e-04
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -2.92790764e-03
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: -7.83460395e-03
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 2.97479134e-03
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: -1.19880779e-02
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
+  art_sys_22: 0.0
   art_sys_23: -9.32768772e-04
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: -2.18413077e-03
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: -4.17107831e-03
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 3.77323538e-03
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
+  art_sys_43: 0.0
   art_sys_44: 4.91183870e-03
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: -5.91482697e-03
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 2.38533248e-02
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 1.30018955e-02
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 3.52977558e-01
   art_sys_62: 0.0
-  art_sys_63: -0.0
+  art_sys_63: 0.0
   art_sys_64: 1.78379506e-02
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
   art_sys_69: -5.61951146e-03
-  art_sys_70: -0.0
+  art_sys_70: 0.0
   art_sys_71: -3.75233618e-05
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: -1.44107323e-05
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 1.42116169e-05
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: -2.92026217e-05
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
   art_sys_90: -3.58813381e-07
   sys_1: 2.25567063e-02
@@ -3992,7 +3992,7 @@ bins:
   sys_7: 2.25567063e-02
   sys_8: -2.25567063e-02
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 2.25567063e-02
   sys_12: -2.25567063e-02
   sys_13: 4.51134126e-02
@@ -4000,7 +4000,7 @@ bins:
   sys_15: 2.25567063e-02
   sys_16: -2.25567063e-02
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 9.02268253e-02
   sys_20: -9.02268253e-02
   sys_21: 2.25567063e-02
@@ -4030,19 +4030,19 @@ bins:
   sys_45: 2.03010357e-01
   sys_46: -2.03010357e-01
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 2.25567063e-02
   sys_52: -2.25567063e-02
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 2.25567063e-02
   sys_62: -2.25567063e-02
   sys_63: 0.0
@@ -4052,19 +4052,19 @@ bins:
   sys_67: 0.0
   sys_68: -2.25567063e-02
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
   sys_84: -2.25567063e-02
   sys_85: 4.51134126e-02
@@ -4076,15 +4076,15 @@ bins:
   sys_91: 2.25567063e-01
   sys_92: -2.48123770e-01
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 2.25567063e-02
   sys_104: -2.25567063e-02
   sys_105: 4.51134126e-02
@@ -4092,23 +4092,23 @@ bins:
   sys_107: 2.25567063e-02
   sys_108: -2.25567063e-02
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 6.76701190e-02
   sys_114: -6.76701190e-02
   sys_115: 1.35340238e-01
   sys_116: -1.35340238e-01
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: 0.0
-  sys_122: -0.0
+  sys_122: 0.0
   sys_123: 2.25567063e-02
   sys_124: -2.25567063e-02
   sys_125: 0.0
-  sys_126: -0.0
+  sys_126: 0.0
   sys_127: 2.25567063e-02
   sys_128: -2.25567063e-02
   sys_129: 2.70680476e-01
@@ -4118,98 +4118,98 @@ bins:
   sys_133: 2.25567063e-02
   sys_134: -2.25567063e-02
   sys_135: 0.0
-  sys_136: -0.0
+  sys_136: 0.0
   sys_137: 1.12783532e-01
   sys_138: -1.12783532e-01
   luminosity_uncertainty: 0.5742
 - art_sys_1: 0.0
   art_sys_2: 1.59903365e-03
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -4.88162348e-04
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 5.07425953e-03
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: -1.14427437e-03
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 6.98922566e-04
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
+  art_sys_22: 0.0
   art_sys_23: -2.22478502e-03
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 4.42147469e-03
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: -3.66366543e-03
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: -1.42404657e-03
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
+  art_sys_43: 0.0
   art_sys_44: -3.11874450e-03
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: -2.67881701e-03
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 5.53810261e-03
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: -1.28019058e-02
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 2.96640044e-02
   art_sys_62: 0.0
-  art_sys_63: -0.0
+  art_sys_63: 0.0
   art_sys_64: -2.21406648e-01
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
   art_sys_69: 1.41042611e-02
-  art_sys_70: -0.0
+  art_sys_70: 0.0
   art_sys_71: -4.29514136e-03
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: -1.08130828e-04
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: -1.02810457e-05
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 1.30791015e-05
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
   art_sys_90: 5.15500715e-07
   sys_1: 1.05358910e-02
@@ -4221,7 +4221,7 @@ bins:
   sys_7: 1.05358910e-02
   sys_8: -1.05358910e-02
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 1.05358910e-02
   sys_12: -1.05358910e-02
   sys_13: 2.10717821e-02
@@ -4229,7 +4229,7 @@ bins:
   sys_15: 1.05358910e-02
   sys_16: -1.05358910e-02
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 5.26794552e-02
   sys_20: -5.26794552e-02
   sys_21: 1.05358910e-02
@@ -4259,17 +4259,17 @@ bins:
   sys_45: 1.15894801e-01
   sys_46: -1.15894801e-01
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 1.05358910e-02
   sys_52: -1.05358910e-02
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
   sys_56: -1.05358910e-02
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
   sys_60: -1.05358910e-02
   sys_61: 1.05358910e-02
@@ -4281,19 +4281,19 @@ bins:
   sys_67: 0.0
   sys_68: -1.05358910e-02
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
   sys_84: -1.05358910e-02
   sys_85: 2.10717821e-02
@@ -4305,15 +4305,15 @@ bins:
   sys_91: 1.26430692e-01
   sys_92: -1.26430692e-01
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 1.05358910e-02
   sys_104: -1.05358910e-02
   sys_105: 3.16076731e-02
@@ -4323,21 +4323,21 @@ bins:
   sys_109: 1.05358910e-02
   sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 4.21435642e-02
   sys_114: -4.21435642e-02
   sys_115: 5.26794552e-02
   sys_116: -5.26794552e-02
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: 0.0
-  sys_122: -0.0
+  sys_122: 0.0
   sys_123: 1.05358910e-02
   sys_124: -1.05358910e-02
   sys_125: 0.0
-  sys_126: -0.0
+  sys_126: 0.0
   sys_127: 1.05358910e-02
   sys_128: -1.05358910e-02
   sys_129: 1.15894801e-01
@@ -4347,98 +4347,98 @@ bins:
   sys_133: 1.05358910e-02
   sys_134: -1.05358910e-02
   sys_135: 0.0
-  sys_136: -0.0
+  sys_136: 0.0
   sys_137: 5.26794552e-02
   sys_138: -5.26794552e-02
   luminosity_uncertainty: 2.68200000e-01
 - art_sys_1: 0.0
   art_sys_2: 1.86630567e-03
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 3.83806142e-04
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 2.00964972e-03
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 3.62178686e-04
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: -3.01797270e-04
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
+  art_sys_22: 0.0
   art_sys_23: 1.24848365e-03
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: -6.64336826e-04
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 5.03706220e-04
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: -7.27098351e-04
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
+  art_sys_43: 0.0
   art_sys_44: -1.98502550e-04
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: -7.13523732e-04
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 1.40810854e-03
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: -1.19428573e-03
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: -1.08710787e-02
   art_sys_62: 0.0
-  art_sys_63: -0.0
+  art_sys_63: 0.0
   art_sys_64: -2.35294277e-02
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
   art_sys_69: -1.41191140e-01
-  art_sys_70: -0.0
+  art_sys_70: 0.0
   art_sys_71: 8.59593556e-03
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 2.16721566e-03
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 1.67789486e-04
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: -3.31225966e-05
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
   art_sys_90: -4.93166581e-07
   sys_1: 4.98510281e-03
@@ -4450,7 +4450,7 @@ bins:
   sys_7: 4.98510281e-03
   sys_8: -4.98510281e-03
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 4.98510281e-03
   sys_12: -4.98510281e-03
   sys_13: 1.49553084e-02
@@ -4458,7 +4458,7 @@ bins:
   sys_15: 4.98510281e-03
   sys_16: -4.98510281e-03
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 2.49255140e-02
   sys_20: -2.49255140e-02
   sys_21: 4.98510281e-03
@@ -4488,17 +4488,17 @@ bins:
   sys_45: 5.98212337e-02
   sys_46: -5.98212337e-02
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 4.98510281e-03
   sys_52: -4.98510281e-03
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
   sys_56: -4.98510281e-03
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 4.98510281e-03
   sys_60: -4.98510281e-03
   sys_61: 4.98510281e-03
@@ -4508,23 +4508,23 @@ bins:
   sys_65: 4.98510281e-03
   sys_66: -4.98510281e-03
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 9.97020561e-03
   sys_86: -9.97020561e-03
   sys_87: 2.99106168e-02
@@ -4534,15 +4534,15 @@ bins:
   sys_91: 6.48063365e-02
   sys_92: -6.48063365e-02
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 4.98510281e-03
   sys_104: -4.98510281e-03
   sys_105: 2.49255140e-02
@@ -4552,7 +4552,7 @@ bins:
   sys_109: 4.98510281e-03
   sys_110: -4.98510281e-03
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 1.99404112e-02
   sys_114: -1.99404112e-02
   sys_115: 1.99404112e-02
@@ -4560,13 +4560,13 @@ bins:
   sys_117: -4.98510281e-03
   sys_118: 4.98510281e-03
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: 0.0
-  sys_122: -0.0
+  sys_122: 0.0
   sys_123: 4.98510281e-03
   sys_124: -4.98510281e-03
   sys_125: 0.0
-  sys_126: -0.0
+  sys_126: 0.0
   sys_127: 4.98510281e-03
   sys_128: -4.98510281e-03
   sys_129: 4.98510281e-02
@@ -4576,98 +4576,98 @@ bins:
   sys_133: 4.98510281e-03
   sys_134: -4.98510281e-03
   sys_135: 0.0
-  sys_136: -0.0
+  sys_136: 0.0
   sys_137: 2.49255140e-02
   sys_138: -2.49255140e-02
   luminosity_uncertainty: 0.1269
 - art_sys_1: 0.0
   art_sys_2: 9.45384979e-04
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -8.70290331e-04
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: -8.24770599e-04
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: -1.44122756e-04
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 6.31617950e-05
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
+  art_sys_22: 0.0
   art_sys_23: 7.87719135e-04
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 5.00670262e-04
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: -2.95521635e-04
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: -7.50044230e-04
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
+  art_sys_43: 0.0
   art_sys_44: -2.03205224e-04
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: -1.17004163e-04
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: -8.68435111e-04
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 1.35573286e-04
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: -2.42616255e-03
   art_sys_62: 0.0
-  art_sys_63: -0.0
+  art_sys_63: 0.0
   art_sys_64: 7.63035902e-03
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
   art_sys_69: -1.34883722e-02
-  art_sys_70: -0.0
+  art_sys_70: 0.0
   art_sys_71: -9.68893641e-02
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: -4.47014928e-03
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: -1.31066873e-03
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 3.76798274e-05
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
   art_sys_90: -1.30240207e-06
   sys_1: 2.28395490e-03
@@ -4679,7 +4679,7 @@ bins:
   sys_7: 0.0
   sys_8: -2.28395490e-03
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 2.28395490e-03
   sys_12: -2.28395490e-03
   sys_13: 6.85186471e-03
@@ -4687,7 +4687,7 @@ bins:
   sys_15: 0.0
   sys_16: -2.28395490e-03
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 1.37037294e-02
   sys_20: -1.37037294e-02
   sys_21: 2.28395490e-03
@@ -4717,17 +4717,17 @@ bins:
   sys_45: 3.19753686e-02
   sys_46: -3.19753686e-02
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 2.28395490e-03
   sys_52: -2.28395490e-03
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 2.28395490e-03
   sys_56: -2.28395490e-03
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 2.28395490e-03
   sys_60: -2.28395490e-03
   sys_61: 2.28395490e-03
@@ -4737,23 +4737,23 @@ bins:
   sys_65: 4.56790981e-03
   sys_66: -2.28395490e-03
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 4.56790981e-03
   sys_86: -4.56790981e-03
   sys_87: 1.59876843e-02
@@ -4763,15 +4763,15 @@ bins:
   sys_91: 2.96914137e-02
   sys_92: -2.96914137e-02
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 2.28395490e-03
   sys_104: -2.28395490e-03
   sys_105: 1.37037294e-02
@@ -4781,7 +4781,7 @@ bins:
   sys_109: 2.28395490e-03
   sys_110: -2.28395490e-03
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 1.14197745e-02
   sys_114: -1.14197745e-02
   sys_115: 9.13581961e-03
@@ -4789,13 +4789,13 @@ bins:
   sys_117: -2.05555941e-02
   sys_118: 2.05555941e-02
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: 0.0
-  sys_122: -0.0
+  sys_122: 0.0
   sys_123: 2.28395490e-03
   sys_124: -2.28395490e-03
   sys_125: 0.0
-  sys_126: -0.0
+  sys_126: 0.0
   sys_127: 0.0
   sys_128: -2.28395490e-03
   sys_129: 2.28395490e-02
@@ -4805,98 +4805,98 @@ bins:
   sys_133: 2.28395490e-03
   sys_134: -2.28395490e-03
   sys_135: 0.0
-  sys_136: -0.0
+  sys_136: 0.0
   sys_137: 1.14197745e-02
   sys_138: -1.14197745e-02
   luminosity_uncertainty: 5.81400000e-02
 - art_sys_1: 0.0
   art_sys_2: -3.56896050e-04
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 3.63503491e-04
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: -3.17847991e-04
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 2.61995734e-04
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 1.06431135e-04
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
+  art_sys_22: 0.0
   art_sys_23: -1.81061970e-04
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 3.27832275e-04
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: -4.77320533e-04
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: -3.31561633e-04
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
+  art_sys_43: 0.0
   art_sys_44: -2.43172450e-04
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 5.26275394e-04
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: -1.58830117e-04
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: -1.33750885e-03
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 3.76527065e-04
   art_sys_62: 0.0
-  art_sys_63: -0.0
+  art_sys_63: 0.0
   art_sys_64: 1.08396822e-03
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
   art_sys_69: 4.17900353e-03
-  art_sys_70: -0.0
+  art_sys_70: 0.0
   art_sys_71: -7.95431387e-03
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 5.85661451e-02
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 3.70234911e-03
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 1.08560343e-03
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
   art_sys_90: 7.43505189e-07
   sys_1: 1.01823376e-03
@@ -4908,7 +4908,7 @@ bins:
   sys_7: 0.0
   sys_8: -1.01823376e-03
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 1.01823376e-03
   sys_12: -1.01823376e-03
   sys_13: 3.05470129e-03
@@ -4916,7 +4916,7 @@ bins:
   sys_15: 0.0
   sys_16: -1.01823376e-03
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 6.10940259e-03
   sys_20: -6.10940259e-03
   sys_21: 1.01823376e-03
@@ -4946,17 +4946,17 @@ bins:
   sys_45: 1.52735065e-02
   sys_46: -1.52735065e-02
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 2.03646753e-03
   sys_52: -1.01823376e-03
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 1.01823376e-03
   sys_56: -1.01823376e-03
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 1.01823376e-03
   sys_60: -1.01823376e-03
   sys_61: 1.01823376e-03
@@ -4966,23 +4966,23 @@ bins:
   sys_65: 2.03646753e-03
   sys_66: -2.03646753e-03
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 1.01823376e-03
   sys_78: -1.01823376e-03
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 2.03646753e-03
   sys_86: -2.03646753e-03
   sys_87: 8.14587012e-03
@@ -4992,15 +4992,15 @@ bins:
   sys_91: 1.42552727e-02
   sys_92: -1.42552727e-02
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 1.01823376e-03
   sys_104: -1.01823376e-03
   sys_105: 6.10940259e-03
@@ -5010,7 +5010,7 @@ bins:
   sys_109: 2.03646753e-03
   sys_110: -1.01823376e-03
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 6.10940259e-03
   sys_114: -6.10940259e-03
   sys_115: 3.05470129e-03
@@ -5018,15 +5018,15 @@ bins:
   sys_117: -1.52735065e-02
   sys_118: 1.62917402e-02
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: 0.0
-  sys_122: -0.0
+  sys_122: 0.0
   sys_123: 1.01823376e-03
   sys_124: -1.01823376e-03
   sys_125: 0.0
-  sys_126: -0.0
+  sys_126: 0.0
   sys_127: 0.0
-  sys_128: -0.0
+  sys_128: 0.0
   sys_129: 9.16410388e-03
   sys_130: -9.16410388e-03
   sys_131: 4.07293506e-03
@@ -5034,98 +5034,98 @@ bins:
   sys_133: 1.01823376e-03
   sys_134: -1.01823376e-03
   sys_135: 0.0
-  sys_136: -0.0
+  sys_136: 0.0
   sys_137: 5.09116882e-03
   sys_138: -5.09116882e-03
   luminosity_uncertainty: 2.59200000e-02
 - art_sys_1: 0.0
   art_sys_2: 2.86758898e-04
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 2.33519970e-04
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 1.04214721e-04
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 1.68795778e-04
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 2.85234691e-04
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
+  art_sys_22: 0.0
   art_sys_23: 1.37763681e-04
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 4.72921381e-04
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 2.84638522e-04
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: -5.97962755e-04
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
+  art_sys_43: 0.0
   art_sys_44: -1.16620506e-04
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 4.51197945e-04
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 2.81990902e-04
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 3.12337233e-04
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 1.27655834e-04
   art_sys_62: 0.0
-  art_sys_63: -0.0
+  art_sys_63: 0.0
   art_sys_64: -2.02533088e-04
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
   art_sys_69: 2.93015810e-04
-  art_sys_70: -0.0
+  art_sys_70: 0.0
   art_sys_71: 2.47588974e-03
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 6.13069375e-03
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: -3.79796250e-02
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: -3.51514731e-03
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
   art_sys_90: -1.64994813e-05
   sys_1: 0.0
@@ -5135,17 +5135,17 @@ bins:
   sys_5: 2.40769859e-02
   sys_6: -2.31139065e-02
   sys_7: 0.0
-  sys_8: -0.0
+  sys_8: 0.0
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 4.81539718e-04
   sys_12: -4.81539718e-04
   sys_13: 1.92615887e-03
   sys_14: -1.44461915e-03
   sys_15: 0.0
-  sys_16: -0.0
+  sys_16: 0.0
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 3.37077803e-03
   sys_20: -2.88923831e-03
   sys_21: 4.81539718e-04
@@ -5175,17 +5175,17 @@ bins:
   sys_45: 7.70463549e-03
   sys_46: -7.70463549e-03
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 9.63079436e-04
   sys_52: -4.81539718e-04
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 4.81539718e-04
   sys_56: -4.81539718e-04
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 4.81539718e-04
   sys_60: -4.81539718e-04
   sys_61: 4.81539718e-04
@@ -5195,23 +5195,23 @@ bins:
   sys_65: 9.63079436e-04
   sys_66: -9.63079436e-04
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 4.81539718e-04
   sys_78: -4.81539718e-04
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 9.63079436e-04
   sys_86: -9.63079436e-04
   sys_87: 3.85231774e-03
@@ -5221,15 +5221,15 @@ bins:
   sys_91: 6.74155605e-03
   sys_92: -6.74155605e-03
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 4.81539718e-04
   sys_104: -4.81539718e-04
   sys_105: 3.37077803e-03
@@ -5239,7 +5239,7 @@ bins:
   sys_109: 9.63079436e-04
   sys_110: -9.63079436e-04
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 3.37077803e-03
   sys_114: -2.88923831e-03
   sys_115: 1.44461915e-03
@@ -5247,114 +5247,114 @@ bins:
   sys_117: 3.37077803e-03
   sys_118: -3.37077803e-03
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: 0.0
-  sys_122: -0.0
+  sys_122: 0.0
   sys_123: 4.81539718e-04
   sys_124: -4.81539718e-04
   sys_125: 0.0
-  sys_126: -0.0
+  sys_126: 0.0
   sys_127: 0.0
-  sys_128: -0.0
+  sys_128: 0.0
   sys_129: 4.33385746e-03
   sys_130: -4.33385746e-03
   sys_131: 1.92615887e-03
   sys_132: -1.92615887e-03
   sys_133: 0.0
-  sys_134: -0.0
+  sys_134: 0.0
   sys_135: 0.0
-  sys_136: -0.0
+  sys_136: 0.0
   sys_137: 2.40769859e-03
   sys_138: -2.40769859e-03
   luminosity_uncertainty: 1.22580000e-02
 - art_sys_1: 0.0
   art_sys_2: -9.89119291e-05
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -4.96248037e-05
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: -4.96220320e-04
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: -2.07463405e-04
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 8.05834636e-05
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
+  art_sys_22: 0.0
   art_sys_23: 4.58438066e-04
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: -2.50109052e-04
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 2.18443117e-04
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: -2.59185077e-04
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
+  art_sys_43: 0.0
   art_sys_44: 7.29630859e-05
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 7.31535374e-05
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: -2.83446159e-05
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 4.10025772e-05
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 4.02513392e-04
   art_sys_62: 0.0
-  art_sys_63: -0.0
+  art_sys_63: 0.0
   art_sys_64: 2.00390623e-05
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
   art_sys_69: -3.31415661e-04
-  art_sys_70: -0.0
+  art_sys_70: 0.0
   art_sys_71: 8.80102295e-04
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: -1.72450427e-03
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: -5.67477883e-03
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 2.42294647e-02
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
   art_sys_90: 1.96414899e-05
   sys_1: 0.0
@@ -5364,17 +5364,17 @@ bins:
   sys_5: 1.02587052e-02
   sys_6: -9.86413960e-03
   sys_7: 0.0
-  sys_8: -0.0
+  sys_8: 0.0
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 1.97282792e-04
   sys_12: -1.97282792e-04
   sys_13: 7.89131168e-04
   sys_14: -5.91848376e-04
   sys_15: 0.0
-  sys_16: -0.0
+  sys_16: 0.0
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 1.38097954e-03
   sys_20: -1.38097954e-03
   sys_21: 1.97282792e-04
@@ -5404,17 +5404,17 @@ bins:
   sys_45: 3.35380746e-03
   sys_46: -3.15652467e-03
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 3.94565584e-04
   sys_52: -1.97282792e-04
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 1.97282792e-04
   sys_56: -1.97282792e-04
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 1.97282792e-04
   sys_60: -1.97282792e-04
   sys_61: 1.97282792e-04
@@ -5424,23 +5424,23 @@ bins:
   sys_65: 3.94565584e-04
   sys_66: -3.94565584e-04
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 1.97282792e-04
   sys_78: -1.97282792e-04
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 3.94565584e-04
   sys_86: -3.94565584e-04
   sys_87: 1.57826234e-03
@@ -5450,15 +5450,15 @@ bins:
   sys_91: 2.76195909e-03
   sys_92: -2.76195909e-03
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 1.97282792e-04
   sys_104: -1.97282792e-04
   sys_105: 1.38097954e-03
@@ -5468,7 +5468,7 @@ bins:
   sys_109: 3.94565584e-04
   sys_110: -3.94565584e-04
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 1.57826234e-03
   sys_114: -1.38097954e-03
   sys_115: 3.94565584e-04
@@ -5476,114 +5476,114 @@ bins:
   sys_117: 1.04559880e-02
   sys_118: -1.26260987e-02
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: 0.0
-  sys_122: -0.0
+  sys_122: 0.0
   sys_123: 1.97282792e-04
   sys_124: -1.97282792e-04
   sys_125: 0.0
-  sys_126: -0.0
+  sys_126: 0.0
   sys_127: 0.0
-  sys_128: -0.0
+  sys_128: 0.0
   sys_129: 1.77554513e-03
   sys_130: -1.57826234e-03
   sys_131: 9.86413960e-04
   sys_132: -9.86413960e-04
   sys_133: 0.0
-  sys_134: -0.0
+  sys_134: 0.0
   sys_135: 0.0
-  sys_136: -0.0
+  sys_136: 0.0
   sys_137: 9.86413960e-04
   sys_138: -9.86413960e-04
   luminosity_uncertainty: 5.02200000e-03
 - art_sys_1: 0.0
   art_sys_2: 3.51192820e-05
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 4.91032841e-05
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: -1.55057942e-05
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: -1.49096125e-05
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 2.26975854e-05
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
+  art_sys_22: 0.0
   art_sys_23: -1.50539349e-05
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 7.50201119e-07
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 5.73578075e-06
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: -1.61928066e-05
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
+  art_sys_43: 0.0
   art_sys_44: 2.03052775e-05
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 3.51266809e-05
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 4.16605593e-05
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 4.65157679e-05
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: -3.24008057e-05
   art_sys_62: 0.0
-  art_sys_63: -0.0
+  art_sys_63: 0.0
   art_sys_64: -3.73927805e-05
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
   art_sys_69: 2.85151249e-05
-  art_sys_70: -0.0
+  art_sys_70: 0.0
   art_sys_71: 2.91284953e-05
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: -2.79996968e-05
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 1.67718168e-04
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 1.72603256e-04
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
   art_sys_90: -3.09782100e-03
   sys_1: 1.78190909e-05
@@ -5595,7 +5595,7 @@ bins:
   sys_7: 1.78190909e-05
   sys_8: 0.0
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 1.78190909e-05
   sys_12: -1.78190909e-05
   sys_13: 8.90954544e-05
@@ -5603,7 +5603,7 @@ bins:
   sys_15: 1.78190909e-05
   sys_16: 0.0
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 1.60371818e-04
   sys_20: -1.60371818e-04
   sys_21: 1.78190909e-05
@@ -5633,17 +5633,17 @@ bins:
   sys_45: 3.92019999e-04
   sys_46: -3.92019999e-04
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 3.56381818e-05
   sys_52: -3.56381818e-05
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 1.78190909e-05
   sys_56: -3.56381818e-05
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 1.78190909e-05
   sys_60: -1.78190909e-05
   sys_61: 1.78190909e-05
@@ -5653,23 +5653,23 @@ bins:
   sys_65: 5.34572727e-05
   sys_66: -5.34572727e-05
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 1.78190909e-05
   sys_78: -1.78190909e-05
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 3.56381818e-05
   sys_86: -5.34572727e-05
   sys_87: 1.78190909e-04
@@ -5679,15 +5679,15 @@ bins:
   sys_91: 3.20743636e-04
   sys_92: -3.20743636e-04
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 1.78190909e-05
   sys_104: -1.78190909e-05
   sys_105: 1.60371818e-04
@@ -5697,7 +5697,7 @@ bins:
   sys_109: 3.56381818e-05
   sys_110: -5.34572727e-05
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 3.02924545e-04
   sys_114: -2.85105454e-04
   sys_115: 1.78190909e-05
@@ -5705,23 +5705,23 @@ bins:
   sys_117: 3.56381818e-03
   sys_118: -3.56381818e-03
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: 0.0
-  sys_122: -0.0
+  sys_122: 0.0
   sys_123: 0.0
-  sys_124: -0.0
+  sys_124: 0.0
   sys_125: 0.0
-  sys_126: -0.0
+  sys_126: 0.0
   sys_127: 0.0
-  sys_128: -0.0
+  sys_128: 0.0
   sys_129: 1.24733636e-04
   sys_130: -1.24733636e-04
   sys_131: 1.42552727e-04
   sys_132: -1.42552727e-04
   sys_133: 0.0
-  sys_134: -0.0
+  sys_134: 0.0
   sys_135: 0.0
-  sys_136: -0.0
+  sys_136: 0.0
   sys_137: 8.90954544e-05
   sys_138: -8.90954544e-05
   luminosity_uncertainty: 4.53600000e-04
@@ -5729,57 +5729,57 @@ bins:
   art_sys_2: 0.0
   art_sys_3: 9.26298040e+01
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 1.68373855e+01
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 1.32147422e+00
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 2.91699581e-02
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 2.09102772e-02
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
+  art_sys_25: 0.0
   art_sys_26: 2.49685756e-03
-  art_sys_27: -0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 3.45364601e-05
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
   art_sys_37: 1.84619899e-05
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
   art_sys_43: 2.14903160e-05
-  art_sys_44: -0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
   art_sys_46: 3.25400048e-06
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
   art_sys_50: 3.78958112e-07
-  art_sys_51: -0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 1.90510808e-07
   art_sys_57: 0.0
   art_sys_58: 0.0
@@ -5788,20 +5788,20 @@ bins:
   art_sys_61: 0.0
   art_sys_62: 0.0
   art_sys_63: 7.32637398e-08
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
   art_sys_68: 5.94682736e-09
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
   art_sys_72: 1.91383404e-09
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
   art_sys_76: 1.03964175e-09
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
   art_sys_80: 1.08906283e-09
@@ -5810,11 +5810,11 @@ bins:
   art_sys_83: 2.89575025e-10
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 6.90149159e-12
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 6.11576655e+03
   sys_2: -5.43623693e+03
   sys_3: 6.79529617e+03
@@ -5824,13 +5824,13 @@ bins:
   sys_7: 5.43623693e+03
   sys_8: -5.43623693e+03
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 2.71811847e+03
   sys_12: -2.03858885e+03
   sys_13: 1.15520035e+04
   sys_14: -1.08724739e+04
   sys_15: 0.0
-  sys_16: -0.0
+  sys_16: 0.0
   sys_17: 0.0
   sys_18: -6.79529617e+02
   sys_19: 4.07717770e+03
@@ -5846,25 +5846,25 @@ bins:
   sys_29: 4.07717770e+03
   sys_30: -4.07717770e+03
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 0.0
-  sys_38: -0.0
+  sys_38: 0.0
   sys_39: 0.0
-  sys_40: -0.0
+  sys_40: 0.0
   sys_41: 0.0
-  sys_42: -0.0
+  sys_42: 0.0
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 6.79529617e+02
   sys_52: -6.79529617e+02
   sys_53: 6.79529617e+02
@@ -5882,59 +5882,59 @@ bins:
   sys_65: 6.79529617e+02
   sys_66: -6.79529617e+02
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
   sys_74: -6.79529617e+02
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 6.79529617e+02
   sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 3.39764808e+03
   sys_114: -3.39764808e+03
   sys_115: 3.26174216e+04
   sys_116: -2.98993031e+04
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: -4.07717770e+03
   sys_122: 2.03858885e+03
   sys_123: -8.15435540e+03
@@ -5958,57 +5958,57 @@ bins:
   art_sys_2: 0.0
   art_sys_3: 3.65139021e+03
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 2.31061640e+01
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 9.70689288e+00
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: -6.80608476e-01
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: -7.02090387e-03
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
+  art_sys_25: 0.0
   art_sys_26: -1.04366041e-02
-  art_sys_27: -0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: -7.44437571e-04
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
   art_sys_37: 9.39701438e-05
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
   art_sys_43: -1.42058685e-05
-  art_sys_44: -0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
   art_sys_46: 1.02961282e-05
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
   art_sys_50: 3.49804795e-07
-  art_sys_51: -0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: -2.15460810e-07
   art_sys_57: 0.0
   art_sys_58: 0.0
@@ -6017,20 +6017,20 @@ bins:
   art_sys_61: 0.0
   art_sys_62: 0.0
   art_sys_63: -1.30477283e-07
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
   art_sys_68: 4.14502348e-09
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
   art_sys_72: 4.93289716e-09
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
   art_sys_76: 4.01447858e-09
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
   art_sys_80: 1.33468720e-09
@@ -6039,11 +6039,11 @@ bins:
   art_sys_83: -6.90948811e-10
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: -2.58828392e-12
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 2.08172236e+03
   sys_2: -2.08172236e+03
   sys_3: 3.12258355e+03
@@ -6053,15 +6053,15 @@ bins:
   sys_7: 1.82150707e+03
   sys_8: -1.82150707e+03
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 1.04086118e+03
   sys_12: -7.80645886e+02
   sys_13: 3.90322943e+03
   sys_14: -3.90322943e+03
   sys_15: 0.0
-  sys_16: -0.0
+  sys_16: 0.0
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 1.30107648e+03
   sys_20: -1.56129177e+03
   sys_21: 2.60215295e+02
@@ -6077,27 +6077,27 @@ bins:
   sys_31: 0.0
   sys_32: -2.60215295e+02
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 0.0
-  sys_38: -0.0
+  sys_38: 0.0
   sys_39: 2.60215295e+02
   sys_40: -2.60215295e+02
   sys_41: 0.0
-  sys_42: -0.0
+  sys_42: 0.0
   sys_43: 0.0
   sys_44: -2.60215295e+02
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
   sys_52: -2.60215295e+02
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 2.60215295e+02
   sys_56: -2.60215295e+02
   sys_57: 2.60215295e+02
@@ -6111,59 +6111,59 @@ bins:
   sys_65: 5.20430591e+02
   sys_66: -2.60215295e+02
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 2.60215295e+02
   sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 1.30107648e+03
   sys_114: -1.30107648e+03
   sys_115: 1.24903342e+04
   sys_116: -1.17096883e+04
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: -1.56129177e+03
   sys_122: 7.80645886e+02
   sys_123: -3.12258355e+03
@@ -6187,57 +6187,57 @@ bins:
   art_sys_2: 0.0
   art_sys_3: -6.10675898e+01
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 1.44672160e+03
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 1.74066184e+01
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: -5.11740677e+00
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 3.25984936e-01
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
+  art_sys_25: 0.0
   art_sys_26: 5.23491103e-02
-  art_sys_27: -0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 9.07658039e-04
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
   art_sys_37: 1.13554253e-04
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
   art_sys_43: 2.15376483e-04
-  art_sys_44: -0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
   art_sys_46: -6.17320859e-05
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
   art_sys_50: -1.46427221e-05
-  art_sys_51: -0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: -2.89415554e-07
   art_sys_57: 0.0
   art_sys_58: 0.0
@@ -6246,20 +6246,20 @@ bins:
   art_sys_61: 0.0
   art_sys_62: 0.0
   art_sys_63: 8.19215976e-07
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
   art_sys_68: -6.30845370e-08
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
   art_sys_72: -2.84417240e-09
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
   art_sys_76: -9.13305396e-10
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
   art_sys_80: -5.54928127e-09
@@ -6268,11 +6268,11 @@ bins:
   art_sys_83: 1.34844779e-09
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: -1.28800958e-11
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 7.22663130e+02
   sys_2: -8.25900720e+02
   sys_3: 1.44532626e+03
@@ -6282,19 +6282,19 @@ bins:
   sys_7: 6.19425540e+02
   sys_8: -7.22663130e+02
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 3.09712770e+02
   sys_12: -3.09712770e+02
   sys_13: 1.34208867e+03
   sys_14: -1.34208867e+03
   sys_15: 0.0
-  sys_16: -0.0
+  sys_16: 0.0
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 5.16187950e+02
   sys_20: -5.16187950e+02
   sys_21: 0.0
-  sys_22: -0.0
+  sys_22: 0.0
   sys_23: 4.12950360e+02
   sys_24: -4.12950360e+02
   sys_25: 3.09712770e+02
@@ -6306,11 +6306,11 @@ bins:
   sys_31: 0.0
   sys_32: -1.03237590e+02
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
   sys_36: -1.03237590e+02
   sys_37: 0.0
-  sys_38: -0.0
+  sys_38: 0.0
   sys_39: 1.03237590e+02
   sys_40: -1.03237590e+02
   sys_41: 0.0
@@ -6318,17 +6318,17 @@ bins:
   sys_43: 1.03237590e+02
   sys_44: -1.03237590e+02
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 1.03237590e+02
   sys_58: -1.03237590e+02
   sys_59: 2.06475180e+02
@@ -6340,59 +6340,59 @@ bins:
   sys_65: 3.09712770e+02
   sys_66: -2.06475180e+02
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 1.03237590e+02
   sys_78: -1.03237590e+02
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 4.12950360e+02
   sys_114: -5.16187950e+02
   sys_115: 4.74892914e+03
   sys_116: -4.64569155e+03
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: -6.19425540e+02
   sys_122: 3.09712770e+02
   sys_123: -1.34208867e+03
@@ -6408,7 +6408,7 @@ bins:
   sys_133: 3.09712770e+02
   sys_134: -3.09712770e+02
   sys_135: 0.0
-  sys_136: -0.0
+  sys_136: 0.0
   sys_137: 5.16187950e+02
   sys_138: -5.16187950e+02
   luminosity_uncertainty: 2.62800000e+03
@@ -6416,57 +6416,57 @@ bins:
   art_sys_2: 0.0
   art_sys_3: -5.52489968e+01
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: -4.17074828e+01
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 6.26769059e+02
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: -1.29573429e+01
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 2.39437533e+00
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
+  art_sys_25: 0.0
   art_sys_26: 6.13805659e-02
-  art_sys_27: -0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 1.12177924e-02
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
   art_sys_37: 2.59363742e-03
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
   art_sys_43: 9.39279509e-04
-  art_sys_44: -0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
   art_sys_46: -1.44880004e-04
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
   art_sys_50: 2.34958238e-05
-  art_sys_51: -0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: -9.12682930e-06
   art_sys_57: 0.0
   art_sys_58: 0.0
@@ -6475,20 +6475,20 @@ bins:
   art_sys_61: 0.0
   art_sys_62: 0.0
   art_sys_63: -1.12036980e-07
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
   art_sys_68: -2.13772792e-07
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
   art_sys_72: -7.60620444e-08
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
   art_sys_76: 1.02583970e-09
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
   art_sys_80: -1.58156715e-09
@@ -6497,11 +6497,11 @@ bins:
   art_sys_83: 1.11134246e-08
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: -6.53689079e-11
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 2.55831233e+02
   sys_2: -2.98469772e+02
   sys_3: 6.82216622e+02
@@ -6511,7 +6511,7 @@ bins:
   sys_7: 2.13192695e+02
   sys_8: -2.55831233e+02
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 8.52770778e+01
   sys_12: -1.27915617e+02
   sys_13: 4.26385389e+02
@@ -6519,7 +6519,7 @@ bins:
   sys_15: 4.26385389e+01
   sys_16: -4.26385389e+01
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 1.70554156e+02
   sys_20: -2.13192695e+02
   sys_21: 4.26385389e+01
@@ -6535,11 +6535,11 @@ bins:
   sys_31: 0.0
   sys_32: -4.26385389e+01
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
   sys_36: -4.26385389e+01
   sys_37: 0.0
-  sys_38: -0.0
+  sys_38: 0.0
   sys_39: 8.52770778e+01
   sys_40: -4.26385389e+01
   sys_41: 0.0
@@ -6549,15 +6549,15 @@ bins:
   sys_45: 4.26385389e+01
   sys_46: -4.26385389e+01
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 4.26385389e+01
   sys_58: -4.26385389e+01
   sys_59: 4.26385389e+01
@@ -6571,57 +6571,57 @@ bins:
   sys_67: 4.26385389e+01
   sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 4.26385389e+01
   sys_78: -4.26385389e+01
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 1.70554156e+02
   sys_114: -1.70554156e+02
   sys_115: 1.87609571e+03
   sys_116: -1.87609571e+03
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: -2.13192695e+02
   sys_122: 1.27915617e+02
   sys_123: -5.96939545e+02
@@ -6637,7 +6637,7 @@ bins:
   sys_133: 8.52770778e+01
   sys_134: -8.52770778e+01
   sys_135: 0.0
-  sys_136: -0.0
+  sys_136: 0.0
   sys_137: 2.13192695e+02
   sys_138: -2.13192695e+02
   luminosity_uncertainty: 1085.4
@@ -6645,57 +6645,57 @@ bins:
   art_sys_2: 0.0
   art_sys_3: -4.97759534e+00
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: -2.38505353e+01
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: -2.86626154e+01
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: -2.89238554e+02
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 2.63445182e+00
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
+  art_sys_25: 0.0
   art_sys_26: 1.03045259e+00
-  art_sys_27: -0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 4.83645775e-02
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
   art_sys_37: 1.16659734e-02
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
   art_sys_43: 6.36159664e-04
-  art_sys_44: -0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
   art_sys_46: -2.37469071e-04
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
   art_sys_50: -4.59008783e-05
-  art_sys_51: -0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 7.38957035e-06
   art_sys_57: 0.0
   art_sys_58: 0.0
@@ -6704,20 +6704,20 @@ bins:
   art_sys_61: 0.0
   art_sys_62: 0.0
   art_sys_63: -9.96614505e-07
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
   art_sys_68: -1.62016668e-06
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
   art_sys_72: 9.45842804e-08
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
   art_sys_76: -3.08106821e-08
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
   art_sys_80: -2.71680892e-09
@@ -6726,11 +6726,11 @@ bins:
   art_sys_83: 4.95602545e-09
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 2.12822070e-10
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 9.65200756e+01
   sys_2: -1.15824091e+02
   sys_3: 3.47472272e+02
@@ -6740,7 +6740,7 @@ bins:
   sys_7: 7.72160605e+01
   sys_8: -9.65200756e+01
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 3.86080303e+01
   sys_12: -5.79120454e+01
   sys_13: 1.54432121e+02
@@ -6748,7 +6748,7 @@ bins:
   sys_15: 1.93040151e+01
   sys_16: -1.93040151e+01
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 7.72160605e+01
   sys_20: -9.65200756e+01
   sys_21: 1.93040151e+01
@@ -6768,7 +6768,7 @@ bins:
   sys_35: 1.93040151e+01
   sys_36: -1.93040151e+01
   sys_37: 0.0
-  sys_38: -0.0
+  sys_38: 0.0
   sys_39: 3.86080303e+01
   sys_40: -1.93040151e+01
   sys_41: 1.93040151e+01
@@ -6778,17 +6778,17 @@ bins:
   sys_45: 1.93040151e+01
   sys_46: -1.93040151e+01
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 1.93040151e+01
   sys_60: -1.93040151e+01
   sys_61: 1.93040151e+01
@@ -6800,57 +6800,57 @@ bins:
   sys_67: 1.93040151e+01
   sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
   sys_78: -1.93040151e+01
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 1.93040151e+01
   sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 5.79120454e+01
   sys_114: -7.72160605e+01
   sys_115: 8.30072650e+02
   sys_116: -7.91464620e+02
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: -9.65200756e+01
   sys_122: 7.72160605e+01
   sys_123: -2.50952197e+02
@@ -6866,7 +6866,7 @@ bins:
   sys_133: 3.86080303e+01
   sys_134: -3.86080303e+01
   sys_135: 0.0
-  sys_136: -0.0
+  sys_136: 0.0
   sys_137: 9.65200756e+01
   sys_138: -9.65200756e+01
   luminosity_uncertainty: 4.91400000e+02
@@ -6874,57 +6874,57 @@ bins:
   art_sys_2: 0.0
   art_sys_3: 1.53205129e+00
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: -2.48576786e+00
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: -1.14117652e+01
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 6.48354595e+00
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 1.25361233e+02
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
+  art_sys_25: 0.0
   art_sys_26: 1.44792701e+00
-  art_sys_27: -0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 3.80054092e-01
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
   art_sys_37: 1.71942618e-02
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
   art_sys_43: 2.79005029e-03
-  art_sys_44: -0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
   art_sys_46: -1.01608603e-03
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
   art_sys_50: -1.01982594e-04
-  art_sys_51: -0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: -3.32065169e-05
   art_sys_57: 0.0
   art_sys_58: 0.0
@@ -6933,20 +6933,20 @@ bins:
   art_sys_61: 0.0
   art_sys_62: 0.0
   art_sys_63: -9.41259663e-07
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
   art_sys_68: -2.94607804e-06
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
   art_sys_72: -1.56252706e-07
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
   art_sys_76: 1.94882985e-07
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
   art_sys_80: 1.36754544e-07
@@ -6955,11 +6955,11 @@ bins:
   art_sys_83: -3.91528408e-09
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 4.67796909e-10
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 3.50724963e+01
   sys_2: -4.38406204e+01
   sys_3: 1.75362482e+02
@@ -6969,7 +6969,7 @@ bins:
   sys_7: 2.63043723e+01
   sys_8: -3.50724963e+01
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 1.75362482e+01
   sys_12: -1.75362482e+01
   sys_13: 6.13768686e+01
@@ -6977,7 +6977,7 @@ bins:
   sys_15: 1.75362482e+01
   sys_16: -8.76812409e+00
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 2.63043723e+01
   sys_20: -3.50724963e+01
   sys_21: 8.76812409e+00
@@ -7007,17 +7007,17 @@ bins:
   sys_45: 1.75362482e+01
   sys_46: -1.75362482e+01
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 8.76812409e+00
   sys_60: -8.76812409e+00
   sys_61: 8.76812409e+00
@@ -7029,57 +7029,57 @@ bins:
   sys_67: 8.76812409e+00
   sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
   sys_78: -8.76812409e+00
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 8.76812409e+00
   sys_84: -8.76812409e+00
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 2.63043723e+01
   sys_114: -2.63043723e+01
   sys_115: 3.50724963e+02
   sys_116: -3.24420591e+02
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: -3.50724963e+01
   sys_122: 3.50724963e+01
   sys_123: -1.05217489e+02
@@ -7095,7 +7095,7 @@ bins:
   sys_133: 1.75362482e+01
   sys_134: -1.75362482e+01
   sys_135: 0.0
-  sys_136: -0.0
+  sys_136: 0.0
   sys_137: 4.38406204e+01
   sys_138: -4.38406204e+01
   luminosity_uncertainty: 2.23200000e+02
@@ -7103,57 +7103,57 @@ bins:
   art_sys_2: 0.0
   art_sys_3: 8.46876719e-01
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: -7.97461045e-01
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 1.17547124e-01
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 5.18134817e+00
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: -3.32918160e+00
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
+  art_sys_25: 0.0
   art_sys_26: 5.60384720e+01
-  art_sys_27: -0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 4.01523101e-01
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
   art_sys_37: 2.30683314e-01
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
   art_sys_43: 7.28439818e-03
-  art_sys_44: -0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
   art_sys_46: -1.11017733e-03
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
   art_sys_50: -2.00617662e-04
-  art_sys_51: -0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 1.25665158e-04
   art_sys_57: 0.0
   art_sys_58: 0.0
@@ -7162,20 +7162,20 @@ bins:
   art_sys_61: 0.0
   art_sys_62: 0.0
   art_sys_63: -6.23072218e-06
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
   art_sys_68: 4.56679298e-06
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
   art_sys_72: -9.64297853e-07
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
   art_sys_76: -2.23790103e-07
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
   art_sys_80: -3.10637309e-07
@@ -7184,11 +7184,11 @@ bins:
   art_sys_83: -7.24158239e-08
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: -2.20717904e-09
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 1.68574257e+01
   sys_2: -1.68574257e+01
   sys_3: 8.85014847e+01
@@ -7198,7 +7198,7 @@ bins:
   sys_7: 1.26430692e+01
   sys_8: -1.26430692e+01
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 4.21435642e+00
   sys_12: -8.42871283e+00
   sys_13: 2.52861385e+01
@@ -7206,7 +7206,7 @@ bins:
   sys_15: 8.42871283e+00
   sys_16: -4.21435642e+00
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 1.68574257e+01
   sys_20: -1.68574257e+01
   sys_21: 4.21435642e+00
@@ -7236,17 +7236,17 @@ bins:
   sys_45: 8.42871283e+00
   sys_46: -8.42871283e+00
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
   sys_60: -4.21435642e+00
   sys_61: 4.21435642e+00
@@ -7258,19 +7258,19 @@ bins:
   sys_67: 8.42871283e+00
   sys_68: -4.21435642e+00
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
   sys_78: -4.21435642e+00
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 4.21435642e+00
   sys_84: -4.21435642e+00
   sys_85: 4.21435642e+00
@@ -7278,37 +7278,37 @@ bins:
   sys_87: 0.0
   sys_88: -4.21435642e+00
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 1.26430692e+01
   sys_114: -1.26430692e+01
   sys_115: 1.55931187e+02
   sys_116: -1.43288118e+02
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: -1.26430692e+01
   sys_122: 2.10717821e+01
   sys_123: -4.21435642e+01
@@ -7324,7 +7324,7 @@ bins:
   sys_133: 8.42871283e+00
   sys_134: -8.42871283e+00
   sys_135: 0.0
-  sys_136: -0.0
+  sys_136: 0.0
   sys_137: 2.10717821e+01
   sys_138: -2.10717821e+01
   luminosity_uncertainty: 1.07280000e+02
@@ -7332,57 +7332,57 @@ bins:
   art_sys_2: 0.0
   art_sys_3: 1.16344122e-01
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 6.93014776e-02
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: -6.52324941e-02
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 4.23154642e-01
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: -2.01615206e+00
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
+  art_sys_25: 0.0
   art_sys_26: -1.04757992e+00
-  art_sys_27: -0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 2.30745202e+01
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
   art_sys_37: 4.39229675e-01
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
   art_sys_43: 9.77952492e-02
-  art_sys_44: -0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
   art_sys_46: -6.78121465e-03
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
   art_sys_50: -1.60631357e-03
-  art_sys_51: -0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 1.04256662e-04
   art_sys_57: 0.0
   art_sys_58: 0.0
@@ -7391,20 +7391,20 @@ bins:
   art_sys_61: 0.0
   art_sys_62: 0.0
   art_sys_63: -1.42531411e-05
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
   art_sys_68: 8.28494075e-06
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
   art_sys_72: 3.06732482e-06
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
   art_sys_76: -1.49259153e-06
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
   art_sys_80: 5.99125235e-08
@@ -7413,11 +7413,11 @@ bins:
   art_sys_83: 7.91953270e-08
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 3.40346514e-10
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 6.23668181e+00
   sys_2: -6.23668181e+00
   sys_3: 4.57356666e+01
@@ -7427,7 +7427,7 @@ bins:
   sys_7: 4.15778787e+00
   sys_8: -4.15778787e+00
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 2.07889394e+00
   sys_12: -2.07889394e+00
   sys_13: 1.03944697e+01
@@ -7435,7 +7435,7 @@ bins:
   sys_15: 6.23668181e+00
   sys_16: -4.15778787e+00
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 8.31557575e+00
   sys_20: -6.23668181e+00
   sys_21: 2.07889394e+00
@@ -7465,19 +7465,19 @@ bins:
   sys_45: 6.23668181e+00
   sys_46: -4.15778787e+00
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 0.0
   sys_62: -2.07889394e+00
   sys_63: 2.07889394e+00
@@ -7487,19 +7487,19 @@ bins:
   sys_67: 4.15778787e+00
   sys_68: -2.07889394e+00
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 2.07889394e+00
   sys_84: -2.07889394e+00
   sys_85: 2.07889394e+00
@@ -7507,37 +7507,37 @@ bins:
   sys_87: 2.07889394e+00
   sys_88: -2.07889394e+00
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 6.23668181e+00
   sys_114: -6.23668181e+00
   sys_115: 6.86034999e+01
   sys_116: -6.44457120e+01
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: -6.23668181e+00
   sys_122: 1.03944697e+01
   sys_123: -1.66311515e+01
@@ -7553,7 +7553,7 @@ bins:
   sys_133: 4.15778787e+00
   sys_134: -4.15778787e+00
   sys_135: 0.0
-  sys_136: -0.0
+  sys_136: 0.0
   sys_137: 1.03944697e+01
   sys_138: -1.03944697e+01
   luminosity_uncertainty: 5.29200000e+01
@@ -7561,57 +7561,57 @@ bins:
   art_sys_2: 0.0
   art_sys_3: -3.56230445e-02
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 3.46221755e-02
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: -1.03983710e-01
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 1.73891297e-01
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: -5.06369185e-02
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
+  art_sys_25: 0.0
   art_sys_26: -1.12923616e+00
-  art_sys_27: -0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: -9.42629549e-01
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
   art_sys_37: 1.10789527e+01
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
   art_sys_43: 2.09584287e-01
-  art_sys_44: -0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
   art_sys_46: -5.51389492e-02
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
   art_sys_50: -1.97184331e-03
-  art_sys_51: -0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 1.86393536e-05
   art_sys_57: 0.0
   art_sys_58: 0.0
@@ -7620,20 +7620,20 @@ bins:
   art_sys_61: 0.0
   art_sys_62: 0.0
   art_sys_63: -6.95015185e-05
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
   art_sys_68: -1.85458063e-05
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
   art_sys_72: 7.58583947e-06
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
   art_sys_76: -1.66890514e-07
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
   art_sys_80: -1.42506911e-07
@@ -7642,11 +7642,11 @@ bins:
   art_sys_83: -3.54771850e-07
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: -9.65349257e-09
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 2.99106168e+00
   sys_2: -2.99106168e+00
   sys_3: 2.29314729e+01
@@ -7656,7 +7656,7 @@ bins:
   sys_7: 1.99404112e+00
   sys_8: -1.99404112e+00
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 9.97020561e-01
   sys_12: -9.97020561e-01
   sys_13: 3.98808225e+00
@@ -7664,7 +7664,7 @@ bins:
   sys_15: 1.99404112e+00
   sys_16: -1.99404112e+00
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 2.99106168e+00
   sys_20: -2.99106168e+00
   sys_21: 9.97020561e-01
@@ -7694,19 +7694,19 @@ bins:
   sys_45: 2.99106168e+00
   sys_46: -2.99106168e+00
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 0.0
   sys_62: -9.97020561e-01
   sys_63: 9.97020561e-01
@@ -7716,17 +7716,17 @@ bins:
   sys_67: 9.97020561e-01
   sys_68: -9.97020561e-01
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 9.97020561e-01
   sys_82: -9.97020561e-01
   sys_83: 9.97020561e-01
@@ -7738,35 +7738,35 @@ bins:
   sys_89: 9.97020561e-01
   sys_90: -9.97020561e-01
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 2.99106168e+00
   sys_114: -2.99106168e+00
   sys_115: 2.89135963e+01
   sys_116: -2.79165757e+01
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: -2.99106168e+00
   sys_122: 3.98808225e+00
   sys_123: -6.97914393e+00
@@ -7782,7 +7782,7 @@ bins:
   sys_133: 9.97020561e-01
   sys_134: -9.97020561e-01
   sys_135: 0.0
-  sys_136: -0.0
+  sys_136: 0.0
   sys_137: 4.98510281e+00
   sys_138: -4.98510281e+00
   luminosity_uncertainty: 2.53800000e+01
@@ -7790,57 +7790,57 @@ bins:
   art_sys_2: 0.0
   art_sys_3: 2.20671127e-02
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: -5.41995903e-02
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: -1.04787953e-01
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 1.41029359e-02
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: -2.72337984e-02
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
+  art_sys_25: 0.0
   art_sys_26: -1.48874760e-02
-  art_sys_27: -0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: -4.17856240e-01
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
   art_sys_37: -4.91009114e-01
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
   art_sys_43: 4.95403531e+00
-  art_sys_44: -0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
   art_sys_46: -1.55479144e-01
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
   art_sys_50: -2.96485780e-02
-  art_sys_51: -0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 2.34324854e-03
   art_sys_57: 0.0
   art_sys_58: 0.0
@@ -7849,20 +7849,20 @@ bins:
   art_sys_61: 0.0
   art_sys_62: 0.0
   art_sys_63: -8.68262610e-05
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
   art_sys_68: -4.95041606e-05
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
   art_sys_72: 4.59382385e-06
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
   art_sys_76: -5.83798876e-06
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
   art_sys_80: 7.84201589e-07
@@ -7871,11 +7871,11 @@ bins:
   art_sys_83: 5.73288382e-07
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: -1.76751750e-08
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 9.65907863e-01
   sys_2: -9.65907863e-01
   sys_3: 1.15908944e+01
@@ -7885,7 +7885,7 @@ bins:
   sys_7: 4.82953932e-01
   sys_8: -9.65907863e-01
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 4.82953932e-01
   sys_12: -4.82953932e-01
   sys_13: 1.44886179e+00
@@ -7893,7 +7893,7 @@ bins:
   sys_15: 9.65907863e-01
   sys_16: -9.65907863e-01
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 1.44886179e+00
   sys_20: -1.44886179e+00
   sys_21: 4.82953932e-01
@@ -7923,19 +7923,19 @@ bins:
   sys_45: 1.44886179e+00
   sys_46: -1.44886179e+00
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
   sys_52: -4.82953932e-01
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 0.0
   sys_62: -4.82953932e-01
   sys_63: 4.82953932e-01
@@ -7945,17 +7945,17 @@ bins:
   sys_67: 4.82953932e-01
   sys_68: -4.82953932e-01
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 4.82953932e-01
   sys_82: -4.82953932e-01
   sys_83: 4.82953932e-01
@@ -7969,33 +7969,33 @@ bins:
   sys_91: 4.82953932e-01
   sys_92: -4.82953932e-01
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 1.44886179e+00
   sys_114: -1.44886179e+00
   sys_115: 1.25568022e+01
   sys_116: -1.25568022e+01
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: -1.44886179e+00
   sys_122: 9.65907863e-01
   sys_123: -2.89772359e+00
@@ -8011,7 +8011,7 @@ bins:
   sys_133: 4.82953932e-01
   sys_134: -4.82953932e-01
   sys_135: 0.0
-  sys_136: -0.0
+  sys_136: 0.0
   sys_137: 2.41476966e+00
   sys_138: -2.41476966e+00
   luminosity_uncertainty: 1.22940000e+01
@@ -8019,57 +8019,57 @@ bins:
   art_sys_2: 0.0
   art_sys_3: 1.81041225e-02
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: -2.73720267e-02
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: -1.90837606e-02
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 1.76601432e-02
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: -4.10100786e-02
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
+  art_sys_25: 0.0
   art_sys_26: 2.56387568e-03
-  art_sys_27: -0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: -1.68075428e-02
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
   art_sys_37: -2.11470708e-01
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
   art_sys_43: -3.13302816e-01
-  art_sys_44: -0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
   art_sys_46: -2.53953279e+00
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
   art_sys_50: -6.08534883e-02
-  art_sys_51: -0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 1.17720970e-02
   art_sys_57: 0.0
   art_sys_58: 0.0
@@ -8078,20 +8078,20 @@ bins:
   art_sys_61: 0.0
   art_sys_62: 0.0
   art_sys_63: -2.50392673e-04
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
   art_sys_68: -5.90660513e-05
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
   art_sys_72: 3.31712314e-06
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
   art_sys_76: 4.13184789e-06
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
   art_sys_80: -1.27483416e-05
@@ -8100,11 +8100,11 @@ bins:
   art_sys_83: -5.16019090e-07
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 3.00991255e-08
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 4.75175757e-01
   sys_2: -4.75175757e-01
   sys_3: 5.93969696e+00
@@ -8114,7 +8114,7 @@ bins:
   sys_7: 2.37587878e-01
   sys_8: -2.37587878e-01
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 2.37587878e-01
   sys_12: -2.37587878e-01
   sys_13: 7.12763635e-01
@@ -8122,7 +8122,7 @@ bins:
   sys_15: 4.75175757e-01
   sys_16: -4.75175757e-01
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 7.12763635e-01
   sys_20: -9.50351514e-01
   sys_21: 2.37587878e-01
@@ -8152,21 +8152,21 @@ bins:
   sys_45: 9.50351514e-01
   sys_46: -9.50351514e-01
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
   sys_52: -2.37587878e-01
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 0.0
-  sys_62: -0.0
+  sys_62: 0.0
   sys_63: 2.37587878e-01
   sys_64: -2.37587878e-01
   sys_65: 2.37587878e-01
@@ -8174,17 +8174,17 @@ bins:
   sys_67: 2.37587878e-01
   sys_68: -2.37587878e-01
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 2.37587878e-01
   sys_82: -2.37587878e-01
   sys_83: 2.37587878e-01
@@ -8198,33 +8198,33 @@ bins:
   sys_91: 2.37587878e-01
   sys_92: -2.37587878e-01
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 7.12763635e-01
   sys_114: -7.12763635e-01
   sys_115: 5.70210908e+00
   sys_116: -5.70210908e+00
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: -4.75175757e-01
   sys_122: 2.37587878e-01
   sys_123: -7.12763635e-01
@@ -8240,7 +8240,7 @@ bins:
   sys_133: 2.37587878e-01
   sys_134: -2.37587878e-01
   sys_135: 0.0
-  sys_136: -0.0
+  sys_136: 0.0
   sys_137: 1.18793939e+00
   sys_138: -1.18793939e+00
   luminosity_uncertainty: 6.04800000e+00
@@ -8248,57 +8248,57 @@ bins:
   art_sys_2: 0.0
   art_sys_3: -8.68512677e-04
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: -1.37465119e-02
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 1.72832139e-02
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 7.00044639e-03
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: -4.10504956e-03
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
+  art_sys_25: 0.0
   art_sys_26: -6.11939284e-03
-  art_sys_27: -0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: -1.74923980e-02
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
   art_sys_37: 4.15894889e-03
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
   art_sys_43: -1.01028631e-01
-  art_sys_44: -0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
   art_sys_46: 1.26479314e-01
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
   art_sys_50: -1.27371770e+00
-  art_sys_51: -0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 1.98615894e-02
   art_sys_57: 0.0
   art_sys_58: 0.0
@@ -8307,20 +8307,20 @@ bins:
   art_sys_61: 0.0
   art_sys_62: 0.0
   art_sys_63: 5.97384564e-04
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
   art_sys_68: -2.60878420e-04
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
   art_sys_72: -1.05940737e-05
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
   art_sys_76: -1.17119672e-05
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
   art_sys_80: -3.66623807e-06
@@ -8329,11 +8329,11 @@ bins:
   art_sys_83: 1.83659760e-06
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 9.80690203e-08
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 1.12429978e-01
   sys_2: -2.24859956e-01
   sys_3: 3.03560941e+00
@@ -8343,7 +8343,7 @@ bins:
   sys_7: 1.12429978e-01
   sys_8: -1.12429978e-01
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 1.12429978e-01
   sys_12: -1.12429978e-01
   sys_13: 2.24859956e-01
@@ -8351,7 +8351,7 @@ bins:
   sys_15: 1.12429978e-01
   sys_16: -1.12429978e-01
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 3.37289935e-01
   sys_20: -4.49719913e-01
   sys_21: 1.12429978e-01
@@ -8381,21 +8381,21 @@ bins:
   sys_45: 5.62149891e-01
   sys_46: -5.62149891e-01
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
   sys_52: -1.12429978e-01
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 0.0
-  sys_62: -0.0
+  sys_62: 0.0
   sys_63: 1.12429978e-01
   sys_64: -1.12429978e-01
   sys_65: 1.12429978e-01
@@ -8403,17 +8403,17 @@ bins:
   sys_67: 1.12429978e-01
   sys_68: -1.12429978e-01
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
   sys_82: -1.12429978e-01
   sys_83: 1.12429978e-01
@@ -8427,33 +8427,33 @@ bins:
   sys_91: 3.37289935e-01
   sys_92: -3.37289935e-01
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 3.37289935e-01
   sys_114: -3.37289935e-01
   sys_115: 2.47345952e+00
   sys_116: -2.47345952e+00
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: -1.12429978e-01
   sys_122: 1.12429978e-01
   sys_123: -2.24859956e-01
@@ -8469,7 +8469,7 @@ bins:
   sys_133: 1.12429978e-01
   sys_134: -1.12429978e-01
   sys_135: 0.0
-  sys_136: -0.0
+  sys_136: 0.0
   sys_137: 5.62149891e-01
   sys_138: -5.62149891e-01
   luminosity_uncertainty: 2.86200000e+00
@@ -8477,57 +8477,57 @@ bins:
   art_sys_2: 0.0
   art_sys_3: 4.18314695e-05
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 1.27756784e-03
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 8.64304389e-03
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 1.73308281e-03
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 8.30590092e-03
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
+  art_sys_25: 0.0
   art_sys_26: -1.02347699e-02
-  art_sys_27: -0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: -1.25070612e-03
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
   art_sys_37: 5.02844014e-03
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
   art_sys_43: -9.02975890e-03
-  art_sys_44: -0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
   art_sys_46: 4.23111013e-02
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
   art_sys_50: 3.96382176e-02
-  art_sys_51: -0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 6.52828491e-01
   art_sys_57: 0.0
   art_sys_58: 0.0
@@ -8536,20 +8536,20 @@ bins:
   art_sys_61: 0.0
   art_sys_62: 0.0
   art_sys_63: 7.64390192e-03
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
   art_sys_68: -1.11375996e-04
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
   art_sys_72: 1.64301837e-04
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
   art_sys_76: 6.38669270e-05
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
   art_sys_80: -8.99617612e-06
@@ -8558,11 +8558,11 @@ bins:
   art_sys_83: -6.22023231e-07
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: -1.46032664e-07
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 5.40229581e-02
   sys_2: -5.40229581e-02
   sys_3: 1.56666578e+00
@@ -8572,7 +8572,7 @@ bins:
   sys_7: 5.40229581e-02
   sys_8: -5.40229581e-02
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 5.40229581e-02
   sys_12: -5.40229581e-02
   sys_13: 1.08045916e-01
@@ -8580,7 +8580,7 @@ bins:
   sys_15: 5.40229581e-02
   sys_16: -5.40229581e-02
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 2.16091832e-01
   sys_20: -2.16091832e-01
   sys_21: 5.40229581e-02
@@ -8610,21 +8610,21 @@ bins:
   sys_45: 3.24137748e-01
   sys_46: -3.24137748e-01
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 5.40229581e-02
   sys_52: -5.40229581e-02
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 0.0
-  sys_62: -0.0
+  sys_62: 0.0
   sys_63: 5.40229581e-02
   sys_64: -5.40229581e-02
   sys_65: 5.40229581e-02
@@ -8632,19 +8632,19 @@ bins:
   sys_67: 5.40229581e-02
   sys_68: -5.40229581e-02
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 5.40229581e-02
   sys_84: -5.40229581e-02
   sys_85: 1.08045916e-01
@@ -8656,37 +8656,37 @@ bins:
   sys_91: 2.70114790e-01
   sys_92: -2.70114790e-01
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 5.40229581e-02
   sys_106: -5.40229581e-02
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 1.62068874e-01
   sys_114: -1.62068874e-01
   sys_115: 1.08045916e+00
   sys_116: -1.02643620e+00
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: -5.40229581e-02
   sys_122: 0.0
   sys_123: 0.0
-  sys_124: -0.0
+  sys_124: 0.0
   sys_125: 1.62068874e-01
   sys_126: -1.62068874e-01
   sys_127: 1.08045916e-01
@@ -8698,7 +8698,7 @@ bins:
   sys_133: 5.40229581e-02
   sys_134: -5.40229581e-02
   sys_135: 0.0
-  sys_136: -0.0
+  sys_136: 0.0
   sys_137: 2.70114790e-01
   sys_138: -2.70114790e-01
   luminosity_uncertainty: 1.37520000e+00
@@ -8706,57 +8706,57 @@ bins:
   art_sys_2: 0.0
   art_sys_3: -1.46128210e-03
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 7.17719645e-05
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 4.55268371e-03
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 4.72667099e-04
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: -2.96729467e-04
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
+  art_sys_25: 0.0
   art_sys_26: -4.24007919e-03
-  art_sys_27: -0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: -8.89037120e-03
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
   art_sys_37: 7.38496352e-03
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
   art_sys_43: 1.62832626e-03
-  art_sys_44: -0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
   art_sys_46: 4.56089216e-03
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
   art_sys_50: 3.58867605e-02
-  art_sys_51: -0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 7.35385680e-03
   art_sys_57: 0.0
   art_sys_58: 0.0
@@ -8765,20 +8765,20 @@ bins:
   art_sys_61: 0.0
   art_sys_62: 0.0
   art_sys_63: -4.79401607e-03
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
   art_sys_68: -5.04022928e-03
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
   art_sys_72: -3.67723413e-05
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
   art_sys_76: 1.04345188e-04
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
   art_sys_80: 1.71991386e-05
@@ -8787,11 +8787,11 @@ bins:
   art_sys_83: 4.37841240e-06
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: -1.32867506e-07
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 2.57386868e-02
   sys_2: -2.57386868e-02
   sys_3: 8.23637979e-01
@@ -8801,7 +8801,7 @@ bins:
   sys_7: 2.57386868e-02
   sys_8: -2.57386868e-02
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 2.57386868e-02
   sys_12: -2.57386868e-02
   sys_13: 5.14773737e-02
@@ -8809,7 +8809,7 @@ bins:
   sys_15: 2.57386868e-02
   sys_16: -2.57386868e-02
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 1.02954747e-01
   sys_20: -1.02954747e-01
   sys_21: 2.57386868e-02
@@ -8839,21 +8839,21 @@ bins:
   sys_45: 1.80170808e-01
   sys_46: -1.80170808e-01
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 2.57386868e-02
   sys_52: -2.57386868e-02
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 0.0
-  sys_62: -0.0
+  sys_62: 0.0
   sys_63: 2.57386868e-02
   sys_64: 0.0
   sys_65: 2.57386868e-02
@@ -8861,19 +8861,19 @@ bins:
   sys_67: 2.57386868e-02
   sys_68: -2.57386868e-02
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 2.57386868e-02
   sys_84: -2.57386868e-02
   sys_85: 5.14773737e-02
@@ -8885,35 +8885,35 @@ bins:
   sys_91: 2.05909495e-01
   sys_92: -1.80170808e-01
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
   sys_104: -2.57386868e-02
   sys_105: 2.57386868e-02
   sys_106: -2.57386868e-02
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 7.72160605e-02
   sys_114: -7.72160605e-02
   sys_115: 4.63296363e-01
   sys_116: -4.37557676e-01
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: 0.0
-  sys_122: -0.0
+  sys_122: 0.0
   sys_123: 2.57386868e-02
   sys_124: -2.57386868e-02
   sys_125: 5.14773737e-02
@@ -8927,7 +8927,7 @@ bins:
   sys_133: 2.57386868e-02
   sys_134: -2.57386868e-02
   sys_135: 0.0
-  sys_136: -0.0
+  sys_136: 0.0
   sys_137: 1.28693434e-01
   sys_138: -1.28693434e-01
   luminosity_uncertainty: 0.6552
@@ -8935,57 +8935,57 @@ bins:
   art_sys_2: 0.0
   art_sys_3: 2.18152173e-03
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: -5.26626015e-03
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: -1.97173830e-04
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: -1.23441144e-03
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 1.61777400e-04
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
+  art_sys_25: 0.0
   art_sys_26: 1.26156351e-03
-  art_sys_27: -0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 7.20949083e-04
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
   art_sys_37: 2.97451271e-03
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
   art_sys_43: 2.26006331e-03
-  art_sys_44: -0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
   art_sys_46: -4.47487527e-03
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
   art_sys_50: 2.55428009e-03
-  art_sys_51: -0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: -2.13235462e-02
   art_sys_57: 0.0
   art_sys_58: 0.0
@@ -8994,20 +8994,20 @@ bins:
   art_sys_61: 0.0
   art_sys_62: 0.0
   art_sys_63: 2.31217805e-01
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
   art_sys_68: 1.03912464e-02
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
   art_sys_72: 3.00561414e-03
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
   art_sys_76: -5.26119197e-05
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
   art_sys_80: 1.33008555e-05
@@ -9016,11 +9016,11 @@ bins:
   art_sys_83: -7.53563100e-06
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 8.93373400e-08
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 1.18086832e-02
   sys_2: -1.18086832e-02
   sys_3: 4.01495230e-01
@@ -9030,7 +9030,7 @@ bins:
   sys_7: 1.18086832e-02
   sys_8: -1.18086832e-02
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 1.18086832e-02
   sys_12: -1.18086832e-02
   sys_13: 2.36173665e-02
@@ -9038,7 +9038,7 @@ bins:
   sys_15: 1.18086832e-02
   sys_16: -1.18086832e-02
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 5.90434162e-02
   sys_20: -4.72347330e-02
   sys_21: 1.18086832e-02
@@ -9068,21 +9068,21 @@ bins:
   sys_45: 1.06278149e-01
   sys_46: -1.06278149e-01
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 1.18086832e-02
   sys_52: -1.18086832e-02
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 0.0
-  sys_62: -0.0
+  sys_62: 0.0
   sys_63: 1.18086832e-02
   sys_64: 0.0
   sys_65: 1.18086832e-02
@@ -9090,19 +9090,19 @@ bins:
   sys_67: 1.18086832e-02
   sys_68: -1.18086832e-02
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 1.18086832e-02
   sys_84: -1.18086832e-02
   sys_85: 2.36173665e-02
@@ -9114,15 +9114,15 @@ bins:
   sys_91: 1.18086832e-01
   sys_92: -1.06278149e-01
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 1.18086832e-02
   sys_104: -1.18086832e-02
   sys_105: 2.36173665e-02
@@ -9130,19 +9130,19 @@ bins:
   sys_107: 1.18086832e-02
   sys_108: -1.18086832e-02
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 4.72347330e-02
   sys_114: -4.72347330e-02
   sys_115: 2.00747615e-01
   sys_116: -1.88938932e-01
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: 0.0
-  sys_122: -0.0
+  sys_122: 0.0
   sys_123: 1.18086832e-02
   sys_124: -1.18086832e-02
   sys_125: 1.18086832e-02
@@ -9156,7 +9156,7 @@ bins:
   sys_133: 1.18086832e-02
   sys_134: -1.18086832e-02
   sys_135: 0.0
-  sys_136: -0.0
+  sys_136: 0.0
   sys_137: 5.90434162e-02
   sys_138: -5.90434162e-02
   luminosity_uncertainty: 3.00600000e-01
@@ -9164,57 +9164,57 @@ bins:
   art_sys_2: 0.0
   art_sys_3: 4.70256924e-04
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: -5.95141835e-04
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: -5.55918199e-04
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 3.01154717e-03
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: -2.68235196e-03
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
+  art_sys_25: 0.0
   art_sys_26: 1.94939435e-03
-  art_sys_27: -0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 1.98932700e-03
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
   art_sys_37: -1.06813239e-03
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
   art_sys_43: -1.20136426e-03
-  art_sys_44: -0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
   art_sys_46: 3.34349253e-04
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
   art_sys_50: 1.19741859e-03
-  art_sys_51: -0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: -2.23616367e-03
   art_sys_57: 0.0
   art_sys_58: 0.0
@@ -9223,20 +9223,20 @@ bins:
   art_sys_61: 0.0
   art_sys_62: 0.0
   art_sys_63: 1.67271422e-02
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
   art_sys_68: -1.49266938e-01
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
   art_sys_72: -6.94854252e-03
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
   art_sys_76: 1.77282868e-03
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
   art_sys_80: -7.09836104e-05
@@ -9245,11 +9245,11 @@ bins:
   art_sys_83: 8.02632490e-06
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: -6.98743401e-08
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 5.35279833e-03
   sys_2: -5.35279833e-03
   sys_3: 1.92700740e-01
@@ -9259,7 +9259,7 @@ bins:
   sys_7: 5.35279833e-03
   sys_8: -5.35279833e-03
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 5.35279833e-03
   sys_12: -5.35279833e-03
   sys_13: 1.07055967e-02
@@ -9267,7 +9267,7 @@ bins:
   sys_15: 5.35279833e-03
   sys_16: -5.35279833e-03
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 2.67639917e-02
   sys_20: -2.67639917e-02
   sys_21: 5.35279833e-03
@@ -9297,17 +9297,17 @@ bins:
   sys_45: 5.88807817e-02
   sys_46: -5.35279833e-02
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 5.35279833e-03
   sys_52: -5.35279833e-03
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 5.35279833e-03
   sys_60: 0.0
   sys_61: 5.35279833e-03
@@ -9319,19 +9319,19 @@ bins:
   sys_67: 5.35279833e-03
   sys_68: -5.35279833e-03
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 5.35279833e-03
   sys_84: -5.35279833e-03
   sys_85: 1.07055967e-02
@@ -9343,15 +9343,15 @@ bins:
   sys_91: 6.42335800e-02
   sys_92: -5.88807817e-02
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 5.35279833e-03
   sys_104: -5.35279833e-03
   sys_105: 1.60583950e-02
@@ -9361,21 +9361,21 @@ bins:
   sys_109: 5.35279833e-03
   sys_110: -5.35279833e-03
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 2.67639917e-02
   sys_114: -2.14111933e-02
   sys_115: 8.56447733e-02
   sys_116: -7.49391767e-02
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: 0.0
-  sys_122: -0.0
+  sys_122: 0.0
   sys_123: 5.35279833e-03
   sys_124: -5.35279833e-03
   sys_125: 0.0
-  sys_126: -0.0
+  sys_126: 0.0
   sys_127: 5.35279833e-03
   sys_128: -5.35279833e-03
   sys_129: 5.88807817e-02
@@ -9385,7 +9385,7 @@ bins:
   sys_133: 5.35279833e-03
   sys_134: -5.35279833e-03
   sys_135: 0.0
-  sys_136: -0.0
+  sys_136: 0.0
   sys_137: 2.67639917e-02
   sys_138: -2.67639917e-02
   luminosity_uncertainty: 1.36260000e-01
@@ -9393,57 +9393,57 @@ bins:
   art_sys_2: 0.0
   art_sys_3: -2.46085850e-04
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 1.47153800e-04
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 4.97699113e-04
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 6.05059961e-04
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 4.76071346e-05
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
+  art_sys_25: 0.0
   art_sys_26: 8.35818202e-04
-  art_sys_27: -0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: -5.85732352e-04
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
   art_sys_37: -1.07114356e-03
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
   art_sys_43: -4.72634953e-04
-  art_sys_44: -0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
   art_sys_46: 1.70478205e-04
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
   art_sys_50: -1.58783756e-04
-  art_sys_51: -0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: -5.56762044e-04
   art_sys_57: 0.0
   art_sys_58: 0.0
@@ -9452,20 +9452,20 @@ bins:
   art_sys_61: 0.0
   art_sys_62: 0.0
   art_sys_63: -6.22142282e-03
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
   art_sys_68: -1.19546130e-02
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
   art_sys_72: 9.20410276e-02
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
   art_sys_76: -4.55292657e-03
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
   art_sys_80: 1.24064517e-03
@@ -9474,11 +9474,11 @@ bins:
   art_sys_83: -5.13397924e-05
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 3.23207248e-06
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 2.37587878e-03
   sys_2: -2.37587878e-03
   sys_3: 8.79075150e-02
@@ -9488,7 +9488,7 @@ bins:
   sys_7: 2.37587878e-03
   sys_8: -2.37587878e-03
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 2.37587878e-03
   sys_12: -2.37587878e-03
   sys_13: 7.12763635e-03
@@ -9496,7 +9496,7 @@ bins:
   sys_15: 2.37587878e-03
   sys_16: -2.37587878e-03
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 1.42552727e-02
   sys_20: -1.18793939e-02
   sys_21: 2.37587878e-03
@@ -9526,17 +9526,17 @@ bins:
   sys_45: 3.08864242e-02
   sys_46: -2.85105454e-02
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 2.37587878e-03
   sys_52: -2.37587878e-03
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 2.37587878e-03
   sys_60: -2.37587878e-03
   sys_61: 2.37587878e-03
@@ -9546,21 +9546,21 @@ bins:
   sys_65: 2.37587878e-03
   sys_66: -2.37587878e-03
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 2.37587878e-03
   sys_84: -2.37587878e-03
   sys_85: 4.75175757e-03
@@ -9572,15 +9572,15 @@ bins:
   sys_91: 3.32623030e-02
   sys_92: -3.08864242e-02
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 2.37587878e-03
   sys_104: -2.37587878e-03
   sys_105: 9.50351514e-03
@@ -9590,7 +9590,7 @@ bins:
   sys_109: 2.37587878e-03
   sys_110: -2.37587878e-03
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 1.18793939e-02
   sys_114: -1.18793939e-02
   sys_115: 3.56381818e-02
@@ -9598,13 +9598,13 @@ bins:
   sys_117: 0.0
   sys_118: -2.37587878e-03
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: 0.0
-  sys_122: -0.0
+  sys_122: 0.0
   sys_123: 2.37587878e-03
   sys_124: -2.37587878e-03
   sys_125: 0.0
-  sys_126: -0.0
+  sys_126: 0.0
   sys_127: 2.37587878e-03
   sys_128: -2.37587878e-03
   sys_129: 2.37587878e-02
@@ -9614,7 +9614,7 @@ bins:
   sys_133: 2.37587878e-03
   sys_134: -2.37587878e-03
   sys_135: 0.0
-  sys_136: -0.0
+  sys_136: 0.0
   sys_137: 1.18793939e-02
   sys_138: -1.18793939e-02
   luminosity_uncertainty: 6.04800000e-02
@@ -9622,57 +9622,57 @@ bins:
   art_sys_2: 0.0
   art_sys_3: -2.88169245e-04
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 1.12439305e-05
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 3.04501558e-05
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: -2.02223515e-04
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: -3.83822047e-04
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
+  art_sys_25: 0.0
   art_sys_26: 1.77777534e-04
-  art_sys_27: -0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 4.94212210e-04
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
   art_sys_37: -5.72344974e-05
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
   art_sys_43: 5.74295647e-04
-  art_sys_44: -0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
   art_sys_46: 2.40080778e-04
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
   art_sys_50: -4.24680898e-04
-  art_sys_51: -0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: -8.03000491e-04
   art_sys_57: 0.0
   art_sys_58: 0.0
@@ -9681,20 +9681,20 @@ bins:
   art_sys_61: 0.0
   art_sys_62: 0.0
   art_sys_63: -8.70524132e-04
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
   art_sys_68: 3.92899790e-03
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
   art_sys_72: 8.40580936e-03
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
   art_sys_76: 5.29940271e-02
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
   art_sys_80: -3.54877870e-03
@@ -9703,11 +9703,11 @@ bins:
   art_sys_83: 4.87573291e-04
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 2.24826071e-06
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 9.12167748e-04
   sys_2: -9.12167748e-04
   sys_3: 3.46623744e-02
@@ -9717,7 +9717,7 @@ bins:
   sys_7: 9.12167748e-04
   sys_8: -9.12167748e-04
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 9.12167748e-04
   sys_12: -9.12167748e-04
   sys_13: 2.73650324e-03
@@ -9725,7 +9725,7 @@ bins:
   sys_15: 9.12167748e-04
   sys_16: -9.12167748e-04
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 5.47300649e-03
   sys_20: -5.47300649e-03
   sys_21: 9.12167748e-04
@@ -9755,17 +9755,17 @@ bins:
   sys_45: 1.36825162e-02
   sys_46: -1.27703485e-02
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 9.12167748e-04
   sys_52: -9.12167748e-04
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 9.12167748e-04
   sys_56: -9.12167748e-04
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 9.12167748e-04
   sys_60: -9.12167748e-04
   sys_61: 9.12167748e-04
@@ -9775,23 +9775,23 @@ bins:
   sys_65: 9.12167748e-04
   sys_66: -9.12167748e-04
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 1.82433550e-03
   sys_86: -1.82433550e-03
   sys_87: 6.38517423e-03
@@ -9801,15 +9801,15 @@ bins:
   sys_91: 1.36825162e-02
   sys_92: -1.27703485e-02
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 9.12167748e-04
   sys_104: -9.12167748e-04
   sys_105: 4.56083874e-03
@@ -9819,7 +9819,7 @@ bins:
   sys_109: 9.12167748e-04
   sys_110: -9.12167748e-04
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 5.47300649e-03
   sys_114: -5.47300649e-03
   sys_115: 1.27703485e-02
@@ -9827,13 +9827,13 @@ bins:
   sys_117: -4.56083874e-03
   sys_118: 4.56083874e-03
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: 0.0
-  sys_122: -0.0
+  sys_122: 0.0
   sys_123: 9.12167748e-04
   sys_124: -9.12167748e-04
   sys_125: 0.0
-  sys_126: -0.0
+  sys_126: 0.0
   sys_127: 9.12167748e-04
   sys_128: -9.12167748e-04
   sys_129: 9.12167748e-03
@@ -9841,9 +9841,9 @@ bins:
   sys_131: 7.29734198e-03
   sys_132: -7.29734198e-03
   sys_133: 0.0
-  sys_134: -0.0
+  sys_134: 0.0
   sys_135: 0.0
-  sys_136: -0.0
+  sys_136: 0.0
   sys_137: 4.56083874e-03
   sys_138: -4.56083874e-03
   luminosity_uncertainty: 2.32200000e-02
@@ -9851,57 +9851,57 @@ bins:
   art_sys_2: 0.0
   art_sys_3: -1.86112779e-04
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 2.23346462e-04
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 9.03836592e-05
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: -4.22132630e-05
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: -5.84248602e-04
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
+  art_sys_25: 0.0
   art_sys_26: 4.68401462e-04
-  art_sys_27: -0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 4.97849826e-05
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
   art_sys_37: -1.26362761e-05
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
   art_sys_43: -1.53132511e-04
-  art_sys_44: -0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
   art_sys_46: -8.81725415e-04
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
   art_sys_50: -2.12504798e-04
-  art_sys_51: -0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 1.11093697e-04
   art_sys_57: 0.0
   art_sys_58: 0.0
@@ -9910,20 +9910,20 @@ bins:
   art_sys_61: 0.0
   art_sys_62: 0.0
   art_sys_63: 7.49741760e-05
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
   art_sys_68: 5.30286564e-04
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
   art_sys_72: -2.45885211e-03
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
   art_sys_76: 5.73510219e-03
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
   art_sys_80: 3.42996232e-02
@@ -9932,11 +9932,11 @@ bins:
   art_sys_83: -1.62729382e-03
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 1.47087510e-05
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 3.84666089e-04
   sys_2: -3.84666089e-04
   sys_3: 1.53866436e-02
@@ -9944,9 +9944,9 @@ bins:
   sys_5: 2.11566349e-02
   sys_6: -2.00026366e-02
   sys_7: 0.0
-  sys_8: -0.0
+  sys_8: 0.0
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 3.84666089e-04
   sys_12: -3.84666089e-04
   sys_13: 1.15399827e-03
@@ -9954,7 +9954,7 @@ bins:
   sys_15: 3.84666089e-04
   sys_16: 0.0
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 2.30799653e-03
   sys_20: -2.30799653e-03
   sys_21: 3.84666089e-04
@@ -9984,17 +9984,17 @@ bins:
   sys_45: 6.15465742e-03
   sys_46: -5.76999133e-03
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 3.84666089e-04
   sys_52: -3.84666089e-04
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 3.84666089e-04
   sys_56: -3.84666089e-04
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 3.84666089e-04
   sys_60: -3.84666089e-04
   sys_61: 3.84666089e-04
@@ -10004,23 +10004,23 @@ bins:
   sys_65: 7.69332178e-04
   sys_66: -7.69332178e-04
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
   sys_78: -3.84666089e-04
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 7.69332178e-04
   sys_86: -7.69332178e-04
   sys_87: 3.07732871e-03
@@ -10030,15 +10030,15 @@ bins:
   sys_91: 6.15465742e-03
   sys_92: -5.76999133e-03
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 3.84666089e-04
   sys_104: -3.84666089e-04
   sys_105: 2.30799653e-03
@@ -10048,7 +10048,7 @@ bins:
   sys_109: 3.84666089e-04
   sys_110: -3.84666089e-04
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 2.69266262e-03
   sys_114: -2.69266262e-03
   sys_115: 5.38532525e-03
@@ -10056,13 +10056,13 @@ bins:
   sys_117: -2.30799653e-03
   sys_118: 2.30799653e-03
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: 0.0
-  sys_122: -0.0
+  sys_122: 0.0
   sys_123: 3.84666089e-04
   sys_124: -3.84666089e-04
   sys_125: 0.0
-  sys_126: -0.0
+  sys_126: 0.0
   sys_127: 3.84666089e-04
   sys_128: -3.84666089e-04
   sys_129: 3.84666089e-03
@@ -10070,7 +10070,7 @@ bins:
   sys_131: 3.46199480e-03
   sys_132: -3.46199480e-03
   sys_133: 0.0
-  sys_134: -0.0
+  sys_134: 0.0
   sys_135: 3.84666089e-04
   sys_136: -3.84666089e-04
   sys_137: 1.92333044e-03
@@ -10080,57 +10080,57 @@ bins:
   art_sys_2: 0.0
   art_sys_3: 1.69681409e-04
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: -5.71602039e-05
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: -3.68633405e-04
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 1.10705351e-04
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: -2.06184352e-05
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
+  art_sys_25: 0.0
   art_sys_26: 2.45025318e-04
-  art_sys_27: -0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: -1.10969370e-04
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
   art_sys_37: 2.20169510e-04
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
   art_sys_43: -1.79880851e-04
-  art_sys_44: -0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
   art_sys_46: -1.66574526e-04
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
   art_sys_50: 1.12096302e-04
-  art_sys_51: -0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 4.04804083e-05
   art_sys_57: 0.0
   art_sys_58: 0.0
@@ -10139,20 +10139,20 @@ bins:
   art_sys_61: 0.0
   art_sys_62: 0.0
   art_sys_63: 1.01634815e-04
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
   art_sys_68: -2.01066406e-05
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
   art_sys_72: -1.79733766e-04
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
   art_sys_76: -9.15421466e-04
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
   art_sys_80: 3.14922015e-03
@@ -10161,11 +10161,11 @@ bins:
   art_sys_83: 1.82970994e-02
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: -1.26793578e-05
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 1.27279221e-04
   sys_2: -1.27279221e-04
   sys_3: 5.21844805e-03
@@ -10173,17 +10173,17 @@ bins:
   sys_5: 7.25491557e-03
   sys_6: -6.87307791e-03
   sys_7: 0.0
-  sys_8: -0.0
+  sys_8: 0.0
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 1.27279221e-04
   sys_12: -1.27279221e-04
   sys_13: 3.81837662e-04
   sys_14: -3.81837662e-04
   sys_15: 0.0
-  sys_16: -0.0
+  sys_16: 0.0
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 8.90954544e-04
   sys_20: -8.90954544e-04
   sys_21: 1.27279221e-04
@@ -10213,17 +10213,17 @@ bins:
   sys_45: 2.16374675e-03
   sys_46: -2.03646753e-03
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 1.27279221e-04
   sys_52: -1.27279221e-04
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 1.27279221e-04
   sys_56: -1.27279221e-04
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 1.27279221e-04
   sys_60: -1.27279221e-04
   sys_61: 1.27279221e-04
@@ -10233,23 +10233,23 @@ bins:
   sys_65: 2.54558441e-04
   sys_66: -2.54558441e-04
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
   sys_78: -1.27279221e-04
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 2.54558441e-04
   sys_86: -2.54558441e-04
   sys_87: 1.01823376e-03
@@ -10259,15 +10259,15 @@ bins:
   sys_91: 2.03646753e-03
   sys_92: -1.90918831e-03
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 1.27279221e-04
   sys_104: -1.27279221e-04
   sys_105: 8.90954544e-04
@@ -10277,7 +10277,7 @@ bins:
   sys_109: 2.54558441e-04
   sys_110: -2.54558441e-04
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 1.01823376e-03
   sys_114: -1.01823376e-03
   sys_115: 1.65462987e-03
@@ -10285,13 +10285,13 @@ bins:
   sys_117: 6.36396103e-04
   sys_118: -1.14551299e-03
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: 0.0
-  sys_122: -0.0
+  sys_122: 0.0
   sys_123: 1.27279221e-04
   sys_124: -1.27279221e-04
   sys_125: 0.0
-  sys_126: -0.0
+  sys_126: 0.0
   sys_127: 1.27279221e-04
   sys_128: -1.27279221e-04
   sys_129: 1.27279221e-03
@@ -10299,7 +10299,7 @@ bins:
   sys_131: 1.14551299e-03
   sys_132: -1.14551299e-03
   sys_133: 0.0
-  sys_134: -0.0
+  sys_134: 0.0
   sys_135: 7.63675324e-04
   sys_136: -7.63675324e-04
   sys_137: 6.36396103e-04
@@ -10309,57 +10309,57 @@ bins:
   art_sys_2: 0.0
   art_sys_3: 3.79588934e-06
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 5.61178365e-06
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 1.34669367e-05
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 2.21024527e-05
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: -1.71852232e-05
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
+  art_sys_25: 0.0
   art_sys_26: 3.23528356e-05
-  art_sys_27: -0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: -7.51576067e-06
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
   art_sys_37: 3.51417643e-05
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
   art_sys_43: 3.36439577e-05
-  art_sys_44: -0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
   art_sys_46: 2.42753463e-05
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
   art_sys_50: 4.45442875e-05
-  art_sys_51: -0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 3.06951183e-05
   art_sys_57: 0.0
   art_sys_58: 0.0
@@ -10368,20 +10368,20 @@ bins:
   art_sys_61: 0.0
   art_sys_62: 0.0
   art_sys_63: 9.96141761e-07
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
   art_sys_68: 3.03943537e-06
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
   art_sys_72: -8.84551020e-05
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
   art_sys_76: -6.25369407e-05
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
   art_sys_80: -1.43853536e-04
@@ -10390,11 +10390,11 @@ bins:
   art_sys_83: 7.96399460e-05
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 3.20193887e-03
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 1.49199531e-05
   sys_2: -1.49199531e-05
   sys_3: 7.90757513e-04
@@ -10404,7 +10404,7 @@ bins:
   sys_7: 0.0
   sys_8: -1.49199531e-05
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 2.98399062e-05
   sys_12: -1.49199531e-05
   sys_13: 7.45997654e-05
@@ -10412,7 +10412,7 @@ bins:
   sys_15: 0.0
   sys_16: -1.49199531e-05
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 1.34279578e-04
   sys_20: -1.34279578e-04
   sys_21: 1.49199531e-05
@@ -10442,17 +10442,17 @@ bins:
   sys_45: 3.43158921e-04
   sys_46: -3.28238968e-04
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 2.98399062e-05
   sys_52: -2.98399062e-05
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 2.98399062e-05
   sys_56: -2.98399062e-05
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 1.49199531e-05
   sys_60: -1.49199531e-05
   sys_61: 1.49199531e-05
@@ -10462,23 +10462,23 @@ bins:
   sys_65: 4.47598592e-05
   sys_66: -4.47598592e-05
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 1.49199531e-05
   sys_78: -1.49199531e-05
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 4.47598592e-05
   sys_86: -4.47598592e-05
   sys_87: 1.79039437e-04
@@ -10488,15 +10488,15 @@ bins:
   sys_91: 2.83479109e-04
   sys_92: -2.68559155e-04
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 1.49199531e-05
   sys_104: -1.49199531e-05
   sys_105: 1.49199531e-04
@@ -10506,7 +10506,7 @@ bins:
   sys_109: 4.47598592e-05
   sys_110: -4.47598592e-05
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 2.23799296e-04
   sys_114: -2.08879343e-04
   sys_115: 1.93959390e-04
@@ -10514,21 +10514,21 @@ bins:
   sys_117: 1.28311597e-03
   sys_118: -1.31295587e-03
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: 0.0
-  sys_122: -0.0
+  sys_122: 0.0
   sys_123: 1.49199531e-05
   sys_124: -1.49199531e-05
   sys_125: 0.0
-  sys_126: -0.0
+  sys_126: 0.0
   sys_127: 0.0
-  sys_128: -0.0
+  sys_128: 0.0
   sys_129: 1.93959390e-04
   sys_130: -1.64119484e-04
   sys_131: 2.83479109e-04
   sys_132: -2.83479109e-04
   sys_133: 0.0
-  sys_134: -0.0
+  sys_134: 0.0
   sys_135: 1.64119484e-04
   sys_136: -1.64119484e-04
   sys_137: 7.45997654e-05
@@ -10536,7 +10536,7 @@ bins:
   luminosity_uncertainty: 3.79800000e-04
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
   art_sys_5: 2.33198035e+03
   art_sys_6: 0.0
@@ -10544,86 +10544,86 @@ bins:
   art_sys_8: 4.11892328e+01
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 1.30479427e+01
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 8.99591665e-01
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 1.51497724e-01
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
   art_sys_25: 2.23487286e-02
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
   art_sys_30: 3.60848773e-04
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 6.21213775e-04
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
   art_sys_40: 9.52007037e-05
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 3.75026894e-05
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
   art_sys_51: 6.17897095e-06
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 1.09362599e-06
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 7.33430682e-07
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
   art_sys_66: 7.34567167e-09
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
   art_sys_70: 3.61209793e-08
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
   art_sys_74: 3.29817357e-08
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 8.33069175e-09
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 3.81855777e-10
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
   art_sys_88: 8.76485834e-11
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 1.14551299e+03
   sys_2: -1.14551299e+03
   sys_3: 1.52735065e+03
@@ -10633,15 +10633,15 @@ bins:
   sys_7: 1.01823376e+03
   sys_8: -1.01823376e+03
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 3.81837662e+02
   sys_12: -5.09116882e+02
   sys_13: 1.90918831e+03
   sys_14: -1.90918831e+03
   sys_15: 0.0
-  sys_16: -0.0
+  sys_16: 0.0
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 8.90954544e+02
   sys_20: -7.63675324e+02
   sys_21: 1.27279221e+02
@@ -10655,25 +10655,25 @@ bins:
   sys_29: 8.90954544e+02
   sys_30: -8.90954544e+02
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 0.0
-  sys_38: -0.0
+  sys_38: 0.0
   sys_39: 0.0
-  sys_40: -0.0
+  sys_40: 0.0
   sys_41: 0.0
-  sys_42: -0.0
+  sys_42: 0.0
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
   sys_52: -1.27279221e+02
   sys_53: 0.0
@@ -10691,59 +10691,59 @@ bins:
   sys_65: 2.54558441e+02
   sys_66: -2.54558441e+02
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
   sys_76: -1.27279221e+02
   sys_77: 1.27279221e+02
   sys_78: -1.27279221e+02
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 8.90954544e+02
   sys_114: -7.63675324e+02
   sys_115: 8.78226622e+03
   sys_116: -8.65498700e+03
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: -6.36396103e+02
   sys_122: 6.36396103e+02
   sys_123: -2.29102597e+03
@@ -10765,7 +10765,7 @@ bins:
   luminosity_uncertainty: 3.24000000e+03
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
   art_sys_5: 8.95636175e+01
   art_sys_6: 0.0
@@ -10773,86 +10773,86 @@ bins:
   art_sys_8: -1.10508932e+03
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: -2.67216941e+01
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 6.47161044e+00
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 1.65984201e-01
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
   art_sys_25: 4.22713500e-02
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
   art_sys_30: -3.15270604e-03
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: -1.21404034e-03
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
   art_sys_40: 1.49855462e-04
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -9.06258801e-05
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
   art_sys_51: 3.89461332e-06
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 1.91543676e-06
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: -1.05365902e-06
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
   art_sys_66: 3.37162322e-07
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
   art_sys_70: 3.58179579e-08
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
   art_sys_74: -2.42476016e-08
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: -2.39989687e-08
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: -2.09965775e-09
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
   art_sys_88: -2.67708388e-11
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 5.13571655e+02
   sys_2: -5.13571655e+02
   sys_3: 7.98889241e+02
@@ -10862,15 +10862,15 @@ bins:
   sys_7: 4.56508138e+02
   sys_8: -3.99444621e+02
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 1.71190552e+02
   sys_12: -2.28254069e+02
   sys_13: 8.55952759e+02
   sys_14: -7.98889241e+02
   sys_15: 0.0
-  sys_16: -0.0
+  sys_16: 0.0
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 3.99444621e+02
   sys_20: -3.42381103e+02
   sys_21: 5.70635172e+01
@@ -10884,29 +10884,29 @@ bins:
   sys_29: 4.56508138e+02
   sys_30: -3.99444621e+02
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 0.0
-  sys_38: -0.0
+  sys_38: 0.0
   sys_39: 5.70635172e+01
   sys_40: -5.70635172e+01
   sys_41: 0.0
-  sys_42: -0.0
+  sys_42: 0.0
   sys_43: 5.70635172e+01
   sys_44: -5.70635172e+01
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 5.70635172e+01
   sys_56: -5.70635172e+01
   sys_57: 5.70635172e+01
@@ -10920,59 +10920,59 @@ bins:
   sys_65: 1.71190552e+02
   sys_66: -1.71190552e+02
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 5.70635172e+01
   sys_78: -5.70635172e+01
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 3.99444621e+02
   sys_114: -3.42381103e+02
   sys_115: 4.05150972e+03
   sys_116: -3.93738269e+03
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: -2.85317586e+02
   sys_122: 2.85317586e+02
   sys_123: -9.13016276e+02
@@ -10994,7 +10994,7 @@ bins:
   luminosity_uncertainty: 1.45260000e+03
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
   art_sys_5: -5.45408283e+01
   art_sys_6: 0.0
@@ -11002,86 +11002,86 @@ bins:
   art_sys_8: -5.97903026e+01
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 5.10268361e+02
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: -8.33812508e+00
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 2.66190364e+00
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
   art_sys_25: 8.50333455e-02
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
   art_sys_30: -1.02489061e-03
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: -3.10105237e-03
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
   art_sys_40: 3.91473778e-04
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 8.69866557e-05
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
   art_sys_51: 5.55024174e-05
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: -5.61323138e-06
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 1.28576822e-07
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
   art_sys_66: -1.85599336e-07
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
   art_sys_70: -2.66378264e-07
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
   art_sys_74: -1.45428562e-08
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: -2.24939332e-10
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 1.73963394e-08
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
   art_sys_88: -1.20617826e-11
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 2.11566349e+02
   sys_2: -2.11566349e+02
   sys_3: 4.23132698e+02
@@ -11091,7 +11091,7 @@ bins:
   sys_7: 1.85120555e+02
   sys_8: -1.58674762e+02
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 7.93373808e+01
   sys_12: -7.93373808e+01
   sys_13: 3.43795317e+02
@@ -11099,7 +11099,7 @@ bins:
   sys_15: 2.64457936e+01
   sys_16: 0.0
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 1.58674762e+02
   sys_20: -1.32228968e+02
   sys_21: 2.64457936e+01
@@ -11113,13 +11113,13 @@ bins:
   sys_29: 1.85120555e+02
   sys_30: -1.85120555e+02
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 0.0
-  sys_38: -0.0
+  sys_38: 0.0
   sys_39: 2.64457936e+01
   sys_40: -2.64457936e+01
   sys_41: 2.64457936e+01
@@ -11129,13 +11129,13 @@ bins:
   sys_45: 2.64457936e+01
   sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
   sys_56: -2.64457936e+01
   sys_57: 2.64457936e+01
@@ -11151,57 +11151,57 @@ bins:
   sys_67: 2.64457936e+01
   sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 2.64457936e+01
   sys_78: -2.64457936e+01
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 1.58674762e+02
   sys_114: -1.58674762e+02
   sys_115: 1.90409714e+03
   sys_116: -1.82475976e+03
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: -1.32228968e+02
   sys_122: 1.32228968e+02
   sys_123: -3.70241111e+02
@@ -11217,13 +11217,13 @@ bins:
   sys_133: 5.28915872e+01
   sys_134: -5.28915872e+01
   sys_135: 0.0
-  sys_136: -0.0
+  sys_136: 0.0
   sys_137: 1.32228968e+02
   sys_138: -1.32228968e+02
   luminosity_uncertainty: 673.2
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
   art_sys_5: -1.24553514e+01
   art_sys_6: 0.0
@@ -11231,86 +11231,86 @@ bins:
   art_sys_8: 2.63409014e+01
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 1.82092681e+01
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 2.49132069e+02
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: -7.08092036e+00
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
   art_sys_25: 1.58584938e+00
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
   art_sys_30: -3.60811479e-02
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: -1.92201199e-02
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
   art_sys_40: -4.84571565e-05
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -1.62737675e-04
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
   art_sys_51: -8.08997589e-05
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 3.15411999e-06
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: -2.69437490e-06
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
   art_sys_66: -2.77549746e-06
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
   art_sys_70: 2.34617921e-08
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
   art_sys_74: 1.06508888e-07
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: -5.82292265e-09
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 5.11123106e-09
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
   art_sys_88: 5.16173485e-11
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 8.66205807e+01
   sys_2: -8.66205807e+01
   sys_3: 2.22738636e+02
@@ -11320,7 +11320,7 @@ bins:
   sys_7: 7.42462120e+01
   sys_8: -6.18718434e+01
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 3.71231060e+01
   sys_12: -3.71231060e+01
   sys_13: 1.48492424e+02
@@ -11328,7 +11328,7 @@ bins:
   sys_15: 2.47487373e+01
   sys_16: -1.23743687e+01
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 6.18718434e+01
   sys_20: -6.18718434e+01
   sys_21: 1.23743687e+01
@@ -11344,11 +11344,11 @@ bins:
   sys_31: 1.23743687e+01
   sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 0.0
-  sys_38: -0.0
+  sys_38: 0.0
   sys_39: 2.47487373e+01
   sys_40: -1.23743687e+01
   sys_41: 1.23743687e+01
@@ -11358,15 +11358,15 @@ bins:
   sys_45: 1.23743687e+01
   sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 1.23743687e+01
   sys_58: -1.23743687e+01
   sys_59: 1.23743687e+01
@@ -11380,57 +11380,57 @@ bins:
   sys_67: 1.23743687e+01
   sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 1.23743687e+01
   sys_78: -1.23743687e+01
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 6.18718434e+01
   sys_114: -6.18718434e+01
   sys_115: 8.90954544e+02
   sys_116: -8.41457070e+02
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: -4.94974747e+01
   sys_122: 4.94974747e+01
   sys_123: -1.48492424e+02
@@ -11446,13 +11446,13 @@ bins:
   sys_133: 3.71231060e+01
   sys_134: -3.71231060e+01
   sys_135: 0.0
-  sys_136: -0.0
+  sys_136: 0.0
   sys_137: 6.18718434e+01
   sys_138: -6.18718434e+01
   luminosity_uncertainty: 3.15000000e+02
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
   art_sys_5: -2.35633244e+00
   art_sys_6: 0.0
@@ -11460,86 +11460,86 @@ bins:
   art_sys_8: 3.99082331e+00
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: -9.32852613e+00
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 1.39793874e+01
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 1.30337400e+02
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
   art_sys_25: -2.76328213e+00
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
   art_sys_30: 7.76356933e-01
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: -4.30527930e-04
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
   art_sys_40: -1.02663986e-03
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -5.32648281e-04
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
   art_sys_51: 1.77002357e-04
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: -1.85461896e-06
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: -4.25636772e-06
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
   art_sys_66: -1.43467859e-07
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
   art_sys_70: 3.50941013e-07
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
   art_sys_74: 2.40483565e-08
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 1.35872271e-07
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: -4.03730569e-08
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
   art_sys_88: 5.92681650e-10
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 3.75049437e+01
   sys_2: -3.75049437e+01
   sys_3: 1.18765655e+02
@@ -11549,7 +11549,7 @@ bins:
   sys_7: 3.12541197e+01
   sys_8: -2.50032958e+01
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 1.25016479e+01
   sys_12: -1.25016479e+01
   sys_13: 6.25082395e+01
@@ -11557,7 +11557,7 @@ bins:
   sys_15: 1.25016479e+01
   sys_16: -6.25082395e+00
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 3.12541197e+01
   sys_20: -2.50032958e+01
   sys_21: 6.25082395e+00
@@ -11573,11 +11573,11 @@ bins:
   sys_31: 6.25082395e+00
   sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 0.0
-  sys_38: -0.0
+  sys_38: 0.0
   sys_39: 1.25016479e+01
   sys_40: -1.25016479e+01
   sys_41: 6.25082395e+00
@@ -11587,17 +11587,17 @@ bins:
   sys_45: 1.25016479e+01
   sys_46: -6.25082395e+00
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 6.25082395e+00
   sys_60: -6.25082395e+00
   sys_61: 6.25082395e+00
@@ -11609,57 +11609,57 @@ bins:
   sys_67: 6.25082395e+00
   sys_68: -6.25082395e+00
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 6.25082395e+00
   sys_78: -6.25082395e+00
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 3.12541197e+01
   sys_114: -2.50032958e+01
   sys_115: 4.43808500e+02
   sys_116: -4.12554380e+02
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: -2.50032958e+01
   sys_122: 2.50032958e+01
   sys_123: -7.50098873e+01
@@ -11675,13 +11675,13 @@ bins:
   sys_133: 1.25016479e+01
   sys_134: -1.25016479e+01
   sys_135: 0.0
-  sys_136: -0.0
+  sys_136: 0.0
   sys_137: 3.12541197e+01
   sys_138: -3.12541197e+01
   luminosity_uncertainty: 159.12
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
   art_sys_5: -6.34567093e-01
   art_sys_6: 0.0
@@ -11689,86 +11689,86 @@ bins:
   art_sys_8: 3.47524300e-01
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: -1.64345245e+00
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: -5.96699599e+00
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 6.36735004e+00
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
   art_sys_25: 5.95698306e+01
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
   art_sys_30: -1.40905539e+00
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: -2.77866576e-01
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
   art_sys_40: -7.92766258e-03
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 3.66278323e-04
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
   art_sys_51: -4.72197729e-05
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 1.58434782e-05
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 9.04300392e-07
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
   art_sys_66: 2.37613082e-06
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
   art_sys_70: 2.50846136e-06
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
   art_sys_74: 1.80489595e-06
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 7.39519526e-08
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: -9.63475484e-09
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
   art_sys_88: 2.36230645e-10
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 1.48845977e+01
   sys_2: -1.48845977e+01
   sys_3: 6.25153105e+01
@@ -11778,7 +11778,7 @@ bins:
   sys_7: 1.19076782e+01
   sys_8: -1.19076782e+01
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 5.95383910e+00
   sys_12: -5.95383910e+00
   sys_13: 2.67922759e+01
@@ -11786,7 +11786,7 @@ bins:
   sys_15: 8.93075865e+00
   sys_16: -5.95383910e+00
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 1.19076782e+01
   sys_20: -1.19076782e+01
   sys_21: 2.97691955e+00
@@ -11816,17 +11816,17 @@ bins:
   sys_45: 5.95383910e+00
   sys_46: -5.95383910e+00
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 2.97691955e+00
   sys_60: -2.97691955e+00
   sys_61: 2.97691955e+00
@@ -11838,57 +11838,57 @@ bins:
   sys_67: 2.97691955e+00
   sys_68: -2.97691955e+00
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
   sys_78: -2.97691955e+00
   sys_79: 2.97691955e+00
   sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 2.97691955e+00
   sys_84: -2.97691955e+00
   sys_85: 2.97691955e+00
   sys_86: -2.97691955e+00
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 1.19076782e+01
   sys_114: -1.19076782e+01
   sys_115: 2.05407449e+02
   sys_116: -1.93499771e+02
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: -1.48845977e+01
   sys_122: 8.93075865e+00
   sys_123: -3.57230346e+01
@@ -11904,13 +11904,13 @@ bins:
   sys_133: 5.95383910e+00
   sys_134: -5.95383910e+00
   sys_135: 0.0
-  sys_136: -0.0
+  sys_136: 0.0
   sys_137: 1.48845977e+01
   sys_138: -1.48845977e+01
   luminosity_uncertainty: 7.57800000e+01
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
   art_sys_5: -7.95687397e-03
   art_sys_6: 0.0
@@ -11918,86 +11918,86 @@ bins:
   art_sys_8: -1.71563210e-01
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 1.98610325e-01
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: -3.24289379e-01
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: -2.98563643e+00
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
   art_sys_25: 2.82177164e+00
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
   art_sys_30: 3.09001221e+01
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 3.48210070e-01
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
   art_sys_40: -1.03335483e-01
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 8.58417823e-04
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
   art_sys_51: -6.75162723e-04
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 1.71980189e-04
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 3.06180889e-05
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
   art_sys_66: 9.20327718e-06
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
   art_sys_70: -3.79205098e-07
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
   art_sys_74: 1.91291931e-06
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: -2.08081108e-07
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: -1.11835987e-07
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
   art_sys_88: -1.98790364e-09
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 7.35391052e+00
   sys_2: -7.35391052e+00
   sys_3: 3.38279884e+01
@@ -12007,7 +12007,7 @@ bins:
   sys_7: 4.41234631e+00
   sys_8: -4.41234631e+00
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 2.94156421e+00
   sys_12: -2.94156421e+00
   sys_13: 1.17662568e+01
@@ -12015,7 +12015,7 @@ bins:
   sys_15: 4.41234631e+00
   sys_16: -2.94156421e+00
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 5.88312842e+00
   sys_20: -5.88312842e+00
   sys_21: 1.47078210e+00
@@ -12045,17 +12045,17 @@ bins:
   sys_45: 4.41234631e+00
   sys_46: -2.94156421e+00
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 1.47078210e+00
   sys_60: -1.47078210e+00
   sys_61: 1.47078210e+00
@@ -12067,15 +12067,15 @@ bins:
   sys_67: 1.47078210e+00
   sys_68: -1.47078210e+00
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 1.47078210e+00
   sys_80: 0.0
   sys_81: 0.0
@@ -12087,37 +12087,37 @@ bins:
   sys_87: 1.47078210e+00
   sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 5.88312842e+00
   sys_114: -5.88312842e+00
   sys_115: 9.85424010e+01
   sys_116: -9.11884905e+01
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: -7.35391052e+00
   sys_122: 4.41234631e+00
   sys_123: -1.91201674e+01
@@ -12133,13 +12133,13 @@ bins:
   sys_133: 2.94156421e+00
   sys_134: -2.94156421e+00
   sys_135: 0.0
-  sys_136: -0.0
+  sys_136: 0.0
   sys_137: 7.35391052e+00
   sys_138: -7.35391052e+00
   luminosity_uncertainty: 3.74400000e+01
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
   art_sys_5: 1.52564913e-01
   art_sys_6: 0.0
@@ -12147,86 +12147,86 @@ bins:
   art_sys_8: 7.23789127e-02
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: -1.11637428e-01
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: -2.60344114e-01
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: -2.21037745e-01
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
   art_sys_25: -1.25054374e+00
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
   art_sys_30: 9.24209004e-01
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: -1.23838037e+01
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
   art_sys_40: 2.50324942e-01
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 5.57036350e-02
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
   art_sys_51: -1.81148878e-03
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 2.70935328e-04
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 2.94249444e-05
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
   art_sys_66: 2.68315412e-05
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
   art_sys_70: 1.31564890e-05
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
   art_sys_74: 6.34924848e-07
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: -4.62932059e-07
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 2.69680101e-07
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
   art_sys_88: 6.22427120e-10
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 2.72660375e+00
   sys_2: -2.72660375e+00
   sys_3: 1.63596225e+01
@@ -12236,7 +12236,7 @@ bins:
   sys_7: 2.04495281e+00
   sys_8: -2.04495281e+00
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 6.81650937e-01
   sys_12: -1.36330187e+00
   sys_13: 4.77155656e+00
@@ -12244,7 +12244,7 @@ bins:
   sys_15: 2.04495281e+00
   sys_16: -2.04495281e+00
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 2.72660375e+00
   sys_20: -2.72660375e+00
   sys_21: 6.81650937e-01
@@ -12274,19 +12274,19 @@ bins:
   sys_45: 2.04495281e+00
   sys_46: -2.04495281e+00
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 6.81650937e-01
   sys_62: -6.81650937e-01
   sys_63: 6.81650937e-01
@@ -12296,15 +12296,15 @@ bins:
   sys_67: 1.36330187e+00
   sys_68: -1.36330187e+00
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 6.81650937e-01
   sys_80: 0.0
   sys_81: 6.81650937e-01
@@ -12316,37 +12316,37 @@ bins:
   sys_87: 6.81650937e-01
   sys_88: -6.81650937e-01
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 2.72660375e+00
   sys_114: -2.72660375e+00
   sys_115: 4.29440090e+01
   sys_116: -4.02174053e+01
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: -3.40825469e+00
   sys_122: 2.72660375e+00
   sys_123: -8.86146218e+00
@@ -12362,13 +12362,13 @@ bins:
   sys_133: 6.81650937e-01
   sys_134: -6.81650937e-01
   sys_135: 0.0
-  sys_136: -0.0
+  sys_136: 0.0
   sys_137: 3.40825469e+00
   sys_138: -3.40825469e+00
   luminosity_uncertainty: 17.352
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
   art_sys_5: 4.83353394e-02
   art_sys_6: 0.0
@@ -12376,86 +12376,86 @@ bins:
   art_sys_8: -2.72779018e-02
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 3.16700332e-02
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: -3.50509083e-03
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 1.21009172e-02
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
   art_sys_25: -1.94002811e-01
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
   art_sys_30: -5.30793968e-01
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: -5.72632250e-01
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
   art_sys_40: -5.54410107e+00
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -1.02990569e-01
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
   art_sys_51: -2.83795870e-02
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 1.29793253e-03
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: -3.07831532e-04
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
   art_sys_66: -9.66556595e-06
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
   art_sys_70: -2.09787115e-05
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
   art_sys_74: 6.81222007e-06
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: -9.85758381e-07
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: -2.84373043e-08
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
   art_sys_88: -8.49427923e-09
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 9.88535280e-01
   sys_2: -9.88535280e-01
   sys_3: 8.23779400e+00
@@ -12465,7 +12465,7 @@ bins:
   sys_7: 6.59023520e-01
   sys_8: -6.59023520e-01
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 3.29511760e-01
   sys_12: -3.29511760e-01
   sys_13: 1.64755880e+00
@@ -12473,7 +12473,7 @@ bins:
   sys_15: 9.88535280e-01
   sys_16: -9.88535280e-01
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 1.31804704e+00
   sys_20: -1.31804704e+00
   sys_21: 3.29511760e-01
@@ -12503,19 +12503,19 @@ bins:
   sys_45: 9.88535280e-01
   sys_46: -1.31804704e+00
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 3.29511760e-01
   sys_62: -3.29511760e-01
   sys_63: 3.29511760e-01
@@ -12525,15 +12525,15 @@ bins:
   sys_67: 6.59023520e-01
   sys_68: -6.59023520e-01
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 3.29511760e-01
   sys_80: 0.0
   sys_81: 3.29511760e-01
@@ -12547,35 +12547,35 @@ bins:
   sys_89: 3.29511760e-01
   sys_90: -3.29511760e-01
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 1.31804704e+00
   sys_114: -1.31804704e+00
   sys_115: 1.94411938e+01
   sys_116: -1.84526586e+01
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: -1.64755880e+00
   sys_122: 1.31804704e+00
   sys_123: -4.28365288e+00
@@ -12591,13 +12591,13 @@ bins:
   sys_133: 3.29511760e-01
   sys_134: -3.29511760e-01
   sys_135: 0.0
-  sys_136: -0.0
+  sys_136: 0.0
   sys_137: 1.64755880e+00
   sys_138: -1.64755880e+00
   luminosity_uncertainty: 8.38800000e+00
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
   art_sys_5: -2.87994536e-02
   art_sys_6: 0.0
@@ -12605,86 +12605,86 @@ bins:
   art_sys_8: -3.34221706e-02
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: -1.45146040e-02
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 2.35673767e-02
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 2.76255337e-02
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
   art_sys_25: 8.32034240e-03
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
   art_sys_30: -4.58442863e-02
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 2.18568410e-01
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
   art_sys_40: -2.09306604e-01
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 2.86173114e+00
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
   art_sys_51: 5.55053002e-02
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 1.36256733e-02
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 5.16461752e-04
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
   art_sys_66: 2.13637863e-04
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
   art_sys_70: -1.61167031e-05
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
   art_sys_74: -1.25662139e-06
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 3.17236260e-06
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 7.82809980e-07
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
   art_sys_88: 3.02582864e-08
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 4.79418398e-01
   sys_2: -4.79418398e-01
   sys_3: 4.15495945e+00
@@ -12694,7 +12694,7 @@ bins:
   sys_7: 3.19612265e-01
   sys_8: -3.19612265e-01
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 1.59806133e-01
   sys_12: -1.59806133e-01
   sys_13: 7.99030663e-01
@@ -12702,7 +12702,7 @@ bins:
   sys_15: 3.19612265e-01
   sys_16: -4.79418398e-01
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 6.39224530e-01
   sys_20: -6.39224530e-01
   sys_21: 1.59806133e-01
@@ -12732,19 +12732,19 @@ bins:
   sys_45: 6.39224530e-01
   sys_46: -6.39224530e-01
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 1.59806133e-01
   sys_62: 0.0
   sys_63: 1.59806133e-01
@@ -12754,17 +12754,17 @@ bins:
   sys_67: 3.19612265e-01
   sys_68: -3.19612265e-01
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 1.59806133e-01
   sys_82: -1.59806133e-01
   sys_83: 1.59806133e-01
@@ -12776,35 +12776,35 @@ bins:
   sys_89: 3.19612265e-01
   sys_90: -3.19612265e-01
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 6.39224530e-01
   sys_114: -6.39224530e-01
   sys_115: 8.94914342e+00
   sys_116: -8.62953116e+00
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: -6.39224530e-01
   sys_122: 4.79418398e-01
   sys_123: -1.91767359e+00
@@ -12820,13 +12820,13 @@ bins:
   sys_133: 1.59806133e-01
   sys_134: -1.59806133e-01
   sys_135: 0.0
-  sys_136: -0.0
+  sys_136: 0.0
   sys_137: 7.99030663e-01
   sys_138: -7.99030663e-01
   luminosity_uncertainty: 4.06800000e+00
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
   art_sys_5: 7.63020783e-03
   art_sys_6: 0.0
@@ -12834,86 +12834,86 @@ bins:
   art_sys_8: -8.01336625e-03
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 1.87431147e-02
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: -1.26243875e-02
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 2.16682890e-02
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
   art_sys_25: 2.41152715e-03
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
   art_sys_30: -7.48560387e-03
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 4.05153204e-02
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
   art_sys_40: 1.16049619e-01
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 1.32557395e-01
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
   art_sys_51: -1.24315602e+00
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: -2.51612667e-02
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: -9.22195097e-03
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
   art_sys_66: -1.63779360e-04
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
   art_sys_70: -3.42989315e-05
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
   art_sys_74: -7.69044821e-07
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: -3.93893188e-06
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 1.32559588e-07
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
   art_sys_88: -1.07199328e-07
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 1.51320851e-01
   sys_2: -1.51320851e-01
   sys_3: 2.04283149e+00
@@ -12923,7 +12923,7 @@ bins:
   sys_7: 1.51320851e-01
   sys_8: -1.51320851e-01
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 7.56604256e-02
   sys_12: -7.56604256e-02
   sys_13: 3.02641702e-01
@@ -12931,7 +12931,7 @@ bins:
   sys_15: 1.51320851e-01
   sys_16: -1.51320851e-01
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 3.02641702e-01
   sys_20: -3.02641702e-01
   sys_21: 7.56604256e-02
@@ -12961,21 +12961,21 @@ bins:
   sys_45: 3.02641702e-01
   sys_46: -3.78302128e-01
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 0.0
-  sys_62: -0.0
+  sys_62: 0.0
   sys_63: 7.56604256e-02
   sys_64: -7.56604256e-02
   sys_65: 7.56604256e-02
@@ -12983,17 +12983,17 @@ bins:
   sys_67: 7.56604256e-02
   sys_68: -7.56604256e-02
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 7.56604256e-02
   sys_82: -7.56604256e-02
   sys_83: 7.56604256e-02
@@ -13007,33 +13007,33 @@ bins:
   sys_91: 7.56604256e-02
   sys_92: -7.56604256e-02
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 3.02641702e-01
   sys_114: -3.02641702e-01
   sys_115: 4.01000256e+00
   sys_116: -3.85868170e+00
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: -2.26981277e-01
   sys_122: 1.51320851e-01
   sys_123: -6.80943830e-01
@@ -13049,13 +13049,13 @@ bins:
   sys_133: 7.56604256e-02
   sys_134: -7.56604256e-02
   sys_135: 0.0
-  sys_136: -0.0
+  sys_136: 0.0
   sys_137: 3.78302128e-01
   sys_138: -3.78302128e-01
   luminosity_uncertainty: 1.92600000e+00
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
   art_sys_5: -4.34520784e-03
   art_sys_6: 0.0
@@ -13063,86 +13063,86 @@ bins:
   art_sys_8: 3.13573120e-03
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 5.76401978e-03
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: -1.81878371e-03
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 1.60382267e-03
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
   art_sys_25: -1.52634349e-03
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
   art_sys_30: -7.48439983e-03
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 3.53954431e-03
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
   art_sys_40: 2.11968683e-02
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -5.86543323e-02
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
   art_sys_51: -5.42906294e-02
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 6.05612221e-01
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 1.52885159e-02
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
   art_sys_66: 4.92673169e-03
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
   art_sys_70: -1.53704969e-04
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
   art_sys_74: 2.35569710e-05
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: -7.65451259e-06
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: -2.79356350e-06
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
   art_sys_88: 2.12624609e-07
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 6.94378859e-02
   sys_2: -6.94378859e-02
   sys_3: 1.00684935e+00
@@ -13152,7 +13152,7 @@ bins:
   sys_7: 3.47189430e-02
   sys_8: -3.47189430e-02
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 3.47189430e-02
   sys_12: -3.47189430e-02
   sys_13: 1.04156829e-01
@@ -13160,7 +13160,7 @@ bins:
   sys_15: 6.94378859e-02
   sys_16: -6.94378859e-02
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 1.38875772e-01
   sys_20: -1.38875772e-01
   sys_21: 3.47189430e-02
@@ -13190,21 +13190,21 @@ bins:
   sys_45: 1.73594715e-01
   sys_46: -1.73594715e-01
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
   sys_52: -3.47189430e-02
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 0.0
-  sys_62: -0.0
+  sys_62: 0.0
   sys_63: 3.47189430e-02
   sys_64: -3.47189430e-02
   sys_65: 3.47189430e-02
@@ -13212,17 +13212,17 @@ bins:
   sys_67: 3.47189430e-02
   sys_68: -3.47189430e-02
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 3.47189430e-02
   sys_82: -3.47189430e-02
   sys_83: 3.47189430e-02
@@ -13236,33 +13236,33 @@ bins:
   sys_91: 6.94378859e-02
   sys_92: -6.94378859e-02
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
   sys_100: -3.47189430e-02
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 1.38875772e-01
   sys_114: -1.38875772e-01
   sys_115: 1.73594715e+00
   sys_116: -1.70122820e+00
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: -6.94378859e-02
   sys_122: 6.94378859e-02
   sys_123: -2.08313658e-01
@@ -13278,13 +13278,13 @@ bins:
   sys_133: 3.47189430e-02
   sys_134: -3.47189430e-02
   sys_135: 0.0
-  sys_136: -0.0
+  sys_136: 0.0
   sys_137: 1.73594715e-01
   sys_138: -1.73594715e-01
   luminosity_uncertainty: 8.83800000e-01
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
   art_sys_5: 4.44328618e-03
   art_sys_6: 0.0
@@ -13292,86 +13292,86 @@ bins:
   art_sys_8: 3.44422933e-03
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: -9.51252728e-05
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: -2.15448156e-03
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: -2.32703303e-03
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
   art_sys_25: 4.52203489e-04
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
   art_sys_30: 3.21855355e-03
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: -1.25044854e-03
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
   art_sys_40: 2.58676170e-03
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -1.71614006e-03
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
   art_sys_51: 3.15078218e-02
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 2.88868612e-02
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: -3.37701525e-01
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
   art_sys_66: -7.81339273e-03
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
   art_sys_70: -2.44957761e-03
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
   art_sys_74: -1.42169631e-05
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: -4.19168303e-05
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: -6.08035069e-06
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
   art_sys_88: 4.28780596e-08
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 3.12541197e-02
   sys_2: -3.12541197e-02
   sys_3: 5.00065916e-01
@@ -13381,7 +13381,7 @@ bins:
   sys_7: 1.56270599e-02
   sys_8: -1.56270599e-02
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 1.56270599e-02
   sys_12: -1.56270599e-02
   sys_13: 4.68811796e-02
@@ -13389,7 +13389,7 @@ bins:
   sys_15: 1.56270599e-02
   sys_16: -3.12541197e-02
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 6.25082395e-02
   sys_20: -6.25082395e-02
   sys_21: 1.56270599e-02
@@ -13419,21 +13419,21 @@ bins:
   sys_45: 9.37623592e-02
   sys_46: -9.37623592e-02
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
   sys_52: -1.56270599e-02
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 0.0
-  sys_62: -0.0
+  sys_62: 0.0
   sys_63: 1.56270599e-02
   sys_64: -1.56270599e-02
   sys_65: 1.56270599e-02
@@ -13441,17 +13441,17 @@ bins:
   sys_67: 1.56270599e-02
   sys_68: -1.56270599e-02
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
   sys_82: -1.56270599e-02
   sys_83: 1.56270599e-02
@@ -13465,33 +13465,33 @@ bins:
   sys_91: 6.25082395e-02
   sys_92: -6.25082395e-02
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
   sys_100: -1.56270599e-02
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 1.56270599e-02
   sys_106: -1.56270599e-02
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 6.25082395e-02
   sys_114: -7.81352993e-02
   sys_115: 7.50098873e-01
   sys_116: -7.18844754e-01
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: -3.12541197e-02
   sys_122: 1.56270599e-02
   sys_123: -4.68811796e-02
@@ -13507,13 +13507,13 @@ bins:
   sys_133: 1.56270599e-02
   sys_134: -1.56270599e-02
   sys_135: 0.0
-  sys_136: -0.0
+  sys_136: 0.0
   sys_137: 7.81352993e-02
   sys_138: -7.81352993e-02
   luminosity_uncertainty: 3.97800000e-01
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
   art_sys_5: -3.15755031e-04
   art_sys_6: 0.0
@@ -13521,86 +13521,86 @@ bins:
   art_sys_8: 2.69947459e-03
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 9.53126026e-04
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 4.16705433e-03
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: -1.28111477e-04
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
   art_sys_25: -9.26640812e-04
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
   art_sys_30: -1.47206210e-03
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 1.69056394e-03
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
   art_sys_40: -5.59117852e-04
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -1.85537167e-03
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
   art_sys_51: 1.80713149e-03
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: -1.63781510e-02
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: -1.70246003e-02
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
   art_sys_66: 1.65556806e-01
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
   art_sys_70: 9.41269596e-03
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
   art_sys_74: 2.38387383e-03
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: -3.25726146e-05
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: -2.35283718e-07
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
   art_sys_88: 5.96572547e-07
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 6.97207286e-03
   sys_2: -6.97207286e-03
   sys_3: 2.44022550e-01
@@ -13610,7 +13610,7 @@ bins:
   sys_7: 6.97207286e-03
   sys_8: -6.97207286e-03
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 6.97207286e-03
   sys_12: -6.97207286e-03
   sys_13: 2.09162186e-02
@@ -13618,7 +13618,7 @@ bins:
   sys_15: 6.97207286e-03
   sys_16: -6.97207286e-03
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 3.48603643e-02
   sys_20: -3.48603643e-02
   sys_21: 6.97207286e-03
@@ -13648,21 +13648,21 @@ bins:
   sys_45: 4.88045100e-02
   sys_46: -5.57765829e-02
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 6.97207286e-03
   sys_52: -6.97207286e-03
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 0.0
-  sys_62: -0.0
+  sys_62: 0.0
   sys_63: 0.0
   sys_64: -6.97207286e-03
   sys_65: 6.97207286e-03
@@ -13670,19 +13670,19 @@ bins:
   sys_67: 6.97207286e-03
   sys_68: -6.97207286e-03
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 6.97207286e-03
   sys_84: -6.97207286e-03
   sys_85: 1.39441457e-02
@@ -13694,33 +13694,33 @@ bins:
   sys_91: 4.88045100e-02
   sys_92: -4.88045100e-02
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
   sys_100: -6.97207286e-03
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
   sys_104: -6.97207286e-03
   sys_105: 6.97207286e-03
   sys_106: -6.97207286e-03
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 3.48603643e-02
   sys_114: -3.48603643e-02
   sys_115: 3.20715352e-01
   sys_116: -3.06771206e-01
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: -6.97207286e-03
   sys_122: 0.0
   sys_123: -6.97207286e-03
@@ -13736,13 +13736,13 @@ bins:
   sys_133: 6.97207286e-03
   sys_134: -6.97207286e-03
   sys_135: 0.0
-  sys_136: -0.0
+  sys_136: 0.0
   sys_137: 3.48603643e-02
   sys_138: -3.48603643e-02
   luminosity_uncertainty: 0.17748
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
   art_sys_5: 1.00952652e-03
   art_sys_6: 0.0
@@ -13750,86 +13750,86 @@ bins:
   art_sys_8: 8.21971106e-05
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: -1.38787719e-03
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 4.42156732e-04
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 6.47787617e-04
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
   art_sys_25: 1.44060249e-03
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
   art_sys_30: -3.49645490e-05
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: -1.39393151e-03
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
   art_sys_40: 9.82839792e-04
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -5.30998535e-04
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
   art_sys_51: -8.66300821e-05
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: -3.22855254e-03
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 6.61896711e-03
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
   art_sys_66: 1.64656363e-02
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
   art_sys_70: -9.86184257e-02
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
   art_sys_74: -6.26548479e-03
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: -9.77059408e-04
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: -3.79118860e-05
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
   art_sys_88: 1.58890740e-07
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 3.04055916e-03
   sys_2: -3.04055916e-03
   sys_3: 1.15541248e-01
@@ -13839,7 +13839,7 @@ bins:
   sys_7: 3.04055916e-03
   sys_8: -3.04055916e-03
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 3.04055916e-03
   sys_12: -3.04055916e-03
   sys_13: 9.12167748e-03
@@ -13847,7 +13847,7 @@ bins:
   sys_15: 3.04055916e-03
   sys_16: -3.04055916e-03
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 1.52027958e-02
   sys_20: -1.52027958e-02
   sys_21: 3.04055916e-03
@@ -13877,19 +13877,19 @@ bins:
   sys_45: 2.73650324e-02
   sys_46: -2.73650324e-02
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 3.04055916e-03
   sys_52: -3.04055916e-03
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 0.0
   sys_62: -3.04055916e-03
   sys_63: 0.0
@@ -13899,19 +13899,19 @@ bins:
   sys_67: 3.04055916e-03
   sys_68: -3.04055916e-03
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 3.04055916e-03
   sys_84: -3.04055916e-03
   sys_85: 6.08111832e-03
@@ -13923,15 +13923,15 @@ bins:
   sys_91: 2.73650324e-02
   sys_92: -2.73650324e-02
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
   sys_100: -3.04055916e-03
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 3.04055916e-03
   sys_104: -3.04055916e-03
   sys_105: 6.08111832e-03
@@ -13939,21 +13939,21 @@ bins:
   sys_107: 3.04055916e-03
   sys_108: -3.04055916e-03
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 1.52027958e-02
   sys_114: -1.52027958e-02
   sys_115: 1.36825162e-01
   sys_116: -1.30744044e-01
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: -3.04055916e-03
   sys_122: 0.0
   sys_123: 0.0
-  sys_124: -0.0
+  sys_124: 0.0
   sys_125: 6.08111832e-03
   sys_126: -6.08111832e-03
   sys_127: 6.08111832e-03
@@ -13965,13 +13965,13 @@ bins:
   sys_133: 3.04055916e-03
   sys_134: -3.04055916e-03
   sys_135: 0.0
-  sys_136: -0.0
+  sys_136: 0.0
   sys_137: 1.52027958e-02
   sys_138: -1.52027958e-02
   luminosity_uncertainty: 7.74000000e-02
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
   art_sys_5: -1.09404651e-03
   art_sys_6: 0.0
@@ -13979,86 +13979,86 @@ bins:
   art_sys_8: -6.62646501e-04
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: -7.94570300e-05
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: -3.61668794e-04
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: -8.47706268e-05
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
   art_sys_25: -1.60869026e-03
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
   art_sys_30: -7.91431867e-04
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: -2.49501975e-05
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
   art_sys_40: 7.14736485e-04
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 8.91490945e-05
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
   art_sys_51: -6.86676486e-05
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 8.57951501e-05
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 1.22234131e-03
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
   art_sys_66: -4.66375998e-03
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
   art_sys_70: -1.04944841e-02
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
   art_sys_74: 6.17784824e-02
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 2.07139205e-03
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 4.72630768e-04
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
   art_sys_88: 3.01096465e-06
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 1.22329473e-03
   sys_2: -1.22329473e-03
   sys_3: 5.01550840e-02
@@ -14068,7 +14068,7 @@ bins:
   sys_7: 1.22329473e-03
   sys_8: -1.22329473e-03
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 1.22329473e-03
   sys_12: -1.22329473e-03
   sys_13: 3.66988419e-03
@@ -14076,7 +14076,7 @@ bins:
   sys_15: 1.22329473e-03
   sys_16: -1.22329473e-03
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 7.33976839e-03
   sys_20: -7.33976839e-03
   sys_21: 1.22329473e-03
@@ -14106,19 +14106,19 @@ bins:
   sys_45: 1.34562420e-02
   sys_46: -1.34562420e-02
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 1.22329473e-03
   sys_52: -1.22329473e-03
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 1.22329473e-03
   sys_62: -1.22329473e-03
   sys_63: 1.22329473e-03
@@ -14128,19 +14128,19 @@ bins:
   sys_67: 1.22329473e-03
   sys_68: -1.22329473e-03
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 1.22329473e-03
   sys_84: -1.22329473e-03
   sys_85: 2.44658946e-03
@@ -14152,15 +14152,15 @@ bins:
   sys_91: 1.46795368e-02
   sys_92: -1.46795368e-02
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 1.22329473e-03
   sys_104: -1.22329473e-03
   sys_105: 3.66988419e-03
@@ -14168,19 +14168,19 @@ bins:
   sys_107: 2.44658946e-03
   sys_108: -1.22329473e-03
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 7.33976839e-03
   sys_114: -7.33976839e-03
   sys_115: 5.38249682e-02
   sys_116: -5.13783787e-02
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: 0.0
-  sys_122: -0.0
+  sys_122: 0.0
   sys_123: 1.22329473e-03
   sys_124: 0.0
   sys_125: 1.22329473e-03
@@ -14194,13 +14194,13 @@ bins:
   sys_133: 1.22329473e-03
   sys_134: -1.22329473e-03
   sys_135: 0.0
-  sys_136: -0.0
+  sys_136: 0.0
   sys_137: 6.11647366e-03
   sys_138: -6.11647366e-03
   luminosity_uncertainty: 3.11400000e-02
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
   art_sys_5: 3.75781788e-04
   art_sys_6: 0.0
@@ -14208,86 +14208,86 @@ bins:
   art_sys_8: 7.28712227e-04
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 4.74809621e-05
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: -2.73257032e-05
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 4.92798949e-04
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
   art_sys_25: -2.30799618e-05
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
   art_sys_30: -2.46427648e-04
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 2.12589442e-04
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
   art_sys_40: 1.29647884e-04
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 2.93203289e-04
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
   art_sys_51: 1.15086968e-04
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: -5.98935240e-05
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 3.14330514e-04
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
   art_sys_66: -8.88056712e-04
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
   art_sys_70: 2.10461293e-03
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
   art_sys_74: 3.93965717e-03
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: -3.50112283e-02
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: -1.49379990e-03
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
   art_sys_88: -2.38061588e-05
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 4.35577777e-04
   sys_2: -4.35577777e-04
   sys_3: 1.91654222e-02
@@ -14297,7 +14297,7 @@ bins:
   sys_7: 4.35577777e-04
   sys_8: -4.35577777e-04
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 4.35577777e-04
   sys_12: -4.35577777e-04
   sys_13: 1.30673333e-03
@@ -14305,7 +14305,7 @@ bins:
   sys_15: 4.35577777e-04
   sys_16: -4.35577777e-04
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 2.61346666e-03
   sys_20: -2.61346666e-03
   sys_21: 4.35577777e-04
@@ -14335,17 +14335,17 @@ bins:
   sys_45: 5.66251110e-03
   sys_46: -5.66251110e-03
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 4.35577777e-04
   sys_52: -4.35577777e-04
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 4.35577777e-04
   sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
   sys_60: -4.35577777e-04
   sys_61: 4.35577777e-04
@@ -14357,19 +14357,19 @@ bins:
   sys_67: 4.35577777e-04
   sys_68: -4.35577777e-04
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 4.35577777e-04
   sys_84: -4.35577777e-04
   sys_85: 8.71155554e-04
@@ -14381,15 +14381,15 @@ bins:
   sys_91: 6.09808888e-03
   sys_92: -6.09808888e-03
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 4.35577777e-04
   sys_104: -4.35577777e-04
   sys_105: 1.74231111e-03
@@ -14399,17 +14399,17 @@ bins:
   sys_109: 4.35577777e-04
   sys_110: -4.35577777e-04
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 3.04904444e-03
   sys_114: -3.04904444e-03
   sys_115: 1.91654222e-02
   sys_116: -1.78586889e-02
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: 0.0
-  sys_122: -0.0
+  sys_122: 0.0
   sys_123: 4.35577777e-04
   sys_124: -4.35577777e-04
   sys_125: 4.35577777e-04
@@ -14429,7 +14429,7 @@ bins:
   luminosity_uncertainty: 0.011088
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
   art_sys_5: 7.30622835e-05
   art_sys_6: 0.0
@@ -14437,86 +14437,86 @@ bins:
   art_sys_8: 8.67752216e-06
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: -5.18515278e-04
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: -2.58460568e-05
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 3.23848987e-04
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
   art_sys_25: 1.04490218e-04
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
   art_sys_30: 1.81578800e-04
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 1.93298848e-04
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
   art_sys_40: -6.84279374e-06
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -1.16004230e-04
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
   art_sys_51: 1.97725129e-05
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 8.90667264e-05
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: -1.04359120e-04
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
   art_sys_66: 8.37153065e-05
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
   art_sys_70: 2.43272098e-04
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
   art_sys_74: -1.31494654e-03
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: -2.97926610e-03
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 1.79118225e-02
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
   art_sys_88: 3.90299005e-05
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 1.32936075e-04
   sys_2: -1.32936075e-04
   sys_3: 6.11505944e-03
@@ -14526,7 +14526,7 @@ bins:
   sys_7: 1.32936075e-04
   sys_8: -1.32936075e-04
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 1.32936075e-04
   sys_12: -1.32936075e-04
   sys_13: 3.98808225e-04
@@ -14534,7 +14534,7 @@ bins:
   sys_15: 1.32936075e-04
   sys_16: -1.32936075e-04
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 9.30552524e-04
   sys_20: -9.30552524e-04
   sys_21: 1.32936075e-04
@@ -14564,17 +14564,17 @@ bins:
   sys_45: 1.99404112e-03
   sys_46: -1.86110505e-03
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 1.32936075e-04
   sys_52: -1.32936075e-04
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 1.32936075e-04
   sys_56: -1.32936075e-04
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
   sys_60: -1.32936075e-04
   sys_61: 1.32936075e-04
@@ -14586,19 +14586,19 @@ bins:
   sys_67: 1.32936075e-04
   sys_68: -1.32936075e-04
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 1.32936075e-04
   sys_84: -1.32936075e-04
   sys_85: 3.98808225e-04
@@ -14610,15 +14610,15 @@ bins:
   sys_91: 2.12697720e-03
   sys_92: -2.12697720e-03
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 1.32936075e-04
   sys_104: -1.32936075e-04
   sys_105: 6.64680374e-04
@@ -14628,7 +14628,7 @@ bins:
   sys_109: 1.32936075e-04
   sys_110: -1.32936075e-04
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 1.06348860e-03
   sys_114: -1.06348860e-03
   sys_115: 5.84918729e-03
@@ -14636,13 +14636,13 @@ bins:
   sys_117: 0.0
   sys_118: -1.32936075e-04
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: 0.0
-  sys_122: -0.0
+  sys_122: 0.0
   sys_123: 1.32936075e-04
   sys_124: -1.32936075e-04
   sys_125: 0.0
-  sys_126: -0.0
+  sys_126: 0.0
   sys_127: 2.65872150e-04
   sys_128: -2.65872150e-04
   sys_129: 1.72816897e-03
@@ -14658,7 +14658,7 @@ bins:
   luminosity_uncertainty: 3.38400000e-03
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
   art_sys_5: 5.65398720e-05
   art_sys_6: 0.0
@@ -14666,86 +14666,86 @@ bins:
   art_sys_8: 6.49130100e-06
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: -9.75490832e-06
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 6.89014973e-06
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 2.50663143e-05
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
   art_sys_25: 2.07886872e-06
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
   art_sys_30: -1.45812828e-05
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 7.69113733e-07
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
   art_sys_40: 9.58227234e-06
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 1.45046920e-05
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
   art_sys_51: 3.71925535e-05
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 3.84229834e-05
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: -8.16692233e-06
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
   art_sys_66: 3.37707324e-05
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
   art_sys_70: -2.47368030e-05
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
   art_sys_74: 1.24092432e-05
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 2.17139387e-04
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 2.20986029e-04
   art_sys_85: 0.0
-  art_sys_86: -0.0
-  art_sys_87: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
   art_sys_88: -3.33086376e-03
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 1.84554870e-05
   sys_2: -1.84554870e-05
   sys_3: 1.14424019e-03
@@ -14755,7 +14755,7 @@ bins:
   sys_7: 1.84554870e-05
   sys_8: -1.84554870e-05
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 3.69109740e-05
   sys_12: -1.84554870e-05
   sys_13: 1.10732922e-04
@@ -14763,7 +14763,7 @@ bins:
   sys_15: 1.84554870e-05
   sys_16: -1.84554870e-05
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 2.03010357e-04
   sys_20: -1.84554870e-04
   sys_21: 1.84554870e-05
@@ -14793,17 +14793,17 @@ bins:
   sys_45: 4.79842662e-04
   sys_46: -4.42931688e-04
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 5.53664610e-05
   sys_52: -3.69109740e-05
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 3.69109740e-05
   sys_56: -3.69109740e-05
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 1.84554870e-05
   sys_60: -1.84554870e-05
   sys_61: 3.69109740e-05
@@ -14815,19 +14815,19 @@ bins:
   sys_67: 1.84554870e-05
   sys_68: -1.84554870e-05
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 1.84554870e-05
   sys_78: -1.84554870e-05
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 1.84554870e-05
   sys_84: -1.84554870e-05
   sys_85: 7.38219480e-05
@@ -14839,15 +14839,15 @@ bins:
   sys_91: 4.61387175e-04
   sys_92: -4.24476201e-04
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 1.84554870e-05
   sys_104: -1.84554870e-05
   sys_105: 2.03010357e-04
@@ -14857,7 +14857,7 @@ bins:
   sys_109: 3.69109740e-05
   sys_110: -3.69109740e-05
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 2.58376818e-04
   sys_114: -2.58376818e-04
   sys_115: 9.04318862e-04
@@ -14865,13 +14865,13 @@ bins:
   sys_117: 5.53664610e-05
   sys_118: -7.38219480e-05
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: 0.0
-  sys_122: -0.0
+  sys_122: 0.0
   sys_123: 3.69109740e-05
   sys_124: -1.84554870e-05
   sys_125: 0.0
-  sys_126: -0.0
+  sys_126: 0.0
   sys_127: 3.69109740e-05
   sys_128: -3.69109740e-05
   sys_129: 2.58376818e-04
@@ -14879,7 +14879,7 @@ bins:
   sys_131: 6.27486558e-04
   sys_132: -6.27486558e-04
   sys_133: 0.0
-  sys_134: -0.0
+  sys_134: 0.0
   sys_135: 3.13743279e-04
   sys_136: -3.13743279e-04
   sys_137: 9.22774349e-05
@@ -14887,9 +14887,9 @@ bins:
   luminosity_uncertainty: 4.69800000e-04
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
@@ -14898,83 +14898,83 @@ bins:
   art_sys_11: 1.05822332e+02
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 1.54662983e+01
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 9.68552044e-01
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 1.74252968e-01
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 5.26652034e-04
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
   art_sys_32: 6.13531138e-03
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 1.75138934e-03
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 7.29104001e-04
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
   art_sys_48: 2.48096920e-05
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 2.28006616e-05
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: 3.24912541e-06
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
   art_sys_65: 2.03780513e-07
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
+  art_sys_72: 0.0
   art_sys_73: 1.01661787e-07
-  art_sys_74: -0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
+  art_sys_76: 0.0
   art_sys_77: 5.42627878e-08
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 7.17831092e-09
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 1.33458464e-10
-  art_sys_88: -0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 3.15652467e+02
   sys_2: -3.15652467e+02
   sys_3: 4.20869956e+02
@@ -14984,13 +14984,13 @@ bins:
   sys_7: 2.80579971e+02
   sys_8: -2.80579971e+02
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 1.40289985e+02
   sys_12: -1.40289985e+02
   sys_13: 5.96232438e+02
   sys_14: -5.96232438e+02
   sys_15: 0.0
-  sys_16: -0.0
+  sys_16: 0.0
   sys_17: 3.50724963e+01
   sys_18: -3.50724963e+01
   sys_19: 2.10434978e+02
@@ -15006,25 +15006,25 @@ bins:
   sys_29: 2.45507474e+02
   sys_30: -2.45507474e+02
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 0.0
-  sys_38: -0.0
+  sys_38: 0.0
   sys_39: 0.0
   sys_40: -3.50724963e+01
   sys_41: 0.0
-  sys_42: -0.0
+  sys_42: 0.0
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 3.50724963e+01
   sys_52: -3.50724963e+01
   sys_53: 3.50724963e+01
@@ -15042,59 +15042,59 @@ bins:
   sys_65: 7.01449927e+01
   sys_66: -7.01449927e+01
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 3.50724963e+01
   sys_74: -3.50724963e+01
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 3.50724963e+01
   sys_78: -3.50724963e+01
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 2.45507474e+02
   sys_114: -2.10434978e+02
   sys_115: 3.85797460e+03
   sys_116: -3.50724963e+03
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: -1.40289985e+02
   sys_122: 1.05217489e+02
   sys_123: -4.91014949e+02
@@ -15116,9 +15116,9 @@ bins:
   luminosity_uncertainty: 8.92800000e+02
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
@@ -15127,83 +15127,83 @@ bins:
   art_sys_11: -5.48380604e+02
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: -4.00954459e+01
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: -7.90760820e+00
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: -4.44007650e-01
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: -5.39301823e-02
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
   art_sys_32: -1.87162444e-03
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 2.28485908e-04
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: -4.18398407e-04
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
   art_sys_48: -3.18959075e-05
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: -5.08200322e-06
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: -1.10585096e-06
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
   art_sys_65: 1.05548441e-07
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
+  art_sys_72: 0.0
   art_sys_73: 3.05399083e-08
-  art_sys_74: -0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
+  art_sys_76: 0.0
   art_sys_77: -2.46576399e-08
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: -1.03499634e-08
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: -6.38749618e-11
-  art_sys_88: -0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 1.62281006e+02
   sys_2: -1.62281006e+02
   sys_3: 2.34405898e+02
@@ -15213,7 +15213,7 @@ bins:
   sys_7: 1.44249783e+02
   sys_8: -1.44249783e+02
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 7.21248917e+01
   sys_12: -7.21248917e+01
   sys_13: 2.88499567e+02
@@ -15235,25 +15235,25 @@ bins:
   sys_29: 1.26218560e+02
   sys_30: -1.26218560e+02
   sys_31: 0.0
-  sys_32: -0.0
+  sys_32: 0.0
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 0.0
-  sys_38: -0.0
+  sys_38: 0.0
   sys_39: 0.0
   sys_40: -1.80312229e+01
   sys_41: 0.0
-  sys_42: -0.0
+  sys_42: 0.0
   sys_43: 1.80312229e+01
   sys_44: 0.0
   sys_45: 1.80312229e+01
   sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 1.80312229e+01
   sys_52: 0.0
   sys_53: 1.80312229e+01
@@ -15271,59 +15271,59 @@ bins:
   sys_65: 5.40936688e+01
   sys_66: -5.40936688e+01
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 1.80312229e+01
   sys_78: -1.80312229e+01
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 1.26218560e+02
   sys_114: -1.08187338e+02
   sys_115: 1.98343452e+03
   sys_116: -1.80312229e+03
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: -7.21248917e+01
   sys_122: 7.21248917e+01
   sys_123: -2.52437121e+02
@@ -15345,9 +15345,9 @@ bins:
   luminosity_uncertainty: 4.59000000e+02
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
@@ -15356,83 +15356,83 @@ bins:
   art_sys_11: -9.17846196e+01
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 2.64335774e+02
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 2.82224968e+01
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 3.37737435e+00
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 2.58525355e-01
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
   art_sys_32: -4.93910361e-02
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 6.41359012e-04
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 1.05304412e-03
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
   art_sys_48: 4.99850286e-05
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 2.38715890e-05
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: -6.36227631e-06
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
   art_sys_65: -2.17630487e-07
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
+  art_sys_72: 0.0
   art_sys_73: 2.74463201e-07
-  art_sys_74: -0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
+  art_sys_76: 0.0
   art_sys_77: 1.66565097e-07
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 1.12107781e-08
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: -2.07223164e-10
-  art_sys_88: -0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 7.76403246e+01
   sys_2: -7.76403246e+01
   sys_3: 1.29400541e+02
@@ -15442,7 +15442,7 @@ bins:
   sys_7: 6.90136218e+01
   sys_8: -6.03869191e+01
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 3.45068109e+01
   sys_12: -3.45068109e+01
   sys_13: 1.29400541e+02
@@ -15450,7 +15450,7 @@ bins:
   sys_15: 8.62670273e+00
   sys_16: 0.0
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 5.17602164e+01
   sys_20: -5.17602164e+01
   sys_21: 8.62670273e+00
@@ -15468,21 +15468,21 @@ bins:
   sys_33: 0.0
   sys_34: -8.62670273e+00
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 0.0
-  sys_38: -0.0
+  sys_38: 0.0
   sys_39: 8.62670273e+00
   sys_40: -8.62670273e+00
   sys_41: 0.0
-  sys_42: -0.0
+  sys_42: 0.0
   sys_43: 8.62670273e+00
   sys_44: 0.0
   sys_45: 8.62670273e+00
   sys_46: -8.62670273e+00
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 8.62670273e+00
   sys_52: 0.0
   sys_53: 8.62670273e+00
@@ -15502,57 +15502,57 @@ bins:
   sys_67: 8.62670273e+00
   sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 8.62670273e+00
   sys_78: -8.62670273e+00
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 6.03869191e+01
   sys_114: -5.17602164e+01
   sys_115: 1.03520433e+03
   sys_116: -9.48937300e+02
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: -3.45068109e+01
   sys_122: 3.45068109e+01
   sys_123: -1.20773838e+02
@@ -15568,15 +15568,15 @@ bins:
   sys_133: 2.58801082e+01
   sys_134: -2.58801082e+01
   sys_135: 0.0
-  sys_136: -0.0
+  sys_136: 0.0
   sys_137: 4.31335137e+01
   sys_138: -4.31335137e+01
   luminosity_uncertainty: 2.19600000e+02
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
@@ -15585,83 +15585,83 @@ bins:
   art_sys_11: 1.21576343e+01
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 5.35467638e+01
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: -1.47703546e+02
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: -9.30058149e+00
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: -2.12197547e+00
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
   art_sys_32: 6.27801622e-02
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: -1.07652466e-02
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: -1.17164265e-03
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
   art_sys_48: 2.25238844e-05
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: -5.54662882e-05
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: -2.51878317e-05
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
   art_sys_65: 4.62254240e-06
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
+  art_sys_72: 0.0
   art_sys_73: -3.11603567e-07
-  art_sys_74: -0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
+  art_sys_76: 0.0
   art_sys_77: -2.88768546e-07
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: -1.21574040e-08
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: -6.21697638e-10
-  art_sys_88: -0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 3.90747207e+01
   sys_2: -3.47330851e+01
   sys_3: 7.38078058e+01
@@ -15671,7 +15671,7 @@ bins:
   sys_7: 3.03914495e+01
   sys_8: -3.03914495e+01
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 1.30249069e+01
   sys_12: -1.73665425e+01
   sys_13: 6.07828989e+01
@@ -15679,7 +15679,7 @@ bins:
   sys_15: 4.34163564e+00
   sys_16: -4.34163564e+00
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 2.60498138e+01
   sys_20: -2.60498138e+01
   sys_21: 4.34163564e+00
@@ -15697,9 +15697,9 @@ bins:
   sys_33: 0.0
   sys_34: -4.34163564e+00
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 0.0
-  sys_38: -0.0
+  sys_38: 0.0
   sys_39: 4.34163564e+00
   sys_40: -4.34163564e+00
   sys_41: 4.34163564e+00
@@ -15709,13 +15709,13 @@ bins:
   sys_45: 4.34163564e+00
   sys_46: -4.34163564e+00
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 4.34163564e+00
   sys_56: -4.34163564e+00
   sys_57: 4.34163564e+00
@@ -15731,57 +15731,57 @@ bins:
   sys_67: 4.34163564e+00
   sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 4.34163564e+00
   sys_78: -4.34163564e+00
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 3.03914495e+01
   sys_114: -2.60498138e+01
   sys_115: 5.20996276e+02
   sys_116: -4.77579920e+02
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: -1.73665425e+01
   sys_122: 2.17081782e+01
   sys_123: -6.07828989e+01
@@ -15797,15 +15797,15 @@ bins:
   sys_133: 1.30249069e+01
   sys_134: -1.30249069e+01
   sys_135: 0.0
-  sys_136: -0.0
+  sys_136: 0.0
   sys_137: 2.17081782e+01
   sys_138: -2.17081782e+01
   luminosity_uncertainty: 1.10520000e+02
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
@@ -15814,83 +15814,83 @@ bins:
   art_sys_11: 2.37026067e+00
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: -5.67694994e+00
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: -2.21383210e+01
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 6.88004975e+01
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 6.79426548e+00
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
   art_sys_32: -1.08646485e+00
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 5.72672639e-02
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 3.69348743e-03
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
   art_sys_48: -9.81332931e-05
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: -8.25164443e-05
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: -2.91006884e-05
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
   art_sys_65: -8.24371422e-06
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
+  art_sys_72: 0.0
   art_sys_73: 5.55643028e-07
-  art_sys_74: -0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
+  art_sys_76: 0.0
   art_sys_77: 4.38999593e-07
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 7.12822837e-08
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 3.92018610e-09
-  art_sys_88: -0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 1.59523290e+01
   sys_2: -1.59523290e+01
   sys_3: 3.78867813e+01
@@ -15900,7 +15900,7 @@ bins:
   sys_7: 1.19642467e+01
   sys_8: -1.19642467e+01
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 5.98212337e+00
   sys_12: -5.98212337e+00
   sys_13: 2.59225346e+01
@@ -15908,7 +15908,7 @@ bins:
   sys_15: 3.98808225e+00
   sys_16: -3.98808225e+00
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 1.19642467e+01
   sys_20: -9.97020561e+00
   sys_21: 1.99404112e+00
@@ -15926,9 +15926,9 @@ bins:
   sys_33: 0.0
   sys_34: -1.99404112e+00
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 0.0
-  sys_38: -0.0
+  sys_38: 0.0
   sys_39: 3.98808225e+00
   sys_40: -3.98808225e+00
   sys_41: 1.99404112e+00
@@ -15938,13 +15938,13 @@ bins:
   sys_45: 3.98808225e+00
   sys_46: -1.99404112e+00
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
   sys_56: -1.99404112e+00
   sys_57: 1.99404112e+00
@@ -15960,57 +15960,57 @@ bins:
   sys_67: 1.99404112e+00
   sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 1.99404112e+00
   sys_78: -1.99404112e+00
   sys_79: 0.0
   sys_80: -1.99404112e+00
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 1.39582879e+01
   sys_114: -1.39582879e+01
   sys_115: 2.39284935e+02
   sys_116: -2.19344524e+02
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: -7.97616449e+00
   sys_122: 9.97020561e+00
   sys_123: -2.79165757e+01
@@ -16026,15 +16026,15 @@ bins:
   sys_133: 3.98808225e+00
   sys_134: -3.98808225e+00
   sys_135: 0.0
-  sys_136: -0.0
+  sys_136: 0.0
   sys_137: 9.97020561e+00
   sys_138: -9.97020561e+00
   luminosity_uncertainty: 5.07600000e+01
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
@@ -16043,83 +16043,83 @@ bins:
   art_sys_11: -1.23682561e-01
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: -2.01230116e+00
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 4.15881071e+00
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 1.26644212e+01
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: -3.93721103e+01
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
   art_sys_32: 2.80465106e+00
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: -4.36143863e-01
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: -1.72570304e-02
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
   art_sys_48: -5.55025645e-04
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: -1.89921974e-04
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: 7.31993643e-05
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
   art_sys_65: 9.33566451e-07
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
+  art_sys_72: 0.0
   art_sys_73: 1.61604621e-06
-  art_sys_74: -0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
+  art_sys_76: 0.0
   art_sys_77: 5.89096510e-07
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: -8.32020540e-08
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: -3.47346911e-09
-  art_sys_88: -0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 7.12763635e+00
   sys_2: -7.12763635e+00
   sys_3: 2.13829091e+01
@@ -16129,7 +16129,7 @@ bins:
   sys_7: 5.09116882e+00
   sys_8: -5.09116882e+00
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 3.05470129e+00
   sys_12: -3.05470129e+00
   sys_13: 1.12005714e+01
@@ -16137,7 +16137,7 @@ bins:
   sys_15: 2.03646753e+00
   sys_16: -3.05470129e+00
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 5.09116882e+00
   sys_20: -5.09116882e+00
   sys_21: 1.01823376e+00
@@ -16167,15 +16167,15 @@ bins:
   sys_45: 2.03646753e+00
   sys_46: -2.03646753e+00
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 1.01823376e+00
   sys_58: -1.01823376e+00
   sys_59: 1.01823376e+00
@@ -16189,13 +16189,13 @@ bins:
   sys_67: 1.01823376e+00
   sys_68: -1.01823376e+00
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 1.01823376e+00
   sys_78: -1.01823376e+00
   sys_79: 0.0
@@ -16205,41 +16205,41 @@ bins:
   sys_83: 1.01823376e+00
   sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 7.12763635e+00
   sys_114: -7.12763635e+00
   sys_115: 1.22188052e+02
   sys_116: -1.12005714e+02
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: -4.07293506e+00
   sys_122: 5.09116882e+00
   sys_123: -1.42552727e+01
@@ -16255,15 +16255,15 @@ bins:
   sys_133: 2.03646753e+00
   sys_134: -2.03646753e+00
   sys_135: 0.0
-  sys_136: -0.0
+  sys_136: 0.0
   sys_137: 5.09116882e+00
   sys_138: -5.09116882e+00
   luminosity_uncertainty: 25.92
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
@@ -16272,83 +16272,83 @@ bins:
   art_sys_11: 1.89706708e-01
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: -4.29940313e-01
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 1.20519807e+00
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: -1.87521084e+00
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: -5.80882287e+00
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
   art_sys_32: -2.07399830e+01
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 1.33860944e+00
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 1.83095320e-01
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
   art_sys_48: -3.87932213e-04
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 1.32983776e-03
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: -1.19885874e-04
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
   art_sys_65: -3.04898435e-05
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
+  art_sys_72: 0.0
   art_sys_73: 3.71659240e-06
-  art_sys_74: -0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
+  art_sys_76: 0.0
   art_sys_77: -8.22742847e-07
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: -3.78076522e-07
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 6.72876271e-09
-  art_sys_88: -0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 2.91469415e+00
   sys_2: -2.91469415e+00
   sys_3: 1.11729942e+01
@@ -16358,7 +16358,7 @@ bins:
   sys_7: 2.42891179e+00
   sys_8: -2.42891179e+00
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 9.71564717e-01
   sys_12: -1.45734708e+00
   sys_13: 4.85782359e+00
@@ -16366,7 +16366,7 @@ bins:
   sys_15: 1.45734708e+00
   sys_16: -1.45734708e+00
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 2.42891179e+00
   sys_20: -2.42891179e+00
   sys_21: 4.85782359e-01
@@ -16396,17 +16396,17 @@ bins:
   sys_45: 1.45734708e+00
   sys_46: -1.45734708e+00
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 4.85782359e-01
   sys_60: -4.85782359e-01
   sys_61: 4.85782359e-01
@@ -16418,13 +16418,13 @@ bins:
   sys_67: 9.71564717e-01
   sys_68: -4.85782359e-01
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 4.85782359e-01
   sys_78: -4.85782359e-01
   sys_79: 4.85782359e-01
@@ -16436,39 +16436,39 @@ bins:
   sys_85: 4.85782359e-01
   sys_86: -4.85782359e-01
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 2.91469415e+00
   sys_114: -2.91469415e+00
   sys_115: 5.82938830e+01
   sys_116: -5.34360595e+01
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: -1.94312943e+00
   sys_122: 2.42891179e+00
   sys_123: -7.28673538e+00
@@ -16484,15 +16484,15 @@ bins:
   sys_133: 9.71564717e-01
   sys_134: -9.71564717e-01
   sys_135: 0.0
-  sys_136: -0.0
+  sys_136: 0.0
   sys_137: 2.42891179e+00
   sys_138: -2.42891179e+00
   luminosity_uncertainty: 1.23660000e+01
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
@@ -16501,83 +16501,83 @@ bins:
   art_sys_11: 3.44222239e-02
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: -3.53092675e-02
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 1.83821823e-02
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: -3.82806679e-01
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 9.20211168e-01
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
   art_sys_32: -2.81729485e+00
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: -1.04761471e+01
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: -5.13238656e-01
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
   art_sys_48: -4.20263416e-02
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: -2.36760669e-03
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: -9.22751094e-05
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
   art_sys_65: 2.07729945e-05
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
+  art_sys_72: 0.0
   art_sys_73: 8.21937211e-06
-  art_sys_74: -0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
+  art_sys_76: 0.0
   art_sys_77: 1.10751250e-06
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: -1.01860325e-07
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 8.39216964e-09
-  art_sys_88: -0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 1.44674047e+00
   sys_2: -1.44674047e+00
   sys_3: 6.02808531e+00
@@ -16587,7 +16587,7 @@ bins:
   sys_7: 9.64493650e-01
   sys_8: -9.64493650e-01
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 4.82246825e-01
   sys_12: -4.82246825e-01
   sys_13: 2.17011071e+00
@@ -16595,7 +16595,7 @@ bins:
   sys_15: 7.23370237e-01
   sys_16: -9.64493650e-01
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 1.20561706e+00
   sys_20: -1.20561706e+00
   sys_21: 2.41123412e-01
@@ -16625,17 +16625,17 @@ bins:
   sys_45: 7.23370237e-01
   sys_46: -7.23370237e-01
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 2.41123412e-01
   sys_60: -2.41123412e-01
   sys_61: 2.41123412e-01
@@ -16647,13 +16647,13 @@ bins:
   sys_67: 4.82246825e-01
   sys_68: -2.41123412e-01
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 2.41123412e-01
   sys_78: -2.41123412e-01
   sys_79: 2.41123412e-01
@@ -16667,37 +16667,37 @@ bins:
   sys_87: 0.0
   sys_88: -2.41123412e-01
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 1.44674047e+00
   sys_114: -1.44674047e+00
   sys_115: 2.89348095e+01
   sys_116: -2.65235754e+01
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: -7.23370237e-01
   sys_122: 1.20561706e+00
   sys_123: -3.85797460e+00
@@ -16713,15 +16713,15 @@ bins:
   sys_133: 4.82246825e-01
   sys_134: -4.82246825e-01
   sys_135: 0.0
-  sys_136: -0.0
+  sys_136: 0.0
   sys_137: 1.20561706e+00
   sys_138: -1.20561706e+00
   luminosity_uncertainty: 6.13800000e+00
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
@@ -16730,83 +16730,83 @@ bins:
   art_sys_11: -4.26261348e-02
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: -3.78322062e-02
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: -4.99806505e-02
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 1.83227932e-02
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 1.56455053e-01
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
   art_sys_32: 4.48493738e-01
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: -1.07499026e+00
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 5.29032997e+00
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
   art_sys_48: 1.13699489e-01
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 3.17628351e-02
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: -7.09890408e-04
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
   art_sys_65: -1.43014484e-04
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
+  art_sys_72: 0.0
   art_sys_73: 1.26575439e-05
-  art_sys_74: -0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
+  art_sys_76: 0.0
   art_sys_77: 4.77472112e-06
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: -1.76815490e-06
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: -2.33251710e-08
-  art_sys_88: -0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 5.30330086e-01
   sys_2: -5.30330086e-01
   sys_3: 2.86378246e+00
@@ -16816,7 +16816,7 @@ bins:
   sys_7: 3.18198052e-01
   sys_8: -4.24264069e-01
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 2.12132034e-01
   sys_12: -2.12132034e-01
   sys_13: 8.48528137e-01
@@ -16824,7 +16824,7 @@ bins:
   sys_15: 3.18198052e-01
   sys_16: -4.24264069e-01
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 5.30330086e-01
   sys_20: -5.30330086e-01
   sys_21: 1.06066017e-01
@@ -16854,17 +16854,17 @@ bins:
   sys_45: 3.18198052e-01
   sys_46: -3.18198052e-01
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
   sys_60: -1.06066017e-01
   sys_61: 1.06066017e-01
@@ -16876,13 +16876,13 @@ bins:
   sys_67: 2.12132034e-01
   sys_68: -2.12132034e-01
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
   sys_78: -1.06066017e-01
   sys_79: 1.06066017e-01
@@ -16896,37 +16896,37 @@ bins:
   sys_87: 1.06066017e-01
   sys_88: -1.06066017e-01
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 6.36396103e-01
   sys_114: -6.36396103e-01
   sys_115: 1.27279221e+01
   sys_116: -1.16672619e+01
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: -3.18198052e-01
   sys_122: 4.24264069e-01
   sys_123: -1.69705627e+00
@@ -16942,15 +16942,15 @@ bins:
   sys_133: 2.12132034e-01
   sys_134: -2.12132034e-01
   sys_135: 0.0
-  sys_136: -0.0
+  sys_136: 0.0
   sys_137: 5.30330086e-01
   sys_138: -5.30330086e-01
   luminosity_uncertainty: 2.7
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
@@ -16959,83 +16959,83 @@ bins:
   art_sys_11: 5.07072742e-03
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 8.62605994e-03
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: -3.77119608e-03
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 1.83012396e-03
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 1.70692257e-03
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
   art_sys_32: 9.41898568e-02
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 1.70815093e-01
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 3.55861120e-01
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
   art_sys_48: -1.82516318e+00
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: -1.17675942e-01
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: 1.11312913e-02
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
   art_sys_65: 1.40460505e-04
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
+  art_sys_72: 0.0
   art_sys_73: -1.81214163e-05
-  art_sys_74: -0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
+  art_sys_76: 0.0
   art_sys_77: 4.41253808e-06
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 2.95108891e-06
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 4.99886735e-08
-  art_sys_88: -0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 1.79039437e-01
   sys_2: -1.79039437e-01
   sys_3: 1.29803592e+00
@@ -17045,7 +17045,7 @@ bins:
   sys_7: 1.34279578e-01
   sys_8: -1.34279578e-01
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 8.95197185e-02
   sys_12: -8.95197185e-02
   sys_13: 3.13319015e-01
@@ -17053,7 +17053,7 @@ bins:
   sys_15: 1.34279578e-01
   sys_16: -1.34279578e-01
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 2.23799296e-01
   sys_20: -2.23799296e-01
   sys_21: 4.47598592e-02
@@ -17083,17 +17083,17 @@ bins:
   sys_45: 1.79039437e-01
   sys_46: -1.79039437e-01
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
   sys_60: -4.47598592e-02
   sys_61: 4.47598592e-02
@@ -17105,15 +17105,15 @@ bins:
   sys_67: 8.95197185e-02
   sys_68: -8.95197185e-02
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
   sys_80: -4.47598592e-02
   sys_81: 4.47598592e-02
@@ -17127,35 +17127,35 @@ bins:
   sys_89: 4.47598592e-02
   sys_90: -4.47598592e-02
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 2.68559155e-01
   sys_114: -2.68559155e-01
   sys_115: 5.37118311e+00
   sys_116: -4.92358452e+00
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: -1.34279578e-01
   sys_122: 1.79039437e-01
   sys_123: -6.71397889e-01
@@ -17171,15 +17171,15 @@ bins:
   sys_133: 8.95197185e-02
   sys_134: -8.95197185e-02
   sys_135: 0.0
-  sys_136: -0.0
+  sys_136: 0.0
   sys_137: 2.23799296e-01
   sys_138: -2.23799296e-01
   luminosity_uncertainty: 1.13940000e+00
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
@@ -17188,83 +17188,83 @@ bins:
   art_sys_11: -1.72112671e-04
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: -2.40189713e-03
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: -9.43149334e-03
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 8.29446490e-03
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: -2.25323746e-03
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
   art_sys_32: 1.83356707e-02
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 2.73408436e-02
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: -1.23995592e-01
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
   art_sys_48: -2.15563571e-01
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 1.02220431e+00
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: -4.12383680e-02
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
   art_sys_65: -4.05735515e-03
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
+  art_sys_72: 0.0
   art_sys_73: -9.43846780e-05
-  art_sys_74: -0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
+  art_sys_76: 0.0
   art_sys_77: -2.38666196e-06
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: -2.78743069e-06
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 1.64409273e-07
-  art_sys_88: -0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 8.59841846e-02
   sys_2: -8.59841846e-02
   sys_3: 6.66377431e-01
@@ -17274,7 +17274,7 @@ bins:
   sys_7: 6.44881384e-02
   sys_8: -6.44881384e-02
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 2.14960461e-02
   sys_12: -2.14960461e-02
   sys_13: 1.28976277e-01
@@ -17282,7 +17282,7 @@ bins:
   sys_15: 6.44881384e-02
   sys_16: -6.44881384e-02
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 1.07480231e-01
   sys_20: -1.07480231e-01
   sys_21: 2.14960461e-02
@@ -17312,19 +17312,19 @@ bins:
   sys_45: 1.07480231e-01
   sys_46: -8.59841846e-02
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 2.14960461e-02
   sys_62: -2.14960461e-02
   sys_63: 2.14960461e-02
@@ -17334,15 +17334,15 @@ bins:
   sys_67: 4.29920923e-02
   sys_68: -4.29920923e-02
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
   sys_80: -2.14960461e-02
   sys_81: 2.14960461e-02
@@ -17356,35 +17356,35 @@ bins:
   sys_89: 2.14960461e-02
   sys_90: -4.29920923e-02
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 1.28976277e-01
   sys_114: -1.28976277e-01
   sys_115: 2.57952554e+00
   sys_116: -2.14960461e+00
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: -6.44881384e-02
   sys_122: 6.44881384e-02
   sys_123: -3.00944646e-01
@@ -17400,15 +17400,15 @@ bins:
   sys_133: 4.29920923e-02
   sys_134: -4.29920923e-02
   sys_135: 0.0
-  sys_136: -0.0
+  sys_136: 0.0
   sys_137: 1.07480231e-01
   sys_138: -1.07480231e-01
   luminosity_uncertainty: 0.5472
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
@@ -17417,83 +17417,83 @@ bins:
   art_sys_11: -2.38809486e-03
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 5.09633103e-03
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: -9.16298949e-03
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 1.98606442e-03
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 4.72702922e-03
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
   art_sys_32: -5.90701995e-03
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: -4.45676358e-03
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: -1.04285455e-02
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
   art_sys_48: 2.23791159e-02
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 8.64339671e-02
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: 5.08482032e-01
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
   art_sys_65: 1.00521977e-02
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
+  art_sys_72: 0.0
   art_sys_73: 1.36673291e-03
-  art_sys_74: -0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
+  art_sys_76: 0.0
   art_sys_77: 9.78069847e-05
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 1.95415916e-06
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 4.76338721e-08
-  art_sys_88: -0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 2.56679762e-02
   sys_2: -2.56679762e-02
   sys_3: 2.90903730e-01
@@ -17503,7 +17503,7 @@ bins:
   sys_7: 1.71119841e-02
   sys_8: -1.71119841e-02
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 8.55599205e-03
   sys_12: -8.55599205e-03
   sys_13: 4.27799603e-02
@@ -17511,7 +17511,7 @@ bins:
   sys_15: 2.56679762e-02
   sys_16: -2.56679762e-02
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 4.27799603e-02
   sys_20: -4.27799603e-02
   sys_21: 8.55599205e-03
@@ -17541,19 +17541,19 @@ bins:
   sys_45: 4.27799603e-02
   sys_46: -4.27799603e-02
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
   sys_52: -8.55599205e-03
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 8.55599205e-03
   sys_62: -8.55599205e-03
   sys_63: 8.55599205e-03
@@ -17563,17 +17563,17 @@ bins:
   sys_67: 1.71119841e-02
   sys_68: -1.71119841e-02
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 8.55599205e-03
   sys_82: -8.55599205e-03
   sys_83: 1.71119841e-02
@@ -17587,33 +17587,33 @@ bins:
   sys_91: 8.55599205e-03
   sys_92: -8.55599205e-03
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 5.98919444e-02
   sys_114: -5.98919444e-02
   sys_115: 1.02671905e+00
   sys_116: -8.55599205e-01
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: -2.56679762e-02
   sys_122: 2.56679762e-02
   sys_123: -1.11227897e-01
@@ -17629,15 +17629,15 @@ bins:
   sys_133: 1.71119841e-02
   sys_134: -1.71119841e-02
   sys_135: 0.0
-  sys_136: -0.0
+  sys_136: 0.0
   sys_137: 4.27799603e-02
   sys_138: -4.27799603e-02
   luminosity_uncertainty: 2.17800000e-01
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
@@ -17646,83 +17646,83 @@ bins:
   art_sys_11: -2.86526427e-05
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 1.66616724e-03
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: -2.98594765e-03
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: -2.86810562e-03
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 6.16518490e-04
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
   art_sys_32: 2.01777641e-03
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: -1.29831166e-03
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: -1.63067670e-03
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
   art_sys_48: 4.31328982e-03
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: -1.70182880e-02
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: 2.77021220e-02
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
   art_sys_65: -1.93062208e-01
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
+  art_sys_72: 0.0
   art_sys_73: -4.47023141e-03
-  art_sys_74: -0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
+  art_sys_76: 0.0
   art_sys_77: -1.22858535e-03
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 1.69099772e-05
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: -7.79627481e-07
-  art_sys_88: -0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 1.03944697e-02
   sys_2: -1.03944697e-02
   sys_3: 1.28198459e-01
@@ -17732,7 +17732,7 @@ bins:
   sys_7: 6.92964646e-03
   sys_8: -6.92964646e-03
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 3.46482323e-03
   sys_12: -3.46482323e-03
   sys_13: 1.73241161e-02
@@ -17740,7 +17740,7 @@ bins:
   sys_15: 1.03944697e-02
   sys_16: -1.03944697e-02
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 1.73241161e-02
   sys_20: -1.73241161e-02
   sys_21: 3.46482323e-03
@@ -17770,19 +17770,19 @@ bins:
   sys_45: 2.07889394e-02
   sys_46: -2.07889394e-02
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 3.46482323e-03
   sys_52: -3.46482323e-03
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 3.46482323e-03
   sys_62: 0.0
   sys_63: 3.46482323e-03
@@ -17792,17 +17792,17 @@ bins:
   sys_67: 6.92964646e-03
   sys_68: -6.92964646e-03
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 3.46482323e-03
   sys_82: -3.46482323e-03
   sys_83: 6.92964646e-03
@@ -17816,33 +17816,33 @@ bins:
   sys_91: 6.92964646e-03
   sys_92: -6.92964646e-03
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 3.46482323e-03
   sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 2.42537626e-02
   sys_114: -2.42537626e-02
   sys_115: 4.15778787e-01
   sys_116: -3.46482323e-01
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: -6.92964646e-03
   sys_122: 1.03944697e-02
   sys_123: -3.81130555e-02
@@ -17858,15 +17858,15 @@ bins:
   sys_133: 6.92964646e-03
   sys_134: -6.92964646e-03
   sys_135: 0.0
-  sys_136: -0.0
+  sys_136: 0.0
   sys_137: 1.73241161e-02
   sys_138: -1.73241161e-02
   luminosity_uncertainty: 8.82000000e-02
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
@@ -17875,83 +17875,83 @@ bins:
   art_sys_11: 4.23155727e-04
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: -5.65511840e-04
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: -6.65782519e-04
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: -8.20818411e-04
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 7.91161800e-04
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
   art_sys_32: 1.26254751e-03
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 1.18228895e-03
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: -7.46045385e-04
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
   art_sys_48: -7.45997841e-04
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: -1.18206259e-03
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: -6.59705252e-03
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
   art_sys_65: -1.03250804e-02
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
+  art_sys_72: 0.0
   art_sys_73: 8.70208991e-02
-  art_sys_74: -0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
+  art_sys_76: 0.0
   art_sys_77: 2.84577107e-03
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: -5.32419747e-04
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 3.33221921e-07
-  art_sys_88: -0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 3.86080303e-03
   sys_2: -3.86080303e-03
   sys_3: 5.27643080e-02
@@ -17961,7 +17961,7 @@ bins:
   sys_7: 2.57386868e-03
   sys_8: -2.57386868e-03
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 1.28693434e-03
   sys_12: -1.28693434e-03
   sys_13: 5.14773737e-03
@@ -17969,7 +17969,7 @@ bins:
   sys_15: 3.86080303e-03
   sys_16: -2.57386868e-03
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 7.72160605e-03
   sys_20: -7.72160605e-03
   sys_21: 2.57386868e-03
@@ -17999,19 +17999,19 @@ bins:
   sys_45: 9.00854039e-03
   sys_46: -9.00854039e-03
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 1.28693434e-03
   sys_52: -1.28693434e-03
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 1.28693434e-03
   sys_62: 0.0
   sys_63: 1.28693434e-03
@@ -18021,17 +18021,17 @@ bins:
   sys_67: 2.57386868e-03
   sys_68: -2.57386868e-03
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 1.28693434e-03
   sys_82: -1.28693434e-03
   sys_83: 2.57386868e-03
@@ -18045,33 +18045,33 @@ bins:
   sys_91: 5.14773737e-03
   sys_92: -5.14773737e-03
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 1.28693434e-03
   sys_100: -1.28693434e-03
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 1.02954747e-02
   sys_114: -1.02954747e-02
   sys_115: 1.54432121e-01
   sys_116: -1.28693434e-01
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: -2.57386868e-03
   sys_122: 2.57386868e-03
   sys_123: -1.15824091e-02
@@ -18087,15 +18087,15 @@ bins:
   sys_133: 2.57386868e-03
   sys_134: -2.57386868e-03
   sys_135: 0.0
-  sys_136: -0.0
+  sys_136: 0.0
   sys_137: 6.43467171e-03
   sys_138: -6.43467171e-03
   luminosity_uncertainty: 3.27600000e-02
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
@@ -18104,83 +18104,83 @@ bins:
   art_sys_11: 3.21937519e-05
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 4.71387127e-04
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 8.05642870e-04
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 8.66219433e-04
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: -2.33297601e-04
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
   art_sys_32: 3.51396400e-04
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: -2.63817757e-04
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 5.24884377e-04
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
   art_sys_48: -2.38103127e-04
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 4.73229993e-04
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: -6.98727479e-05
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
   art_sys_65: 4.20270264e-03
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
+  art_sys_72: 0.0
   art_sys_73: 5.20116947e-03
-  art_sys_74: -0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
+  art_sys_76: 0.0
   art_sys_77: -4.95060369e-02
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 1.16467374e-03
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: -1.50999986e-05
-  art_sys_88: -0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 1.49765216e-03
   sys_2: -9.98434775e-04
   sys_3: 2.24647824e-02
@@ -18190,7 +18190,7 @@ bins:
   sys_7: 9.98434775e-04
   sys_8: -9.98434775e-04
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 4.99217388e-04
   sys_12: -4.99217388e-04
   sys_13: 1.99686955e-03
@@ -18198,7 +18198,7 @@ bins:
   sys_15: 1.49765216e-03
   sys_16: -9.98434775e-04
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 2.99530433e-03
   sys_20: -2.99530433e-03
   sys_21: 9.98434775e-04
@@ -18228,19 +18228,19 @@ bins:
   sys_45: 3.99373910e-03
   sys_46: -3.99373910e-03
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 4.99217388e-04
   sys_52: -4.99217388e-04
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 4.99217388e-04
   sys_62: 0.0
   sys_63: 4.99217388e-04
@@ -18250,17 +18250,17 @@ bins:
   sys_67: 4.99217388e-04
   sys_68: -4.99217388e-04
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 4.99217388e-04
   sys_82: -4.99217388e-04
   sys_83: 9.98434775e-04
@@ -18274,33 +18274,33 @@ bins:
   sys_91: 2.99530433e-03
   sys_92: -2.99530433e-03
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 4.99217388e-04
   sys_100: -4.99217388e-04
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 4.99217388e-04
   sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 3.99373910e-03
   sys_114: -3.99373910e-03
   sys_115: 5.99060865e-02
   sys_116: -5.49139126e-02
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: -4.99217388e-04
   sys_122: 9.98434775e-04
   sys_123: -3.49452171e-03
@@ -18322,9 +18322,9 @@ bins:
   luminosity_uncertainty: 0.012708
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
@@ -18333,83 +18333,83 @@ bins:
   art_sys_11: 2.21087555e-04
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 1.58138588e-04
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 4.82841032e-05
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 2.56390419e-04
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 2.08041692e-04
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
   art_sys_32: 2.95201005e-04
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 8.26193202e-05
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: -2.94659728e-04
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
   art_sys_48: -1.99308000e-04
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: -9.25225280e-05
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: 2.12072163e-04
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
   art_sys_65: 3.00913493e-04
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
+  art_sys_72: 0.0
   art_sys_73: -1.69677812e-03
-  art_sys_74: -0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
+  art_sys_76: 0.0
   art_sys_77: -2.49111781e-03
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: -2.37758854e-02
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 2.38317378e-05
-  art_sys_88: -0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 3.45068109e-04
   sys_2: -3.45068109e-04
   sys_3: 8.45416868e-03
@@ -18419,7 +18419,7 @@ bins:
   sys_7: 3.45068109e-04
   sys_8: -3.45068109e-04
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 1.72534055e-04
   sys_12: -1.72534055e-04
   sys_13: 6.90136218e-04
@@ -18427,7 +18427,7 @@ bins:
   sys_15: 3.45068109e-04
   sys_16: -3.45068109e-04
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 1.20773838e-03
   sys_20: -1.03520433e-03
   sys_21: 3.45068109e-04
@@ -18457,17 +18457,17 @@ bins:
   sys_45: 1.72534055e-03
   sys_46: -1.72534055e-03
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 1.72534055e-04
   sys_52: -1.72534055e-04
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 1.72534055e-04
   sys_60: 0.0
   sys_61: 1.72534055e-04
@@ -18479,17 +18479,17 @@ bins:
   sys_67: 1.72534055e-04
   sys_68: -1.72534055e-04
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 1.72534055e-04
   sys_82: -1.72534055e-04
   sys_83: 3.45068109e-04
@@ -18503,33 +18503,33 @@ bins:
   sys_91: 1.38027244e-03
   sys_92: -1.38027244e-03
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 1.72534055e-04
   sys_100: -1.72534055e-04
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 1.72534055e-04
   sys_104: -1.72534055e-04
   sys_105: 1.72534055e-04
   sys_106: -1.72534055e-04
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 1.55280649e-03
   sys_114: -1.55280649e-03
   sys_115: 2.07040866e-02
   sys_116: -1.89787460e-02
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: -1.72534055e-04
   sys_122: 1.72534055e-04
   sys_123: -8.62670273e-04
@@ -18551,9 +18551,9 @@ bins:
   luminosity_uncertainty: 0.004392
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
@@ -18562,83 +18562,83 @@ bins:
   art_sys_11: 2.27773825e-05
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: -3.08479414e-05
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: -4.75510954e-06
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 6.16954980e-05
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 4.02807869e-05
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
   art_sys_32: -5.24997416e-05
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: -9.32401160e-06
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: -4.19067169e-05
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
   art_sys_48: -3.89749968e-05
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 4.94015305e-05
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: 9.51325399e-08
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
   art_sys_65: 2.64759986e-05
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
+  art_sys_72: 0.0
   art_sys_73: -2.52590857e-05
-  art_sys_74: -0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
+  art_sys_76: 0.0
   art_sys_77: 2.01643797e-04
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: -1.70762182e-04
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: -3.42229180e-03
-  art_sys_88: -0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 3.04055916e-05
   sys_2: -3.04055916e-05
   sys_3: 1.07939850e-03
@@ -18648,7 +18648,7 @@ bins:
   sys_7: 1.52027958e-05
   sys_8: -3.04055916e-05
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 1.52027958e-05
   sys_12: -1.52027958e-05
   sys_13: 6.08111832e-05
@@ -18656,7 +18656,7 @@ bins:
   sys_15: 1.52027958e-05
   sys_16: -3.04055916e-05
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 1.52027958e-04
   sys_20: -1.36825162e-04
   sys_21: 3.04055916e-05
@@ -18686,17 +18686,17 @@ bins:
   sys_45: 2.88853120e-04
   sys_46: -2.73650324e-04
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 1.52027958e-05
   sys_52: -3.04055916e-05
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 1.52027958e-05
   sys_60: -1.52027958e-05
   sys_61: 1.52027958e-05
@@ -18708,17 +18708,17 @@ bins:
   sys_67: 1.52027958e-05
   sys_68: -1.52027958e-05
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
   sys_82: -1.52027958e-05
   sys_83: 1.52027958e-05
@@ -18732,15 +18732,15 @@ bins:
   sys_91: 3.19258712e-04
   sys_92: -3.19258712e-04
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 1.52027958e-05
   sys_100: -1.52027958e-05
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 3.04055916e-05
   sys_104: -3.04055916e-05
   sys_105: 7.60139790e-05
@@ -18750,21 +18750,21 @@ bins:
   sys_109: 0.0
   sys_110: -1.52027958e-05
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 2.12839141e-04
   sys_114: -2.12839141e-04
   sys_115: 1.97636345e-03
   sys_116: -1.82433550e-03
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: 0.0
-  sys_122: -0.0
+  sys_122: 0.0
   sys_123: 3.04055916e-05
   sys_124: -6.08111832e-05
   sys_125: 0.0
-  sys_126: -0.0
+  sys_126: 0.0
   sys_127: 9.12167748e-05
   sys_128: -9.12167748e-05
   sys_129: 2.88853120e-04
@@ -18780,94 +18780,94 @@ bins:
   luminosity_uncertainty: 3.87000000e-04
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
   art_sys_18: 1.49862187e+02
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 2.06764197e+01
-  art_sys_23: -0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
   art_sys_27: 3.71626761e+00
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: 5.06153428e-03
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 9.61911284e-04
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 4.17149953e-05
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
   art_sys_67: 3.07025971e-06
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
   art_sys_86: 3.02921495e-09
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 2.63680119e+01
   sys_2: -3.11621958e+01
   sys_3: 3.59563798e+01
@@ -18883,7 +18883,7 @@ bins:
   sys_13: 4.31476558e+01
   sys_14: -4.79418398e+01
   sys_15: 0.0
-  sys_16: -0.0
+  sys_16: 0.0
   sys_17: 2.39709199e+00
   sys_18: -2.39709199e+00
   sys_19: 1.91767359e+01
@@ -18901,23 +18901,23 @@ bins:
   sys_31: 0.0
   sys_32: -2.39709199e+00
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
   sys_36: -2.39709199e+00
   sys_37: 0.0
-  sys_38: -0.0
+  sys_38: 0.0
   sys_39: 0.0
-  sys_40: -0.0
+  sys_40: 0.0
   sys_41: 0.0
-  sys_42: -0.0
+  sys_42: 0.0
   sys_43: 0.0
-  sys_44: -0.0
+  sys_44: 0.0
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 2.39709199e+00
   sys_52: -2.39709199e+00
   sys_53: 2.39709199e+00
@@ -18935,11 +18935,11 @@ bins:
   sys_65: 7.19127596e+00
   sys_66: -9.58836795e+00
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 2.39709199e+00
   sys_74: -2.39709199e+00
   sys_75: 0.0
@@ -18951,43 +18951,43 @@ bins:
   sys_81: 0.0
   sys_82: -2.39709199e+00
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
   sys_94: -2.39709199e+00
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 2.39709199e+01
   sys_114: -2.87651039e+01
   sys_115: 4.31476558e+02
   sys_116: -3.83534718e+02
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: -9.58836795e+00
   sys_122: 1.19854599e+01
   sys_123: -5.03389318e+01
@@ -19009,94 +19009,94 @@ bins:
   luminosity_uncertainty: 6.10200000e+01
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
   art_sys_18: 3.78759431e+01
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: -8.34742434e+01
-  art_sys_23: -0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
   art_sys_27: -1.08242828e+01
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: 5.46364825e-01
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 4.37183375e-03
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 2.54220642e-05
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
   art_sys_67: 5.71071172e-07
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
   art_sys_86: -2.59731501e-08
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 1.25865007e+01
   sys_2: -1.51038008e+01
   sys_3: 1.88797511e+01
@@ -19130,23 +19130,23 @@ bins:
   sys_31: 0.0
   sys_32: -1.25865007e+00
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
   sys_36: -1.25865007e+00
   sys_37: 0.0
-  sys_38: -0.0
+  sys_38: 0.0
   sys_39: 0.0
   sys_40: -1.25865007e+00
   sys_41: 0.0
-  sys_42: -0.0
+  sys_42: 0.0
   sys_43: 0.0
   sys_44: -1.25865007e+00
   sys_45: 1.25865007e+00
   sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 1.25865007e+00
   sys_52: -1.25865007e+00
   sys_53: 1.25865007e+00
@@ -19164,11 +19164,11 @@ bins:
   sys_65: 5.03460028e+00
   sys_66: -5.03460028e+00
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
   sys_74: -1.25865007e+00
   sys_75: 0.0
@@ -19180,43 +19180,43 @@ bins:
   sys_81: 0.0
   sys_82: -1.25865007e+00
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
   sys_94: -1.25865007e+00
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 1.13278506e+01
   sys_114: -1.51038008e+01
   sys_115: 2.26557013e+02
   sys_116: -2.01384011e+02
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: -5.03460028e+00
   sys_122: 6.29325035e+00
   sys_123: -2.51730014e+01
@@ -19238,94 +19238,94 @@ bins:
   luminosity_uncertainty: 3.20400000e+01
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
   art_sys_18: -3.07552504e+00
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: -2.11049840e+01
-  art_sys_23: -0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
   art_sys_27: 4.66288056e+01
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: -9.35108289e-01
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 2.92368151e-02
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 6.42178263e-04
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
   art_sys_67: 3.30260184e-06
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
   art_sys_86: -5.33727002e-09
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 5.88312842e+00
   sys_2: -7.05975410e+00
   sys_3: 1.00013183e+01
@@ -19359,11 +19359,11 @@ bins:
   sys_31: 5.88312842e-01
   sys_32: -5.88312842e-01
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
   sys_36: -5.88312842e-01
   sys_37: 0.0
-  sys_38: -0.0
+  sys_38: 0.0
   sys_39: 5.88312842e-01
   sys_40: -5.88312842e-01
   sys_41: 0.0
@@ -19373,9 +19373,9 @@ bins:
   sys_45: 5.88312842e-01
   sys_46: -5.88312842e-01
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 5.88312842e-01
   sys_52: -5.88312842e-01
   sys_53: 0.0
@@ -19395,9 +19395,9 @@ bins:
   sys_67: 5.88312842e-01
   sys_68: -5.88312842e-01
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
   sys_74: -5.88312842e-01
   sys_75: 0.0
@@ -19409,43 +19409,43 @@ bins:
   sys_81: 5.88312842e-01
   sys_82: -5.88312842e-01
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 5.29481558e+00
   sys_114: -6.47144126e+00
   sys_115: 1.05896312e+02
   sys_116: -9.41300547e+01
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: -1.76493853e+00
   sys_122: 2.94156421e+00
   sys_123: -1.05896312e+01
@@ -19467,94 +19467,94 @@ bins:
   luminosity_uncertainty: 1.49760000e+01
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
   art_sys_18: -1.32147505e+00
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 1.40091930e+00
-  art_sys_23: -0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
   art_sys_27: 2.68546225e+00
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: 1.84140486e+01
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 4.72072270e-02
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 2.51965782e-03
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
   art_sys_67: -1.80518292e-05
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
   art_sys_86: 6.61780487e-08
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 1.86464058e+00
   sys_2: -2.07182287e+00
   sys_3: 4.35082802e+00
@@ -19564,7 +19564,7 @@ bins:
   sys_7: 1.45027601e+00
   sys_8: -1.65745830e+00
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 8.28729148e-01
   sys_12: -8.28729148e-01
   sys_13: 3.31491659e+00
@@ -19572,7 +19572,7 @@ bins:
   sys_15: 2.07182287e-01
   sys_16: -4.14364574e-01
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 1.24309372e+00
   sys_20: -1.45027601e+00
   sys_21: 2.07182287e-01
@@ -19588,11 +19588,11 @@ bins:
   sys_31: 2.07182287e-01
   sys_32: -2.07182287e-01
   sys_33: 0.0
-  sys_34: -0.0
+  sys_34: 0.0
   sys_35: 0.0
   sys_36: -2.07182287e-01
   sys_37: 0.0
-  sys_38: -0.0
+  sys_38: 0.0
   sys_39: 2.07182287e-01
   sys_40: -4.14364574e-01
   sys_41: 2.07182287e-01
@@ -19602,9 +19602,9 @@ bins:
   sys_45: 2.07182287e-01
   sys_46: -2.07182287e-01
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
   sys_52: -2.07182287e-01
   sys_53: 0.0
@@ -19624,13 +19624,13 @@ bins:
   sys_67: 2.07182287e-01
   sys_68: -2.07182287e-01
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 2.07182287e-01
   sys_78: -2.07182287e-01
   sys_79: 2.07182287e-01
@@ -19638,43 +19638,43 @@ bins:
   sys_81: 2.07182287e-01
   sys_82: -2.07182287e-01
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 2.07182287e+00
   sys_114: -2.27900516e+00
   sys_115: 3.93646345e+01
   sys_116: -3.31491659e+01
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: -6.21546861e-01
   sys_122: 1.03591143e+00
   sys_123: -3.72928116e+00
@@ -19690,100 +19690,100 @@ bins:
   sys_133: 1.03591143e+00
   sys_134: -1.03591143e+00
   sys_135: 0.0
-  sys_136: -0.0
+  sys_136: 0.0
   sys_137: 1.03591143e+00
   sys_138: -1.03591143e+00
   luminosity_uncertainty: 5.27400000e+00
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
   art_sys_18: -3.08000966e-02
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 1.75259006e-01
-  art_sys_23: -0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
   art_sys_27: -2.83090956e-01
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: -1.65497567e-01
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 5.11474775e+00
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 1.26924195e-02
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
   art_sys_67: 2.19082476e-04
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
   art_sys_86: 1.09905922e-08
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 3.25269119e-01
   sys_2: -3.25269119e-01
   sys_3: 1.09778328e+00
@@ -19793,7 +19793,7 @@ bins:
   sys_7: 2.43951840e-01
   sys_8: -2.43951840e-01
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 1.21975920e-01
   sys_12: -1.21975920e-01
   sys_13: 6.09879599e-01
@@ -19801,7 +19801,7 @@ bins:
   sys_15: 1.21975920e-01
   sys_16: -1.21975920e-01
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 2.43951840e-01
   sys_20: -2.43951840e-01
   sys_21: 4.06586399e-02
@@ -19831,15 +19831,15 @@ bins:
   sys_45: 1.21975920e-01
   sys_46: -8.13172798e-02
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
   sys_52: -4.06586399e-02
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 4.06586399e-02
   sys_58: -4.06586399e-02
   sys_59: 4.06586399e-02
@@ -19853,13 +19853,13 @@ bins:
   sys_67: 8.13172798e-02
   sys_68: -8.13172798e-02
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 4.06586399e-02
   sys_78: -4.06586399e-02
   sys_79: 4.06586399e-02
@@ -19871,39 +19871,39 @@ bins:
   sys_85: 4.06586399e-02
   sys_86: -4.06586399e-02
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 4.47245039e-01
   sys_114: -4.06586399e-01
   sys_115: 8.53831438e+00
   sys_116: -7.31855519e+00
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: -1.21975920e-01
   sys_122: 2.03293200e-01
   sys_123: -8.13172798e-01
@@ -19919,100 +19919,100 @@ bins:
   sys_133: 1.21975920e-01
   sys_134: -1.21975920e-01
   sys_135: 0.0
-  sys_136: -0.0
+  sys_136: 0.0
   sys_137: 2.03293200e-01
   sys_138: -2.03293200e-01
   luminosity_uncertainty: 1.03500000e+00
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
   art_sys_18: -1.34277756e-03
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 7.90235306e-03
-  art_sys_23: -0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
   art_sys_27: -2.87818616e-02
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: -3.81100626e-02
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: -5.67834895e-02
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 1.14648575e+00
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
   art_sys_67: 1.01952026e-03
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
   art_sys_86: -6.97139213e-06
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 4.74680782e-02
   sys_2: -4.74680782e-02
   sys_3: 2.30559237e-01
@@ -20022,7 +20022,7 @@ bins:
   sys_7: 3.39057702e-02
   sys_8: -3.39057702e-02
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 2.03434621e-02
   sys_12: -1.35623081e-02
   sys_13: 8.13738484e-02
@@ -20030,7 +20030,7 @@ bins:
   sys_15: 3.39057702e-02
   sys_16: -3.39057702e-02
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 4.74680782e-02
   sys_20: -4.06869242e-02
   sys_21: 1.35623081e-02
@@ -20060,17 +20060,17 @@ bins:
   sys_45: 3.39057702e-02
   sys_46: -2.71246161e-02
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
   sys_52: -6.78115403e-03
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 6.78115403e-03
   sys_60: -6.78115403e-03
   sys_61: 6.78115403e-03
@@ -20082,13 +20082,13 @@ bins:
   sys_67: 2.03434621e-02
   sys_68: -2.03434621e-02
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 6.78115403e-03
   sys_78: -6.78115403e-03
   sys_79: 6.78115403e-03
@@ -20102,37 +20102,37 @@ bins:
   sys_87: 6.78115403e-03
   sys_88: -6.78115403e-03
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 8.81550024e-02
   sys_114: -8.13738484e-02
   sys_115: 1.55966543e+00
   sys_116: -1.28841927e+00
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: -2.03434621e-02
   sys_122: 3.39057702e-02
   sys_123: -1.42404235e-01
@@ -20148,100 +20148,100 @@ bins:
   sys_133: 2.03434621e-02
   sys_134: -2.03434621e-02
   sys_135: 0.0
-  sys_136: -0.0
+  sys_136: 0.0
   sys_137: 3.39057702e-02
   sys_138: -3.39057702e-02
   luminosity_uncertainty: 1.72620000e-01
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
   art_sys_18: -2.93370846e-03
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 1.97270885e-04
-  art_sys_23: -0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
   art_sys_27: -1.16638320e-04
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: 2.46999396e-03
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: -6.39250230e-03
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: -7.05379139e-03
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
   art_sys_67: 1.66116283e-01
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
   art_sys_86: -1.92373591e-05
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 5.68513852e-03
   sys_2: -6.63266161e-03
   sys_3: 3.97959696e-02
@@ -20251,7 +20251,7 @@ bins:
   sys_7: 4.73761543e-03
   sys_8: -4.73761543e-03
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 2.84256926e-03
   sys_12: -1.89504617e-03
   sys_13: 9.47523087e-03
@@ -20259,7 +20259,7 @@ bins:
   sys_15: 4.73761543e-03
   sys_16: -5.68513852e-03
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 6.63266161e-03
   sys_20: -7.58018469e-03
   sys_21: 1.89504617e-03
@@ -20289,17 +20289,17 @@ bins:
   sys_45: 5.68513852e-03
   sys_46: -6.63266161e-03
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 9.47523087e-04
   sys_52: -9.47523087e-04
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 9.47523087e-04
   sys_60: -9.47523087e-04
   sys_61: 9.47523087e-04
@@ -20311,13 +20311,13 @@ bins:
   sys_67: 3.79009235e-03
   sys_68: -2.84256926e-03
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 9.47523087e-04
   sys_78: -9.47523087e-04
   sys_79: 9.47523087e-04
@@ -20333,35 +20333,35 @@ bins:
   sys_89: 9.47523087e-04
   sys_90: -9.47523087e-04
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 1.42128463e-02
   sys_114: -1.42128463e-02
   sys_115: 2.36880772e-01
   sys_116: -1.89504617e-01
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: -2.84256926e-03
   sys_122: 4.73761543e-03
   sys_123: -2.17930310e-02
@@ -20383,94 +20383,94 @@ bins:
   luminosity_uncertainty: 2.41200000e-02
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
   art_sys_18: -4.08774582e-05
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 1.81653830e-04
-  art_sys_23: -0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
   art_sys_27: 3.21469826e-05
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: 1.08862236e-04
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 4.41251655e-05
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 0.0
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: -5.99879061e-04
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
-  art_sys_55: -0.0
+  art_sys_55: 0.0
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
   art_sys_67: -2.44540746e-04
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
   art_sys_86: -1.30969784e-02
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 1.59099026e-04
   sys_2: -2.54558441e-04
   sys_3: 1.94100811e-03
@@ -20480,7 +20480,7 @@ bins:
   sys_7: 9.54594155e-05
   sys_8: -1.90918831e-04
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 6.36396103e-05
   sys_12: -6.36396103e-05
   sys_13: 2.54558441e-04
@@ -20488,7 +20488,7 @@ bins:
   sys_15: 1.59099026e-04
   sys_16: -2.54558441e-04
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 2.86378246e-04
   sys_20: -3.81837662e-04
   sys_21: 9.54594155e-05
@@ -20518,19 +20518,19 @@ bins:
   sys_45: 3.18198052e-04
   sys_46: -4.13657467e-04
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 6.36396103e-05
   sys_52: -3.18198052e-05
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 3.18198052e-05
   sys_62: -3.18198052e-05
   sys_63: 6.36396103e-05
@@ -20540,17 +20540,17 @@ bins:
   sys_67: 1.27279221e-04
   sys_68: -9.54594155e-05
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 6.36396103e-05
   sys_82: -3.18198052e-05
   sys_83: 9.54594155e-05
@@ -20564,35 +20564,35 @@ bins:
   sys_91: 9.54594155e-05
   sys_92: -6.36396103e-05
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 6.36396103e-04
   sys_114: -7.00035713e-04
   sys_115: 9.86413960e-03
   sys_116: -7.95495129e-03
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: 0.0
-  sys_122: -0.0
+  sys_122: 0.0
   sys_123: -9.86413960e-04
   sys_124: 1.40007143e-03
   sys_125: 8.90954544e-04
@@ -20612,94 +20612,94 @@ bins:
   luminosity_uncertainty: 8.10000000e-04
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
+  art_sys_32: 0.0
   art_sys_33: 1.95703857e+01
-  art_sys_34: -0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 1.17015922e-03
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
   art_sys_55: 1.75380701e-03
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 2.71779798e-08
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 1.00197031e+00
   sys_2: -9.24895670e-01
   sys_3: 1.54149278e+00
@@ -20709,7 +20709,7 @@ bins:
   sys_7: 8.47821031e-01
   sys_8: -7.70746391e-01
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 4.62447835e-01
   sys_12: -3.85373196e-01
   sys_13: 1.54149278e+00
@@ -20717,7 +20717,7 @@ bins:
   sys_15: 0.0
   sys_16: -7.70746391e-02
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 6.93671752e-01
   sys_20: -6.16597113e-01
   sys_21: 7.70746391e-02
@@ -20735,27 +20735,27 @@ bins:
   sys_33: 0.0
   sys_34: -7.70746391e-02
   sys_35: 0.0
-  sys_36: -0.0
+  sys_36: 0.0
   sys_37: 0.0
-  sys_38: -0.0
+  sys_38: 0.0
   sys_39: 1.54149278e-01
   sys_40: -7.70746391e-02
   sys_41: 0.0
-  sys_42: -0.0
+  sys_42: 0.0
   sys_43: 1.54149278e-01
   sys_44: -7.70746391e-02
   sys_45: 0.0
-  sys_46: -0.0
+  sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 7.70746391e-02
   sys_52: 0.0
   sys_53: 0.0
   sys_54: -7.70746391e-02
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 1.54149278e-01
   sys_58: -7.70746391e-02
   sys_59: 2.31223917e-01
@@ -20767,59 +20767,59 @@ bins:
   sys_65: 3.85373196e-01
   sys_66: -3.85373196e-01
   sys_67: 0.0
-  sys_68: -0.0
+  sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 7.70746391e-02
   sys_78: -7.70746391e-02
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 1.23319423e+00
   sys_114: -1.23319423e+00
   sys_115: 2.00394062e+01
   sys_116: -1.61856742e+01
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: -2.31223917e-01
   sys_122: 2.31223917e-01
   sys_123: -1.92686598e+00
@@ -20841,94 +20841,94 @@ bins:
   luminosity_uncertainty: 1.96200000e+00
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
+  art_sys_32: 0.0
   art_sys_33: -8.42175261e-03
-  art_sys_34: -0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 2.43915516e+00
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
   art_sys_55: -2.12413806e-02
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 2.10810424e-06
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 8.27314934e-02
   sys_2: -7.58372023e-02
   sys_3: 1.79251569e-01
@@ -20938,7 +20938,7 @@ bins:
   sys_7: 6.89429112e-02
   sys_8: -5.51543289e-02
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 3.44714556e-02
   sys_12: -3.44714556e-02
   sys_13: 1.30991531e-01
@@ -20946,7 +20946,7 @@ bins:
   sys_15: 6.89429112e-03
   sys_16: -2.06828733e-02
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 6.20486200e-02
   sys_20: -5.51543289e-02
   sys_21: 6.89429112e-03
@@ -20966,7 +20966,7 @@ bins:
   sys_35: 6.89429112e-03
   sys_36: 0.0
   sys_37: 0.0
-  sys_38: -0.0
+  sys_38: 0.0
   sys_39: 2.06828733e-02
   sys_40: -6.89429112e-03
   sys_41: 6.89429112e-03
@@ -20976,15 +20976,15 @@ bins:
   sys_45: 6.89429112e-03
   sys_46: 0.0
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 6.89429112e-03
   sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 6.89429112e-03
   sys_58: -6.89429112e-03
   sys_59: 1.37885822e-02
@@ -20998,57 +20998,57 @@ bins:
   sys_67: 6.89429112e-03
   sys_68: 0.0
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 6.89429112e-03
   sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 0.0
-  sys_82: -0.0
+  sys_82: 0.0
   sys_83: 0.0
-  sys_84: -0.0
+  sys_84: 0.0
   sys_85: 0.0
-  sys_86: -0.0
+  sys_86: 0.0
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 1.24097240e-01
   sys_114: -1.24097240e-01
   sys_115: 2.06828733e+00
   sys_116: -1.58568696e+00
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: -2.06828733e-02
   sys_122: 2.06828733e-02
   sys_123: -1.51674405e-01
@@ -21070,94 +21070,94 @@ bins:
   luminosity_uncertainty: 1.75500000e-01
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
+  art_sys_32: 0.0
   art_sys_33: -3.96311273e-02
-  art_sys_34: -0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: 5.95117089e-02
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
   art_sys_55: 8.70567476e-01
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 7.45713266e-07
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 1.88231825e-02
   sys_2: -1.54007857e-02
   sys_3: 6.33143412e-02
@@ -21167,7 +21167,7 @@ bins:
   sys_7: 1.54007857e-02
   sys_8: -1.02671905e-02
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 6.84479364e-03
   sys_12: -5.13359523e-03
   sys_13: 2.73791746e-02
@@ -21175,7 +21175,7 @@ bins:
   sys_15: 6.84479364e-03
   sys_16: -8.55599205e-03
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 1.54007857e-02
   sys_20: -1.19783889e-02
   sys_21: 1.71119841e-03
@@ -21205,15 +21205,15 @@ bins:
   sys_45: 5.13359523e-03
   sys_46: -5.13359523e-03
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 1.71119841e-03
   sys_58: 0.0
   sys_59: 1.71119841e-03
@@ -21227,17 +21227,17 @@ bins:
   sys_67: 5.13359523e-03
   sys_68: -3.42239682e-03
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 3.42239682e-03
   sys_82: -1.71119841e-03
   sys_83: 3.42239682e-03
@@ -21245,39 +21245,39 @@ bins:
   sys_85: 1.71119841e-03
   sys_86: -1.71119841e-03
   sys_87: 0.0
-  sys_88: -0.0
+  sys_88: 0.0
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 3.93575634e-02
   sys_114: -3.93575634e-02
   sys_115: 6.33143412e-01
   sys_116: -4.79135555e-01
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: -5.13359523e-03
   sys_122: 5.13359523e-03
   sys_123: -4.10687619e-02
@@ -21299,94 +21299,94 @@ bins:
   luminosity_uncertainty: 0.04356
 - art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 0.0
-  art_sys_5: -0.0
+  art_sys_5: 0.0
   art_sys_6: 0.0
   art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
+  art_sys_11: 0.0
   art_sys_12: 0.0
   art_sys_13: 0.0
-  art_sys_14: -0.0
+  art_sys_14: 0.0
   art_sys_15: 0.0
-  art_sys_16: -0.0
+  art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
-  art_sys_20: -0.0
+  art_sys_20: 0.0
   art_sys_21: 0.0
-  art_sys_22: -0.0
-  art_sys_23: -0.0
+  art_sys_22: 0.0
+  art_sys_23: 0.0
   art_sys_24: 0.0
-  art_sys_25: -0.0
-  art_sys_26: -0.0
-  art_sys_27: -0.0
+  art_sys_25: 0.0
+  art_sys_26: 0.0
+  art_sys_27: 0.0
   art_sys_28: 0.0
   art_sys_29: 0.0
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 0.0
-  art_sys_32: -0.0
+  art_sys_32: 0.0
   art_sys_33: -3.08397967e-05
-  art_sys_34: -0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
   art_sys_36: 0.0
-  art_sys_37: -0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 0.0
-  art_sys_40: -0.0
+  art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 0.0
-  art_sys_46: -0.0
+  art_sys_46: 0.0
   art_sys_47: -3.30077403e-04
-  art_sys_48: -0.0
-  art_sys_49: -0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_48: 0.0
+  art_sys_49: 0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
-  art_sys_53: -0.0
+  art_sys_53: 0.0
   art_sys_54: 0.0
   art_sys_55: -3.84696921e-05
   art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
   art_sys_59: 0.0
-  art_sys_60: -0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 0.0
-  art_sys_63: -0.0
-  art_sys_64: -0.0
-  art_sys_65: -0.0
-  art_sys_66: -0.0
-  art_sys_67: -0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_63: 0.0
+  art_sys_64: 0.0
+  art_sys_65: 0.0
+  art_sys_66: 0.0
+  art_sys_67: 0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 0.0
-  art_sys_72: -0.0
-  art_sys_73: -0.0
-  art_sys_74: -0.0
+  art_sys_72: 0.0
+  art_sys_73: 0.0
+  art_sys_74: 0.0
   art_sys_75: 0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
   art_sys_79: 0.0
-  art_sys_80: -0.0
+  art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
   art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 1.57126897e-02
-  art_sys_86: -0.0
-  art_sys_87: -0.0
-  art_sys_88: -0.0
+  art_sys_86: 0.0
+  art_sys_87: 0.0
+  art_sys_88: 0.0
   art_sys_89: 0.0
-  art_sys_90: -0.0
+  art_sys_90: 0.0
   sys_1: 1.48492424e-04
   sys_2: -2.07889394e-04
   sys_3: 1.00974848e-03
@@ -21396,7 +21396,7 @@ bins:
   sys_7: 1.33643182e-04
   sys_8: -1.48492424e-04
   sys_9: 0.0
-  sys_10: -0.0
+  sys_10: 0.0
   sys_11: 1.48492424e-05
   sys_12: -1.48492424e-05
   sys_13: 2.37587878e-04
@@ -21404,7 +21404,7 @@ bins:
   sys_15: 1.48492424e-04
   sys_16: -1.78190909e-04
   sys_17: 0.0
-  sys_18: -0.0
+  sys_18: 0.0
   sys_19: 1.63341666e-04
   sys_20: -2.07889394e-04
   sys_21: 2.96984848e-05
@@ -21434,21 +21434,21 @@ bins:
   sys_45: 1.48492424e-04
   sys_46: -1.93040151e-04
   sys_47: 0.0
-  sys_48: -0.0
+  sys_48: 0.0
   sys_49: 0.0
-  sys_50: -0.0
+  sys_50: 0.0
   sys_51: 0.0
-  sys_52: -0.0
+  sys_52: 0.0
   sys_53: 0.0
-  sys_54: -0.0
+  sys_54: 0.0
   sys_55: 0.0
-  sys_56: -0.0
+  sys_56: 0.0
   sys_57: 0.0
-  sys_58: -0.0
+  sys_58: 0.0
   sys_59: 0.0
-  sys_60: -0.0
+  sys_60: 0.0
   sys_61: 0.0
-  sys_62: -0.0
+  sys_62: 0.0
   sys_63: 4.45477272e-05
   sys_64: -4.45477272e-05
   sys_65: 1.03944697e-04
@@ -21456,17 +21456,17 @@ bins:
   sys_67: 8.90954544e-05
   sys_68: -1.33643182e-04
   sys_69: 0.0
-  sys_70: -0.0
+  sys_70: 0.0
   sys_71: 0.0
-  sys_72: -0.0
+  sys_72: 0.0
   sys_73: 0.0
-  sys_74: -0.0
+  sys_74: 0.0
   sys_75: 0.0
-  sys_76: -0.0
+  sys_76: 0.0
   sys_77: 0.0
-  sys_78: -0.0
+  sys_78: 0.0
   sys_79: 0.0
-  sys_80: -0.0
+  sys_80: 0.0
   sys_81: 4.45477272e-05
   sys_82: -8.90954544e-05
   sys_83: 8.90954544e-05
@@ -21476,37 +21476,37 @@ bins:
   sys_87: 4.45477272e-05
   sys_88: -4.45477272e-05
   sys_89: 0.0
-  sys_90: -0.0
+  sys_90: 0.0
   sys_91: 0.0
-  sys_92: -0.0
+  sys_92: 0.0
   sys_93: 0.0
-  sys_94: -0.0
+  sys_94: 0.0
   sys_95: 0.0
-  sys_96: -0.0
+  sys_96: 0.0
   sys_97: 0.0
-  sys_98: -0.0
+  sys_98: 0.0
   sys_99: 0.0
-  sys_100: -0.0
+  sys_100: 0.0
   sys_101: 0.0
-  sys_102: -0.0
+  sys_102: 0.0
   sys_103: 0.0
-  sys_104: -0.0
+  sys_104: 0.0
   sys_105: 0.0
-  sys_106: -0.0
+  sys_106: 0.0
   sys_107: 0.0
-  sys_108: -0.0
+  sys_108: 0.0
   sys_109: 0.0
-  sys_110: -0.0
+  sys_110: 0.0
   sys_111: 0.0
-  sys_112: -0.0
+  sys_112: 0.0
   sys_113: 6.53366666e-04
   sys_114: -6.38517423e-04
   sys_115: 8.76105302e-03
   sys_116: -5.93969696e-03
   sys_117: 0.0
-  sys_118: -0.0
+  sys_118: 0.0
   sys_119: 0.0
-  sys_120: -0.0
+  sys_120: 0.0
   sys_121: 1.48492424e-05
   sys_122: -1.48492424e-05
   sys_123: -7.57311363e-04

--- a/nnpdf_data/nnpdf_data/commondata/ATLAS_WPWM_7TEV_46FB/uncertainties.yaml
+++ b/nnpdf_data/nnpdf_data/commondata/ATLAS_WPWM_7TEV_46FB/uncertainties.yaml
@@ -607,7 +607,7 @@ bins:
   sys_corr_68: -40.4005
   sys_corr_69: -28.8575
   sys_corr_70: -1.09658500e+02
-  sys_corr_71: -0.0
+  sys_corr_71: 0.0
   sys_corr_72: 132.7445
   sys_corr_73: 80.801
   sys_corr_74: 57.715
@@ -627,18 +627,18 @@ bins:
   sys_corr_88: 46.172
   sys_corr_89: 5.19435000e+01
   sys_corr_90: 17.3145
-  sys_corr_91: -0.0
+  sys_corr_91: 0.0
   sys_corr_92: 0.0
-  sys_corr_93: -0.0
+  sys_corr_93: 0.0
   sys_corr_94: 0.0
-  sys_corr_95: -0.0
+  sys_corr_95: 0.0
   sys_corr_96: 0.0
-  sys_corr_97: -0.0
+  sys_corr_97: 0.0
   sys_corr_98: 0.0
   sys_corr_99: 0.0
   sys_corr_100: 150.059
   sys_corr_101: 144.2875
-  sys_corr_102: -0.0
+  sys_corr_102: 0.0
   sys_corr_103: 57.715
   sys_corr_104: -28.8575
   sys_corr_105: -69.258
@@ -676,7 +676,7 @@ bins:
   sys_corr_3: 11.5374
   sys_corr_4: 11.5374
   sys_corr_5: 5.7687
-  sys_corr_6: -0.0
+  sys_corr_6: 0.0
   sys_corr_7: 28.8435
   sys_corr_8: -69.2244
   sys_corr_9: 6.69169200e+02
@@ -684,7 +684,7 @@ bins:
   sys_corr_11: -5.7687
   sys_corr_12: -46.1496
   sys_corr_13: 1.96135800e+02
-  sys_corr_14: -0.0
+  sys_corr_14: 0.0
   sys_corr_15: 6.63400500e+02
   sys_corr_16: 51.9183
   sys_corr_17: 17.3061
@@ -724,7 +724,7 @@ bins:
   sys_corr_51: 28.8435
   sys_corr_52: 1.67292300e+02
   sys_corr_53: -1.09605300e+02
-  sys_corr_54: -0.0
+  sys_corr_54: 0.0
   sys_corr_55: -1.55754900e+02
   sys_corr_56: -1.38448800e+02
   sys_corr_57: 28.8435
@@ -741,7 +741,7 @@ bins:
   sys_corr_68: -9.80679000e+01
   sys_corr_69: -2.48054100e+02
   sys_corr_70: -74.9931
-  sys_corr_71: -0.0
+  sys_corr_71: 0.0
   sys_corr_72: 149.9862
   sys_corr_73: 1.09605300e+02
   sys_corr_74: -28.8435
@@ -753,7 +753,7 @@ bins:
   sys_corr_80: 3.46122000e+02
   sys_corr_81: -51.9183
   sys_corr_82: -3.46122000e+02
-  sys_corr_83: -0.0
+  sys_corr_83: 0.0
   sys_corr_84: -11.5374
   sys_corr_85: 138.4488
   sys_corr_86: 28.8435
@@ -765,10 +765,10 @@ bins:
   sys_corr_92: 0.0
   sys_corr_93: 0.0
   sys_corr_94: 0.0
-  sys_corr_95: -0.0
+  sys_corr_95: 0.0
   sys_corr_96: 0.0
-  sys_corr_97: -0.0
-  sys_corr_98: -0.0
+  sys_corr_97: 0.0
+  sys_corr_98: 0.0
   sys_corr_99: 0.0
   sys_corr_100: 224.9793
   sys_corr_101: -17.3061
@@ -818,7 +818,7 @@ bins:
   sys_corr_11: -2.61787500e+02
   sys_corr_12: -104.715
   sys_corr_13: 191.9775
-  sys_corr_14: -0.0
+  sys_corr_14: 0.0
   sys_corr_15: 663.195
   sys_corr_16: 52.3575
   sys_corr_17: 17.4525
@@ -827,9 +827,9 @@ bins:
   sys_corr_20: 63.9925
   sys_corr_21: -23.27
   sys_corr_22: -17.4525
-  sys_corr_23: -0.0
+  sys_corr_23: 0.0
   sys_corr_24: -23.27
-  sys_corr_25: -0.0
+  sys_corr_25: 0.0
   sys_corr_26: 34.905
   sys_corr_27: -40.7225
   sys_corr_28: 29.0875
@@ -899,10 +899,10 @@ bins:
   sys_corr_92: 0.0
   sys_corr_93: 0.0
   sys_corr_94: 0.0
-  sys_corr_95: -0.0
+  sys_corr_95: 0.0
   sys_corr_96: 0.0
-  sys_corr_97: -0.0
-  sys_corr_98: -0.0
+  sys_corr_97: 0.0
+  sys_corr_98: 0.0
   sys_corr_99: 0.0
   sys_corr_100: 81.445
   sys_corr_101: -5.8175
@@ -952,7 +952,7 @@ bins:
   sys_corr_11: -4.92298800e+02
   sys_corr_12: -1.52378200e+02
   sys_corr_13: 1.81681700e+02
-  sys_corr_14: -0.0
+  sys_corr_14: 0.0
   sys_corr_15: 662.2591
   sys_corr_16: 5.27463000e+01
   sys_corr_17: 17.5821
@@ -1031,12 +1031,12 @@ bins:
   sys_corr_90: -5.86070000e+00
   sys_corr_91: -5.86070000e+00
   sys_corr_92: 0.0
-  sys_corr_93: -0.0
+  sys_corr_93: 0.0
   sys_corr_94: 0.0
-  sys_corr_95: -0.0
+  sys_corr_95: 0.0
   sys_corr_96: 0.0
-  sys_corr_97: -0.0
-  sys_corr_98: -0.0
+  sys_corr_97: 0.0
+  sys_corr_98: 0.0
   sys_corr_99: 0.0
   sys_corr_100: 29.3035
   sys_corr_101: 70.3284
@@ -1086,7 +1086,7 @@ bins:
   sys_corr_11: -6.86006100e+02
   sys_corr_12: -1.81762300e+02
   sys_corr_13: 164.1724
-  sys_corr_14: -0.0
+  sys_corr_14: 0.0
   sys_corr_15: 6.62552900e+02
   sys_corr_16: 4.69064000e+01
   sys_corr_17: 17.5899
@@ -1100,11 +1100,11 @@ bins:
   sys_corr_25: -17.5899
   sys_corr_26: 17.5899
   sys_corr_27: 1.17266000e+01
-  sys_corr_28: -0.0
+  sys_corr_28: 0.0
   sys_corr_29: -5.86330000e+00
   sys_corr_30: -5.86330000e+00
   sys_corr_31: -5.86330000e+00
-  sys_corr_32: -0.0
+  sys_corr_32: 0.0
   sys_corr_33: 1.17266000e+01
   sys_corr_34: 0.0
   sys_corr_35: 1.17266000e+01
@@ -1112,13 +1112,13 @@ bins:
   sys_corr_37: 2.57985200e+02
   sys_corr_38: 5.27697000e+01
   sys_corr_39: -6.44963000e+01
-  sys_corr_40: -0.0
+  sys_corr_40: 0.0
   sys_corr_41: 70.3596
   sys_corr_42: 4.69064000e+01
   sys_corr_43: -29.3165
   sys_corr_44: -4.69064000e+01
   sys_corr_45: -5.86330000e+00
-  sys_corr_46: -0.0
+  sys_corr_46: 0.0
   sys_corr_47: 1.17266000e+01
   sys_corr_48: -4.69064000e+01
   sys_corr_49: 1.17266000e+01
@@ -1165,13 +1165,13 @@ bins:
   sys_corr_90: 5.86330000e+00
   sys_corr_91: -1.17266000e+01
   sys_corr_92: 0.0
-  sys_corr_93: -0.0
-  sys_corr_94: -0.0
-  sys_corr_95: -0.0
+  sys_corr_93: 0.0
+  sys_corr_94: 0.0
+  sys_corr_95: 0.0
   sys_corr_96: 0.0
-  sys_corr_97: -0.0
-  sys_corr_98: -0.0
-  sys_corr_99: -0.0
+  sys_corr_97: 0.0
+  sys_corr_98: 0.0
+  sys_corr_99: 0.0
   sys_corr_100: -1.05539400e+02
   sys_corr_101: -35.1798
   sys_corr_102: 9.38128000e+01
@@ -1220,7 +1220,7 @@ bins:
   sys_corr_11: -8.74642200e+02
   sys_corr_12: -2.33637300e+02
   sys_corr_13: 143.7768
-  sys_corr_14: -0.0
+  sys_corr_14: 0.0
   sys_corr_15: 664.9677
   sys_corr_16: 47.9256
   sys_corr_17: 17.9721
@@ -1235,14 +1235,14 @@ bins:
   sys_corr_26: 17.9721
   sys_corr_27: 17.9721
   sys_corr_28: -11.9814
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
   sys_corr_31: -5.9907
   sys_corr_32: -5.9907
   sys_corr_33: 11.9814
   sys_corr_34: -5.9907
   sys_corr_35: 17.9721
-  sys_corr_36: -0.0
+  sys_corr_36: 0.0
   sys_corr_37: 8.98605000e+01
   sys_corr_38: -5.9907
   sys_corr_39: -65.8977
@@ -1299,12 +1299,12 @@ bins:
   sys_corr_90: -5.9907
   sys_corr_91: -11.9814
   sys_corr_92: 0.0
-  sys_corr_93: -0.0
-  sys_corr_94: -0.0
-  sys_corr_95: -0.0
+  sys_corr_93: 0.0
+  sys_corr_94: 0.0
+  sys_corr_95: 0.0
   sys_corr_96: 0.0
-  sys_corr_97: -0.0
-  sys_corr_98: -0.0
+  sys_corr_97: 0.0
+  sys_corr_98: 0.0
   sys_corr_99: 0.0
   sys_corr_100: -3.05525700e+02
   sys_corr_101: 17.9721
@@ -1354,7 +1354,7 @@ bins:
   sys_corr_11: -5.13205000e+02
   sys_corr_12: -190.96
   sys_corr_13: 113.3825
-  sys_corr_14: -0.0
+  sys_corr_14: 0.0
   sys_corr_15: 674.3275
   sys_corr_16: 47.74
   sys_corr_17: 17.9025
@@ -1435,15 +1435,15 @@ bins:
   sys_corr_92: 0.0
   sys_corr_93: 0.0
   sys_corr_94: 0.0
-  sys_corr_95: -0.0
+  sys_corr_95: 0.0
   sys_corr_96: 0.0
-  sys_corr_97: -0.0
-  sys_corr_98: -0.0
-  sys_corr_99: -0.0
+  sys_corr_97: 0.0
+  sys_corr_98: 0.0
+  sys_corr_99: 0.0
   sys_corr_100: 0.0
   sys_corr_101: 35.805
   sys_corr_102: 0.0
-  sys_corr_103: -0.0
+  sys_corr_103: 0.0
   sys_corr_104: -5.9675
   sys_corr_105: -5.9675
   sys_corr_106: 17.9025
@@ -1488,7 +1488,7 @@ bins:
   sys_corr_11: -1.02708900e+03
   sys_corr_12: -2.71876500e+02
   sys_corr_13: 1.02708900e+02
-  sys_corr_14: -0.0
+  sys_corr_14: 0.0
   sys_corr_15: 6.76670400e+02
   sys_corr_16: 48.3336
   sys_corr_17: 18.1251
@@ -1500,7 +1500,7 @@ bins:
   sys_corr_23: 12.0834
   sys_corr_24: -12.0834
   sys_corr_25: -12.0834
-  sys_corr_26: -0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: -12.0834
   sys_corr_29: 6.0417
@@ -1509,7 +1509,7 @@ bins:
   sys_corr_32: -18.1251
   sys_corr_33: -12.0834
   sys_corr_34: -72.5004
-  sys_corr_35: -0.0
+  sys_corr_35: 0.0
   sys_corr_36: -18.1251
   sys_corr_37: 9.06255000e+01
   sys_corr_38: -18.1251
@@ -1569,16 +1569,16 @@ bins:
   sys_corr_92: 0.0
   sys_corr_93: 0.0
   sys_corr_94: 0.0
-  sys_corr_95: -0.0
+  sys_corr_95: 0.0
   sys_corr_96: 0.0
-  sys_corr_97: -0.0
-  sys_corr_98: -0.0
-  sys_corr_99: -0.0
+  sys_corr_97: 0.0
+  sys_corr_98: 0.0
+  sys_corr_99: 0.0
   sys_corr_100: 277.9182
   sys_corr_101: 48.3336
   sys_corr_102: 6.0417
   sys_corr_103: -18.1251
-  sys_corr_104: -0.0
+  sys_corr_104: 0.0
   sys_corr_105: -6.0417
   sys_corr_106: 6.0417
   sys_corr_107: 193.3344
@@ -1622,7 +1622,7 @@ bins:
   sys_corr_11: -1.12282050e+03
   sys_corr_12: -2.91326400e+02
   sys_corr_13: 78.9009
-  sys_corr_14: -0.0
+  sys_corr_14: 0.0
   sys_corr_15: 6.37276500e+02
   sys_corr_16: 42.4851
   sys_corr_17: 1.21386000e+01
@@ -1635,7 +1635,7 @@ bins:
   sys_corr_24: -1.21386000e+01
   sys_corr_25: -6.06930000e+00
   sys_corr_26: 6.06930000e+00
-  sys_corr_27: -0.0
+  sys_corr_27: 0.0
   sys_corr_28: -18.2079
   sys_corr_29: 66.7623
   sys_corr_30: -1.21386000e+01
@@ -1701,12 +1701,12 @@ bins:
   sys_corr_90: 0.0
   sys_corr_91: -6.06930000e+00
   sys_corr_92: 0.0
-  sys_corr_93: -0.0
+  sys_corr_93: 0.0
   sys_corr_94: 0.0
-  sys_corr_95: -0.0
+  sys_corr_95: 0.0
   sys_corr_96: 0.0
-  sys_corr_97: -0.0
-  sys_corr_98: -0.0
+  sys_corr_97: 0.0
+  sys_corr_98: 0.0
   sys_corr_99: 0.0
   sys_corr_100: 18.2079
   sys_corr_101: 18.2079
@@ -1756,7 +1756,7 @@ bins:
   sys_corr_11: -1.14526200e+03
   sys_corr_12: -284.832
   sys_corr_13: 59.34
-  sys_corr_14: -0.0
+  sys_corr_14: 0.0
   sys_corr_15: 623.07
   sys_corr_16: 4.15380000e+01
   sys_corr_17: 11.868
@@ -1787,7 +1787,7 @@ bins:
   sys_corr_42: 29.67
   sys_corr_43: -71.208
   sys_corr_44: -5.34060000e+01
-  sys_corr_45: -0.0
+  sys_corr_45: 0.0
   sys_corr_46: -1.24614000e+02
   sys_corr_47: 59.34
   sys_corr_48: -1.12746000e+02
@@ -1832,16 +1832,16 @@ bins:
   sys_corr_87: 8.30760000e+01
   sys_corr_88: 5.34060000e+01
   sys_corr_89: 23.736
-  sys_corr_90: -0.0
-  sys_corr_91: -0.0
+  sys_corr_90: 0.0
+  sys_corr_91: 0.0
   sys_corr_92: 0.0
-  sys_corr_93: -0.0
-  sys_corr_94: -0.0
-  sys_corr_95: -0.0
+  sys_corr_93: 0.0
+  sys_corr_94: 0.0
+  sys_corr_95: 0.0
   sys_corr_96: 0.0
-  sys_corr_97: -0.0
-  sys_corr_98: -0.0
-  sys_corr_99: -0.0
+  sys_corr_97: 0.0
+  sys_corr_98: 0.0
+  sys_corr_99: 0.0
   sys_corr_100: 65.274
   sys_corr_101: -29.67
   sys_corr_102: -183.954
@@ -1878,10 +1878,10 @@ bins:
   sys_corr_133: 8.84166000e+02
 - stat: 6.57084036e+02
   sys_corr_1: 8.08147466e+02
-  sys_corr_2: -0.0
+  sys_corr_2: 0.0
   sys_corr_3: 3.90922000e+01
   sys_corr_4: 0.0
-  sys_corr_5: -0.0
+  sys_corr_5: 0.0
   sys_corr_6: -11.1692
   sys_corr_7: 22.3384
   sys_corr_8: -2.79230000e+01
@@ -1890,7 +1890,7 @@ bins:
   sys_corr_11: -1.04432020e+03
   sys_corr_12: -2.40137800e+02
   sys_corr_13: 3.90922000e+01
-  sys_corr_14: -0.0
+  sys_corr_14: 0.0
   sys_corr_15: 5.86383000e+02
   sys_corr_16: 3.35076000e+01
   sys_corr_17: 11.1692
@@ -1917,7 +1917,7 @@ bins:
   sys_corr_38: -1.67538000e+01
   sys_corr_39: -22.3384
   sys_corr_40: -5.5846
-  sys_corr_41: -0.0
+  sys_corr_41: 0.0
   sys_corr_42: 22.3384
   sys_corr_43: -1.00522800e+02
   sys_corr_44: -5.02614000e+01
@@ -1965,17 +1965,17 @@ bins:
   sys_corr_86: 1.67538000e+01
   sys_corr_87: 5.5846
   sys_corr_88: 8.37690000e+01
-  sys_corr_89: -0.0
+  sys_corr_89: 0.0
   sys_corr_90: 11.1692
-  sys_corr_91: -0.0
+  sys_corr_91: 0.0
   sys_corr_92: 0.0
-  sys_corr_93: -0.0
-  sys_corr_94: -0.0
-  sys_corr_95: -0.0
+  sys_corr_93: 0.0
+  sys_corr_94: 0.0
+  sys_corr_95: 0.0
   sys_corr_96: 0.0
-  sys_corr_97: -0.0
-  sys_corr_98: -0.0
-  sys_corr_99: -0.0
+  sys_corr_97: 0.0
+  sys_corr_98: 0.0
+  sys_corr_99: 0.0
   sys_corr_100: -1.45199600e+02
   sys_corr_101: -11.1692
   sys_corr_102: -9.49382000e+01
@@ -2015,7 +2015,7 @@ bins:
   sys_corr_2: -1.17841500e+02
   sys_corr_3: 4.3645
   sys_corr_4: 0.0
-  sys_corr_5: -0.0
+  sys_corr_5: 0.0
   sys_corr_6: -4.3645
   sys_corr_7: 26.187
   sys_corr_8: 82.9255
@@ -2024,7 +2024,7 @@ bins:
   sys_corr_11: -244.412
   sys_corr_12: -1.00383500e+02
   sys_corr_13: 2.05131500e+02
-  sys_corr_14: -0.0
+  sys_corr_14: 0.0
   sys_corr_15: 4.97553000e+02
   sys_corr_16: 4.80095000e+01
   sys_corr_17: 13.0935
@@ -2041,7 +2041,7 @@ bins:
   sys_corr_28: 8.729
   sys_corr_29: -8.729
   sys_corr_30: -4.3645
-  sys_corr_31: -0.0
+  sys_corr_31: 0.0
   sys_corr_32: -4.3645
   sys_corr_33: 8.729
   sys_corr_34: 4.3645
@@ -2103,12 +2103,12 @@ bins:
   sys_corr_90: 8.729
   sys_corr_91: -4.3645
   sys_corr_92: 0.0
-  sys_corr_93: -0.0
+  sys_corr_93: 0.0
   sys_corr_94: 0.0
-  sys_corr_95: -0.0
+  sys_corr_95: 0.0
   sys_corr_96: 0.0
-  sys_corr_97: -0.0
-  sys_corr_98: -0.0
+  sys_corr_97: 0.0
+  sys_corr_98: 0.0
   sys_corr_99: 0.0
   sys_corr_100: 61.103
   sys_corr_101: 109.1125
@@ -2158,7 +2158,7 @@ bins:
   sys_corr_11: -302.946
   sys_corr_12: -108.195
   sys_corr_13: 199.0788
-  sys_corr_14: -0.0
+  sys_corr_14: 0.0
   sys_corr_15: 484.7136
   sys_corr_16: 47.6058
   sys_corr_17: 12.9834
@@ -2174,8 +2174,8 @@ bins:
   sys_corr_27: -8.6556
   sys_corr_28: 8.6556
   sys_corr_29: -8.6556
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
   sys_corr_32: -4.3278
   sys_corr_33: 17.3112
   sys_corr_34: 4.3278
@@ -2237,12 +2237,12 @@ bins:
   sys_corr_90: 4.3278
   sys_corr_91: -8.6556
   sys_corr_92: 0.0
-  sys_corr_93: -0.0
-  sys_corr_94: -0.0
-  sys_corr_95: -0.0
+  sys_corr_93: 0.0
+  sys_corr_94: 0.0
+  sys_corr_95: 0.0
   sys_corr_96: 0.0
-  sys_corr_97: -0.0
-  sys_corr_98: -0.0
+  sys_corr_97: 0.0
+  sys_corr_98: 0.0
   sys_corr_99: 0.0
   sys_corr_100: 125.5062
   sys_corr_101: -4.3278
@@ -2283,7 +2283,7 @@ bins:
   sys_corr_2: -1.24494100e+02
   sys_corr_3: 3.00503000e+01
   sys_corr_4: 1.28787000e+01
-  sys_corr_5: -0.0
+  sys_corr_5: 0.0
   sys_corr_6: 8.5858
   sys_corr_7: 47.2219
   sys_corr_8: 107.3225
@@ -2292,7 +2292,7 @@ bins:
   sys_corr_11: -3.39139100e+02
   sys_corr_12: -1.28787000e+02
   sys_corr_13: 193.1805
-  sys_corr_14: -0.0
+  sys_corr_14: 0.0
   sys_corr_15: 4.85097700e+02
   sys_corr_16: 47.2219
   sys_corr_17: 1.28787000e+01
@@ -2321,7 +2321,7 @@ bins:
   sys_corr_40: 8.5858
   sys_corr_41: 55.8077
   sys_corr_42: 34.3432
-  sys_corr_43: -0.0
+  sys_corr_43: 0.0
   sys_corr_44: -2.14645000e+01
   sys_corr_45: 55.8077
   sys_corr_46: -4.2929
@@ -2353,7 +2353,7 @@ bins:
   sys_corr_72: 158.8373
   sys_corr_73: 167.4231
   sys_corr_74: 6.43935000e+01
-  sys_corr_75: -0.0
+  sys_corr_75: 0.0
   sys_corr_76: -2.57574000e+01
   sys_corr_77: -4.2929
   sys_corr_78: -34.3432
@@ -2372,11 +2372,11 @@ bins:
   sys_corr_91: -8.5858
   sys_corr_92: 0.0
   sys_corr_93: 0.0
-  sys_corr_94: -0.0
-  sys_corr_95: -0.0
+  sys_corr_94: 0.0
+  sys_corr_95: 0.0
   sys_corr_96: 0.0
-  sys_corr_97: -0.0
-  sys_corr_98: -0.0
+  sys_corr_97: 0.0
+  sys_corr_98: 0.0
   sys_corr_99: 0.0
   sys_corr_100: 17.1716
   sys_corr_101: 0.0
@@ -2426,7 +2426,7 @@ bins:
   sys_corr_11: -402.211
   sys_corr_12: -1.35481600e+02
   sys_corr_13: 182.0534
-  sys_corr_14: -0.0
+  sys_corr_14: 0.0
   sys_corr_15: 4.74185600e+02
   sys_corr_16: 4.65718000e+01
   sys_corr_17: 1.27014000e+01
@@ -2437,10 +2437,10 @@ bins:
   sys_corr_22: -21.169
   sys_corr_23: 1.27014000e+01
   sys_corr_24: -8.4676
-  sys_corr_25: -0.0
+  sys_corr_25: 0.0
   sys_corr_26: 1.27014000e+01
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
+  sys_corr_28: 0.0
   sys_corr_29: -4.2338
   sys_corr_30: -4.2338
   sys_corr_31: -4.2338
@@ -2505,12 +2505,12 @@ bins:
   sys_corr_90: -4.2338
   sys_corr_91: -8.4676
   sys_corr_92: 0.0
-  sys_corr_93: -0.0
-  sys_corr_94: -0.0
-  sys_corr_95: -0.0
+  sys_corr_93: 0.0
+  sys_corr_94: 0.0
+  sys_corr_95: 0.0
   sys_corr_96: 0.0
-  sys_corr_97: -0.0
-  sys_corr_98: -0.0
+  sys_corr_97: 0.0
+  sys_corr_98: 0.0
   sys_corr_99: 0.0
   sys_corr_100: -16.9352
   sys_corr_101: 4.65718000e+01
@@ -2560,7 +2560,7 @@ bins:
   sys_corr_11: -4.71549600e+02
   sys_corr_12: -1.57183200e+02
   sys_corr_13: 1.61319600e+02
-  sys_corr_14: -0.0
+  sys_corr_14: 0.0
   sys_corr_15: 471.5496
   sys_corr_16: 41.364
   sys_corr_17: 12.4092
@@ -2636,16 +2636,16 @@ bins:
   sys_corr_87: 70.3188
   sys_corr_88: 3.72276000e+01
   sys_corr_89: 8.2728
-  sys_corr_90: -0.0
+  sys_corr_90: 0.0
   sys_corr_91: -8.2728
   sys_corr_92: 0.0
-  sys_corr_93: -0.0
-  sys_corr_94: -0.0
-  sys_corr_95: -0.0
+  sys_corr_93: 0.0
+  sys_corr_94: 0.0
+  sys_corr_95: 0.0
   sys_corr_96: 0.0
-  sys_corr_97: -0.0
-  sys_corr_98: -0.0
-  sys_corr_99: -0.0
+  sys_corr_97: 0.0
+  sys_corr_98: 0.0
+  sys_corr_99: 0.0
   sys_corr_100: -66.1824
   sys_corr_101: -20.682
   sys_corr_102: 57.9096
@@ -2694,7 +2694,7 @@ bins:
   sys_corr_11: -5.18732800e+02
   sys_corr_12: -1.58051400e+02
   sys_corr_13: 137.7884
-  sys_corr_14: -0.0
+  sys_corr_14: 0.0
   sys_corr_15: 453.8912
   sys_corr_16: 4.45786000e+01
   sys_corr_17: 12.1578
@@ -2773,12 +2773,12 @@ bins:
   sys_corr_90: -4.0526
   sys_corr_91: -8.1052
   sys_corr_92: 0.0
-  sys_corr_93: -0.0
-  sys_corr_94: -0.0
-  sys_corr_95: -0.0
+  sys_corr_93: 0.0
+  sys_corr_94: 0.0
+  sys_corr_95: 0.0
   sys_corr_96: 0.0
-  sys_corr_97: -0.0
-  sys_corr_98: -0.0
+  sys_corr_97: 0.0
+  sys_corr_98: 0.0
   sys_corr_99: 0.0
   sys_corr_100: -1.78314400e+02
   sys_corr_101: 24.3156
@@ -2828,7 +2828,7 @@ bins:
   sys_corr_11: -4.73384400e+02
   sys_corr_12: -1.70728800e+02
   sys_corr_13: 108.6456
-  sys_corr_14: -0.0
+  sys_corr_14: 0.0
   sys_corr_15: 438.4626
   sys_corr_16: 4.26822000e+01
   sys_corr_17: 11.6406
@@ -2847,7 +2847,7 @@ bins:
   sys_corr_30: -11.6406
   sys_corr_31: -23.2812
   sys_corr_32: -7.7604
-  sys_corr_33: -0.0
+  sys_corr_33: 0.0
   sys_corr_34: -7.7604
   sys_corr_35: 4.26822000e+01
   sys_corr_36: 19.401
@@ -2881,7 +2881,7 @@ bins:
   sys_corr_64: 7.7604
   sys_corr_65: 23.2812
   sys_corr_66: -27.1614
-  sys_corr_67: -0.0
+  sys_corr_67: 0.0
   sys_corr_68: -23.2812
   sys_corr_69: -81.4842
   sys_corr_70: 3.8802
@@ -2904,28 +2904,28 @@ bins:
   sys_corr_87: 69.8436
   sys_corr_88: 46.5624
   sys_corr_89: 11.6406
-  sys_corr_90: -0.0
+  sys_corr_90: 0.0
   sys_corr_91: -7.7604
   sys_corr_92: 0.0
-  sys_corr_93: -0.0
-  sys_corr_94: -0.0
-  sys_corr_95: -0.0
+  sys_corr_93: 0.0
+  sys_corr_94: 0.0
+  sys_corr_95: 0.0
   sys_corr_96: 0.0
-  sys_corr_97: -0.0
-  sys_corr_98: -0.0
-  sys_corr_99: -0.0
+  sys_corr_97: 0.0
+  sys_corr_98: 0.0
+  sys_corr_99: 0.0
   sys_corr_100: -3.8802
   sys_corr_101: 27.1614
   sys_corr_102: 3.8802
   sys_corr_103: 3.8802
   sys_corr_104: -3.8802
-  sys_corr_105: -0.0
+  sys_corr_105: 0.0
   sys_corr_106: 3.8802
   sys_corr_107: -11.6406
   sys_corr_108: 23.2812
   sys_corr_109: 0.0
   sys_corr_110: -11.6406
-  sys_corr_111: -0.0
+  sys_corr_111: 0.0
   sys_corr_112: -11.6406
   sys_corr_113: -892.446
   sys_corr_114: -2.48332800e+02
@@ -2937,7 +2937,7 @@ bins:
   sys_corr_120: 430.7022
   sys_corr_121: 803.2014
   sys_corr_122: 287.1348
-  sys_corr_123: -0.0
+  sys_corr_123: 0.0
   sys_corr_124: -62.0832
   sys_corr_125: 6.59634000e+01
   sys_corr_126: 147.4476
@@ -2962,7 +2962,7 @@ bins:
   sys_corr_11: -5.62489900e+02
   sys_corr_12: -1.77429700e+02
   sys_corr_13: 94.3775
-  sys_corr_14: -0.0
+  sys_corr_14: 0.0
   sys_corr_15: 4.41686700e+02
   sys_corr_16: 41.5261
   sys_corr_17: 11.3253
@@ -2976,8 +2976,8 @@ bins:
   sys_corr_25: -3.7751
   sys_corr_26: 7.5502
   sys_corr_27: 3.7751
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
   sys_corr_30: -3.7751
   sys_corr_31: -3.7751
   sys_corr_32: -7.5502
@@ -3043,11 +3043,11 @@ bins:
   sys_corr_92: 0.0
   sys_corr_93: 0.0
   sys_corr_94: 0.0
-  sys_corr_95: -0.0
+  sys_corr_95: 0.0
   sys_corr_96: 0.0
-  sys_corr_97: -0.0
-  sys_corr_98: -0.0
-  sys_corr_99: -0.0
+  sys_corr_97: 0.0
+  sys_corr_98: 0.0
+  sys_corr_99: 0.0
   sys_corr_100: 203.8554
   sys_corr_101: 41.5261
   sys_corr_102: -3.7751
@@ -3096,7 +3096,7 @@ bins:
   sys_corr_11: -5.45071800e+02
   sys_corr_12: -1.75593600e+02
   sys_corr_13: 73.164
-  sys_corr_14: -0.0
+  sys_corr_14: 0.0
   sys_corr_15: 402.402
   sys_corr_16: 40.2402
   sys_corr_17: 7.3164
@@ -3112,9 +3112,9 @@ bins:
   sys_corr_27: 7.3164
   sys_corr_28: -7.3164
   sys_corr_29: 7.3164
-  sys_corr_30: -0.0
+  sys_corr_30: 0.0
   sys_corr_31: -10.9746
-  sys_corr_32: -0.0
+  sys_corr_32: 0.0
   sys_corr_33: 7.3164
   sys_corr_34: -7.3164
   sys_corr_35: -7.3164
@@ -3168,19 +3168,19 @@ bins:
   sys_corr_83: -1.13404200e+02
   sys_corr_84: 3.6582
   sys_corr_85: -7.3164
-  sys_corr_86: -0.0
+  sys_corr_86: 0.0
   sys_corr_87: 73.164
   sys_corr_88: 43.8984
   sys_corr_89: 21.9492
   sys_corr_90: 3.6582
   sys_corr_91: -3.6582
   sys_corr_92: 0.0
-  sys_corr_93: -0.0
+  sys_corr_93: 0.0
   sys_corr_94: 0.0
-  sys_corr_95: -0.0
+  sys_corr_95: 0.0
   sys_corr_96: 0.0
-  sys_corr_97: -0.0
-  sys_corr_98: -0.0
+  sys_corr_97: 0.0
+  sys_corr_98: 0.0
   sys_corr_99: 0.0
   sys_corr_100: 5.48730000e+01
   sys_corr_101: 40.2402
@@ -3230,7 +3230,7 @@ bins:
   sys_corr_11: -596.331
   sys_corr_12: -196.479
   sys_corr_13: 51.705
-  sys_corr_14: -0.0
+  sys_corr_14: 0.0
   sys_corr_15: 3.89511000e+02
   sys_corr_16: 37.917
   sys_corr_17: 6.894
@@ -3265,7 +3265,7 @@ bins:
   sys_corr_46: -27.576
   sys_corr_47: 10.341
   sys_corr_48: -72.387
-  sys_corr_49: -0.0
+  sys_corr_49: 0.0
   sys_corr_50: 0.0
   sys_corr_51: 27.576
   sys_corr_52: 113.751
@@ -3307,14 +3307,14 @@ bins:
   sys_corr_88: 6.20460000e+01
   sys_corr_89: 13.788
   sys_corr_90: 0.0
-  sys_corr_91: -0.0
+  sys_corr_91: 0.0
   sys_corr_92: 0.0
   sys_corr_93: 0.0
-  sys_corr_94: -0.0
-  sys_corr_95: -0.0
+  sys_corr_94: 0.0
+  sys_corr_95: 0.0
   sys_corr_96: 0.0
-  sys_corr_97: -0.0
-  sys_corr_98: -0.0
+  sys_corr_97: 0.0
+  sys_corr_98: 0.0
   sys_corr_99: 0.0
   sys_corr_100: 34.47
   sys_corr_101: 17.235
@@ -3354,7 +3354,7 @@ bins:
   sys_corr_1: 6.18203808e+02
   sys_corr_2: 1.27616000e+01
   sys_corr_3: 5.74272000e+01
-  sys_corr_4: -0.0
+  sys_corr_4: 0.0
   sys_corr_5: -9.5712
   sys_corr_6: -15.952
   sys_corr_7: 38.2848
@@ -3364,7 +3364,7 @@ bins:
   sys_corr_11: -638.08
   sys_corr_12: -1.94614400e+02
   sys_corr_13: 3.50944000e+01
-  sys_corr_14: -0.0
+  sys_corr_14: 0.0
   sys_corr_15: 3.57324800e+02
   sys_corr_16: 3.50944000e+01
   sys_corr_17: 6.38080000e+00
@@ -3384,7 +3384,7 @@ bins:
   sys_corr_31: -3.19040000e+00
   sys_corr_32: -6.38080000e+00
   sys_corr_33: 15.952
-  sys_corr_34: -0.0
+  sys_corr_34: 0.0
   sys_corr_35: 1.27616000e+01
   sys_corr_36: -9.5712
   sys_corr_37: 9.25216000e+01
@@ -3441,15 +3441,15 @@ bins:
   sys_corr_88: 76.5696
   sys_corr_89: 3.19040000e+00
   sys_corr_90: 6.38080000e+00
-  sys_corr_91: -0.0
+  sys_corr_91: 0.0
   sys_corr_92: 0.0
   sys_corr_93: 0.0
-  sys_corr_94: -0.0
-  sys_corr_95: -0.0
+  sys_corr_94: 0.0
+  sys_corr_95: 0.0
   sys_corr_96: 0.0
-  sys_corr_97: -0.0
-  sys_corr_98: -0.0
-  sys_corr_99: -0.0
+  sys_corr_97: 0.0
+  sys_corr_98: 0.0
+  sys_corr_99: 0.0
   sys_corr_100: -5.74272000e+01
   sys_corr_101: 4.14752000e+01
   sys_corr_102: -4.78560000e+01

--- a/nnpdf_data/nnpdf_data/commondata/ATLAS_Z0J_8TEV/uncertainties_PT-M.yaml
+++ b/nnpdf_data/nnpdf_data/commondata/ATLAS_Z0J_8TEV/uncertainties_PT-M.yaml
@@ -427,60 +427,60 @@ bins:
   sys_corr_15: 2.47041060e-04
   sys_corr_16: -9.05817220e-04
   sys_corr_17: -2.88214570e-04
-  sys_corr_18: -0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
   sys_corr_29: 0.0
   sys_corr_30: 0.0
-  sys_corr_31: -0.0
+  sys_corr_31: 0.0
   sys_corr_32: 0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: 0.0
-  sys_corr_67: -0.0
-  sys_corr_68: -0.0
+  sys_corr_67: 0.0
+  sys_corr_68: 0.0
   sys_corr_69: 0.0
-  sys_corr_70: -0.0
-  sys_corr_71: -0.0
+  sys_corr_70: 0.0
+  sys_corr_71: 0.0
   sys_corr_72: -2.47041060e-04
   sys_corr_73: 2.05867550e-04
   sys_corr_74: -5.39372981e-03
@@ -530,60 +530,60 @@ bins:
   sys_corr_16: -2.22432630e-04
   sys_corr_17: 2.54208720e-04
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
-  sys_corr_20: -0.0
+  sys_corr_19: 0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
+  sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
+  sys_corr_30: 0.0
   sys_corr_31: 0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 0.0
   sys_corr_68: 0.0
-  sys_corr_69: -0.0
+  sys_corr_69: 0.0
   sys_corr_70: 0.0
   sys_corr_71: 0.0
-  sys_corr_72: -0.0
+  sys_corr_72: 0.0
   sys_corr_73: 1.27104360e-04
   sys_corr_74: -7.21317243e-03
   sys_corr_75: 1.31870774e-02
@@ -593,7 +593,7 @@ bins:
   sys_corr_79: 6.19633755e-03
   sys_corr_80: -9.53282700e-05
   sys_corr_81: -2.16077412e-03
-  sys_corr_82: -0.0
+  sys_corr_82: 0.0
   sys_corr_83: 5.02062222e-03
   sys_corr_84: -5.62436793e-03
   sys_corr_85: 2.17666216e-02
@@ -632,57 +632,57 @@ bins:
   sys_corr_16: -4.54853000e-05
   sys_corr_17: 5.00338300e-04
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
-  sys_corr_20: -0.0
+  sys_corr_19: 0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
   sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 0.0
   sys_corr_68: 0.0
-  sys_corr_69: -0.0
+  sys_corr_69: 0.0
   sys_corr_70: 0.0
   sys_corr_71: 0.0
   sys_corr_72: -6.82279500e-05
@@ -732,60 +732,60 @@ bins:
   sys_corr_14: -3.69636720e-04
   sys_corr_15: -1.54015300e-05
   sys_corr_16: -4.77447430e-04
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
-  sys_corr_22: -0.0
+  sys_corr_21: 0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
   sys_corr_29: 0.0
   sys_corr_30: 0.0
   sys_corr_31: 0.0
   sys_corr_32: 0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: 0.0
-  sys_corr_67: -0.0
-  sys_corr_68: -0.0
+  sys_corr_67: 0.0
+  sys_corr_68: 0.0
   sys_corr_69: 0.0
-  sys_corr_70: -0.0
+  sys_corr_70: 0.0
   sys_corr_71: 0.0
   sys_corr_72: 4.62045900e-05
   sys_corr_73: -3.08030600e-05
@@ -836,57 +836,57 @@ bins:
   sys_corr_16: 7.10394320e-05
   sys_corr_17: 1.95358438e-04
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
-  sys_corr_20: -0.0
+  sys_corr_19: 0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
+  sys_corr_30: 0.0
   sys_corr_31: 0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 0.0
   sys_corr_68: 0.0
-  sys_corr_69: -0.0
+  sys_corr_69: 0.0
   sys_corr_70: 0.0
   sys_corr_71: 0.0
   sys_corr_72: 9.76792190e-05
@@ -938,58 +938,58 @@ bins:
   sys_corr_16: 4.82420320e-05
   sys_corr_17: 2.11058890e-05
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
-  sys_corr_20: -0.0
+  sys_corr_19: 0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
   sys_corr_25: 0.0
-  sys_corr_26: -0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
   sys_corr_31: 0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
+  sys_corr_66: 0.0
   sys_corr_67: 0.0
   sys_corr_68: 0.0
-  sys_corr_69: -0.0
-  sys_corr_70: -0.0
+  sys_corr_69: 0.0
+  sys_corr_70: 0.0
   sys_corr_71: 0.0
   sys_corr_72: -1.20605080e-05
   sys_corr_73: 4.22117780e-05
@@ -1039,60 +1039,60 @@ bins:
   sys_corr_15: 3.96710936e-05
   sys_corr_16: 1.19761792e-05
   sys_corr_17: 1.87127800e-05
-  sys_corr_18: -0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
-  sys_corr_27: -0.0
+  sys_corr_27: 0.0
   sys_corr_28: 0.0
-  sys_corr_29: -0.0
+  sys_corr_29: 0.0
   sys_corr_30: 0.0
   sys_corr_31: 0.0
   sys_corr_32: 0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
-  sys_corr_67: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
+  sys_corr_67: 0.0
   sys_corr_68: 0.0
   sys_corr_69: 0.0
-  sys_corr_70: -0.0
-  sys_corr_71: -0.0
+  sys_corr_70: 0.0
+  sys_corr_71: 0.0
   sys_corr_72: 2.84434256e-05
   sys_corr_73: 3.81740712e-05
   sys_corr_74: 1.34732016e-04
@@ -1142,60 +1142,60 @@ bins:
   sys_corr_16: 1.27752020e-06
   sys_corr_17: 1.09169908e-06
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
-  sys_corr_20: -0.0
+  sys_corr_19: 0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
   sys_corr_25: 0.0
-  sys_corr_26: -0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
   sys_corr_31: 0.0
   sys_corr_32: -2.32276400e-08
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 0.0
   sys_corr_68: 0.0
-  sys_corr_69: -0.0
+  sys_corr_69: 0.0
   sys_corr_70: 0.0
   sys_corr_71: 0.0
-  sys_corr_72: -0.0
+  sys_corr_72: 0.0
   sys_corr_73: 3.48414600e-07
   sys_corr_74: 1.18925517e-05
   sys_corr_75: 2.93132817e-05
@@ -1245,53 +1245,53 @@ bins:
   sys_corr_17: -1.03649252e-02
   sys_corr_18: 1.94700252e-03
   sys_corr_19: -2.23332642e-03
-  sys_corr_20: -0.0
-  sys_corr_21: -0.0
-  sys_corr_22: -0.0
+  sys_corr_20: 0.0
+  sys_corr_21: 0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
   sys_corr_25: 0.0
   sys_corr_26: 0.0
-  sys_corr_27: -0.0
+  sys_corr_27: 0.0
   sys_corr_28: 0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
   sys_corr_31: 0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
   sys_corr_35: 0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
+  sys_corr_66: 0.0
   sys_corr_67: 0.0
   sys_corr_68: 0.0
   sys_corr_69: 0.0
@@ -1299,7 +1299,7 @@ bins:
   sys_corr_71: 0.0
   sys_corr_72: 0.0
   sys_corr_73: 0.0
-  sys_corr_74: -0.0
+  sys_corr_74: 0.0
   sys_corr_75: -8.58971700e-05
   sys_corr_76: -2.34785598e-03
   sys_corr_77: 1.38867092e-02
@@ -1347,60 +1347,60 @@ bins:
   sys_corr_17: -3.22478668e-03
   sys_corr_18: -8.83503200e-04
   sys_corr_19: 3.75488860e-04
-  sys_corr_20: -0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
   sys_corr_25: 0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
   sys_corr_28: 0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
   sys_corr_31: 0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
   sys_corr_35: 0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
-  sys_corr_67: -0.0
+  sys_corr_66: 0.0
+  sys_corr_67: 0.0
   sys_corr_68: 0.0
-  sys_corr_69: -0.0
+  sys_corr_69: 0.0
   sys_corr_70: 0.0
   sys_corr_71: 0.0
-  sys_corr_72: -0.0
-  sys_corr_73: -0.0
+  sys_corr_72: 0.0
+  sys_corr_73: 0.0
   sys_corr_74: 0.0
   sys_corr_75: 2.87138540e-04
   sys_corr_76: 2.71677234e-03
@@ -1449,60 +1449,60 @@ bins:
   sys_corr_17: -4.96797300e-03
   sys_corr_18: -2.02398900e-03
   sys_corr_19: -1.25732650e-03
-  sys_corr_20: -0.0
-  sys_corr_21: -0.0
+  sys_corr_20: 0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
   sys_corr_25: 0.0
   sys_corr_26: 0.0
-  sys_corr_27: -0.0
+  sys_corr_27: 0.0
   sys_corr_28: 0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
   sys_corr_31: 0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
   sys_corr_35: 0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
+  sys_corr_66: 0.0
   sys_corr_67: 0.0
   sys_corr_68: 0.0
   sys_corr_69: 0.0
   sys_corr_70: 0.0
   sys_corr_71: 0.0
-  sys_corr_72: -0.0
-  sys_corr_73: -0.0
+  sys_corr_72: 0.0
+  sys_corr_73: 0.0
   sys_corr_74: 0.0
   sys_corr_75: -2.60665250e-04
   sys_corr_76: -4.07864450e-03
@@ -1551,61 +1551,61 @@ bins:
   sys_corr_17: -2.51838220e-03
   sys_corr_18: 5.57259040e-04
   sys_corr_19: -9.21620720e-04
-  sys_corr_20: -0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
   sys_corr_25: 0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
   sys_corr_28: 0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
   sys_corr_31: 0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
   sys_corr_35: 0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
-  sys_corr_67: -0.0
+  sys_corr_66: 0.0
+  sys_corr_67: 0.0
   sys_corr_68: 0.0
   sys_corr_69: 0.0
   sys_corr_70: 0.0
   sys_corr_71: 0.0
   sys_corr_72: 0.0
-  sys_corr_73: -0.0
-  sys_corr_74: -0.0
+  sys_corr_73: 0.0
+  sys_corr_74: 0.0
   sys_corr_75: 1.50031280e-04
   sys_corr_76: 3.96511240e-04
   sys_corr_77: 2.48623264e-03
@@ -1653,60 +1653,60 @@ bins:
   sys_corr_17: 5.79209220e-04
   sys_corr_18: -6.75744090e-04
   sys_corr_19: -4.50496060e-04
-  sys_corr_20: -0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
   sys_corr_25: 0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
   sys_corr_28: 0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
   sys_corr_31: 0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
   sys_corr_35: 0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
-  sys_corr_67: -0.0
+  sys_corr_66: 0.0
+  sys_corr_67: 0.0
   sys_corr_68: 0.0
   sys_corr_69: 0.0
   sys_corr_70: 0.0
   sys_corr_71: 0.0
   sys_corr_72: 0.0
-  sys_corr_73: -0.0
+  sys_corr_73: 0.0
   sys_corr_74: 0.0
   sys_corr_75: 1.28713160e-05
   sys_corr_76: -2.57426320e-05
@@ -1757,58 +1757,58 @@ bins:
   sys_corr_19: 2.36265520e-04
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
   sys_corr_33: 0.0
   sys_corr_34: 0.0
   sys_corr_35: 0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: 0.0
-  sys_corr_67: -0.0
+  sys_corr_67: 0.0
   sys_corr_68: 0.0
-  sys_corr_69: -0.0
-  sys_corr_70: -0.0
-  sys_corr_71: -0.0
+  sys_corr_69: 0.0
+  sys_corr_70: 0.0
+  sys_corr_71: 0.0
   sys_corr_72: 0.0
-  sys_corr_73: -0.0
+  sys_corr_73: 0.0
   sys_corr_74: 0.0
   sys_corr_75: 8.02844000e-05
   sys_corr_76: 4.22066560e-04
@@ -1857,14 +1857,14 @@ bins:
   sys_corr_17: 8.41576764e-05
   sys_corr_18: 1.68315353e-04
   sys_corr_19: 4.98076044e-05
-  sys_corr_20: -0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
   sys_corr_25: 0.0
   sys_corr_26: 0.0
-  sys_corr_27: -0.0
+  sys_corr_27: 0.0
   sys_corr_28: 0.0
   sys_corr_29: 0.0
   sys_corr_30: 0.0
@@ -1872,44 +1872,44 @@ bins:
   sys_corr_32: 0.0
   sys_corr_33: 0.0
   sys_corr_34: 0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 0.0
-  sys_corr_68: -0.0
-  sys_corr_69: -0.0
+  sys_corr_68: 0.0
+  sys_corr_69: 0.0
   sys_corr_70: 0.0
-  sys_corr_71: -0.0
-  sys_corr_72: -0.0
+  sys_corr_71: 0.0
+  sys_corr_72: 0.0
   sys_corr_73: 0.0
   sys_corr_74: 0.0
   sys_corr_75: 2.46175516e-05
@@ -1960,58 +1960,58 @@ bins:
   sys_corr_18: -1.31356548e-06
   sys_corr_19: 6.18646968e-06
   sys_corr_20: 2.11865400e-08
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: -2.11865400e-08
   sys_corr_29: 0.0
   sys_corr_30: 0.0
-  sys_corr_31: -0.0
+  sys_corr_31: 0.0
   sys_corr_32: 0.0
   sys_corr_33: 0.0
   sys_corr_34: 0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
-  sys_corr_65: -0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
+  sys_corr_65: 0.0
   sys_corr_66: 0.0
   sys_corr_67: 0.0
-  sys_corr_68: -0.0
-  sys_corr_69: -0.0
-  sys_corr_70: -0.0
-  sys_corr_71: -0.0
-  sys_corr_72: -0.0
+  sys_corr_68: 0.0
+  sys_corr_69: 0.0
+  sys_corr_70: 0.0
+  sys_corr_71: 0.0
+  sys_corr_72: 0.0
   sys_corr_73: 0.0
   sys_corr_74: 0.0
   sys_corr_75: -2.96611560e-07
@@ -2061,58 +2061,58 @@ bins:
   sys_corr_17: -8.99755840e-04
   sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
   sys_corr_63: 0.0
-  sys_corr_64: -0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: 0.0
   sys_corr_67: 0.0
   sys_corr_68: 0.0
   sys_corr_69: 0.0
-  sys_corr_70: -0.0
-  sys_corr_71: -0.0
+  sys_corr_70: 0.0
+  sys_corr_71: 0.0
   sys_corr_72: 0.0
   sys_corr_73: 0.0
   sys_corr_74: 8.99755840e-04
@@ -2163,60 +2163,60 @@ bins:
   sys_corr_17: 3.02408632e-03
   sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
-  sys_corr_21: -0.0
-  sys_corr_22: -0.0
+  sys_corr_20: 0.0
+  sys_corr_21: 0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 0.0
   sys_corr_68: 0.0
-  sys_corr_69: -0.0
+  sys_corr_69: 0.0
   sys_corr_70: 0.0
   sys_corr_71: 0.0
-  sys_corr_72: -0.0
-  sys_corr_73: -0.0
+  sys_corr_72: 0.0
+  sys_corr_73: 0.0
   sys_corr_74: 6.21387600e-04
   sys_corr_75: -5.92389512e-03
   sys_corr_76: 1.71917236e-03
@@ -2264,61 +2264,61 @@ bins:
   sys_corr_16: 2.80672800e-04
   sys_corr_17: 1.16479212e-03
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
-  sys_corr_22: -0.0
+  sys_corr_21: 0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
-  sys_corr_67: -0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
+  sys_corr_67: 0.0
   sys_corr_68: 0.0
-  sys_corr_69: -0.0
+  sys_corr_69: 0.0
   sys_corr_70: 0.0
   sys_corr_71: 0.0
-  sys_corr_72: -0.0
-  sys_corr_73: -0.0
+  sys_corr_72: 0.0
+  sys_corr_73: 0.0
   sys_corr_74: -2.94706440e-04
   sys_corr_75: -2.69445888e-03
   sys_corr_76: 1.54370040e-04
@@ -2366,61 +2366,61 @@ bins:
   sys_corr_16: 4.87857010e-03
   sys_corr_17: 1.11133450e-03
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
   sys_corr_23: 0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
+  sys_corr_66: 0.0
   sys_corr_67: 0.0
-  sys_corr_68: -0.0
-  sys_corr_69: -0.0
+  sys_corr_68: 0.0
+  sys_corr_69: 0.0
   sys_corr_70: 0.0
-  sys_corr_71: -0.0
-  sys_corr_72: -0.0
-  sys_corr_73: -0.0
+  sys_corr_71: 0.0
+  sys_corr_72: 0.0
+  sys_corr_73: 0.0
   sys_corr_74: 6.68684319e-04
   sys_corr_75: -2.89135332e-03
   sys_corr_76: -1.13958877e-03
@@ -2469,58 +2469,58 @@ bins:
   sys_corr_17: 8.41952400e-05
   sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0
-  sys_corr_64: -0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
-  sys_corr_67: -0.0
+  sys_corr_66: 0.0
+  sys_corr_67: 0.0
   sys_corr_68: 0.0
   sys_corr_69: 0.0
-  sys_corr_70: -0.0
-  sys_corr_71: -0.0
+  sys_corr_70: 0.0
+  sys_corr_71: 0.0
   sys_corr_72: 0.0
   sys_corr_73: 0.0
   sys_corr_74: 3.70459056e-04
@@ -2570,59 +2570,59 @@ bins:
   sys_corr_16: 7.26731627e-04
   sys_corr_17: 2.87874301e-04
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
   sys_corr_25: 0.0
-  sys_corr_26: -0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: 0.0
-  sys_corr_67: -0.0
-  sys_corr_68: -0.0
-  sys_corr_69: -0.0
-  sys_corr_70: -0.0
-  sys_corr_71: -0.0
+  sys_corr_67: 0.0
+  sys_corr_68: 0.0
+  sys_corr_69: 0.0
+  sys_corr_70: 0.0
+  sys_corr_71: 0.0
   sys_corr_72: 0.0
   sys_corr_73: 0.0
   sys_corr_74: 2.05336914e-04
@@ -2673,58 +2673,58 @@ bins:
   sys_corr_17: -3.09156258e-05
   sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
   sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
+  sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0
-  sys_corr_64: -0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
-  sys_corr_67: -0.0
+  sys_corr_66: 0.0
+  sys_corr_67: 0.0
   sys_corr_68: 0.0
   sys_corr_69: 0.0
   sys_corr_70: 0.0
-  sys_corr_71: -0.0
+  sys_corr_71: 0.0
   sys_corr_72: 0.0
   sys_corr_73: 0.0
   sys_corr_74: 2.16951760e-06
@@ -2774,60 +2774,60 @@ bins:
   sys_corr_16: 6.90422838e-06
   sys_corr_17: 1.46276025e-06
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
-  sys_corr_20: -0.0
-  sys_corr_21: -0.0
+  sys_corr_19: 0.0
+  sys_corr_20: 0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
-  sys_corr_67: -0.0
+  sys_corr_66: 0.0
+  sys_corr_67: 0.0
   sys_corr_68: 0.0
   sys_corr_69: 0.0
   sys_corr_70: 0.0
-  sys_corr_71: -0.0
-  sys_corr_72: -0.0
+  sys_corr_71: 0.0
+  sys_corr_72: 0.0
   sys_corr_73: 0.0
   sys_corr_74: 1.56027760e-06
   sys_corr_75: -6.10458611e-06
@@ -2870,59 +2870,59 @@ bins:
   sys_corr_10: 6.64625552e-01
   sys_corr_11: 6.48255465e-02
   sys_corr_12: 0.0
-  sys_corr_13: -0.0
-  sys_corr_14: -0.0
-  sys_corr_15: -0.0
+  sys_corr_13: 0.0
+  sys_corr_14: 0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
+  sys_corr_17: 0.0
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
   sys_corr_25: 0.0
-  sys_corr_26: -0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
+  sys_corr_65: 0.0
   sys_corr_66: 0.0
   sys_corr_67: -3.60141925e-02
   sys_corr_68: 1.53878823e-01
@@ -2971,55 +2971,55 @@ bins:
   sys_corr_9: 5.43884978e-01
   sys_corr_10: -2.36257728e-01
   sys_corr_11: -4.38061204e-01
-  sys_corr_12: -0.0
-  sys_corr_13: -0.0
+  sys_corr_12: 0.0
+  sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
+  sys_corr_17: 0.0
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
-  sys_corr_20: -0.0
+  sys_corr_19: 0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0
@@ -3073,55 +3073,55 @@ bins:
   sys_corr_9: 6.02632440e-01
   sys_corr_10: -4.01754960e-01
   sys_corr_11: -3.33679814e-01
-  sys_corr_12: -0.0
+  sys_corr_12: 0.0
   sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
+  sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0
@@ -3175,56 +3175,56 @@ bins:
   sys_corr_9: 1.62239675e-01
   sys_corr_10: -1.24117784e-01
   sys_corr_11: -2.12773344e-02
-  sys_corr_12: -0.0
-  sys_corr_13: -0.0
+  sys_corr_12: 0.0
+  sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
+  sys_corr_17: 0.0
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
-  sys_corr_20: -0.0
+  sys_corr_19: 0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
@@ -3277,56 +3277,56 @@ bins:
   sys_corr_9: 1.48313924e-01
   sys_corr_10: 1.89658071e-01
   sys_corr_11: -3.69472297e-01
-  sys_corr_12: -0.0
-  sys_corr_13: -0.0
-  sys_corr_14: -0.0
-  sys_corr_15: -0.0
+  sys_corr_12: 0.0
+  sys_corr_13: 0.0
+  sys_corr_14: 0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
+  sys_corr_17: 0.0
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
   sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
@@ -3379,61 +3379,61 @@ bins:
   sys_corr_9: 1.42749456e-01
   sys_corr_10: -3.70091183e-02
   sys_corr_11: -6.34442028e-02
-  sys_corr_12: -0.0
+  sys_corr_12: 0.0
   sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
-  sys_corr_16: -0.0
+  sys_corr_15: 0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
   sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
+  sys_corr_66: 0.0
   sys_corr_67: -9.61275800e-04
   sys_corr_68: -9.61275800e-03
   sys_corr_69: 7.40182366e-02
@@ -3481,56 +3481,56 @@ bins:
   sys_corr_9: 9.69195045e-02
   sys_corr_10: 1.91245845e-02
   sys_corr_11: -7.29327375e-02
-  sys_corr_12: -0.0
+  sys_corr_12: 0.0
   sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
-  sys_corr_16: -0.0
-  sys_corr_17: -0.0
+  sys_corr_15: 0.0
+  sys_corr_16: 0.0
+  sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
@@ -3583,59 +3583,59 @@ bins:
   sys_corr_9: 7.20146214e-02
   sys_corr_10: 3.96410760e-03
   sys_corr_11: -8.06035212e-02
-  sys_corr_12: -0.0
+  sys_corr_12: 0.0
   sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
+  sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0
-  sys_corr_64: -0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: 0.0
   sys_corr_67: -6.60684600e-03
@@ -3685,56 +3685,56 @@ bins:
   sys_corr_9: 6.29466741e-02
   sys_corr_10: -7.04101500e-04
   sys_corr_11: -4.94279253e-02
-  sys_corr_12: -0.0
-  sys_corr_13: -0.0
+  sys_corr_12: 0.0
+  sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
+  sys_corr_17: 0.0
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
-  sys_corr_20: -0.0
+  sys_corr_19: 0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
@@ -3787,61 +3787,61 @@ bins:
   sys_corr_9: 4.96805155e-02
   sys_corr_10: 1.89689241e-03
   sys_corr_11: 2.75501041e-02
-  sys_corr_12: -0.0
+  sys_corr_12: 0.0
   sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
   sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
+  sys_corr_66: 0.0
   sys_corr_67: 2.34853346e-03
   sys_corr_68: 1.26459494e-02
   sys_corr_69: 3.08019196e-02
@@ -3889,11 +3889,11 @@ bins:
   sys_corr_9: 4.58295317e-02
   sys_corr_10: 3.75328062e-02
   sys_corr_11: -2.48337364e-03
-  sys_corr_12: -0.0
+  sys_corr_12: 0.0
   sys_corr_13: 0.0
   sys_corr_14: 0.0
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
@@ -3902,48 +3902,48 @@ bins:
   sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0
-  sys_corr_64: -0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
+  sys_corr_66: 0.0
   sys_corr_67: 7.90164340e-04
   sys_corr_68: 3.89438139e-03
   sys_corr_69: 1.05543380e-02
@@ -3991,11 +3991,11 @@ bins:
   sys_corr_9: 3.43355553e-02
   sys_corr_10: 3.92190025e-02
   sys_corr_11: -1.24925394e-03
-  sys_corr_12: -0.0
+  sys_corr_12: 0.0
   sys_corr_13: 0.0
   sys_corr_14: 0.0
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
@@ -4003,49 +4003,49 @@ bins:
   sys_corr_21: 0.0
   sys_corr_22: 0.0
   sys_corr_23: 0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0
-  sys_corr_64: -0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
+  sys_corr_66: 0.0
   sys_corr_67: 1.13568540e-03
   sys_corr_68: 4.65631014e-03
   sys_corr_69: 1.09025798e-02
@@ -4093,61 +4093,61 @@ bins:
   sys_corr_9: 2.85367794e-02
   sys_corr_10: 2.77405236e-02
   sys_corr_11: -9.76055460e-04
-  sys_corr_12: -0.0
+  sys_corr_12: 0.0
   sys_corr_13: 0.0
   sys_corr_14: 0.0
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
   sys_corr_22: 0.0
   sys_corr_23: 0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0
-  sys_corr_64: -0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
+  sys_corr_66: 0.0
   sys_corr_67: 3.85285050e-04
   sys_corr_68: 2.18328195e-03
   sys_corr_69: 6.49847451e-03
@@ -4195,61 +4195,61 @@ bins:
   sys_corr_9: 1.74753321e-02
   sys_corr_10: 1.10424835e-02
   sys_corr_11: 3.54322678e-03
-  sys_corr_12: -0.0
+  sys_corr_12: 0.0
   sys_corr_13: 0.0
   sys_corr_14: 0.0
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
   sys_corr_22: 0.0
   sys_corr_23: 0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
+  sys_corr_66: 0.0
   sys_corr_67: 8.77206630e-04
   sys_corr_68: 2.18441651e-03
   sys_corr_69: 7.51645681e-03
@@ -4297,11 +4297,11 @@ bins:
   sys_corr_9: 1.42645954e-02
   sys_corr_10: 5.29695072e-03
   sys_corr_11: -7.06260096e-03
-  sys_corr_12: -0.0
+  sys_corr_12: 0.0
   sys_corr_13: 0.0
   sys_corr_14: 0.0
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
@@ -4310,48 +4310,48 @@ bins:
   sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
   sys_corr_63: 0.0
-  sys_corr_64: -0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
+  sys_corr_66: 0.0
   sys_corr_67: -2.09090160e-04
   sys_corr_68: -1.35908604e-03
   sys_corr_69: 1.23130872e-03
@@ -4399,61 +4399,61 @@ bins:
   sys_corr_9: 8.20800609e-03
   sys_corr_10: 4.50700134e-03
   sys_corr_11: -9.98448837e-03
-  sys_corr_12: -0.0
+  sys_corr_12: 0.0
   sys_corr_13: 0.0
   sys_corr_14: 0.0
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
   sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
   sys_corr_63: 0.0
-  sys_corr_64: -0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
+  sys_corr_66: 0.0
   sys_corr_67: 4.11222750e-05
   sys_corr_68: -2.33574522e-03
   sys_corr_69: -3.61876020e-04
@@ -4503,59 +4503,59 @@ bins:
   sys_corr_11: -7.74768168e-03
   sys_corr_12: 0.0
   sys_corr_13: 0.0
-  sys_corr_14: -0.0
+  sys_corr_14: 0.0
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
   sys_corr_25: 0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: -1.32397092e-04
   sys_corr_68: -2.91273602e-03
   sys_corr_69: -2.64303824e-03
@@ -4603,61 +4603,61 @@ bins:
   sys_corr_9: 3.11789730e-04
   sys_corr_10: -1.97108450e-04
   sys_corr_11: -1.45322685e-03
-  sys_corr_12: -0.0
+  sys_corr_12: 0.0
   sys_corr_13: 0.0
   sys_corr_14: 0.0
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
   sys_corr_25: 0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
+  sys_corr_66: 0.0
   sys_corr_67: 1.75605710e-04
   sys_corr_68: -2.49073405e-04
   sys_corr_69: -6.57625465e-04
@@ -4705,61 +4705,61 @@ bins:
   sys_corr_9: 3.56939621e-04
   sys_corr_10: 2.83124912e-05
   sys_corr_11: -8.74653746e-04
-  sys_corr_12: -0.0
+  sys_corr_12: 0.0
   sys_corr_13: 0.0
   sys_corr_14: 0.0
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
   sys_corr_25: 0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
+  sys_corr_66: 0.0
   sys_corr_67: -1.36506654e-05
   sys_corr_68: -2.69474247e-04
   sys_corr_69: -2.20432967e-04
@@ -4807,61 +4807,61 @@ bins:
   sys_corr_9: 3.15331604e-05
   sys_corr_10: -2.67900632e-05
   sys_corr_11: 1.70039099e-05
-  sys_corr_12: -0.0
+  sys_corr_12: 0.0
   sys_corr_13: 0.0
   sys_corr_14: 0.0
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
-  sys_corr_21: -0.0
+  sys_corr_20: 0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
   sys_corr_23: 0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
+  sys_corr_66: 0.0
   sys_corr_67: 7.16151444e-06
   sys_corr_68: 5.26802502e-06
   sys_corr_69: 1.07422717e-05
@@ -4910,59 +4910,59 @@ bins:
   sys_corr_10: -2.36499676e-02
   sys_corr_11: -7.48111220e-03
   sys_corr_12: -9.65304800e-04
-  sys_corr_13: -0.0
+  sys_corr_13: 0.0
   sys_corr_14: 0.0
   sys_corr_15: 0.0
   sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
-  sys_corr_20: -0.0
-  sys_corr_21: -0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
+  sys_corr_20: 0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
   sys_corr_56: 0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
-  sys_corr_65: -0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
+  sys_corr_65: 0.0
   sys_corr_66: 1.37555934e-02
   sys_corr_67: -1.29109517e-02
   sys_corr_68: -1.62895185e-02
@@ -5012,57 +5012,57 @@ bins:
   sys_corr_10: 2.25930760e-02
   sys_corr_11: 2.43902525e-02
   sys_corr_12: -3.38896140e-02
-  sys_corr_13: -0.0
+  sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
-  sys_corr_16: -0.0
-  sys_corr_17: -0.0
+  sys_corr_15: 0.0
+  sys_corr_16: 0.0
+  sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
-  sys_corr_21: -0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
+  sys_corr_20: 0.0
+  sys_corr_21: 0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: -1.69448070e-02
@@ -5114,57 +5114,57 @@ bins:
   sys_corr_10: 6.93394980e-02
   sys_corr_11: -5.43839200e-04
   sys_corr_12: -3.50776284e-02
-  sys_corr_13: -0.0
+  sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
-  sys_corr_16: -0.0
-  sys_corr_17: -0.0
+  sys_corr_15: 0.0
+  sys_corr_16: 0.0
+  sys_corr_17: 0.0
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
-  sys_corr_20: -0.0
-  sys_corr_21: -0.0
+  sys_corr_19: 0.0
+  sys_corr_20: 0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: -7.88566840e-03
@@ -5216,57 +5216,57 @@ bins:
   sys_corr_10: 1.22018092e-01
   sys_corr_11: 3.15354910e-03
   sys_corr_12: -3.88129120e-02
-  sys_corr_13: -0.0
+  sys_corr_13: 0.0
   sys_corr_14: 0.0
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
-  sys_corr_17: -0.0
+  sys_corr_16: 0.0
+  sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
-  sys_corr_21: -0.0
+  sys_corr_20: 0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: -1.69806490e-02
@@ -5318,58 +5318,58 @@ bins:
   sys_corr_10: -1.10192232e-02
   sys_corr_11: 5.68246216e-02
   sys_corr_12: -2.13902568e-02
-  sys_corr_13: -0.0
+  sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
-  sys_corr_21: -0.0
+  sys_corr_20: 0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
   sys_corr_56: 0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: 8.42646480e-03
   sys_corr_67: -1.83653720e-02
@@ -5420,57 +5420,57 @@ bins:
   sys_corr_10: 2.42683560e-02
   sys_corr_11: 2.49568200e-02
   sys_corr_12: -2.08260360e-02
-  sys_corr_13: -0.0
+  sys_corr_13: 0.0
   sys_corr_14: 0.0
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
-  sys_corr_21: -0.0
+  sys_corr_20: 0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: -6.71252400e-03
@@ -5522,57 +5522,57 @@ bins:
   sys_corr_10: 5.11612368e-02
   sys_corr_11: 1.07634296e-02
   sys_corr_12: -1.94300872e-02
-  sys_corr_13: -0.0
+  sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
-  sys_corr_20: -0.0
-  sys_corr_21: -0.0
+  sys_corr_19: 0.0
+  sys_corr_20: 0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
   sys_corr_56: 0.0
-  sys_corr_57: -0.0
+  sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: -5.59139200e-04
@@ -5624,57 +5624,57 @@ bins:
   sys_corr_10: 2.28623132e-02
   sys_corr_11: 1.53134362e-02
   sys_corr_12: -1.04605867e-02
-  sys_corr_13: -0.0
+  sys_corr_13: 0.0
   sys_corr_14: 0.0
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
-  sys_corr_21: -0.0
+  sys_corr_20: 0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: -4.31364400e-04
@@ -5726,57 +5726,57 @@ bins:
   sys_corr_10: 1.61712533e-02
   sys_corr_11: 7.38788220e-03
   sys_corr_12: -1.24773122e-02
-  sys_corr_13: -0.0
+  sys_corr_13: 0.0
   sys_corr_14: 0.0
   sys_corr_15: 0.0
   sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
-  sys_corr_20: -0.0
-  sys_corr_21: -0.0
+  sys_corr_19: 0.0
+  sys_corr_20: 0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: 1.80592676e-03
@@ -5828,57 +5828,57 @@ bins:
   sys_corr_10: 2.31174989e-02
   sys_corr_11: 7.76650880e-03
   sys_corr_12: -3.39784760e-03
-  sys_corr_13: -0.0
+  sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
-  sys_corr_16: -0.0
+  sys_corr_15: 0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
-  sys_corr_21: -0.0
+  sys_corr_20: 0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
   sys_corr_56: 0.0
-  sys_corr_57: -0.0
+  sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: -1.21351700e-03
@@ -5930,59 +5930,59 @@ bins:
   sys_corr_10: 9.74661471e-03
   sys_corr_11: 1.42416288e-03
   sys_corr_12: -2.84832576e-03
-  sys_corr_13: -0.0
+  sys_corr_13: 0.0
   sys_corr_14: 0.0
   sys_corr_15: 0.0
   sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
-  sys_corr_20: -0.0
-  sys_corr_21: -0.0
+  sys_corr_19: 0.0
+  sys_corr_20: 0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
   sys_corr_56: 0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
-  sys_corr_65: -0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
+  sys_corr_65: 0.0
   sys_corr_66: 2.09173923e-03
   sys_corr_67: -4.76204463e-03
   sys_corr_68: -5.51863116e-03
@@ -6032,59 +6032,59 @@ bins:
   sys_corr_10: 9.56069009e-03
   sys_corr_11: 1.39757596e-03
   sys_corr_12: -9.84655790e-04
-  sys_corr_13: -0.0
+  sys_corr_13: 0.0
   sys_corr_14: 0.0
   sys_corr_15: 0.0
   sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
-  sys_corr_20: -0.0
-  sys_corr_21: -0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
+  sys_corr_20: 0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
   sys_corr_56: 0.0
-  sys_corr_57: -0.0
+  sys_corr_57: 0.0
   sys_corr_58: 0.0
-  sys_corr_59: -0.0
+  sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
+  sys_corr_65: 0.0
   sys_corr_66: 1.14347124e-03
   sys_corr_67: -4.12920170e-04
   sys_corr_68: -5.20914676e-03
@@ -6135,58 +6135,58 @@ bins:
   sys_corr_11: -6.09378560e-04
   sys_corr_12: 5.22324480e-04
   sys_corr_13: 0.0
-  sys_corr_14: -0.0
-  sys_corr_15: -0.0
-  sys_corr_16: -0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
+  sys_corr_14: 0.0
+  sys_corr_15: 0.0
+  sys_corr_16: 0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
-  sys_corr_22: -0.0
+  sys_corr_21: 0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
   sys_corr_25: 0.0
   sys_corr_26: 0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
   sys_corr_56: 0.0
-  sys_corr_57: -0.0
+  sys_corr_57: 0.0
   sys_corr_58: 0.0
-  sys_corr_59: -0.0
+  sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
+  sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
+  sys_corr_65: 0.0
   sys_corr_66: -6.09378560e-04
   sys_corr_67: 6.09378560e-04
   sys_corr_68: 1.52344640e-03
@@ -6237,58 +6237,58 @@ bins:
   sys_corr_11: 1.00710652e-03
   sys_corr_12: 1.00710652e-03
   sys_corr_13: 0.0
-  sys_corr_14: -0.0
-  sys_corr_15: -0.0
+  sys_corr_14: 0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
-  sys_corr_20: -0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
   sys_corr_56: 0.0
   sys_corr_57: 0.0
   sys_corr_58: 0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
   sys_corr_63: 0.0
-  sys_corr_64: -0.0
-  sys_corr_65: -0.0
+  sys_corr_64: 0.0
+  sys_corr_65: 0.0
   sys_corr_66: 9.77485740e-04
   sys_corr_67: -2.66587020e-04
   sys_corr_68: -5.96858717e-03
@@ -6339,56 +6339,56 @@ bins:
   sys_corr_11: -5.02162000e-05
   sys_corr_12: -3.51513400e-04
   sys_corr_13: 0.0
-  sys_corr_14: -0.0
-  sys_corr_15: -0.0
-  sys_corr_16: -0.0
-  sys_corr_17: -0.0
+  sys_corr_14: 0.0
+  sys_corr_15: 0.0
+  sys_corr_16: 0.0
+  sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
   sys_corr_25: 0.0
   sys_corr_26: 0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
   sys_corr_56: 0.0
-  sys_corr_57: -0.0
+  sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: -1.11479964e-03
@@ -6441,48 +6441,48 @@ bins:
   sys_corr_11: 1.48721412e-03
   sys_corr_12: 2.90188120e-05
   sys_corr_13: 0.0
-  sys_corr_14: -0.0
-  sys_corr_15: -0.0
-  sys_corr_16: -0.0
+  sys_corr_14: 0.0
+  sys_corr_15: 0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
-  sys_corr_22: -0.0
+  sys_corr_21: 0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
   sys_corr_25: 0.0
   sys_corr_26: 0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
   sys_corr_56: 0.0
   sys_corr_57: 0.0
   sys_corr_58: 0.0
@@ -6543,53 +6543,53 @@ bins:
   sys_corr_11: -9.75830800e-06
   sys_corr_12: 8.78247720e-04
   sys_corr_13: 0.0
-  sys_corr_14: -0.0
-  sys_corr_15: -0.0
-  sys_corr_16: -0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
+  sys_corr_14: 0.0
+  sys_corr_15: 0.0
+  sys_corr_16: 0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
   sys_corr_25: 0.0
   sys_corr_26: 0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0
@@ -6645,49 +6645,49 @@ bins:
   sys_corr_11: 1.06253250e-04
   sys_corr_12: 1.80630525e-04
   sys_corr_13: 0.0
-  sys_corr_14: -0.0
-  sys_corr_15: -0.0
-  sys_corr_16: -0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
+  sys_corr_14: 0.0
+  sys_corr_15: 0.0
+  sys_corr_16: 0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
   sys_corr_25: 0.0
   sys_corr_26: 0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
@@ -6747,49 +6747,49 @@ bins:
   sys_corr_11: 1.91372740e-04
   sys_corr_12: -1.18783080e-05
   sys_corr_13: 0.0
-  sys_corr_14: -0.0
-  sys_corr_15: -0.0
-  sys_corr_16: -0.0
-  sys_corr_17: -0.0
+  sys_corr_14: 0.0
+  sys_corr_15: 0.0
+  sys_corr_16: 0.0
+  sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
   sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
@@ -6850,52 +6850,52 @@ bins:
   sys_corr_12: 2.02990974e-06
   sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
-  sys_corr_16: -0.0
-  sys_corr_17: -0.0
+  sys_corr_15: 0.0
+  sys_corr_16: 0.0
+  sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
   sys_corr_25: 0.0
   sys_corr_26: 0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0

--- a/nnpdf_data/nnpdf_data/commondata/ATLAS_Z0J_8TEV/uncertainties_PT-Y.yaml
+++ b/nnpdf_data/nnpdf_data/commondata/ATLAS_Z0J_8TEV/uncertainties_PT-Y.yaml
@@ -422,60 +422,60 @@ bins:
   sys_corr_10: -2.01960474e-01
   sys_corr_11: -7.65495345e-01
   sys_corr_12: -1.59613923e-01
-  sys_corr_13: -0.0
+  sys_corr_13: 0.0
   sys_corr_14: 0.0
   sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
   sys_corr_54: 0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 1.46584215e-01
   sys_corr_68: 7.49208210e-02
   sys_corr_69: -1.53099069e-01
@@ -524,60 +524,60 @@ bins:
   sys_corr_10: -1.34159220e-01
   sys_corr_11: -2.95150284e-01
   sys_corr_12: -1.00619415e-01
-  sys_corr_13: -0.0
+  sys_corr_13: 0.0
   sys_corr_14: 0.0
   sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
+  sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
   sys_corr_54: 0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 5.36636880e-02
   sys_corr_68: 2.81734362e-01
   sys_corr_69: 1.54283103e-01
@@ -627,57 +627,57 @@ bins:
   sys_corr_11: 1.94712960e-01
   sys_corr_12: 6.04281600e-02
   sys_corr_13: 0.0
-  sys_corr_14: -0.0
-  sys_corr_15: -0.0
-  sys_corr_16: -0.0
+  sys_corr_14: 0.0
+  sys_corr_15: 0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
-  sys_corr_20: -0.0
-  sys_corr_21: -0.0
+  sys_corr_19: 0.0
+  sys_corr_20: 0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
   sys_corr_53: 0.0
-  sys_corr_54: -0.0
+  sys_corr_54: 0.0
   sys_corr_55: 0.0
   sys_corr_56: 0.0
   sys_corr_57: 0.0
   sys_corr_58: 0.0
-  sys_corr_59: -0.0
+  sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
+  sys_corr_62: 0.0
   sys_corr_63: 0.0
-  sys_corr_64: -0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: 0.0
   sys_corr_67: -6.71424000e-03
@@ -732,56 +732,56 @@ bins:
   sys_corr_14: 0.0
   sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
   sys_corr_54: 0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 5.88610900e-02
   sys_corr_68: 8.82916350e-02
   sys_corr_69: 1.00063853e-01
@@ -830,60 +830,60 @@ bins:
   sys_corr_10: -7.38902250e-02
   sys_corr_11: -9.35942850e-02
   sys_corr_12: -7.38902250e-02
-  sys_corr_13: -0.0
-  sys_corr_14: -0.0
+  sys_corr_13: 0.0
+  sys_corr_14: 0.0
   sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
   sys_corr_53: 0.0
   sys_corr_54: 0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
+  sys_corr_66: 0.0
   sys_corr_67: 1.47780450e-02
   sys_corr_68: -2.95560900e-02
   sys_corr_69: -8.37422550e-02
@@ -933,59 +933,59 @@ bins:
   sys_corr_11: 6.26986240e-02
   sys_corr_12: 3.52679760e-02
   sys_corr_13: 0.0
-  sys_corr_14: -0.0
-  sys_corr_15: -0.0
-  sys_corr_16: -0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_14: 0.0
+  sys_corr_15: 0.0
+  sys_corr_16: 0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
+  sys_corr_21: 0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
   sys_corr_54: 0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
   sys_corr_58: 0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 1.95933200e-02
   sys_corr_68: 9.79666000e-02
   sys_corr_69: 1.29315912e-01
@@ -1035,59 +1035,59 @@ bins:
   sys_corr_11: 3.01918300e-02
   sys_corr_12: 3.01918300e-03
   sys_corr_13: 0.0
-  sys_corr_14: -0.0
+  sys_corr_14: 0.0
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
+  sys_corr_16: 0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
   sys_corr_53: 0.0
   sys_corr_54: 0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
+  sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
+  sys_corr_66: 0.0
   sys_corr_67: 6.03836600e-03
   sys_corr_68: 4.22685620e-02
   sys_corr_69: 5.73644770e-02
@@ -1139,57 +1139,57 @@ bins:
   sys_corr_13: 0.0
   sys_corr_14: 0.0
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
+  sys_corr_16: 0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
   sys_corr_54: 0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 1.82370320e-02
   sys_corr_68: 4.78722090e-02
   sys_corr_69: 7.06684990e-02
@@ -1238,60 +1238,60 @@ bins:
   sys_corr_10: -3.94732320e-02
   sys_corr_11: -2.46707700e-02
   sys_corr_12: 8.22359000e-03
-  sys_corr_13: -0.0
+  sys_corr_13: 0.0
   sys_corr_14: 0.0
   sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
   sys_corr_54: 0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 1.97366160e-02
   sys_corr_68: 3.12496420e-02
   sys_corr_69: 4.76968220e-02
@@ -1341,59 +1341,59 @@ bins:
   sys_corr_11: 3.51684600e-02
   sys_corr_12: 1.99287940e-02
   sys_corr_13: 0.0
-  sys_corr_14: -0.0
-  sys_corr_15: -0.0
-  sys_corr_16: -0.0
+  sys_corr_14: 0.0
+  sys_corr_15: 0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
+  sys_corr_21: 0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
   sys_corr_54: 0.0
   sys_corr_55: 0.0
   sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 5.86141000e-03
   sys_corr_68: 4.80635620e-02
   sys_corr_69: 2.93070500e-02
@@ -1444,58 +1444,58 @@ bins:
   sys_corr_12: 1.15392830e-02
   sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
-  sys_corr_16: -0.0
+  sys_corr_15: 0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
+  sys_corr_21: 0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
   sys_corr_54: 0.0
   sys_corr_55: 0.0
-  sys_corr_56: -0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 8.24234500e-03
   sys_corr_68: 3.29693800e-02
   sys_corr_69: 1.31877520e-02
@@ -1545,59 +1545,59 @@ bins:
   sys_corr_11: 5.55167700e-03
   sys_corr_12: 7.21718010e-03
   sys_corr_13: 0.0
-  sys_corr_14: -0.0
+  sys_corr_14: 0.0
   sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
   sys_corr_54: 0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 1.11033540e-02
   sys_corr_68: 4.21927452e-02
   sys_corr_69: -1.66550310e-03
@@ -1651,55 +1651,55 @@ bins:
   sys_corr_15: 0.0
   sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
   sys_corr_54: 0.0
   sys_corr_55: 0.0
-  sys_corr_56: -0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 8.77467840e-03
   sys_corr_68: 1.31620176e-02
   sys_corr_69: 1.46244640e-03
@@ -1749,59 +1749,59 @@ bins:
   sys_corr_11: 7.68470340e-03
   sys_corr_12: 8.84905240e-03
   sys_corr_13: 0.0
-  sys_corr_14: -0.0
+  sys_corr_14: 0.0
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
+  sys_corr_16: 0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
   sys_corr_54: 0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 8.61618260e-03
   sys_corr_68: 1.60680162e-02
   sys_corr_69: 1.25749692e-02
@@ -1852,58 +1852,58 @@ bins:
   sys_corr_12: 8.22532440e-03
   sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
-  sys_corr_16: -0.0
+  sys_corr_15: 0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
+  sys_corr_21: 0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
   sys_corr_54: 0.0
   sys_corr_55: 0.0
-  sys_corr_56: -0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 6.36298680e-03
   sys_corr_68: 9.31168800e-04
   sys_corr_69: 9.77727240e-03
@@ -1954,58 +1954,58 @@ bins:
   sys_corr_12: 4.23572230e-03
   sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
-  sys_corr_16: -0.0
+  sys_corr_15: 0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
+  sys_corr_21: 0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
   sys_corr_54: 0.0
   sys_corr_55: 0.0
-  sys_corr_56: -0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 3.30592960e-03
   sys_corr_68: -5.26882530e-03
   sys_corr_69: 2.78937810e-03
@@ -2056,58 +2056,58 @@ bins:
   sys_corr_12: 3.62239045e-03
   sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
-  sys_corr_16: -0.0
+  sys_corr_15: 0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
+  sys_corr_21: 0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
   sys_corr_54: 0.0
   sys_corr_55: 0.0
-  sys_corr_56: -0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 2.25657110e-03
   sys_corr_68: -8.13553265e-03
   sys_corr_69: 5.70081120e-03
@@ -2156,59 +2156,59 @@ bins:
   sys_corr_10: -3.63338880e-04
   sys_corr_11: -9.53764560e-04
   sys_corr_12: 6.58551720e-04
-  sys_corr_13: -0.0
+  sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
-  sys_corr_16: -0.0
+  sys_corr_15: 0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
+  sys_corr_21: 0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
   sys_corr_54: 0.0
   sys_corr_55: 0.0
   sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
-  sys_corr_65: -0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
+  sys_corr_65: 0.0
   sys_corr_66: 0.0
   sys_corr_67: 2.27086800e-04
   sys_corr_68: -4.22381448e-03
@@ -2258,59 +2258,59 @@ bins:
   sys_corr_10: 3.90459780e-05
   sys_corr_11: -1.41216287e-03
   sys_corr_12: -1.49676249e-04
-  sys_corr_13: -0.0
+  sys_corr_13: 0.0
   sys_corr_14: 0.0
   sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
+  sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
   sys_corr_22: 0.0
   sys_corr_23: 0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
   sys_corr_54: 0.0
   sys_corr_55: 0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
-  sys_corr_65: -0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
+  sys_corr_65: 0.0
   sys_corr_66: 0.0
   sys_corr_67: 6.50766300e-05
   sys_corr_68: -1.17788700e-03
@@ -2360,58 +2360,58 @@ bins:
   sys_corr_10: 2.67029360e-05
   sys_corr_11: -4.81754000e-05
   sys_corr_12: -1.59667040e-05
-  sys_corr_13: -0.0
+  sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
-  sys_corr_20: -0.0
+  sys_corr_19: 0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
   sys_corr_22: 0.0
   sys_corr_23: 0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
   sys_corr_55: 0.0
   sys_corr_56: 0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0
-  sys_corr_64: -0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: 0.0
   sys_corr_67: -1.37644000e-05
@@ -2463,59 +2463,59 @@ bins:
   sys_corr_11: -3.86236440e-01
   sys_corr_12: -1.38401391e-01
   sys_corr_13: -2.96114604e-01
-  sys_corr_14: -0.0
+  sys_corr_14: 0.0
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
   sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
   sys_corr_58: 0.0
-  sys_corr_59: -0.0
+  sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
+  sys_corr_66: 0.0
   sys_corr_67: -7.08100140e-02
   sys_corr_68: -1.67369124e-01
   sys_corr_69: 8.72250627e-01
@@ -2565,58 +2565,58 @@ bins:
   sys_corr_11: -7.47763968e-01
   sys_corr_12: 1.80264528e-01
   sys_corr_13: 1.40205744e-01
-  sys_corr_14: -0.0
-  sys_corr_15: -0.0
+  sys_corr_14: 0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
-  sys_corr_65: -0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
+  sys_corr_65: 0.0
   sys_corr_66: 0.0
   sys_corr_67: -1.06823424e-01
   sys_corr_68: 3.80558448e-01
@@ -2667,58 +2667,58 @@ bins:
   sys_corr_11: -2.82970590e-01
   sys_corr_12: 6.53527315e-01
   sys_corr_13: 1.34747900e-01
-  sys_corr_14: -0.0
-  sys_corr_15: -0.0
+  sys_corr_14: 0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
-  sys_corr_20: -0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
-  sys_corr_65: -0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
+  sys_corr_65: 0.0
   sys_corr_66: 0.0
   sys_corr_67: -4.51405465e-01
   sys_corr_68: 4.71617650e-01
@@ -2769,59 +2769,59 @@ bins:
   sys_corr_11: -5.40229888e-01
   sys_corr_12: 9.39530240e-02
   sys_corr_13: -1.11569216e-01
-  sys_corr_14: -0.0
+  sys_corr_14: 0.0
   sys_corr_15: 0.0
   sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
-  sys_corr_20: -0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
   sys_corr_25: 0.0
-  sys_corr_26: -0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: -2.23138432e-01
   sys_corr_68: -1.76161920e-02
   sys_corr_69: 4.46276864e-01
@@ -2871,54 +2871,54 @@ bins:
   sys_corr_11: -3.45280881e-01
   sys_corr_12: -2.43155550e-01
   sys_corr_13: -1.89661329e-01
-  sys_corr_14: -0.0
+  sys_corr_14: 0.0
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
-  sys_corr_21: -0.0
+  sys_corr_20: 0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
   sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
   sys_corr_58: 0.0
-  sys_corr_59: -0.0
+  sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
@@ -2973,59 +2973,59 @@ bins:
   sys_corr_11: -4.55467311e-01
   sys_corr_12: 0.0
   sys_corr_13: -6.22861280e-02
-  sys_corr_14: -0.0
+  sys_corr_14: 0.0
   sys_corr_15: 0.0
   sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
-  sys_corr_20: -0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
   sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: -7.39647770e-02
   sys_corr_68: -1.24572256e-01
   sys_corr_69: 1.44036671e-01
@@ -3075,56 +3075,56 @@ bins:
   sys_corr_11: -1.94675455e-01
   sys_corr_12: -4.49251050e-02
   sys_corr_13: -2.39600560e-02
-  sys_corr_14: -0.0
-  sys_corr_15: -0.0
+  sys_corr_14: 0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
-  sys_corr_21: -0.0
+  sys_corr_20: 0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
   sys_corr_23: 0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: 0.0
@@ -3177,56 +3177,56 @@ bins:
   sys_corr_11: -2.26615500e-01
   sys_corr_12: -8.15815800e-02
   sys_corr_13: 4.53231000e-03
-  sys_corr_14: -0.0
-  sys_corr_15: -0.0
+  sys_corr_14: 0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
-  sys_corr_20: -0.0
-  sys_corr_21: -0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
+  sys_corr_20: 0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: 0.0
@@ -3279,59 +3279,59 @@ bins:
   sys_corr_11: -2.01639872e-01
   sys_corr_12: -2.43919200e-02
   sys_corr_13: -2.11396640e-02
-  sys_corr_14: -0.0
+  sys_corr_14: 0.0
   sys_corr_15: 0.0
   sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
-  sys_corr_20: -0.0
+  sys_corr_19: 0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
   sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
+  sys_corr_62: 0.0
   sys_corr_63: 0.0
-  sys_corr_64: -0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
+  sys_corr_66: 0.0
   sys_corr_67: -1.62612800e-03
   sys_corr_68: -4.39054560e-02
   sys_corr_69: 6.01667360e-02
@@ -3381,58 +3381,58 @@ bins:
   sys_corr_11: -1.50020292e-01
   sys_corr_12: -4.41920240e-02
   sys_corr_13: -1.16294800e-03
-  sys_corr_14: -0.0
-  sys_corr_15: -0.0
+  sys_corr_14: 0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
-  sys_corr_20: -0.0
-  sys_corr_21: -0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
+  sys_corr_20: 0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
   sys_corr_23: 0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
+  sys_corr_65: 0.0
   sys_corr_66: 0.0
   sys_corr_67: -5.34956080e-02
   sys_corr_68: -2.32589600e-03
@@ -3483,55 +3483,55 @@ bins:
   sys_corr_11: -1.23032524e-01
   sys_corr_12: -3.88523760e-02
   sys_corr_13: -2.99487065e-02
-  sys_corr_14: -0.0
+  sys_corr_14: 0.0
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
-  sys_corr_20: -0.0
-  sys_corr_21: -0.0
+  sys_corr_19: 0.0
+  sys_corr_20: 0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
   sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
   sys_corr_58: 0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
@@ -3585,58 +3585,58 @@ bins:
   sys_corr_11: -9.54923310e-02
   sys_corr_12: -2.14034535e-02
   sys_corr_13: -1.15249365e-02
-  sys_corr_14: -0.0
+  sys_corr_14: 0.0
   sys_corr_15: 0.0
   sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
-  sys_corr_20: -0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
+  sys_corr_65: 0.0
   sys_corr_66: 0.0
   sys_corr_67: -1.86594210e-02
   sys_corr_68: -2.14034535e-02
@@ -3687,58 +3687,58 @@ bins:
   sys_corr_11: -6.66759159e-02
   sys_corr_12: -1.06966710e-02
   sys_corr_13: -3.20900130e-03
-  sys_corr_14: -0.0
-  sys_corr_15: -0.0
+  sys_corr_14: 0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
+  sys_corr_65: 0.0
   sys_corr_66: 0.0
   sys_corr_67: -1.21228938e-02
   sys_corr_68: -1.28360052e-02
@@ -3789,57 +3789,57 @@ bins:
   sys_corr_11: -3.66205461e-02
   sys_corr_12: -1.10552592e-02
   sys_corr_13: 0.0
-  sys_corr_14: -0.0
-  sys_corr_15: -0.0
+  sys_corr_14: 0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
   sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: 0.0
   sys_corr_67: 2.76381480e-03
@@ -3891,58 +3891,58 @@ bins:
   sys_corr_11: -1.17915182e-02
   sys_corr_12: -3.36900520e-03
   sys_corr_13: -3.06273200e-04
-  sys_corr_14: -0.0
-  sys_corr_15: -0.0
+  sys_corr_14: 0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
-  sys_corr_65: -0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
+  sys_corr_65: 0.0
   sys_corr_66: 0.0
   sys_corr_67: -3.06273200e-03
   sys_corr_68: -9.95387900e-03
@@ -3993,56 +3993,56 @@ bins:
   sys_corr_11: 5.46913890e-03
   sys_corr_12: -5.15956500e-04
   sys_corr_13: -1.13510430e-03
-  sys_corr_14: -0.0
-  sys_corr_15: -0.0
+  sys_corr_14: 0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
-  sys_corr_21: -0.0
+  sys_corr_20: 0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
   sys_corr_25: 0.0
-  sys_corr_26: -0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
+  sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
   sys_corr_58: 0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: 0.0
@@ -4095,59 +4095,59 @@ bins:
   sys_corr_11: 2.20469008e-03
   sys_corr_12: -1.97261744e-03
   sys_corr_13: -1.16036320e-03
-  sys_corr_14: -0.0
+  sys_corr_14: 0.0
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
-  sys_corr_21: -0.0
+  sys_corr_20: 0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
+  sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: -2.72685352e-03
   sys_corr_68: -5.91785232e-03
   sys_corr_69: 1.79856296e-03
@@ -4197,55 +4197,55 @@ bins:
   sys_corr_11: 3.67370332e-03
   sys_corr_12: -1.32163717e-03
   sys_corr_13: -1.09763087e-03
-  sys_corr_14: -0.0
+  sys_corr_14: 0.0
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
-  sys_corr_21: -0.0
+  sys_corr_20: 0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
   sys_corr_25: 0.0
-  sys_corr_26: -0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
   sys_corr_58: 0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
@@ -4301,53 +4301,53 @@ bins:
   sys_corr_13: -4.12738625e-04
   sys_corr_14: 0.0
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
-  sys_corr_21: -0.0
+  sys_corr_20: 0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
   sys_corr_25: 0.0
-  sys_corr_26: -0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
   sys_corr_58: 0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
@@ -4403,53 +4403,53 @@ bins:
   sys_corr_13: -2.66428864e-05
   sys_corr_14: 0.0
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
-  sys_corr_21: -0.0
+  sys_corr_20: 0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
   sys_corr_25: 0.0
-  sys_corr_26: -0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
   sys_corr_58: 0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
@@ -4504,58 +4504,58 @@ bins:
   sys_corr_12: 9.05472800e-02
   sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 1.09281200e-01
   sys_corr_68: -1.56116000e-01
   sys_corr_69: 2.18562400e-02
@@ -4608,56 +4608,56 @@ bins:
   sys_corr_14: 0.0
   sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 1.80926984e-01
   sys_corr_68: -3.03698866e-01
   sys_corr_69: 7.75401360e-02
@@ -4708,58 +4708,58 @@ bins:
   sys_corr_12: 1.57151664e-01
   sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 1.57151664e-01
   sys_corr_68: -1.37507706e-01
   sys_corr_69: 1.04767776e-01
@@ -4810,58 +4810,58 @@ bins:
   sys_corr_12: 1.69405860e-01
   sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 2.08933894e-01
   sys_corr_68: -5.13864442e-01
   sys_corr_69: 1.91993308e-01
@@ -4912,58 +4912,58 @@ bins:
   sys_corr_12: 1.13186856e-01
   sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 1.83928641e-01
   sys_corr_68: -5.28205328e-01
   sys_corr_69: 3.72573401e-01
@@ -5014,58 +5014,58 @@ bins:
   sys_corr_12: 8.21605840e-02
   sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 1.34444592e-01
   sys_corr_68: -4.51883212e-01
   sys_corr_69: 1.45648308e-01
@@ -5116,58 +5116,58 @@ bins:
   sys_corr_12: 6.67174340e-02
   sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 1.10228804e-01
   sys_corr_68: -2.98778074e-01
   sys_corr_69: 9.57250140e-02
@@ -5218,58 +5218,58 @@ bins:
   sys_corr_12: 2.17312700e-02
   sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 6.95400640e-02
   sys_corr_68: -2.32524589e-01
   sys_corr_69: 9.12713340e-02
@@ -5320,58 +5320,58 @@ bins:
   sys_corr_12: 3.43242460e-02
   sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 6.39679130e-02
   sys_corr_68: -1.80982388e-01
   sys_corr_69: 3.12038600e-02
@@ -5404,7 +5404,7 @@ bins:
   sys_corr_96: -1.81606465e+00
   sys_corr_97: -2.73969891e+00
   sys_corr_98: -9.25194449e-01
-  sys_corr_99: -0.0
+  sys_corr_99: 0.0
   sys_lumi_corr: 4.36854040e+01
 - stat: 3.563653
   sys_uncorr: 1.436297
@@ -5422,58 +5422,58 @@ bins:
   sys_corr_12: 4.12884480e-02
   sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 4.12884480e-02
   sys_corr_68: -1.27213056e-01
   sys_corr_69: 2.00862720e-02
@@ -5524,58 +5524,58 @@ bins:
   sys_corr_12: 1.87139184e-02
   sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 2.41721446e-02
   sys_corr_68: -7.48556736e-02
   sys_corr_69: -6.23797280e-03
@@ -5626,58 +5626,58 @@ bins:
   sys_corr_12: 2.82478320e-02
   sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 1.67394560e-02
   sys_corr_68: -7.11426880e-02
   sys_corr_69: -2.19705360e-02
@@ -5728,58 +5728,58 @@ bins:
   sys_corr_12: 1.42232580e-02
   sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 1.49005560e-02
   sys_corr_68: -4.63949130e-02
   sys_corr_69: -2.47213770e-02
@@ -5830,58 +5830,58 @@ bins:
   sys_corr_12: 7.69791050e-03
   sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 1.23166568e-02
   sys_corr_68: -3.54103883e-02
   sys_corr_69: -1.67154628e-02
@@ -5932,58 +5932,58 @@ bins:
   sys_corr_12: 8.20748130e-03
   sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 1.06553266e-02
   sys_corr_68: -2.87981800e-02
   sys_corr_69: -7.91949950e-03
@@ -6034,58 +6034,58 @@ bins:
   sys_corr_12: 8.94136131e-03
   sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 8.84521764e-03
   sys_corr_68: -2.47089232e-02
   sys_corr_69: -1.31716828e-02
@@ -6136,58 +6136,58 @@ bins:
   sys_corr_12: 6.68417520e-03
   sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 5.96005622e-03
   sys_corr_68: -1.73231541e-02
   sys_corr_69: -7.57539856e-03
@@ -6238,58 +6238,58 @@ bins:
   sys_corr_12: 2.19533808e-03
   sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 2.32199220e-03
   sys_corr_68: -7.70479230e-03
   sys_corr_69: -7.81033740e-04
@@ -6340,58 +6340,58 @@ bins:
   sys_corr_12: 5.08232000e-04
   sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 6.63691200e-04
   sys_corr_68: -1.99107360e-03
   sys_corr_69: 5.38128000e-05
@@ -6442,58 +6442,58 @@ bins:
   sys_corr_12: 2.52277456e-05
   sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 1.28518704e-05
   sys_corr_68: -7.90152032e-05
   sys_corr_69: 2.26097720e-05
@@ -6544,54 +6544,54 @@ bins:
   sys_corr_12: 3.94710162e-01
   sys_corr_13: -1.53783180e-02
   sys_corr_14: -2.05044240e-02
-  sys_corr_15: -0.0
-  sys_corr_16: -0.0
-  sys_corr_17: -0.0
+  sys_corr_15: 0.0
+  sys_corr_16: 0.0
+  sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
-  sys_corr_24: -0.0
+  sys_corr_24: 0.0
   sys_corr_25: 0.0
   sys_corr_26: 0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
   sys_corr_56: 0.0
   sys_corr_57: 0.0
   sys_corr_58: 0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
@@ -6617,7 +6617,7 @@ bins:
   sys_corr_85: 1.91716364e+00
   sys_corr_86: -1.05341478e+00
   sys_corr_87: -4.53660381e-01
-  sys_corr_88: -0.0
+  sys_corr_88: 0.0
   sys_corr_89: -2.79116472e+00
   sys_corr_90: -7.17654840e-01
   sys_corr_91: 5.09791242e+00
@@ -6647,59 +6647,59 @@ bins:
   sys_corr_13: -1.60235610e-01
   sys_corr_14: 3.20471220e-02
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
   sys_corr_56: 0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
   sys_corr_63: 0.0
-  sys_corr_64: -0.0
-  sys_corr_65: -0.0
+  sys_corr_64: 0.0
+  sys_corr_65: 0.0
   sys_corr_66: 0.0
   sys_corr_67: -1.17506114e-01
-  sys_corr_68: -0.0
+  sys_corr_68: 0.0
   sys_corr_69: 4.64683269e-01
   sys_corr_70: -2.56376976e-01
   sys_corr_71: -6.30260066e-01
@@ -6749,57 +6749,57 @@ bins:
   sys_corr_13: -8.53086880e-02
   sys_corr_14: 1.97276341e-01
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
+  sys_corr_21: 0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
+  sys_corr_66: 0.0
   sys_corr_67: -4.79861370e-02
   sys_corr_68: -1.81280962e-01
   sys_corr_69: 3.41234752e-01
@@ -6851,57 +6851,57 @@ bins:
   sys_corr_13: 1.76587254e-01
   sys_corr_14: 5.57643960e-02
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
+  sys_corr_66: 0.0
   sys_corr_67: 1.39410990e-02
   sys_corr_68: -1.11528792e-01
   sys_corr_69: -1.85881320e-02
@@ -6952,58 +6952,58 @@ bins:
   sys_corr_12: 1.56918080e-02
   sys_corr_13: 2.15762360e-01
   sys_corr_14: -1.56918080e-02
-  sys_corr_15: -0.0
-  sys_corr_16: -0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
+  sys_corr_15: 0.0
+  sys_corr_16: 0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
+  sys_corr_66: 0.0
   sys_corr_67: -4.31524720e-02
   sys_corr_68: -1.05919704e-01
   sys_corr_69: -1.33380368e-01
@@ -7055,56 +7055,56 @@ bins:
   sys_corr_13: 0.0
   sys_corr_14: 6.30391000e-03
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
   sys_corr_28: 0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
   sys_corr_56: 0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
-  sys_corr_65: -0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
+  sys_corr_65: 0.0
   sys_corr_66: 0.0
   sys_corr_67: -4.72793250e-02
   sys_corr_68: -2.20636850e-02
@@ -7157,57 +7157,57 @@ bins:
   sys_corr_13: 3.17599880e-02
   sys_corr_14: 2.44307600e-03
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
+  sys_corr_66: 0.0
   sys_corr_67: -7.32922800e-03
   sys_corr_68: -5.37476720e-02
   sys_corr_69: 4.88615200e-02
@@ -7259,57 +7259,57 @@ bins:
   sys_corr_13: 3.51022530e-02
   sys_corr_14: -1.84748700e-03
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
+  sys_corr_66: 0.0
   sys_corr_67: -2.40173310e-02
   sys_corr_68: -4.24922010e-02
   sys_corr_69: 3.69497400e-02
@@ -7361,57 +7361,57 @@ bins:
   sys_corr_13: 4.36957290e-02
   sys_corr_14: 5.29645200e-03
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
+  sys_corr_16: 0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
+  sys_corr_66: 0.0
   sys_corr_67: 2.64822600e-03
   sys_corr_68: -3.17787120e-02
   sys_corr_69: 5.82609720e-02
@@ -7419,7 +7419,7 @@ bins:
   sys_corr_71: -1.45652430e-02
   sys_corr_72: 3.97233900e-03
   sys_corr_73: -7.67985540e-02
-  sys_corr_74: -0.0
+  sys_corr_74: 0.0
   sys_corr_75: -6.88538760e-02
   sys_corr_76: 1.43004204e-01
   sys_corr_77: 1.35059526e-01
@@ -7463,57 +7463,57 @@ bins:
   sys_corr_13: 4.01419662e-02
   sys_corr_14: 1.05133721e-02
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
+  sys_corr_66: 0.0
   sys_corr_67: 1.91152220e-03
   sys_corr_68: -3.72746829e-02
   sys_corr_69: -1.52921776e-02
@@ -7565,57 +7565,57 @@ bins:
   sys_corr_13: 3.60141066e-02
   sys_corr_14: 8.00313480e-03
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
+  sys_corr_66: 0.0
   sys_corr_67: 7.33620690e-03
   sys_corr_68: -2.53432602e-02
   sys_corr_69: 4.26833856e-02
@@ -7667,57 +7667,57 @@ bins:
   sys_corr_13: 1.68784752e-02
   sys_corr_14: 3.10919280e-03
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
+  sys_corr_66: 0.0
   sys_corr_67: 1.77668160e-03
   sys_corr_68: -1.73226456e-02
   sys_corr_69: 1.42134528e-02
@@ -7771,55 +7771,55 @@ bins:
   sys_corr_15: 0.0
   sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
+  sys_corr_66: 0.0
   sys_corr_67: 4.87882660e-03
   sys_corr_68: -1.49234696e-02
   sys_corr_69: 1.06186226e-02
@@ -7871,57 +7871,57 @@ bins:
   sys_corr_13: 1.98145800e-02
   sys_corr_14: 3.36474000e-03
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
+  sys_corr_16: 0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
+  sys_corr_66: 0.0
   sys_corr_67: 2.80395000e-03
   sys_corr_68: -8.59878000e-03
   sys_corr_69: 3.73860000e-03
@@ -7973,54 +7973,54 @@ bins:
   sys_corr_13: 1.10213506e-02
   sys_corr_14: -1.73369560e-03
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
+  sys_corr_16: 0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
+  sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: 0.0
@@ -8074,58 +8074,58 @@ bins:
   sys_corr_12: 1.44093088e-03
   sys_corr_13: 1.01712768e-02
   sys_corr_14: 1.01712768e-03
-  sys_corr_15: -0.0
-  sys_corr_16: -0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
+  sys_corr_15: 0.0
+  sys_corr_16: 0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
+  sys_corr_66: 0.0
   sys_corr_67: 1.69521280e-03
   sys_corr_68: -4.32279264e-03
   sys_corr_69: -6.69609056e-03
@@ -8176,60 +8176,60 @@ bins:
   sys_corr_12: 3.68124757e-03
   sys_corr_13: 1.29082707e-03
   sys_corr_14: -1.19521025e-03
-  sys_corr_15: -0.0
-  sys_corr_16: -0.0
-  sys_corr_17: -0.0
+  sys_corr_15: 0.0
+  sys_corr_16: 0.0
+  sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: 0.0
   sys_corr_67: -9.56168200e-05
-  sys_corr_68: -0.0
+  sys_corr_68: 0.0
   sys_corr_69: -7.17126150e-04
   sys_corr_70: 1.57767753e-03
   sys_corr_71: -3.29878029e-03
@@ -8278,54 +8278,54 @@ bins:
   sys_corr_12: 7.46465200e-05
   sys_corr_13: 1.66088507e-03
   sys_corr_14: -1.19434432e-03
-  sys_corr_15: -0.0
-  sys_corr_16: -0.0
-  sys_corr_17: -0.0
+  sys_corr_15: 0.0
+  sys_corr_16: 0.0
+  sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
   sys_corr_22: 0.0
   sys_corr_23: 0.0
-  sys_corr_24: -0.0
+  sys_corr_24: 0.0
   sys_corr_25: 0.0
   sys_corr_26: 0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
+  sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
@@ -8381,54 +8381,54 @@ bins:
   sys_corr_13: 4.65126840e-04
   sys_corr_14: -7.23530640e-05
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
-  sys_corr_17: -0.0
+  sys_corr_16: 0.0
+  sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
   sys_corr_25: 0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
   sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: 0.0
@@ -8483,54 +8483,54 @@ bins:
   sys_corr_13: 2.48848188e-05
   sys_corr_14: -9.71114880e-06
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
-  sys_corr_17: -0.0
+  sys_corr_16: 0.0
+  sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
   sys_corr_25: 0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
   sys_corr_56: 0.0
   sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: 0.0
@@ -8584,56 +8584,56 @@ bins:
   sys_corr_12: 4.91791800e-02
   sys_corr_13: -8.19653000e-03
   sys_corr_14: -1.49176846e-01
-  sys_corr_15: -0.0
-  sys_corr_16: -0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
+  sys_corr_15: 0.0
+  sys_corr_16: 0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: 0.0
   sys_corr_67: 4.26219560e-02
@@ -8687,56 +8687,56 @@ bins:
   sys_corr_13: 4.41271610e-02
   sys_corr_14: 1.35775880e-02
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
-  sys_corr_20: -0.0
-  sys_corr_21: -0.0
+  sys_corr_19: 0.0
+  sys_corr_20: 0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
   sys_corr_25: 0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
   sys_corr_55: 0.0
   sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
+  sys_corr_65: 0.0
   sys_corr_66: 0.0
   sys_corr_67: -8.48599250e-02
   sys_corr_68: -1.83297438e-01
@@ -8788,55 +8788,55 @@ bins:
   sys_corr_12: -7.51735600e-02
   sys_corr_13: 8.54245000e-02
   sys_corr_14: -1.16177320e-01
-  sys_corr_15: -0.0
-  sys_corr_16: -0.0
-  sys_corr_17: -0.0
+  sys_corr_15: 0.0
+  sys_corr_16: 0.0
+  sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
-  sys_corr_24: -0.0
+  sys_corr_24: 0.0
   sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
+  sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
   sys_corr_56: 0.0
-  sys_corr_57: -0.0
+  sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: 0.0
@@ -8890,55 +8890,55 @@ bins:
   sys_corr_12: -1.00032964e-01
   sys_corr_13: 1.38280862e-01
   sys_corr_14: -1.17685840e-01
-  sys_corr_15: -0.0
-  sys_corr_16: -0.0
+  sys_corr_15: 0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
-  sys_corr_24: -0.0
+  sys_corr_24: 0.0
   sys_corr_25: 0.0
   sys_corr_26: 0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
   sys_corr_56: 0.0
-  sys_corr_57: -0.0
+  sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: 0.0
@@ -8993,55 +8993,55 @@ bins:
   sys_corr_13: 2.96641440e-02
   sys_corr_14: -1.58208768e-01
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
+  sys_corr_16: 0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
-  sys_corr_24: -0.0
+  sys_corr_24: 0.0
   sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
+  sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
   sys_corr_56: 0.0
-  sys_corr_57: -0.0
+  sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: 0.0
   sys_corr_67: 1.48320720e-02
@@ -9095,54 +9095,54 @@ bins:
   sys_corr_13: 3.00203100e-02
   sys_corr_14: -5.00338500e-02
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
-  sys_corr_17: -0.0
+  sys_corr_16: 0.0
+  sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
-  sys_corr_24: -0.0
+  sys_corr_24: 0.0
   sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
+  sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
   sys_corr_56: 0.0
-  sys_corr_57: -0.0
+  sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: 0.0
@@ -9196,56 +9196,56 @@ bins:
   sys_corr_12: -2.19470720e-02
   sys_corr_13: 1.72441280e-02
   sys_corr_14: -3.91912000e-02
-  sys_corr_15: -0.0
-  sys_corr_16: -0.0
+  sys_corr_15: 0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
-  sys_corr_24: -0.0
+  sys_corr_24: 0.0
   sys_corr_25: 0.0
   sys_corr_26: 0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
   sys_corr_56: 0.0
-  sys_corr_57: -0.0
+  sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: 0.0
   sys_corr_67: -3.13529600e-03
@@ -9298,56 +9298,56 @@ bins:
   sys_corr_12: 3.61561500e-03
   sys_corr_13: 1.68728700e-02
   sys_corr_14: -4.33873800e-02
-  sys_corr_15: -0.0
-  sys_corr_16: -0.0
-  sys_corr_17: -0.0
+  sys_corr_15: 0.0
+  sys_corr_16: 0.0
+  sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
-  sys_corr_24: -0.0
+  sys_corr_24: 0.0
   sys_corr_25: 0.0
   sys_corr_26: 0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
   sys_corr_56: 0.0
-  sys_corr_57: -0.0
+  sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: 0.0
   sys_corr_67: 4.82082000e-03
@@ -9374,7 +9374,7 @@ bins:
   sys_corr_88: -1.49445420e-01
   sys_corr_89: 4.01333265e-01
   sys_corr_90: -1.22087267e+00
-  sys_corr_91: -0.0
+  sys_corr_91: 0.0
   sys_corr_92: 2.77197150e-02
   sys_corr_93: -4.41105030e-01
   sys_corr_94: 9.78626460e-01
@@ -9400,57 +9400,57 @@ bins:
   sys_corr_12: -4.68141209e-02
   sys_corr_13: 1.05994236e-02
   sys_corr_14: -4.41642650e-03
-  sys_corr_15: -0.0
-  sys_corr_16: -0.0
+  sys_corr_15: 0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
   sys_corr_23: 0.0
-  sys_corr_24: -0.0
+  sys_corr_24: 0.0
   sys_corr_25: 0.0
   sys_corr_26: 0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
   sys_corr_55: 0.0
   sys_corr_56: 0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
+  sys_corr_65: 0.0
   sys_corr_66: 0.0
   sys_corr_67: -2.64985590e-03
   sys_corr_68: -1.50158501e-02
@@ -9502,56 +9502,56 @@ bins:
   sys_corr_12: -3.87372840e-03
   sys_corr_13: -3.22810700e-03
   sys_corr_14: 1.42036708e-02
-  sys_corr_15: -0.0
-  sys_corr_16: -0.0
+  sys_corr_15: 0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
-  sys_corr_22: -0.0
+  sys_corr_21: 0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
   sys_corr_28: 0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
   sys_corr_55: 0.0
   sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
+  sys_corr_62: 0.0
   sys_corr_63: 0.0
-  sys_corr_64: -0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: 0.0
   sys_corr_67: -6.45621400e-04
@@ -9604,57 +9604,57 @@ bins:
   sys_corr_12: 1.16435675e-02
   sys_corr_13: -1.07120821e-02
   sys_corr_14: -3.72594160e-03
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
-  sys_corr_20: -0.0
-  sys_corr_21: -0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
+  sys_corr_20: 0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
   sys_corr_25: 0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
   sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
   sys_corr_55: 0.0
   sys_corr_56: 0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
-  sys_corr_65: -0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
+  sys_corr_65: 0.0
   sys_corr_66: 0.0
   sys_corr_67: -9.31485400e-04
   sys_corr_68: 1.67667372e-02
@@ -9706,58 +9706,58 @@ bins:
   sys_corr_12: -5.34411660e-03
   sys_corr_13: -1.25743920e-02
   sys_corr_14: 7.23027540e-03
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
-  sys_corr_20: -0.0
-  sys_corr_21: -0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
+  sys_corr_20: 0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
   sys_corr_28: 0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
   sys_corr_55: 0.0
   sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: -5.02975680e-03
   sys_corr_68: 2.67205830e-02
   sys_corr_69: -4.36960122e-02
@@ -9808,57 +9808,57 @@ bins:
   sys_corr_12: -1.46922840e-02
   sys_corr_13: -1.63247600e-02
   sys_corr_14: -1.63247600e-03
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
   sys_corr_28: 0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0
-  sys_corr_64: -0.0
-  sys_corr_65: -0.0
+  sys_corr_64: 0.0
+  sys_corr_65: 0.0
   sys_corr_66: 0.0
   sys_corr_67: 2.24465450e-03
   sys_corr_68: 1.81612955e-02
@@ -9910,57 +9910,57 @@ bins:
   sys_corr_12: -1.33134401e-02
   sys_corr_13: -1.17623597e-02
   sys_corr_14: 1.29256700e-04
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
   sys_corr_23: 0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
   sys_corr_28: 0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
   sys_corr_55: 0.0
-  sys_corr_56: -0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
+  sys_corr_65: 0.0
   sys_corr_66: 0.0
   sys_corr_67: -6.46283500e-04
   sys_corr_68: 1.51230339e-02
@@ -10012,58 +10012,58 @@ bins:
   sys_corr_12: -6.20176318e-03
   sys_corr_13: -6.03185186e-03
   sys_corr_14: 7.98583204e-03
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
   sys_corr_28: 0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
   sys_corr_55: 0.0
-  sys_corr_56: -0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
+  sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: -1.69911320e-03
   sys_corr_68: 1.44424622e-02
   sys_corr_69: -2.61663433e-02
@@ -10114,57 +10114,57 @@ bins:
   sys_corr_12: -3.40433481e-03
   sys_corr_13: -3.34663422e-03
   sys_corr_14: 3.75053835e-03
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
   sys_corr_23: 0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
   sys_corr_28: 0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
   sys_corr_55: 0.0
   sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
+  sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
+  sys_corr_65: 0.0
   sys_corr_66: 0.0
   sys_corr_67: -1.32711357e-03
   sys_corr_68: 7.90498083e-03
@@ -10220,54 +10220,54 @@ bins:
   sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
   sys_corr_28: 0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
   sys_corr_55: 0.0
   sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
+  sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: -1.63110808e-03
   sys_corr_68: 7.15690280e-03
   sys_corr_69: -1.25162579e-02
@@ -10319,56 +10319,56 @@ bins:
   sys_corr_13: -2.97743510e-04
   sys_corr_14: 2.03242309e-03
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
   sys_corr_23: 0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
   sys_corr_55: 0.0
   sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
+  sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
+  sys_corr_65: 0.0
   sys_corr_66: 0.0
   sys_corr_67: -4.91924060e-04
   sys_corr_68: 2.45962030e-03
@@ -10424,54 +10424,54 @@ bins:
   sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
   sys_corr_55: 0.0
-  sys_corr_56: -0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 9.08669520e-05
   sys_corr_68: -1.89306150e-05
   sys_corr_69: -7.30721739e-04
@@ -10522,57 +10522,57 @@ bins:
   sys_corr_12: -2.86025740e-05
   sys_corr_13: -1.95017550e-06
   sys_corr_14: 5.46049140e-06
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
   sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
+  sys_corr_65: 0.0
   sys_corr_66: 0.0
   sys_corr_67: 8.32074880e-06
   sys_corr_68: -1.09209828e-05
@@ -10626,55 +10626,55 @@ bins:
   sys_corr_14: -3.26454218e-02
   sys_corr_15: 1.85741193e-02
   sys_corr_16: 1.06941899e-02
-  sys_corr_17: -0.0
+  sys_corr_17: 0.0
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
   sys_corr_25: 0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
+  sys_corr_30: 0.0
   sys_corr_31: 0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
   sys_corr_55: 0.0
   sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
+  sys_corr_65: 0.0
   sys_corr_66: -1.24390314e-01
   sys_corr_67: -1.78986968e-01
   sys_corr_68: 1.68855630e-03
@@ -10728,53 +10728,53 @@ bins:
   sys_corr_14: 4.56484800e-03
   sys_corr_15: 2.28242400e-03
   sys_corr_16: 5.70606000e-03
-  sys_corr_17: -0.0
+  sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
-  sys_corr_21: -0.0
-  sys_corr_22: -0.0
+  sys_corr_20: 0.0
+  sys_corr_21: 0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
   sys_corr_25: 0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
   sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
+  sys_corr_30: 0.0
   sys_corr_31: 0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
   sys_corr_55: 0.0
   sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: -7.64612040e-02
@@ -10831,53 +10831,53 @@ bins:
   sys_corr_15: -3.58471680e-02
   sys_corr_16: -2.24044800e-02
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
-  sys_corr_29: -0.0
+  sys_corr_29: 0.0
   sys_corr_30: 0.0
-  sys_corr_31: -0.0
+  sys_corr_31: 0.0
   sys_corr_32: 0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
   sys_corr_54: 0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0
-  sys_corr_64: -0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: 3.80876160e-02
   sys_corr_67: -2.01640320e-02
@@ -10933,53 +10933,53 @@ bins:
   sys_corr_15: -2.49164500e-02
   sys_corr_16: -2.10831500e-02
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
-  sys_corr_20: -0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
-  sys_corr_29: -0.0
+  sys_corr_29: 0.0
   sys_corr_30: 0.0
-  sys_corr_31: -0.0
+  sys_corr_31: 0.0
   sys_corr_32: 0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
   sys_corr_54: 0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
+  sys_corr_62: 0.0
   sys_corr_63: 0.0
-  sys_corr_64: -0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: 3.83330000e-03
   sys_corr_67: -4.12079750e-02
@@ -11034,55 +11034,55 @@ bins:
   sys_corr_14: 7.38286094e-02
   sys_corr_15: 2.59617088e-02
   sys_corr_16: 8.92433740e-03
-  sys_corr_17: -0.0
+  sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
   sys_corr_25: 0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
   sys_corr_31: 0.0
   sys_corr_32: 0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
   sys_corr_54: 0.0
   sys_corr_55: 0.0
   sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
+  sys_corr_65: 0.0
   sys_corr_66: -3.32634394e-02
   sys_corr_67: -1.51713736e-01
   sys_corr_68: -2.13372794e-01
@@ -11137,54 +11137,54 @@ bins:
   sys_corr_15: -1.88686296e-02
   sys_corr_16: -1.17115632e-02
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
   sys_corr_30: 0.0
-  sys_corr_31: -0.0
+  sys_corr_31: 0.0
   sys_corr_32: 0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
   sys_corr_54: 0.0
   sys_corr_55: 0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
+  sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
+  sys_corr_65: 0.0
   sys_corr_66: -3.90385440e-03
   sys_corr_67: -2.34231264e-02
   sys_corr_68: -5.40033192e-02
@@ -11239,53 +11239,53 @@ bins:
   sys_corr_15: -2.26843695e-02
   sys_corr_16: -1.66352043e-02
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
-  sys_corr_20: -0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
-  sys_corr_29: -0.0
+  sys_corr_29: 0.0
   sys_corr_30: 0.0
-  sys_corr_31: -0.0
+  sys_corr_31: 0.0
   sys_corr_32: 0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
   sys_corr_54: 0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
   sys_corr_58: 0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
+  sys_corr_62: 0.0
   sys_corr_63: 0.0
-  sys_corr_64: -0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: 7.56145650e-03
   sys_corr_67: 5.04097100e-04
@@ -11341,54 +11341,54 @@ bins:
   sys_corr_15: -1.06365042e-02
   sys_corr_16: -4.33339060e-03
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
+  sys_corr_28: 0.0
   sys_corr_29: 0.0
   sys_corr_30: 0.0
-  sys_corr_31: -0.0
+  sys_corr_31: 0.0
   sys_corr_32: 0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
   sys_corr_55: 0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
+  sys_corr_65: 0.0
   sys_corr_66: -3.93944600e-04
   sys_corr_67: -1.18183380e-02
   sys_corr_68: -2.95458450e-02
@@ -11443,54 +11443,54 @@ bins:
   sys_corr_15: -3.78708980e-03
   sys_corr_16: -2.33051680e-03
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
   sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
+  sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
   sys_corr_32: 0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
   sys_corr_54: 0.0
   sys_corr_55: 0.0
-  sys_corr_56: -0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
+  sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
+  sys_corr_65: 0.0
   sys_corr_66: -9.90469640e-03
   sys_corr_67: -2.21399096e-02
   sys_corr_68: -3.55403812e-02
@@ -11545,54 +11545,54 @@ bins:
   sys_corr_15: -4.05914670e-03
   sys_corr_16: -4.91370390e-03
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
   sys_corr_32: 0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
   sys_corr_54: 0.0
   sys_corr_55: 0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
   sys_corr_58: 0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
+  sys_corr_62: 0.0
   sys_corr_63: 0.0
-  sys_corr_64: -0.0
-  sys_corr_65: -0.0
+  sys_corr_64: 0.0
+  sys_corr_65: 0.0
   sys_corr_66: -1.04683257e-02
   sys_corr_67: -6.83645760e-03
   sys_corr_68: -1.68775047e-02
@@ -11647,54 +11647,54 @@ bins:
   sys_corr_15: -6.50386380e-03
   sys_corr_16: -6.03930210e-03
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
-  sys_corr_20: -0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
-  sys_corr_29: -0.0
+  sys_corr_29: 0.0
   sys_corr_30: 0.0
-  sys_corr_31: -0.0
+  sys_corr_31: 0.0
   sys_corr_32: 0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
   sys_corr_54: 0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
   sys_corr_58: 0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
+  sys_corr_62: 0.0
   sys_corr_63: 0.0
-  sys_corr_64: -0.0
-  sys_corr_65: -0.0
+  sys_corr_64: 0.0
+  sys_corr_65: 0.0
   sys_corr_66: -3.87134750e-03
   sys_corr_67: -3.09707800e-03
   sys_corr_68: -9.29123400e-04
@@ -11749,49 +11749,49 @@ bins:
   sys_corr_15: -4.38633600e-03
   sys_corr_16: -1.31590080e-03
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
   sys_corr_29: 0.0
   sys_corr_30: 0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
   sys_corr_58: 0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0
@@ -11851,53 +11851,53 @@ bins:
   sys_corr_15: -2.65825872e-03
   sys_corr_16: -3.10130184e-03
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
-  sys_corr_20: -0.0
-  sys_corr_21: -0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
+  sys_corr_20: 0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
   sys_corr_23: 0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
-  sys_corr_29: -0.0
+  sys_corr_29: 0.0
   sys_corr_30: 0.0
-  sys_corr_31: -0.0
+  sys_corr_31: 0.0
   sys_corr_32: 0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
   sys_corr_54: 0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
   sys_corr_58: 0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
+  sys_corr_62: 0.0
   sys_corr_63: 0.0
-  sys_corr_64: -0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: -5.46419848e-03
   sys_corr_67: 2.36289664e-03
@@ -11952,55 +11952,55 @@ bins:
   sys_corr_14: 2.13689274e-03
   sys_corr_15: 2.48475900e-04
   sys_corr_16: 1.49085540e-04
-  sys_corr_17: -0.0
+  sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
   sys_corr_25: 0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
   sys_corr_31: 0.0
   sys_corr_32: 0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
   sys_corr_55: 0.0
-  sys_corr_56: -0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
+  sys_corr_65: 0.0
   sys_corr_66: -3.18049152e-03
   sys_corr_67: -2.83262526e-03
   sys_corr_68: -5.21799390e-03
@@ -12052,56 +12052,56 @@ bins:
   sys_corr_12: 4.71347568e-03
   sys_corr_13: 4.13236224e-03
   sys_corr_14: -3.03470352e-03
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: -5.81113440e-04
   sys_corr_17: 0.0
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
   sys_corr_31: 0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
   sys_corr_54: 0.0
-  sys_corr_55: -0.0
+  sys_corr_55: 0.0
   sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0
-  sys_corr_64: -0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: 2.51815824e-03
   sys_corr_67: 2.25988560e-03
@@ -12157,54 +12157,54 @@ bins:
   sys_corr_15: -5.79160530e-04
   sys_corr_16: -7.50763650e-04
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
-  sys_corr_20: -0.0
-  sys_corr_21: -0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
+  sys_corr_20: 0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
   sys_corr_32: 0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
   sys_corr_54: 0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
   sys_corr_58: 0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
+  sys_corr_62: 0.0
   sys_corr_63: 0.0
-  sys_corr_64: -0.0
-  sys_corr_65: -0.0
+  sys_corr_64: 0.0
+  sys_corr_65: 0.0
   sys_corr_66: -2.20939017e-03
   sys_corr_67: -6.22061310e-04
   sys_corr_68: 7.93664430e-04
@@ -12253,59 +12253,59 @@ bins:
   sys_corr_9: -7.62082002e-03
   sys_corr_10: -4.11337839e-03
   sys_corr_11: -8.27336730e-04
-  sys_corr_12: -0.0
+  sys_corr_12: 0.0
   sys_corr_13: -1.40996823e-03
   sys_corr_14: -4.31147310e-04
   sys_corr_15: 1.16526300e-05
   sys_corr_16: -3.49578900e-04
   sys_corr_17: 0.0
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
   sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
   sys_corr_31: 0.0
   sys_corr_32: 0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
   sys_corr_54: 0.0
   sys_corr_55: 0.0
   sys_corr_56: 0.0
   sys_corr_57: 0.0
   sys_corr_58: 0.0
-  sys_corr_59: -0.0
+  sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
   sys_corr_63: 0.0
-  sys_corr_64: -0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: -8.50641990e-04
   sys_corr_67: -1.04873670e-04
@@ -12362,52 +12362,52 @@ bins:
   sys_corr_16: -1.05252025e-04
   sys_corr_17: 0.0
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
   sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
   sys_corr_31: 0.0
   sys_corr_32: 0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
   sys_corr_54: 0.0
   sys_corr_55: 0.0
   sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
   sys_corr_63: 0.0
-  sys_corr_64: -0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: 1.17882268e-04
   sys_corr_67: 9.26217820e-05
@@ -12463,49 +12463,49 @@ bins:
   sys_corr_15: -5.43456000e-05
   sys_corr_16: -1.93228800e-05
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
   sys_corr_29: 0.0
   sys_corr_30: 0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
   sys_corr_58: 0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0
@@ -12566,52 +12566,52 @@ bins:
   sys_corr_16: -5.19808800e-07
   sys_corr_17: 0.0
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
   sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
   sys_corr_31: 0.0
   sys_corr_32: 0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
   sys_corr_54: 0.0
   sys_corr_55: 0.0
   sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: -1.15100520e-06
   sys_corr_67: -3.15598200e-06

--- a/nnpdf_data/nnpdf_data/commondata/ATLAS_Z0J_8TEV/uncertainties_sys_10_PT-M.yaml
+++ b/nnpdf_data/nnpdf_data/commondata/ATLAS_Z0J_8TEV/uncertainties_sys_10_PT-M.yaml
@@ -431,60 +431,60 @@ bins:
   sys_corr_15: 2.47041060e-04
   sys_corr_16: -9.05817220e-04
   sys_corr_17: -2.88214570e-04
-  sys_corr_18: -0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
   sys_corr_29: 0.0
   sys_corr_30: 0.0
-  sys_corr_31: -0.0
+  sys_corr_31: 0.0
   sys_corr_32: 0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: 0.0
-  sys_corr_67: -0.0
-  sys_corr_68: -0.0
+  sys_corr_67: 0.0
+  sys_corr_68: 0.0
   sys_corr_69: 0.0
-  sys_corr_70: -0.0
-  sys_corr_71: -0.0
+  sys_corr_70: 0.0
+  sys_corr_71: 0.0
   sys_corr_72: -2.47041060e-04
   sys_corr_73: 2.05867550e-04
   sys_corr_74: -5.39372981e-03
@@ -535,60 +535,60 @@ bins:
   sys_corr_16: -2.22432630e-04
   sys_corr_17: 2.54208720e-04
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
-  sys_corr_20: -0.0
+  sys_corr_19: 0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
+  sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
+  sys_corr_30: 0.0
   sys_corr_31: 0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 0.0
   sys_corr_68: 0.0
-  sys_corr_69: -0.0
+  sys_corr_69: 0.0
   sys_corr_70: 0.0
   sys_corr_71: 0.0
-  sys_corr_72: -0.0
+  sys_corr_72: 0.0
   sys_corr_73: 1.27104360e-04
   sys_corr_74: -7.21317243e-03
   sys_corr_75: 1.31870774e-02
@@ -598,7 +598,7 @@ bins:
   sys_corr_79: 6.19633755e-03
   sys_corr_80: -9.53282700e-05
   sys_corr_81: -2.16077412e-03
-  sys_corr_82: -0.0
+  sys_corr_82: 0.0
   sys_corr_83: 5.02062222e-03
   sys_corr_84: -5.62436793e-03
   sys_corr_85: 2.17666216e-02
@@ -638,57 +638,57 @@ bins:
   sys_corr_16: -4.54853000e-05
   sys_corr_17: 5.00338300e-04
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
-  sys_corr_20: -0.0
+  sys_corr_19: 0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
   sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 0.0
   sys_corr_68: 0.0
-  sys_corr_69: -0.0
+  sys_corr_69: 0.0
   sys_corr_70: 0.0
   sys_corr_71: 0.0
   sys_corr_72: -6.82279500e-05
@@ -739,60 +739,60 @@ bins:
   sys_corr_14: -3.69636720e-04
   sys_corr_15: -1.54015300e-05
   sys_corr_16: -4.77447430e-04
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
-  sys_corr_22: -0.0
+  sys_corr_21: 0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
   sys_corr_29: 0.0
   sys_corr_30: 0.0
   sys_corr_31: 0.0
   sys_corr_32: 0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: 0.0
-  sys_corr_67: -0.0
-  sys_corr_68: -0.0
+  sys_corr_67: 0.0
+  sys_corr_68: 0.0
   sys_corr_69: 0.0
-  sys_corr_70: -0.0
+  sys_corr_70: 0.0
   sys_corr_71: 0.0
   sys_corr_72: 4.62045900e-05
   sys_corr_73: -3.08030600e-05
@@ -844,57 +844,57 @@ bins:
   sys_corr_16: 7.10394320e-05
   sys_corr_17: 1.95358438e-04
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
-  sys_corr_20: -0.0
+  sys_corr_19: 0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
+  sys_corr_30: 0.0
   sys_corr_31: 0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 0.0
   sys_corr_68: 0.0
-  sys_corr_69: -0.0
+  sys_corr_69: 0.0
   sys_corr_70: 0.0
   sys_corr_71: 0.0
   sys_corr_72: 9.76792190e-05
@@ -947,58 +947,58 @@ bins:
   sys_corr_16: 4.82420320e-05
   sys_corr_17: 2.11058890e-05
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
-  sys_corr_20: -0.0
+  sys_corr_19: 0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
   sys_corr_25: 0.0
-  sys_corr_26: -0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
   sys_corr_31: 0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
+  sys_corr_66: 0.0
   sys_corr_67: 0.0
   sys_corr_68: 0.0
-  sys_corr_69: -0.0
-  sys_corr_70: -0.0
+  sys_corr_69: 0.0
+  sys_corr_70: 0.0
   sys_corr_71: 0.0
   sys_corr_72: -1.20605080e-05
   sys_corr_73: 4.22117780e-05
@@ -1049,60 +1049,60 @@ bins:
   sys_corr_15: 3.96710936e-05
   sys_corr_16: 1.19761792e-05
   sys_corr_17: 1.87127800e-05
-  sys_corr_18: -0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
-  sys_corr_27: -0.0
+  sys_corr_27: 0.0
   sys_corr_28: 0.0
-  sys_corr_29: -0.0
+  sys_corr_29: 0.0
   sys_corr_30: 0.0
   sys_corr_31: 0.0
   sys_corr_32: 0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
-  sys_corr_67: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
+  sys_corr_67: 0.0
   sys_corr_68: 0.0
   sys_corr_69: 0.0
-  sys_corr_70: -0.0
-  sys_corr_71: -0.0
+  sys_corr_70: 0.0
+  sys_corr_71: 0.0
   sys_corr_72: 2.84434256e-05
   sys_corr_73: 3.81740712e-05
   sys_corr_74: 1.34732016e-04
@@ -1153,60 +1153,60 @@ bins:
   sys_corr_16: 1.27752020e-06
   sys_corr_17: 1.09169908e-06
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
-  sys_corr_20: -0.0
+  sys_corr_19: 0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
   sys_corr_25: 0.0
-  sys_corr_26: -0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
   sys_corr_31: 0.0
   sys_corr_32: -2.32276400e-08
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 0.0
   sys_corr_68: 0.0
-  sys_corr_69: -0.0
+  sys_corr_69: 0.0
   sys_corr_70: 0.0
   sys_corr_71: 0.0
-  sys_corr_72: -0.0
+  sys_corr_72: 0.0
   sys_corr_73: 3.48414600e-07
   sys_corr_74: 1.18925517e-05
   sys_corr_75: 2.93132817e-05
@@ -1257,53 +1257,53 @@ bins:
   sys_corr_17: -1.03649252e-02
   sys_corr_18: 1.94700252e-03
   sys_corr_19: -2.23332642e-03
-  sys_corr_20: -0.0
-  sys_corr_21: -0.0
-  sys_corr_22: -0.0
+  sys_corr_20: 0.0
+  sys_corr_21: 0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
   sys_corr_25: 0.0
   sys_corr_26: 0.0
-  sys_corr_27: -0.0
+  sys_corr_27: 0.0
   sys_corr_28: 0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
   sys_corr_31: 0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
   sys_corr_35: 0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
+  sys_corr_66: 0.0
   sys_corr_67: 0.0
   sys_corr_68: 0.0
   sys_corr_69: 0.0
@@ -1311,7 +1311,7 @@ bins:
   sys_corr_71: 0.0
   sys_corr_72: 0.0
   sys_corr_73: 0.0
-  sys_corr_74: -0.0
+  sys_corr_74: 0.0
   sys_corr_75: -8.58971700e-05
   sys_corr_76: -2.34785598e-03
   sys_corr_77: 1.38867092e-02
@@ -1360,60 +1360,60 @@ bins:
   sys_corr_17: -3.22478668e-03
   sys_corr_18: -8.83503200e-04
   sys_corr_19: 3.75488860e-04
-  sys_corr_20: -0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
   sys_corr_25: 0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
   sys_corr_28: 0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
   sys_corr_31: 0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
   sys_corr_35: 0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
-  sys_corr_67: -0.0
+  sys_corr_66: 0.0
+  sys_corr_67: 0.0
   sys_corr_68: 0.0
-  sys_corr_69: -0.0
+  sys_corr_69: 0.0
   sys_corr_70: 0.0
   sys_corr_71: 0.0
-  sys_corr_72: -0.0
-  sys_corr_73: -0.0
+  sys_corr_72: 0.0
+  sys_corr_73: 0.0
   sys_corr_74: 0.0
   sys_corr_75: 2.87138540e-04
   sys_corr_76: 2.71677234e-03
@@ -1463,60 +1463,60 @@ bins:
   sys_corr_17: -4.96797300e-03
   sys_corr_18: -2.02398900e-03
   sys_corr_19: -1.25732650e-03
-  sys_corr_20: -0.0
-  sys_corr_21: -0.0
+  sys_corr_20: 0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
   sys_corr_25: 0.0
   sys_corr_26: 0.0
-  sys_corr_27: -0.0
+  sys_corr_27: 0.0
   sys_corr_28: 0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
   sys_corr_31: 0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
   sys_corr_35: 0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
+  sys_corr_66: 0.0
   sys_corr_67: 0.0
   sys_corr_68: 0.0
   sys_corr_69: 0.0
   sys_corr_70: 0.0
   sys_corr_71: 0.0
-  sys_corr_72: -0.0
-  sys_corr_73: -0.0
+  sys_corr_72: 0.0
+  sys_corr_73: 0.0
   sys_corr_74: 0.0
   sys_corr_75: -2.60665250e-04
   sys_corr_76: -4.07864450e-03
@@ -1566,61 +1566,61 @@ bins:
   sys_corr_17: -2.51838220e-03
   sys_corr_18: 5.57259040e-04
   sys_corr_19: -9.21620720e-04
-  sys_corr_20: -0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
   sys_corr_25: 0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
   sys_corr_28: 0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
   sys_corr_31: 0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
   sys_corr_35: 0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
-  sys_corr_67: -0.0
+  sys_corr_66: 0.0
+  sys_corr_67: 0.0
   sys_corr_68: 0.0
   sys_corr_69: 0.0
   sys_corr_70: 0.0
   sys_corr_71: 0.0
   sys_corr_72: 0.0
-  sys_corr_73: -0.0
-  sys_corr_74: -0.0
+  sys_corr_73: 0.0
+  sys_corr_74: 0.0
   sys_corr_75: 1.50031280e-04
   sys_corr_76: 3.96511240e-04
   sys_corr_77: 2.48623264e-03
@@ -1669,60 +1669,60 @@ bins:
   sys_corr_17: 5.79209220e-04
   sys_corr_18: -6.75744090e-04
   sys_corr_19: -4.50496060e-04
-  sys_corr_20: -0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
   sys_corr_25: 0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
   sys_corr_28: 0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
   sys_corr_31: 0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
   sys_corr_35: 0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
-  sys_corr_67: -0.0
+  sys_corr_66: 0.0
+  sys_corr_67: 0.0
   sys_corr_68: 0.0
   sys_corr_69: 0.0
   sys_corr_70: 0.0
   sys_corr_71: 0.0
   sys_corr_72: 0.0
-  sys_corr_73: -0.0
+  sys_corr_73: 0.0
   sys_corr_74: 0.0
   sys_corr_75: 1.28713160e-05
   sys_corr_76: -2.57426320e-05
@@ -1774,58 +1774,58 @@ bins:
   sys_corr_19: 2.36265520e-04
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
   sys_corr_33: 0.0
   sys_corr_34: 0.0
   sys_corr_35: 0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: 0.0
-  sys_corr_67: -0.0
+  sys_corr_67: 0.0
   sys_corr_68: 0.0
-  sys_corr_69: -0.0
-  sys_corr_70: -0.0
-  sys_corr_71: -0.0
+  sys_corr_69: 0.0
+  sys_corr_70: 0.0
+  sys_corr_71: 0.0
   sys_corr_72: 0.0
-  sys_corr_73: -0.0
+  sys_corr_73: 0.0
   sys_corr_74: 0.0
   sys_corr_75: 8.02844000e-05
   sys_corr_76: 4.22066560e-04
@@ -1875,14 +1875,14 @@ bins:
   sys_corr_17: 8.41576764e-05
   sys_corr_18: 1.68315353e-04
   sys_corr_19: 4.98076044e-05
-  sys_corr_20: -0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
   sys_corr_25: 0.0
   sys_corr_26: 0.0
-  sys_corr_27: -0.0
+  sys_corr_27: 0.0
   sys_corr_28: 0.0
   sys_corr_29: 0.0
   sys_corr_30: 0.0
@@ -1890,44 +1890,44 @@ bins:
   sys_corr_32: 0.0
   sys_corr_33: 0.0
   sys_corr_34: 0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 0.0
-  sys_corr_68: -0.0
-  sys_corr_69: -0.0
+  sys_corr_68: 0.0
+  sys_corr_69: 0.0
   sys_corr_70: 0.0
-  sys_corr_71: -0.0
-  sys_corr_72: -0.0
+  sys_corr_71: 0.0
+  sys_corr_72: 0.0
   sys_corr_73: 0.0
   sys_corr_74: 0.0
   sys_corr_75: 2.46175516e-05
@@ -1979,58 +1979,58 @@ bins:
   sys_corr_18: -1.31356548e-06
   sys_corr_19: 6.18646968e-06
   sys_corr_20: 2.11865400e-08
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: -2.11865400e-08
   sys_corr_29: 0.0
   sys_corr_30: 0.0
-  sys_corr_31: -0.0
+  sys_corr_31: 0.0
   sys_corr_32: 0.0
   sys_corr_33: 0.0
   sys_corr_34: 0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
-  sys_corr_65: -0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
+  sys_corr_65: 0.0
   sys_corr_66: 0.0
   sys_corr_67: 0.0
-  sys_corr_68: -0.0
-  sys_corr_69: -0.0
-  sys_corr_70: -0.0
-  sys_corr_71: -0.0
-  sys_corr_72: -0.0
+  sys_corr_68: 0.0
+  sys_corr_69: 0.0
+  sys_corr_70: 0.0
+  sys_corr_71: 0.0
+  sys_corr_72: 0.0
   sys_corr_73: 0.0
   sys_corr_74: 0.0
   sys_corr_75: -2.96611560e-07
@@ -2081,58 +2081,58 @@ bins:
   sys_corr_17: -8.99755840e-04
   sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
   sys_corr_63: 0.0
-  sys_corr_64: -0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: 0.0
   sys_corr_67: 0.0
   sys_corr_68: 0.0
   sys_corr_69: 0.0
-  sys_corr_70: -0.0
-  sys_corr_71: -0.0
+  sys_corr_70: 0.0
+  sys_corr_71: 0.0
   sys_corr_72: 0.0
   sys_corr_73: 0.0
   sys_corr_74: 8.99755840e-04
@@ -2184,60 +2184,60 @@ bins:
   sys_corr_17: 3.02408632e-03
   sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
-  sys_corr_21: -0.0
-  sys_corr_22: -0.0
+  sys_corr_20: 0.0
+  sys_corr_21: 0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 0.0
   sys_corr_68: 0.0
-  sys_corr_69: -0.0
+  sys_corr_69: 0.0
   sys_corr_70: 0.0
   sys_corr_71: 0.0
-  sys_corr_72: -0.0
-  sys_corr_73: -0.0
+  sys_corr_72: 0.0
+  sys_corr_73: 0.0
   sys_corr_74: 6.21387600e-04
   sys_corr_75: -5.92389512e-03
   sys_corr_76: 1.71917236e-03
@@ -2286,61 +2286,61 @@ bins:
   sys_corr_16: 2.80672800e-04
   sys_corr_17: 1.16479212e-03
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
-  sys_corr_22: -0.0
+  sys_corr_21: 0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
-  sys_corr_67: -0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
+  sys_corr_67: 0.0
   sys_corr_68: 0.0
-  sys_corr_69: -0.0
+  sys_corr_69: 0.0
   sys_corr_70: 0.0
   sys_corr_71: 0.0
-  sys_corr_72: -0.0
-  sys_corr_73: -0.0
+  sys_corr_72: 0.0
+  sys_corr_73: 0.0
   sys_corr_74: -2.94706440e-04
   sys_corr_75: -2.69445888e-03
   sys_corr_76: 1.54370040e-04
@@ -2389,61 +2389,61 @@ bins:
   sys_corr_16: 4.87857010e-03
   sys_corr_17: 1.11133450e-03
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
   sys_corr_23: 0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
+  sys_corr_66: 0.0
   sys_corr_67: 0.0
-  sys_corr_68: -0.0
-  sys_corr_69: -0.0
+  sys_corr_68: 0.0
+  sys_corr_69: 0.0
   sys_corr_70: 0.0
-  sys_corr_71: -0.0
-  sys_corr_72: -0.0
-  sys_corr_73: -0.0
+  sys_corr_71: 0.0
+  sys_corr_72: 0.0
+  sys_corr_73: 0.0
   sys_corr_74: 6.68684319e-04
   sys_corr_75: -2.89135332e-03
   sys_corr_76: -1.13958877e-03
@@ -2493,58 +2493,58 @@ bins:
   sys_corr_17: 8.41952400e-05
   sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0
-  sys_corr_64: -0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
-  sys_corr_67: -0.0
+  sys_corr_66: 0.0
+  sys_corr_67: 0.0
   sys_corr_68: 0.0
   sys_corr_69: 0.0
-  sys_corr_70: -0.0
-  sys_corr_71: -0.0
+  sys_corr_70: 0.0
+  sys_corr_71: 0.0
   sys_corr_72: 0.0
   sys_corr_73: 0.0
   sys_corr_74: 3.70459056e-04
@@ -2595,59 +2595,59 @@ bins:
   sys_corr_16: 7.26731627e-04
   sys_corr_17: 2.87874301e-04
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
   sys_corr_25: 0.0
-  sys_corr_26: -0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: 0.0
-  sys_corr_67: -0.0
-  sys_corr_68: -0.0
-  sys_corr_69: -0.0
-  sys_corr_70: -0.0
-  sys_corr_71: -0.0
+  sys_corr_67: 0.0
+  sys_corr_68: 0.0
+  sys_corr_69: 0.0
+  sys_corr_70: 0.0
+  sys_corr_71: 0.0
   sys_corr_72: 0.0
   sys_corr_73: 0.0
   sys_corr_74: 2.05336914e-04
@@ -2699,58 +2699,58 @@ bins:
   sys_corr_17: -3.09156258e-05
   sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
   sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
+  sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0
-  sys_corr_64: -0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
-  sys_corr_67: -0.0
+  sys_corr_66: 0.0
+  sys_corr_67: 0.0
   sys_corr_68: 0.0
   sys_corr_69: 0.0
   sys_corr_70: 0.0
-  sys_corr_71: -0.0
+  sys_corr_71: 0.0
   sys_corr_72: 0.0
   sys_corr_73: 0.0
   sys_corr_74: 2.16951760e-06
@@ -2801,60 +2801,60 @@ bins:
   sys_corr_16: 6.90422838e-06
   sys_corr_17: 1.46276025e-06
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
-  sys_corr_20: -0.0
-  sys_corr_21: -0.0
+  sys_corr_19: 0.0
+  sys_corr_20: 0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
-  sys_corr_67: -0.0
+  sys_corr_66: 0.0
+  sys_corr_67: 0.0
   sys_corr_68: 0.0
   sys_corr_69: 0.0
   sys_corr_70: 0.0
-  sys_corr_71: -0.0
-  sys_corr_72: -0.0
+  sys_corr_71: 0.0
+  sys_corr_72: 0.0
   sys_corr_73: 0.0
   sys_corr_74: 1.56027760e-06
   sys_corr_75: -6.10458611e-06
@@ -2898,59 +2898,59 @@ bins:
   sys_corr_10: 6.64625552e-01
   sys_corr_11: 6.48255465e-02
   sys_corr_12: 0.0
-  sys_corr_13: -0.0
-  sys_corr_14: -0.0
-  sys_corr_15: -0.0
+  sys_corr_13: 0.0
+  sys_corr_14: 0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
+  sys_corr_17: 0.0
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
   sys_corr_25: 0.0
-  sys_corr_26: -0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
+  sys_corr_65: 0.0
   sys_corr_66: 0.0
   sys_corr_67: -3.60141925e-02
   sys_corr_68: 1.53878823e-01
@@ -3000,55 +3000,55 @@ bins:
   sys_corr_9: 5.43884978e-01
   sys_corr_10: -2.36257728e-01
   sys_corr_11: -4.38061204e-01
-  sys_corr_12: -0.0
-  sys_corr_13: -0.0
+  sys_corr_12: 0.0
+  sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
+  sys_corr_17: 0.0
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
-  sys_corr_20: -0.0
+  sys_corr_19: 0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0
@@ -3103,55 +3103,55 @@ bins:
   sys_corr_9: 6.02632440e-01
   sys_corr_10: -4.01754960e-01
   sys_corr_11: -3.33679814e-01
-  sys_corr_12: -0.0
+  sys_corr_12: 0.0
   sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
+  sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0
@@ -3206,56 +3206,56 @@ bins:
   sys_corr_9: 1.62239675e-01
   sys_corr_10: -1.24117784e-01
   sys_corr_11: -2.12773344e-02
-  sys_corr_12: -0.0
-  sys_corr_13: -0.0
+  sys_corr_12: 0.0
+  sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
+  sys_corr_17: 0.0
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
-  sys_corr_20: -0.0
+  sys_corr_19: 0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
@@ -3309,56 +3309,56 @@ bins:
   sys_corr_9: 1.48313924e-01
   sys_corr_10: 1.89658071e-01
   sys_corr_11: -3.69472297e-01
-  sys_corr_12: -0.0
-  sys_corr_13: -0.0
-  sys_corr_14: -0.0
-  sys_corr_15: -0.0
+  sys_corr_12: 0.0
+  sys_corr_13: 0.0
+  sys_corr_14: 0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
+  sys_corr_17: 0.0
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
   sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
@@ -3412,61 +3412,61 @@ bins:
   sys_corr_9: 1.42749456e-01
   sys_corr_10: -3.70091183e-02
   sys_corr_11: -6.34442028e-02
-  sys_corr_12: -0.0
+  sys_corr_12: 0.0
   sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
-  sys_corr_16: -0.0
+  sys_corr_15: 0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
   sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
+  sys_corr_66: 0.0
   sys_corr_67: -9.61275800e-04
   sys_corr_68: -9.61275800e-03
   sys_corr_69: 7.40182366e-02
@@ -3515,56 +3515,56 @@ bins:
   sys_corr_9: 9.69195045e-02
   sys_corr_10: 1.91245845e-02
   sys_corr_11: -7.29327375e-02
-  sys_corr_12: -0.0
+  sys_corr_12: 0.0
   sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
-  sys_corr_16: -0.0
-  sys_corr_17: -0.0
+  sys_corr_15: 0.0
+  sys_corr_16: 0.0
+  sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
@@ -3618,59 +3618,59 @@ bins:
   sys_corr_9: 7.20146214e-02
   sys_corr_10: 3.96410760e-03
   sys_corr_11: -8.06035212e-02
-  sys_corr_12: -0.0
+  sys_corr_12: 0.0
   sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
+  sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0
-  sys_corr_64: -0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: 0.0
   sys_corr_67: -6.60684600e-03
@@ -3721,56 +3721,56 @@ bins:
   sys_corr_9: 6.29466741e-02
   sys_corr_10: -7.04101500e-04
   sys_corr_11: -4.94279253e-02
-  sys_corr_12: -0.0
-  sys_corr_13: -0.0
+  sys_corr_12: 0.0
+  sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
+  sys_corr_17: 0.0
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
-  sys_corr_20: -0.0
+  sys_corr_19: 0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
@@ -3824,61 +3824,61 @@ bins:
   sys_corr_9: 4.96805155e-02
   sys_corr_10: 1.89689241e-03
   sys_corr_11: 2.75501041e-02
-  sys_corr_12: -0.0
+  sys_corr_12: 0.0
   sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
   sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
+  sys_corr_66: 0.0
   sys_corr_67: 2.34853346e-03
   sys_corr_68: 1.26459494e-02
   sys_corr_69: 3.08019196e-02
@@ -3927,11 +3927,11 @@ bins:
   sys_corr_9: 4.58295317e-02
   sys_corr_10: 3.75328062e-02
   sys_corr_11: -2.48337364e-03
-  sys_corr_12: -0.0
+  sys_corr_12: 0.0
   sys_corr_13: 0.0
   sys_corr_14: 0.0
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
@@ -3940,48 +3940,48 @@ bins:
   sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0
-  sys_corr_64: -0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
+  sys_corr_66: 0.0
   sys_corr_67: 7.90164340e-04
   sys_corr_68: 3.89438139e-03
   sys_corr_69: 1.05543380e-02
@@ -4030,11 +4030,11 @@ bins:
   sys_corr_9: 3.43355553e-02
   sys_corr_10: 3.92190025e-02
   sys_corr_11: -1.24925394e-03
-  sys_corr_12: -0.0
+  sys_corr_12: 0.0
   sys_corr_13: 0.0
   sys_corr_14: 0.0
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
@@ -4042,49 +4042,49 @@ bins:
   sys_corr_21: 0.0
   sys_corr_22: 0.0
   sys_corr_23: 0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0
-  sys_corr_64: -0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
+  sys_corr_66: 0.0
   sys_corr_67: 1.13568540e-03
   sys_corr_68: 4.65631014e-03
   sys_corr_69: 1.09025798e-02
@@ -4133,61 +4133,61 @@ bins:
   sys_corr_9: 2.85367794e-02
   sys_corr_10: 2.77405236e-02
   sys_corr_11: -9.76055460e-04
-  sys_corr_12: -0.0
+  sys_corr_12: 0.0
   sys_corr_13: 0.0
   sys_corr_14: 0.0
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
   sys_corr_22: 0.0
   sys_corr_23: 0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0
-  sys_corr_64: -0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
+  sys_corr_66: 0.0
   sys_corr_67: 3.85285050e-04
   sys_corr_68: 2.18328195e-03
   sys_corr_69: 6.49847451e-03
@@ -4236,61 +4236,61 @@ bins:
   sys_corr_9: 1.74753321e-02
   sys_corr_10: 1.10424835e-02
   sys_corr_11: 3.54322678e-03
-  sys_corr_12: -0.0
+  sys_corr_12: 0.0
   sys_corr_13: 0.0
   sys_corr_14: 0.0
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
   sys_corr_22: 0.0
   sys_corr_23: 0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
+  sys_corr_66: 0.0
   sys_corr_67: 8.77206630e-04
   sys_corr_68: 2.18441651e-03
   sys_corr_69: 7.51645681e-03
@@ -4339,11 +4339,11 @@ bins:
   sys_corr_9: 1.42645954e-02
   sys_corr_10: 5.29695072e-03
   sys_corr_11: -7.06260096e-03
-  sys_corr_12: -0.0
+  sys_corr_12: 0.0
   sys_corr_13: 0.0
   sys_corr_14: 0.0
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
@@ -4352,48 +4352,48 @@ bins:
   sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
   sys_corr_63: 0.0
-  sys_corr_64: -0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
+  sys_corr_66: 0.0
   sys_corr_67: -2.09090160e-04
   sys_corr_68: -1.35908604e-03
   sys_corr_69: 1.23130872e-03
@@ -4442,61 +4442,61 @@ bins:
   sys_corr_9: 8.20800609e-03
   sys_corr_10: 4.50700134e-03
   sys_corr_11: -9.98448837e-03
-  sys_corr_12: -0.0
+  sys_corr_12: 0.0
   sys_corr_13: 0.0
   sys_corr_14: 0.0
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
   sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
   sys_corr_63: 0.0
-  sys_corr_64: -0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
+  sys_corr_66: 0.0
   sys_corr_67: 4.11222750e-05
   sys_corr_68: -2.33574522e-03
   sys_corr_69: -3.61876020e-04
@@ -4547,59 +4547,59 @@ bins:
   sys_corr_11: -7.74768168e-03
   sys_corr_12: 0.0
   sys_corr_13: 0.0
-  sys_corr_14: -0.0
+  sys_corr_14: 0.0
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
   sys_corr_25: 0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: -1.32397092e-04
   sys_corr_68: -2.91273602e-03
   sys_corr_69: -2.64303824e-03
@@ -4648,61 +4648,61 @@ bins:
   sys_corr_9: 3.11789730e-04
   sys_corr_10: -1.97108450e-04
   sys_corr_11: -1.45322685e-03
-  sys_corr_12: -0.0
+  sys_corr_12: 0.0
   sys_corr_13: 0.0
   sys_corr_14: 0.0
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
   sys_corr_25: 0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
+  sys_corr_66: 0.0
   sys_corr_67: 1.75605710e-04
   sys_corr_68: -2.49073405e-04
   sys_corr_69: -6.57625465e-04
@@ -4751,61 +4751,61 @@ bins:
   sys_corr_9: 3.56939621e-04
   sys_corr_10: 2.83124912e-05
   sys_corr_11: -8.74653746e-04
-  sys_corr_12: -0.0
+  sys_corr_12: 0.0
   sys_corr_13: 0.0
   sys_corr_14: 0.0
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
   sys_corr_25: 0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
+  sys_corr_66: 0.0
   sys_corr_67: -1.36506654e-05
   sys_corr_68: -2.69474247e-04
   sys_corr_69: -2.20432967e-04
@@ -4854,61 +4854,61 @@ bins:
   sys_corr_9: 3.15331604e-05
   sys_corr_10: -2.67900632e-05
   sys_corr_11: 1.70039099e-05
-  sys_corr_12: -0.0
+  sys_corr_12: 0.0
   sys_corr_13: 0.0
   sys_corr_14: 0.0
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
-  sys_corr_21: -0.0
+  sys_corr_20: 0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
   sys_corr_23: 0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
+  sys_corr_66: 0.0
   sys_corr_67: 7.16151444e-06
   sys_corr_68: 5.26802502e-06
   sys_corr_69: 1.07422717e-05
@@ -4958,59 +4958,59 @@ bins:
   sys_corr_10: -2.36499676e-02
   sys_corr_11: -7.48111220e-03
   sys_corr_12: -9.65304800e-04
-  sys_corr_13: -0.0
+  sys_corr_13: 0.0
   sys_corr_14: 0.0
   sys_corr_15: 0.0
   sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
-  sys_corr_20: -0.0
-  sys_corr_21: -0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
+  sys_corr_20: 0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
   sys_corr_56: 0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
-  sys_corr_65: -0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
+  sys_corr_65: 0.0
   sys_corr_66: 1.37555934e-02
   sys_corr_67: -1.29109517e-02
   sys_corr_68: -1.62895185e-02
@@ -5061,57 +5061,57 @@ bins:
   sys_corr_10: 2.25930760e-02
   sys_corr_11: 2.43902525e-02
   sys_corr_12: -3.38896140e-02
-  sys_corr_13: -0.0
+  sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
-  sys_corr_16: -0.0
-  sys_corr_17: -0.0
+  sys_corr_15: 0.0
+  sys_corr_16: 0.0
+  sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
-  sys_corr_21: -0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
+  sys_corr_20: 0.0
+  sys_corr_21: 0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: -1.69448070e-02
@@ -5164,57 +5164,57 @@ bins:
   sys_corr_10: 6.93394980e-02
   sys_corr_11: -5.43839200e-04
   sys_corr_12: -3.50776284e-02
-  sys_corr_13: -0.0
+  sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
-  sys_corr_16: -0.0
-  sys_corr_17: -0.0
+  sys_corr_15: 0.0
+  sys_corr_16: 0.0
+  sys_corr_17: 0.0
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
-  sys_corr_20: -0.0
-  sys_corr_21: -0.0
+  sys_corr_19: 0.0
+  sys_corr_20: 0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: -7.88566840e-03
@@ -5267,57 +5267,57 @@ bins:
   sys_corr_10: 1.22018092e-01
   sys_corr_11: 3.15354910e-03
   sys_corr_12: -3.88129120e-02
-  sys_corr_13: -0.0
+  sys_corr_13: 0.0
   sys_corr_14: 0.0
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
-  sys_corr_17: -0.0
+  sys_corr_16: 0.0
+  sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
-  sys_corr_21: -0.0
+  sys_corr_20: 0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: -1.69806490e-02
@@ -5370,58 +5370,58 @@ bins:
   sys_corr_10: -1.10192232e-02
   sys_corr_11: 5.68246216e-02
   sys_corr_12: -2.13902568e-02
-  sys_corr_13: -0.0
+  sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
-  sys_corr_21: -0.0
+  sys_corr_20: 0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
   sys_corr_56: 0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: 8.42646480e-03
   sys_corr_67: -1.83653720e-02
@@ -5473,57 +5473,57 @@ bins:
   sys_corr_10: 2.42683560e-02
   sys_corr_11: 2.49568200e-02
   sys_corr_12: -2.08260360e-02
-  sys_corr_13: -0.0
+  sys_corr_13: 0.0
   sys_corr_14: 0.0
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
-  sys_corr_21: -0.0
+  sys_corr_20: 0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: -6.71252400e-03
@@ -5576,57 +5576,57 @@ bins:
   sys_corr_10: 5.11612368e-02
   sys_corr_11: 1.07634296e-02
   sys_corr_12: -1.94300872e-02
-  sys_corr_13: -0.0
+  sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
-  sys_corr_20: -0.0
-  sys_corr_21: -0.0
+  sys_corr_19: 0.0
+  sys_corr_20: 0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
   sys_corr_56: 0.0
-  sys_corr_57: -0.0
+  sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: -5.59139200e-04
@@ -5679,57 +5679,57 @@ bins:
   sys_corr_10: 2.28623132e-02
   sys_corr_11: 1.53134362e-02
   sys_corr_12: -1.04605867e-02
-  sys_corr_13: -0.0
+  sys_corr_13: 0.0
   sys_corr_14: 0.0
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
-  sys_corr_21: -0.0
+  sys_corr_20: 0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: -4.31364400e-04
@@ -5782,57 +5782,57 @@ bins:
   sys_corr_10: 1.61712533e-02
   sys_corr_11: 7.38788220e-03
   sys_corr_12: -1.24773122e-02
-  sys_corr_13: -0.0
+  sys_corr_13: 0.0
   sys_corr_14: 0.0
   sys_corr_15: 0.0
   sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
-  sys_corr_20: -0.0
-  sys_corr_21: -0.0
+  sys_corr_19: 0.0
+  sys_corr_20: 0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: 1.80592676e-03
@@ -5885,57 +5885,57 @@ bins:
   sys_corr_10: 2.31174989e-02
   sys_corr_11: 7.76650880e-03
   sys_corr_12: -3.39784760e-03
-  sys_corr_13: -0.0
+  sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
-  sys_corr_16: -0.0
+  sys_corr_15: 0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
-  sys_corr_21: -0.0
+  sys_corr_20: 0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
   sys_corr_56: 0.0
-  sys_corr_57: -0.0
+  sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: -1.21351700e-03
@@ -5988,59 +5988,59 @@ bins:
   sys_corr_10: 9.74661471e-03
   sys_corr_11: 1.42416288e-03
   sys_corr_12: -2.84832576e-03
-  sys_corr_13: -0.0
+  sys_corr_13: 0.0
   sys_corr_14: 0.0
   sys_corr_15: 0.0
   sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
-  sys_corr_20: -0.0
-  sys_corr_21: -0.0
+  sys_corr_19: 0.0
+  sys_corr_20: 0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
   sys_corr_56: 0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
-  sys_corr_65: -0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
+  sys_corr_65: 0.0
   sys_corr_66: 2.09173923e-03
   sys_corr_67: -4.76204463e-03
   sys_corr_68: -5.51863116e-03
@@ -6091,59 +6091,59 @@ bins:
   sys_corr_10: 9.56069009e-03
   sys_corr_11: 1.39757596e-03
   sys_corr_12: -9.84655790e-04
-  sys_corr_13: -0.0
+  sys_corr_13: 0.0
   sys_corr_14: 0.0
   sys_corr_15: 0.0
   sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
-  sys_corr_20: -0.0
-  sys_corr_21: -0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
+  sys_corr_20: 0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
   sys_corr_56: 0.0
-  sys_corr_57: -0.0
+  sys_corr_57: 0.0
   sys_corr_58: 0.0
-  sys_corr_59: -0.0
+  sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
+  sys_corr_65: 0.0
   sys_corr_66: 1.14347124e-03
   sys_corr_67: -4.12920170e-04
   sys_corr_68: -5.20914676e-03
@@ -6195,58 +6195,58 @@ bins:
   sys_corr_11: -6.09378560e-04
   sys_corr_12: 5.22324480e-04
   sys_corr_13: 0.0
-  sys_corr_14: -0.0
-  sys_corr_15: -0.0
-  sys_corr_16: -0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
+  sys_corr_14: 0.0
+  sys_corr_15: 0.0
+  sys_corr_16: 0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
-  sys_corr_22: -0.0
+  sys_corr_21: 0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
   sys_corr_25: 0.0
   sys_corr_26: 0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
   sys_corr_56: 0.0
-  sys_corr_57: -0.0
+  sys_corr_57: 0.0
   sys_corr_58: 0.0
-  sys_corr_59: -0.0
+  sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
+  sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
+  sys_corr_65: 0.0
   sys_corr_66: -6.09378560e-04
   sys_corr_67: 6.09378560e-04
   sys_corr_68: 1.52344640e-03
@@ -6298,58 +6298,58 @@ bins:
   sys_corr_11: 1.00710652e-03
   sys_corr_12: 1.00710652e-03
   sys_corr_13: 0.0
-  sys_corr_14: -0.0
-  sys_corr_15: -0.0
+  sys_corr_14: 0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
-  sys_corr_20: -0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
   sys_corr_56: 0.0
   sys_corr_57: 0.0
   sys_corr_58: 0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
   sys_corr_63: 0.0
-  sys_corr_64: -0.0
-  sys_corr_65: -0.0
+  sys_corr_64: 0.0
+  sys_corr_65: 0.0
   sys_corr_66: 9.77485740e-04
   sys_corr_67: -2.66587020e-04
   sys_corr_68: -5.96858717e-03
@@ -6401,56 +6401,56 @@ bins:
   sys_corr_11: -5.02162000e-05
   sys_corr_12: -3.51513400e-04
   sys_corr_13: 0.0
-  sys_corr_14: -0.0
-  sys_corr_15: -0.0
-  sys_corr_16: -0.0
-  sys_corr_17: -0.0
+  sys_corr_14: 0.0
+  sys_corr_15: 0.0
+  sys_corr_16: 0.0
+  sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
   sys_corr_25: 0.0
   sys_corr_26: 0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
   sys_corr_56: 0.0
-  sys_corr_57: -0.0
+  sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: -1.11479964e-03
@@ -6504,48 +6504,48 @@ bins:
   sys_corr_11: 1.48721412e-03
   sys_corr_12: 2.90188120e-05
   sys_corr_13: 0.0
-  sys_corr_14: -0.0
-  sys_corr_15: -0.0
-  sys_corr_16: -0.0
+  sys_corr_14: 0.0
+  sys_corr_15: 0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
-  sys_corr_22: -0.0
+  sys_corr_21: 0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
   sys_corr_25: 0.0
   sys_corr_26: 0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
   sys_corr_56: 0.0
   sys_corr_57: 0.0
   sys_corr_58: 0.0
@@ -6607,53 +6607,53 @@ bins:
   sys_corr_11: -9.75830800e-06
   sys_corr_12: 8.78247720e-04
   sys_corr_13: 0.0
-  sys_corr_14: -0.0
-  sys_corr_15: -0.0
-  sys_corr_16: -0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
+  sys_corr_14: 0.0
+  sys_corr_15: 0.0
+  sys_corr_16: 0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
   sys_corr_25: 0.0
   sys_corr_26: 0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0
@@ -6710,49 +6710,49 @@ bins:
   sys_corr_11: 1.06253250e-04
   sys_corr_12: 1.80630525e-04
   sys_corr_13: 0.0
-  sys_corr_14: -0.0
-  sys_corr_15: -0.0
-  sys_corr_16: -0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
+  sys_corr_14: 0.0
+  sys_corr_15: 0.0
+  sys_corr_16: 0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
   sys_corr_25: 0.0
   sys_corr_26: 0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
@@ -6813,49 +6813,49 @@ bins:
   sys_corr_11: 1.91372740e-04
   sys_corr_12: -1.18783080e-05
   sys_corr_13: 0.0
-  sys_corr_14: -0.0
-  sys_corr_15: -0.0
-  sys_corr_16: -0.0
-  sys_corr_17: -0.0
+  sys_corr_14: 0.0
+  sys_corr_15: 0.0
+  sys_corr_16: 0.0
+  sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
   sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
@@ -6917,52 +6917,52 @@ bins:
   sys_corr_12: 2.02990974e-06
   sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
-  sys_corr_16: -0.0
-  sys_corr_17: -0.0
+  sys_corr_15: 0.0
+  sys_corr_16: 0.0
+  sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
   sys_corr_25: 0.0
   sys_corr_26: 0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0

--- a/nnpdf_data/nnpdf_data/commondata/ATLAS_Z0J_8TEV/uncertainties_sys_10_PT-Y.yaml
+++ b/nnpdf_data/nnpdf_data/commondata/ATLAS_Z0J_8TEV/uncertainties_sys_10_PT-Y.yaml
@@ -426,60 +426,60 @@ bins:
   sys_corr_10: -2.01960474e-01
   sys_corr_11: -7.65495345e-01
   sys_corr_12: -1.59613923e-01
-  sys_corr_13: -0.0
+  sys_corr_13: 0.0
   sys_corr_14: 0.0
   sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
   sys_corr_54: 0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 1.46584215e-01
   sys_corr_68: 7.49208210e-02
   sys_corr_69: -1.53099069e-01
@@ -529,60 +529,60 @@ bins:
   sys_corr_10: -1.34159220e-01
   sys_corr_11: -2.95150284e-01
   sys_corr_12: -1.00619415e-01
-  sys_corr_13: -0.0
+  sys_corr_13: 0.0
   sys_corr_14: 0.0
   sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
+  sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
   sys_corr_54: 0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 5.36636880e-02
   sys_corr_68: 2.81734362e-01
   sys_corr_69: 1.54283103e-01
@@ -633,57 +633,57 @@ bins:
   sys_corr_11: 1.94712960e-01
   sys_corr_12: 6.04281600e-02
   sys_corr_13: 0.0
-  sys_corr_14: -0.0
-  sys_corr_15: -0.0
-  sys_corr_16: -0.0
+  sys_corr_14: 0.0
+  sys_corr_15: 0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
-  sys_corr_20: -0.0
-  sys_corr_21: -0.0
+  sys_corr_19: 0.0
+  sys_corr_20: 0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
   sys_corr_53: 0.0
-  sys_corr_54: -0.0
+  sys_corr_54: 0.0
   sys_corr_55: 0.0
   sys_corr_56: 0.0
   sys_corr_57: 0.0
   sys_corr_58: 0.0
-  sys_corr_59: -0.0
+  sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
+  sys_corr_62: 0.0
   sys_corr_63: 0.0
-  sys_corr_64: -0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: 0.0
   sys_corr_67: -6.71424000e-03
@@ -739,56 +739,56 @@ bins:
   sys_corr_14: 0.0
   sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
   sys_corr_54: 0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 5.88610900e-02
   sys_corr_68: 8.82916350e-02
   sys_corr_69: 1.00063853e-01
@@ -838,60 +838,60 @@ bins:
   sys_corr_10: -7.38902250e-02
   sys_corr_11: -9.35942850e-02
   sys_corr_12: -7.38902250e-02
-  sys_corr_13: -0.0
-  sys_corr_14: -0.0
+  sys_corr_13: 0.0
+  sys_corr_14: 0.0
   sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
   sys_corr_53: 0.0
   sys_corr_54: 0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
+  sys_corr_66: 0.0
   sys_corr_67: 1.47780450e-02
   sys_corr_68: -2.95560900e-02
   sys_corr_69: -8.37422550e-02
@@ -942,59 +942,59 @@ bins:
   sys_corr_11: 6.26986240e-02
   sys_corr_12: 3.52679760e-02
   sys_corr_13: 0.0
-  sys_corr_14: -0.0
-  sys_corr_15: -0.0
-  sys_corr_16: -0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_14: 0.0
+  sys_corr_15: 0.0
+  sys_corr_16: 0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
+  sys_corr_21: 0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
   sys_corr_54: 0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
   sys_corr_58: 0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 1.95933200e-02
   sys_corr_68: 9.79666000e-02
   sys_corr_69: 1.29315912e-01
@@ -1045,59 +1045,59 @@ bins:
   sys_corr_11: 3.01918300e-02
   sys_corr_12: 3.01918300e-03
   sys_corr_13: 0.0
-  sys_corr_14: -0.0
+  sys_corr_14: 0.0
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
+  sys_corr_16: 0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
   sys_corr_53: 0.0
   sys_corr_54: 0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
+  sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
+  sys_corr_66: 0.0
   sys_corr_67: 6.03836600e-03
   sys_corr_68: 4.22685620e-02
   sys_corr_69: 5.73644770e-02
@@ -1150,57 +1150,57 @@ bins:
   sys_corr_13: 0.0
   sys_corr_14: 0.0
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
+  sys_corr_16: 0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
   sys_corr_54: 0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 1.82370320e-02
   sys_corr_68: 4.78722090e-02
   sys_corr_69: 7.06684990e-02
@@ -1250,60 +1250,60 @@ bins:
   sys_corr_10: -3.94732320e-02
   sys_corr_11: -2.46707700e-02
   sys_corr_12: 8.22359000e-03
-  sys_corr_13: -0.0
+  sys_corr_13: 0.0
   sys_corr_14: 0.0
   sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
   sys_corr_54: 0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 1.97366160e-02
   sys_corr_68: 3.12496420e-02
   sys_corr_69: 4.76968220e-02
@@ -1354,59 +1354,59 @@ bins:
   sys_corr_11: 3.51684600e-02
   sys_corr_12: 1.99287940e-02
   sys_corr_13: 0.0
-  sys_corr_14: -0.0
-  sys_corr_15: -0.0
-  sys_corr_16: -0.0
+  sys_corr_14: 0.0
+  sys_corr_15: 0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
+  sys_corr_21: 0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
   sys_corr_54: 0.0
   sys_corr_55: 0.0
   sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 5.86141000e-03
   sys_corr_68: 4.80635620e-02
   sys_corr_69: 2.93070500e-02
@@ -1458,58 +1458,58 @@ bins:
   sys_corr_12: 1.15392830e-02
   sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
-  sys_corr_16: -0.0
+  sys_corr_15: 0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
+  sys_corr_21: 0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
   sys_corr_54: 0.0
   sys_corr_55: 0.0
-  sys_corr_56: -0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 8.24234500e-03
   sys_corr_68: 3.29693800e-02
   sys_corr_69: 1.31877520e-02
@@ -1560,59 +1560,59 @@ bins:
   sys_corr_11: 5.55167700e-03
   sys_corr_12: 7.21718010e-03
   sys_corr_13: 0.0
-  sys_corr_14: -0.0
+  sys_corr_14: 0.0
   sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
   sys_corr_54: 0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 1.11033540e-02
   sys_corr_68: 4.21927452e-02
   sys_corr_69: -1.66550310e-03
@@ -1667,55 +1667,55 @@ bins:
   sys_corr_15: 0.0
   sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
   sys_corr_54: 0.0
   sys_corr_55: 0.0
-  sys_corr_56: -0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 8.77467840e-03
   sys_corr_68: 1.31620176e-02
   sys_corr_69: 1.46244640e-03
@@ -1766,59 +1766,59 @@ bins:
   sys_corr_11: 7.68470340e-03
   sys_corr_12: 8.84905240e-03
   sys_corr_13: 0.0
-  sys_corr_14: -0.0
+  sys_corr_14: 0.0
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
+  sys_corr_16: 0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
   sys_corr_54: 0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 8.61618260e-03
   sys_corr_68: 1.60680162e-02
   sys_corr_69: 1.25749692e-02
@@ -1870,58 +1870,58 @@ bins:
   sys_corr_12: 8.22532440e-03
   sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
-  sys_corr_16: -0.0
+  sys_corr_15: 0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
+  sys_corr_21: 0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
   sys_corr_54: 0.0
   sys_corr_55: 0.0
-  sys_corr_56: -0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 6.36298680e-03
   sys_corr_68: 9.31168800e-04
   sys_corr_69: 9.77727240e-03
@@ -1973,58 +1973,58 @@ bins:
   sys_corr_12: 4.23572230e-03
   sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
-  sys_corr_16: -0.0
+  sys_corr_15: 0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
+  sys_corr_21: 0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
   sys_corr_54: 0.0
   sys_corr_55: 0.0
-  sys_corr_56: -0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 3.30592960e-03
   sys_corr_68: -5.26882530e-03
   sys_corr_69: 2.78937810e-03
@@ -2076,58 +2076,58 @@ bins:
   sys_corr_12: 3.62239045e-03
   sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
-  sys_corr_16: -0.0
+  sys_corr_15: 0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
+  sys_corr_21: 0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
   sys_corr_54: 0.0
   sys_corr_55: 0.0
-  sys_corr_56: -0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 2.25657110e-03
   sys_corr_68: -8.13553265e-03
   sys_corr_69: 5.70081120e-03
@@ -2177,59 +2177,59 @@ bins:
   sys_corr_10: -3.63338880e-04
   sys_corr_11: -9.53764560e-04
   sys_corr_12: 6.58551720e-04
-  sys_corr_13: -0.0
+  sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
-  sys_corr_16: -0.0
+  sys_corr_15: 0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
+  sys_corr_21: 0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
   sys_corr_54: 0.0
   sys_corr_55: 0.0
   sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
-  sys_corr_65: -0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
+  sys_corr_65: 0.0
   sys_corr_66: 0.0
   sys_corr_67: 2.27086800e-04
   sys_corr_68: -4.22381448e-03
@@ -2280,59 +2280,59 @@ bins:
   sys_corr_10: 3.90459780e-05
   sys_corr_11: -1.41216287e-03
   sys_corr_12: -1.49676249e-04
-  sys_corr_13: -0.0
+  sys_corr_13: 0.0
   sys_corr_14: 0.0
   sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
+  sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
   sys_corr_22: 0.0
   sys_corr_23: 0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
   sys_corr_54: 0.0
   sys_corr_55: 0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
-  sys_corr_65: -0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
+  sys_corr_65: 0.0
   sys_corr_66: 0.0
   sys_corr_67: 6.50766300e-05
   sys_corr_68: -1.17788700e-03
@@ -2383,58 +2383,58 @@ bins:
   sys_corr_10: 2.67029360e-05
   sys_corr_11: -4.81754000e-05
   sys_corr_12: -1.59667040e-05
-  sys_corr_13: -0.0
+  sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
-  sys_corr_20: -0.0
+  sys_corr_19: 0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
   sys_corr_22: 0.0
   sys_corr_23: 0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
   sys_corr_55: 0.0
   sys_corr_56: 0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0
-  sys_corr_64: -0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: 0.0
   sys_corr_67: -1.37644000e-05
@@ -2487,59 +2487,59 @@ bins:
   sys_corr_11: -3.86236440e-01
   sys_corr_12: -1.38401391e-01
   sys_corr_13: -2.96114604e-01
-  sys_corr_14: -0.0
+  sys_corr_14: 0.0
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
   sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
   sys_corr_58: 0.0
-  sys_corr_59: -0.0
+  sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
+  sys_corr_66: 0.0
   sys_corr_67: -7.08100140e-02
   sys_corr_68: -1.67369124e-01
   sys_corr_69: 8.72250627e-01
@@ -2590,58 +2590,58 @@ bins:
   sys_corr_11: -7.47763968e-01
   sys_corr_12: 1.80264528e-01
   sys_corr_13: 1.40205744e-01
-  sys_corr_14: -0.0
-  sys_corr_15: -0.0
+  sys_corr_14: 0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
-  sys_corr_65: -0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
+  sys_corr_65: 0.0
   sys_corr_66: 0.0
   sys_corr_67: -1.06823424e-01
   sys_corr_68: 3.80558448e-01
@@ -2693,58 +2693,58 @@ bins:
   sys_corr_11: -2.82970590e-01
   sys_corr_12: 6.53527315e-01
   sys_corr_13: 1.34747900e-01
-  sys_corr_14: -0.0
-  sys_corr_15: -0.0
+  sys_corr_14: 0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
-  sys_corr_20: -0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
-  sys_corr_65: -0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
+  sys_corr_65: 0.0
   sys_corr_66: 0.0
   sys_corr_67: -4.51405465e-01
   sys_corr_68: 4.71617650e-01
@@ -2796,59 +2796,59 @@ bins:
   sys_corr_11: -5.40229888e-01
   sys_corr_12: 9.39530240e-02
   sys_corr_13: -1.11569216e-01
-  sys_corr_14: -0.0
+  sys_corr_14: 0.0
   sys_corr_15: 0.0
   sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
-  sys_corr_20: -0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
   sys_corr_25: 0.0
-  sys_corr_26: -0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: -2.23138432e-01
   sys_corr_68: -1.76161920e-02
   sys_corr_69: 4.46276864e-01
@@ -2899,54 +2899,54 @@ bins:
   sys_corr_11: -3.45280881e-01
   sys_corr_12: -2.43155550e-01
   sys_corr_13: -1.89661329e-01
-  sys_corr_14: -0.0
+  sys_corr_14: 0.0
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
-  sys_corr_21: -0.0
+  sys_corr_20: 0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
   sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
   sys_corr_58: 0.0
-  sys_corr_59: -0.0
+  sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
@@ -3002,59 +3002,59 @@ bins:
   sys_corr_11: -4.55467311e-01
   sys_corr_12: 0.0
   sys_corr_13: -6.22861280e-02
-  sys_corr_14: -0.0
+  sys_corr_14: 0.0
   sys_corr_15: 0.0
   sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
-  sys_corr_20: -0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
   sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: -7.39647770e-02
   sys_corr_68: -1.24572256e-01
   sys_corr_69: 1.44036671e-01
@@ -3105,56 +3105,56 @@ bins:
   sys_corr_11: -1.94675455e-01
   sys_corr_12: -4.49251050e-02
   sys_corr_13: -2.39600560e-02
-  sys_corr_14: -0.0
-  sys_corr_15: -0.0
+  sys_corr_14: 0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
-  sys_corr_21: -0.0
+  sys_corr_20: 0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
   sys_corr_23: 0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: 0.0
@@ -3208,56 +3208,56 @@ bins:
   sys_corr_11: -2.26615500e-01
   sys_corr_12: -8.15815800e-02
   sys_corr_13: 4.53231000e-03
-  sys_corr_14: -0.0
-  sys_corr_15: -0.0
+  sys_corr_14: 0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
-  sys_corr_20: -0.0
-  sys_corr_21: -0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
+  sys_corr_20: 0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: 0.0
@@ -3311,59 +3311,59 @@ bins:
   sys_corr_11: -2.01639872e-01
   sys_corr_12: -2.43919200e-02
   sys_corr_13: -2.11396640e-02
-  sys_corr_14: -0.0
+  sys_corr_14: 0.0
   sys_corr_15: 0.0
   sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
-  sys_corr_20: -0.0
+  sys_corr_19: 0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
   sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
+  sys_corr_62: 0.0
   sys_corr_63: 0.0
-  sys_corr_64: -0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
+  sys_corr_66: 0.0
   sys_corr_67: -1.62612800e-03
   sys_corr_68: -4.39054560e-02
   sys_corr_69: 6.01667360e-02
@@ -3414,58 +3414,58 @@ bins:
   sys_corr_11: -1.50020292e-01
   sys_corr_12: -4.41920240e-02
   sys_corr_13: -1.16294800e-03
-  sys_corr_14: -0.0
-  sys_corr_15: -0.0
+  sys_corr_14: 0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
-  sys_corr_20: -0.0
-  sys_corr_21: -0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
+  sys_corr_20: 0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
   sys_corr_23: 0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
+  sys_corr_65: 0.0
   sys_corr_66: 0.0
   sys_corr_67: -5.34956080e-02
   sys_corr_68: -2.32589600e-03
@@ -3517,55 +3517,55 @@ bins:
   sys_corr_11: -1.23032524e-01
   sys_corr_12: -3.88523760e-02
   sys_corr_13: -2.99487065e-02
-  sys_corr_14: -0.0
+  sys_corr_14: 0.0
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
-  sys_corr_20: -0.0
-  sys_corr_21: -0.0
+  sys_corr_19: 0.0
+  sys_corr_20: 0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
   sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
   sys_corr_58: 0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
@@ -3620,58 +3620,58 @@ bins:
   sys_corr_11: -9.54923310e-02
   sys_corr_12: -2.14034535e-02
   sys_corr_13: -1.15249365e-02
-  sys_corr_14: -0.0
+  sys_corr_14: 0.0
   sys_corr_15: 0.0
   sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
-  sys_corr_20: -0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
+  sys_corr_65: 0.0
   sys_corr_66: 0.0
   sys_corr_67: -1.86594210e-02
   sys_corr_68: -2.14034535e-02
@@ -3723,58 +3723,58 @@ bins:
   sys_corr_11: -6.66759159e-02
   sys_corr_12: -1.06966710e-02
   sys_corr_13: -3.20900130e-03
-  sys_corr_14: -0.0
-  sys_corr_15: -0.0
+  sys_corr_14: 0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
+  sys_corr_65: 0.0
   sys_corr_66: 0.0
   sys_corr_67: -1.21228938e-02
   sys_corr_68: -1.28360052e-02
@@ -3826,57 +3826,57 @@ bins:
   sys_corr_11: -3.66205461e-02
   sys_corr_12: -1.10552592e-02
   sys_corr_13: 0.0
-  sys_corr_14: -0.0
-  sys_corr_15: -0.0
+  sys_corr_14: 0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
   sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: 0.0
   sys_corr_67: 2.76381480e-03
@@ -3929,58 +3929,58 @@ bins:
   sys_corr_11: -1.17915182e-02
   sys_corr_12: -3.36900520e-03
   sys_corr_13: -3.06273200e-04
-  sys_corr_14: -0.0
-  sys_corr_15: -0.0
+  sys_corr_14: 0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
-  sys_corr_65: -0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
+  sys_corr_65: 0.0
   sys_corr_66: 0.0
   sys_corr_67: -3.06273200e-03
   sys_corr_68: -9.95387900e-03
@@ -4032,56 +4032,56 @@ bins:
   sys_corr_11: 5.46913890e-03
   sys_corr_12: -5.15956500e-04
   sys_corr_13: -1.13510430e-03
-  sys_corr_14: -0.0
-  sys_corr_15: -0.0
+  sys_corr_14: 0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
-  sys_corr_21: -0.0
+  sys_corr_20: 0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
   sys_corr_25: 0.0
-  sys_corr_26: -0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
+  sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
   sys_corr_58: 0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: 0.0
@@ -4135,59 +4135,59 @@ bins:
   sys_corr_11: 2.20469008e-03
   sys_corr_12: -1.97261744e-03
   sys_corr_13: -1.16036320e-03
-  sys_corr_14: -0.0
+  sys_corr_14: 0.0
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
-  sys_corr_21: -0.0
+  sys_corr_20: 0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
+  sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: -2.72685352e-03
   sys_corr_68: -5.91785232e-03
   sys_corr_69: 1.79856296e-03
@@ -4238,55 +4238,55 @@ bins:
   sys_corr_11: 3.67370332e-03
   sys_corr_12: -1.32163717e-03
   sys_corr_13: -1.09763087e-03
-  sys_corr_14: -0.0
+  sys_corr_14: 0.0
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
-  sys_corr_21: -0.0
+  sys_corr_20: 0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
   sys_corr_25: 0.0
-  sys_corr_26: -0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
   sys_corr_58: 0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
@@ -4343,53 +4343,53 @@ bins:
   sys_corr_13: -4.12738625e-04
   sys_corr_14: 0.0
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
-  sys_corr_21: -0.0
+  sys_corr_20: 0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
   sys_corr_25: 0.0
-  sys_corr_26: -0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
   sys_corr_58: 0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
@@ -4446,53 +4446,53 @@ bins:
   sys_corr_13: -2.66428864e-05
   sys_corr_14: 0.0
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
-  sys_corr_21: -0.0
+  sys_corr_20: 0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
   sys_corr_25: 0.0
-  sys_corr_26: -0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
   sys_corr_58: 0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
@@ -4548,58 +4548,58 @@ bins:
   sys_corr_12: 9.05472800e-02
   sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 1.09281200e-01
   sys_corr_68: -1.56116000e-01
   sys_corr_69: 2.18562400e-02
@@ -4653,56 +4653,56 @@ bins:
   sys_corr_14: 0.0
   sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 1.80926984e-01
   sys_corr_68: -3.03698866e-01
   sys_corr_69: 7.75401360e-02
@@ -4754,58 +4754,58 @@ bins:
   sys_corr_12: 1.57151664e-01
   sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 1.57151664e-01
   sys_corr_68: -1.37507706e-01
   sys_corr_69: 1.04767776e-01
@@ -4857,58 +4857,58 @@ bins:
   sys_corr_12: 1.69405860e-01
   sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 2.08933894e-01
   sys_corr_68: -5.13864442e-01
   sys_corr_69: 1.91993308e-01
@@ -4960,58 +4960,58 @@ bins:
   sys_corr_12: 1.13186856e-01
   sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 1.83928641e-01
   sys_corr_68: -5.28205328e-01
   sys_corr_69: 3.72573401e-01
@@ -5063,58 +5063,58 @@ bins:
   sys_corr_12: 8.21605840e-02
   sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 1.34444592e-01
   sys_corr_68: -4.51883212e-01
   sys_corr_69: 1.45648308e-01
@@ -5166,58 +5166,58 @@ bins:
   sys_corr_12: 6.67174340e-02
   sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 1.10228804e-01
   sys_corr_68: -2.98778074e-01
   sys_corr_69: 9.57250140e-02
@@ -5269,58 +5269,58 @@ bins:
   sys_corr_12: 2.17312700e-02
   sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 6.95400640e-02
   sys_corr_68: -2.32524589e-01
   sys_corr_69: 9.12713340e-02
@@ -5372,58 +5372,58 @@ bins:
   sys_corr_12: 3.43242460e-02
   sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 6.39679130e-02
   sys_corr_68: -1.80982388e-01
   sys_corr_69: 3.12038600e-02
@@ -5456,7 +5456,7 @@ bins:
   sys_corr_96: -1.81606465e+00
   sys_corr_97: -2.73969891e+00
   sys_corr_98: -9.25194449e-01
-  sys_corr_99: -0.0
+  sys_corr_99: 0.0
   sys_lumi_corr: 4.36854040e+01
   sys_mc_uncorr: 15.60193
 - stat: 3.563653
@@ -5475,58 +5475,58 @@ bins:
   sys_corr_12: 4.12884480e-02
   sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 4.12884480e-02
   sys_corr_68: -1.27213056e-01
   sys_corr_69: 2.00862720e-02
@@ -5578,58 +5578,58 @@ bins:
   sys_corr_12: 1.87139184e-02
   sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 2.41721446e-02
   sys_corr_68: -7.48556736e-02
   sys_corr_69: -6.23797280e-03
@@ -5681,58 +5681,58 @@ bins:
   sys_corr_12: 2.82478320e-02
   sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 1.67394560e-02
   sys_corr_68: -7.11426880e-02
   sys_corr_69: -2.19705360e-02
@@ -5784,58 +5784,58 @@ bins:
   sys_corr_12: 1.42232580e-02
   sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 1.49005560e-02
   sys_corr_68: -4.63949130e-02
   sys_corr_69: -2.47213770e-02
@@ -5887,58 +5887,58 @@ bins:
   sys_corr_12: 7.69791050e-03
   sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 1.23166568e-02
   sys_corr_68: -3.54103883e-02
   sys_corr_69: -1.67154628e-02
@@ -5990,58 +5990,58 @@ bins:
   sys_corr_12: 8.20748130e-03
   sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 1.06553266e-02
   sys_corr_68: -2.87981800e-02
   sys_corr_69: -7.91949950e-03
@@ -6093,58 +6093,58 @@ bins:
   sys_corr_12: 8.94136131e-03
   sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 8.84521764e-03
   sys_corr_68: -2.47089232e-02
   sys_corr_69: -1.31716828e-02
@@ -6196,58 +6196,58 @@ bins:
   sys_corr_12: 6.68417520e-03
   sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 5.96005622e-03
   sys_corr_68: -1.73231541e-02
   sys_corr_69: -7.57539856e-03
@@ -6299,58 +6299,58 @@ bins:
   sys_corr_12: 2.19533808e-03
   sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 2.32199220e-03
   sys_corr_68: -7.70479230e-03
   sys_corr_69: -7.81033740e-04
@@ -6402,58 +6402,58 @@ bins:
   sys_corr_12: 5.08232000e-04
   sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 6.63691200e-04
   sys_corr_68: -1.99107360e-03
   sys_corr_69: 5.38128000e-05
@@ -6505,58 +6505,58 @@ bins:
   sys_corr_12: 2.52277456e-05
   sys_corr_13: 0.0
   sys_corr_14: 0.0
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 1.28518704e-05
   sys_corr_68: -7.90152032e-05
   sys_corr_69: 2.26097720e-05
@@ -6608,54 +6608,54 @@ bins:
   sys_corr_12: 3.94710162e-01
   sys_corr_13: -1.53783180e-02
   sys_corr_14: -2.05044240e-02
-  sys_corr_15: -0.0
-  sys_corr_16: -0.0
-  sys_corr_17: -0.0
+  sys_corr_15: 0.0
+  sys_corr_16: 0.0
+  sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
-  sys_corr_24: -0.0
+  sys_corr_24: 0.0
   sys_corr_25: 0.0
   sys_corr_26: 0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
   sys_corr_56: 0.0
   sys_corr_57: 0.0
   sys_corr_58: 0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
@@ -6681,7 +6681,7 @@ bins:
   sys_corr_85: 1.91716364e+00
   sys_corr_86: -1.05341478e+00
   sys_corr_87: -4.53660381e-01
-  sys_corr_88: -0.0
+  sys_corr_88: 0.0
   sys_corr_89: -2.79116472e+00
   sys_corr_90: -7.17654840e-01
   sys_corr_91: 5.09791242e+00
@@ -6712,59 +6712,59 @@ bins:
   sys_corr_13: -1.60235610e-01
   sys_corr_14: 3.20471220e-02
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
   sys_corr_56: 0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
   sys_corr_63: 0.0
-  sys_corr_64: -0.0
-  sys_corr_65: -0.0
+  sys_corr_64: 0.0
+  sys_corr_65: 0.0
   sys_corr_66: 0.0
   sys_corr_67: -1.17506114e-01
-  sys_corr_68: -0.0
+  sys_corr_68: 0.0
   sys_corr_69: 4.64683269e-01
   sys_corr_70: -2.56376976e-01
   sys_corr_71: -6.30260066e-01
@@ -6815,57 +6815,57 @@ bins:
   sys_corr_13: -8.53086880e-02
   sys_corr_14: 1.97276341e-01
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
+  sys_corr_21: 0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
+  sys_corr_66: 0.0
   sys_corr_67: -4.79861370e-02
   sys_corr_68: -1.81280962e-01
   sys_corr_69: 3.41234752e-01
@@ -6918,57 +6918,57 @@ bins:
   sys_corr_13: 1.76587254e-01
   sys_corr_14: 5.57643960e-02
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
+  sys_corr_66: 0.0
   sys_corr_67: 1.39410990e-02
   sys_corr_68: -1.11528792e-01
   sys_corr_69: -1.85881320e-02
@@ -7020,58 +7020,58 @@ bins:
   sys_corr_12: 1.56918080e-02
   sys_corr_13: 2.15762360e-01
   sys_corr_14: -1.56918080e-02
-  sys_corr_15: -0.0
-  sys_corr_16: -0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
+  sys_corr_15: 0.0
+  sys_corr_16: 0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
+  sys_corr_66: 0.0
   sys_corr_67: -4.31524720e-02
   sys_corr_68: -1.05919704e-01
   sys_corr_69: -1.33380368e-01
@@ -7124,56 +7124,56 @@ bins:
   sys_corr_13: 0.0
   sys_corr_14: 6.30391000e-03
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
   sys_corr_28: 0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
   sys_corr_56: 0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
-  sys_corr_65: -0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
+  sys_corr_65: 0.0
   sys_corr_66: 0.0
   sys_corr_67: -4.72793250e-02
   sys_corr_68: -2.20636850e-02
@@ -7227,57 +7227,57 @@ bins:
   sys_corr_13: 3.17599880e-02
   sys_corr_14: 2.44307600e-03
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
+  sys_corr_66: 0.0
   sys_corr_67: -7.32922800e-03
   sys_corr_68: -5.37476720e-02
   sys_corr_69: 4.88615200e-02
@@ -7330,57 +7330,57 @@ bins:
   sys_corr_13: 3.51022530e-02
   sys_corr_14: -1.84748700e-03
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
+  sys_corr_66: 0.0
   sys_corr_67: -2.40173310e-02
   sys_corr_68: -4.24922010e-02
   sys_corr_69: 3.69497400e-02
@@ -7433,57 +7433,57 @@ bins:
   sys_corr_13: 4.36957290e-02
   sys_corr_14: 5.29645200e-03
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
+  sys_corr_16: 0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
+  sys_corr_66: 0.0
   sys_corr_67: 2.64822600e-03
   sys_corr_68: -3.17787120e-02
   sys_corr_69: 5.82609720e-02
@@ -7491,7 +7491,7 @@ bins:
   sys_corr_71: -1.45652430e-02
   sys_corr_72: 3.97233900e-03
   sys_corr_73: -7.67985540e-02
-  sys_corr_74: -0.0
+  sys_corr_74: 0.0
   sys_corr_75: -6.88538760e-02
   sys_corr_76: 1.43004204e-01
   sys_corr_77: 1.35059526e-01
@@ -7536,57 +7536,57 @@ bins:
   sys_corr_13: 4.01419662e-02
   sys_corr_14: 1.05133721e-02
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
+  sys_corr_66: 0.0
   sys_corr_67: 1.91152220e-03
   sys_corr_68: -3.72746829e-02
   sys_corr_69: -1.52921776e-02
@@ -7639,57 +7639,57 @@ bins:
   sys_corr_13: 3.60141066e-02
   sys_corr_14: 8.00313480e-03
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
+  sys_corr_66: 0.0
   sys_corr_67: 7.33620690e-03
   sys_corr_68: -2.53432602e-02
   sys_corr_69: 4.26833856e-02
@@ -7742,57 +7742,57 @@ bins:
   sys_corr_13: 1.68784752e-02
   sys_corr_14: 3.10919280e-03
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
+  sys_corr_66: 0.0
   sys_corr_67: 1.77668160e-03
   sys_corr_68: -1.73226456e-02
   sys_corr_69: 1.42134528e-02
@@ -7847,55 +7847,55 @@ bins:
   sys_corr_15: 0.0
   sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
+  sys_corr_66: 0.0
   sys_corr_67: 4.87882660e-03
   sys_corr_68: -1.49234696e-02
   sys_corr_69: 1.06186226e-02
@@ -7948,57 +7948,57 @@ bins:
   sys_corr_13: 1.98145800e-02
   sys_corr_14: 3.36474000e-03
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
+  sys_corr_16: 0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
+  sys_corr_66: 0.0
   sys_corr_67: 2.80395000e-03
   sys_corr_68: -8.59878000e-03
   sys_corr_69: 3.73860000e-03
@@ -8051,54 +8051,54 @@ bins:
   sys_corr_13: 1.10213506e-02
   sys_corr_14: -1.73369560e-03
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
+  sys_corr_16: 0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
+  sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: 0.0
@@ -8153,58 +8153,58 @@ bins:
   sys_corr_12: 1.44093088e-03
   sys_corr_13: 1.01712768e-02
   sys_corr_14: 1.01712768e-03
-  sys_corr_15: -0.0
-  sys_corr_16: -0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
+  sys_corr_15: 0.0
+  sys_corr_16: 0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
-  sys_corr_66: -0.0
+  sys_corr_66: 0.0
   sys_corr_67: 1.69521280e-03
   sys_corr_68: -4.32279264e-03
   sys_corr_69: -6.69609056e-03
@@ -8256,60 +8256,60 @@ bins:
   sys_corr_12: 3.68124757e-03
   sys_corr_13: 1.29082707e-03
   sys_corr_14: -1.19521025e-03
-  sys_corr_15: -0.0
-  sys_corr_16: -0.0
-  sys_corr_17: -0.0
+  sys_corr_15: 0.0
+  sys_corr_16: 0.0
+  sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: 0.0
   sys_corr_67: -9.56168200e-05
-  sys_corr_68: -0.0
+  sys_corr_68: 0.0
   sys_corr_69: -7.17126150e-04
   sys_corr_70: 1.57767753e-03
   sys_corr_71: -3.29878029e-03
@@ -8359,54 +8359,54 @@ bins:
   sys_corr_12: 7.46465200e-05
   sys_corr_13: 1.66088507e-03
   sys_corr_14: -1.19434432e-03
-  sys_corr_15: -0.0
-  sys_corr_16: -0.0
-  sys_corr_17: -0.0
+  sys_corr_15: 0.0
+  sys_corr_16: 0.0
+  sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
   sys_corr_22: 0.0
   sys_corr_23: 0.0
-  sys_corr_24: -0.0
+  sys_corr_24: 0.0
   sys_corr_25: 0.0
   sys_corr_26: 0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
+  sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
@@ -8463,54 +8463,54 @@ bins:
   sys_corr_13: 4.65126840e-04
   sys_corr_14: -7.23530640e-05
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
-  sys_corr_17: -0.0
+  sys_corr_16: 0.0
+  sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
   sys_corr_25: 0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
   sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: 0.0
@@ -8566,54 +8566,54 @@ bins:
   sys_corr_13: 2.48848188e-05
   sys_corr_14: -9.71114880e-06
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
-  sys_corr_17: -0.0
+  sys_corr_16: 0.0
+  sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
   sys_corr_25: 0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
   sys_corr_56: 0.0
   sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: 0.0
@@ -8668,56 +8668,56 @@ bins:
   sys_corr_12: 4.91791800e-02
   sys_corr_13: -8.19653000e-03
   sys_corr_14: -1.49176846e-01
-  sys_corr_15: -0.0
-  sys_corr_16: -0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
+  sys_corr_15: 0.0
+  sys_corr_16: 0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: 0.0
   sys_corr_67: 4.26219560e-02
@@ -8772,56 +8772,56 @@ bins:
   sys_corr_13: 4.41271610e-02
   sys_corr_14: 1.35775880e-02
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
-  sys_corr_20: -0.0
-  sys_corr_21: -0.0
+  sys_corr_19: 0.0
+  sys_corr_20: 0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
   sys_corr_25: 0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
   sys_corr_55: 0.0
   sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
+  sys_corr_65: 0.0
   sys_corr_66: 0.0
   sys_corr_67: -8.48599250e-02
   sys_corr_68: -1.83297438e-01
@@ -8874,55 +8874,55 @@ bins:
   sys_corr_12: -7.51735600e-02
   sys_corr_13: 8.54245000e-02
   sys_corr_14: -1.16177320e-01
-  sys_corr_15: -0.0
-  sys_corr_16: -0.0
-  sys_corr_17: -0.0
+  sys_corr_15: 0.0
+  sys_corr_16: 0.0
+  sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
-  sys_corr_24: -0.0
+  sys_corr_24: 0.0
   sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
+  sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
   sys_corr_56: 0.0
-  sys_corr_57: -0.0
+  sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: 0.0
@@ -8977,55 +8977,55 @@ bins:
   sys_corr_12: -1.00032964e-01
   sys_corr_13: 1.38280862e-01
   sys_corr_14: -1.17685840e-01
-  sys_corr_15: -0.0
-  sys_corr_16: -0.0
+  sys_corr_15: 0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
-  sys_corr_24: -0.0
+  sys_corr_24: 0.0
   sys_corr_25: 0.0
   sys_corr_26: 0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
   sys_corr_56: 0.0
-  sys_corr_57: -0.0
+  sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: 0.0
@@ -9081,55 +9081,55 @@ bins:
   sys_corr_13: 2.96641440e-02
   sys_corr_14: -1.58208768e-01
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
-  sys_corr_17: -0.0
-  sys_corr_18: -0.0
+  sys_corr_16: 0.0
+  sys_corr_17: 0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
-  sys_corr_24: -0.0
+  sys_corr_24: 0.0
   sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
+  sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
   sys_corr_56: 0.0
-  sys_corr_57: -0.0
+  sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: 0.0
   sys_corr_67: 1.48320720e-02
@@ -9184,54 +9184,54 @@ bins:
   sys_corr_13: 3.00203100e-02
   sys_corr_14: -5.00338500e-02
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
-  sys_corr_17: -0.0
+  sys_corr_16: 0.0
+  sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
-  sys_corr_24: -0.0
+  sys_corr_24: 0.0
   sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
+  sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
   sys_corr_56: 0.0
-  sys_corr_57: -0.0
+  sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: 0.0
@@ -9286,56 +9286,56 @@ bins:
   sys_corr_12: -2.19470720e-02
   sys_corr_13: 1.72441280e-02
   sys_corr_14: -3.91912000e-02
-  sys_corr_15: -0.0
-  sys_corr_16: -0.0
+  sys_corr_15: 0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
-  sys_corr_24: -0.0
+  sys_corr_24: 0.0
   sys_corr_25: 0.0
   sys_corr_26: 0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
   sys_corr_56: 0.0
-  sys_corr_57: -0.0
+  sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: 0.0
   sys_corr_67: -3.13529600e-03
@@ -9389,56 +9389,56 @@ bins:
   sys_corr_12: 3.61561500e-03
   sys_corr_13: 1.68728700e-02
   sys_corr_14: -4.33873800e-02
-  sys_corr_15: -0.0
-  sys_corr_16: -0.0
-  sys_corr_17: -0.0
+  sys_corr_15: 0.0
+  sys_corr_16: 0.0
+  sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
-  sys_corr_24: -0.0
+  sys_corr_24: 0.0
   sys_corr_25: 0.0
   sys_corr_26: 0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
   sys_corr_56: 0.0
-  sys_corr_57: -0.0
+  sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: 0.0
   sys_corr_67: 4.82082000e-03
@@ -9465,7 +9465,7 @@ bins:
   sys_corr_88: -1.49445420e-01
   sys_corr_89: 4.01333265e-01
   sys_corr_90: -1.22087267e+00
-  sys_corr_91: -0.0
+  sys_corr_91: 0.0
   sys_corr_92: 2.77197150e-02
   sys_corr_93: -4.41105030e-01
   sys_corr_94: 9.78626460e-01
@@ -9492,57 +9492,57 @@ bins:
   sys_corr_12: -4.68141209e-02
   sys_corr_13: 1.05994236e-02
   sys_corr_14: -4.41642650e-03
-  sys_corr_15: -0.0
-  sys_corr_16: -0.0
+  sys_corr_15: 0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
   sys_corr_23: 0.0
-  sys_corr_24: -0.0
+  sys_corr_24: 0.0
   sys_corr_25: 0.0
   sys_corr_26: 0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
   sys_corr_55: 0.0
   sys_corr_56: 0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
+  sys_corr_65: 0.0
   sys_corr_66: 0.0
   sys_corr_67: -2.64985590e-03
   sys_corr_68: -1.50158501e-02
@@ -9595,56 +9595,56 @@ bins:
   sys_corr_12: -3.87372840e-03
   sys_corr_13: -3.22810700e-03
   sys_corr_14: 1.42036708e-02
-  sys_corr_15: -0.0
-  sys_corr_16: -0.0
+  sys_corr_15: 0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
-  sys_corr_22: -0.0
+  sys_corr_21: 0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
   sys_corr_28: 0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
   sys_corr_55: 0.0
   sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
+  sys_corr_62: 0.0
   sys_corr_63: 0.0
-  sys_corr_64: -0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: 0.0
   sys_corr_67: -6.45621400e-04
@@ -9698,57 +9698,57 @@ bins:
   sys_corr_12: 1.16435675e-02
   sys_corr_13: -1.07120821e-02
   sys_corr_14: -3.72594160e-03
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
-  sys_corr_20: -0.0
-  sys_corr_21: -0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
+  sys_corr_20: 0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
   sys_corr_25: 0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
   sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
   sys_corr_55: 0.0
   sys_corr_56: 0.0
-  sys_corr_57: -0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
+  sys_corr_57: 0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
-  sys_corr_65: -0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
+  sys_corr_65: 0.0
   sys_corr_66: 0.0
   sys_corr_67: -9.31485400e-04
   sys_corr_68: 1.67667372e-02
@@ -9801,58 +9801,58 @@ bins:
   sys_corr_12: -5.34411660e-03
   sys_corr_13: -1.25743920e-02
   sys_corr_14: 7.23027540e-03
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
-  sys_corr_20: -0.0
-  sys_corr_21: -0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
+  sys_corr_20: 0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
   sys_corr_28: 0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
   sys_corr_55: 0.0
   sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: -5.02975680e-03
   sys_corr_68: 2.67205830e-02
   sys_corr_69: -4.36960122e-02
@@ -9904,57 +9904,57 @@ bins:
   sys_corr_12: -1.46922840e-02
   sys_corr_13: -1.63247600e-02
   sys_corr_14: -1.63247600e-03
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
   sys_corr_28: 0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0
-  sys_corr_64: -0.0
-  sys_corr_65: -0.0
+  sys_corr_64: 0.0
+  sys_corr_65: 0.0
   sys_corr_66: 0.0
   sys_corr_67: 2.24465450e-03
   sys_corr_68: 1.81612955e-02
@@ -10007,57 +10007,57 @@ bins:
   sys_corr_12: -1.33134401e-02
   sys_corr_13: -1.17623597e-02
   sys_corr_14: 1.29256700e-04
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
   sys_corr_23: 0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
   sys_corr_28: 0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
   sys_corr_55: 0.0
-  sys_corr_56: -0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
+  sys_corr_65: 0.0
   sys_corr_66: 0.0
   sys_corr_67: -6.46283500e-04
   sys_corr_68: 1.51230339e-02
@@ -10110,58 +10110,58 @@ bins:
   sys_corr_12: -6.20176318e-03
   sys_corr_13: -6.03185186e-03
   sys_corr_14: 7.98583204e-03
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
   sys_corr_28: 0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
   sys_corr_55: 0.0
-  sys_corr_56: -0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
+  sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: -1.69911320e-03
   sys_corr_68: 1.44424622e-02
   sys_corr_69: -2.61663433e-02
@@ -10213,57 +10213,57 @@ bins:
   sys_corr_12: -3.40433481e-03
   sys_corr_13: -3.34663422e-03
   sys_corr_14: 3.75053835e-03
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
   sys_corr_23: 0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
   sys_corr_28: 0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
   sys_corr_55: 0.0
   sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
+  sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
+  sys_corr_65: 0.0
   sys_corr_66: 0.0
   sys_corr_67: -1.32711357e-03
   sys_corr_68: 7.90498083e-03
@@ -10320,54 +10320,54 @@ bins:
   sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
   sys_corr_28: 0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
   sys_corr_55: 0.0
   sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
+  sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: -1.63110808e-03
   sys_corr_68: 7.15690280e-03
   sys_corr_69: -1.25162579e-02
@@ -10420,56 +10420,56 @@ bins:
   sys_corr_13: -2.97743510e-04
   sys_corr_14: 2.03242309e-03
   sys_corr_15: 0.0
-  sys_corr_16: -0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
   sys_corr_23: 0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
   sys_corr_55: 0.0
   sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
+  sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
+  sys_corr_65: 0.0
   sys_corr_66: 0.0
   sys_corr_67: -4.91924060e-04
   sys_corr_68: 2.45962030e-03
@@ -10526,54 +10526,54 @@ bins:
   sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
   sys_corr_55: 0.0
-  sys_corr_56: -0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
-  sys_corr_66: -0.0
+  sys_corr_65: 0.0
+  sys_corr_66: 0.0
   sys_corr_67: 9.08669520e-05
   sys_corr_68: -1.89306150e-05
   sys_corr_69: -7.30721739e-04
@@ -10625,57 +10625,57 @@ bins:
   sys_corr_12: -2.86025740e-05
   sys_corr_13: -1.95017550e-06
   sys_corr_14: 5.46049140e-06
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
   sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
+  sys_corr_65: 0.0
   sys_corr_66: 0.0
   sys_corr_67: 8.32074880e-06
   sys_corr_68: -1.09209828e-05
@@ -10730,55 +10730,55 @@ bins:
   sys_corr_14: -3.26454218e-02
   sys_corr_15: 1.85741193e-02
   sys_corr_16: 1.06941899e-02
-  sys_corr_17: -0.0
+  sys_corr_17: 0.0
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
   sys_corr_25: 0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
+  sys_corr_30: 0.0
   sys_corr_31: 0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
   sys_corr_55: 0.0
   sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
+  sys_corr_65: 0.0
   sys_corr_66: -1.24390314e-01
   sys_corr_67: -1.78986968e-01
   sys_corr_68: 1.68855630e-03
@@ -10833,53 +10833,53 @@ bins:
   sys_corr_14: 4.56484800e-03
   sys_corr_15: 2.28242400e-03
   sys_corr_16: 5.70606000e-03
-  sys_corr_17: -0.0
+  sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
-  sys_corr_21: -0.0
-  sys_corr_22: -0.0
+  sys_corr_20: 0.0
+  sys_corr_21: 0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
   sys_corr_24: 0.0
   sys_corr_25: 0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
   sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
+  sys_corr_30: 0.0
   sys_corr_31: 0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
   sys_corr_55: 0.0
   sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
+  sys_corr_61: 0.0
   sys_corr_62: 0.0
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: -7.64612040e-02
@@ -10937,53 +10937,53 @@ bins:
   sys_corr_15: -3.58471680e-02
   sys_corr_16: -2.24044800e-02
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
-  sys_corr_29: -0.0
+  sys_corr_29: 0.0
   sys_corr_30: 0.0
-  sys_corr_31: -0.0
+  sys_corr_31: 0.0
   sys_corr_32: 0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
   sys_corr_54: 0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0
-  sys_corr_64: -0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: 3.80876160e-02
   sys_corr_67: -2.01640320e-02
@@ -11040,53 +11040,53 @@ bins:
   sys_corr_15: -2.49164500e-02
   sys_corr_16: -2.10831500e-02
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
-  sys_corr_20: -0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
-  sys_corr_29: -0.0
+  sys_corr_29: 0.0
   sys_corr_30: 0.0
-  sys_corr_31: -0.0
+  sys_corr_31: 0.0
   sys_corr_32: 0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
   sys_corr_54: 0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
+  sys_corr_62: 0.0
   sys_corr_63: 0.0
-  sys_corr_64: -0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: 3.83330000e-03
   sys_corr_67: -4.12079750e-02
@@ -11142,55 +11142,55 @@ bins:
   sys_corr_14: 7.38286094e-02
   sys_corr_15: 2.59617088e-02
   sys_corr_16: 8.92433740e-03
-  sys_corr_17: -0.0
+  sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
   sys_corr_25: 0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
   sys_corr_31: 0.0
   sys_corr_32: 0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
   sys_corr_54: 0.0
   sys_corr_55: 0.0
   sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
+  sys_corr_65: 0.0
   sys_corr_66: -3.32634394e-02
   sys_corr_67: -1.51713736e-01
   sys_corr_68: -2.13372794e-01
@@ -11246,54 +11246,54 @@ bins:
   sys_corr_15: -1.88686296e-02
   sys_corr_16: -1.17115632e-02
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
   sys_corr_30: 0.0
-  sys_corr_31: -0.0
+  sys_corr_31: 0.0
   sys_corr_32: 0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
   sys_corr_54: 0.0
   sys_corr_55: 0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
+  sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
+  sys_corr_65: 0.0
   sys_corr_66: -3.90385440e-03
   sys_corr_67: -2.34231264e-02
   sys_corr_68: -5.40033192e-02
@@ -11349,53 +11349,53 @@ bins:
   sys_corr_15: -2.26843695e-02
   sys_corr_16: -1.66352043e-02
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
-  sys_corr_20: -0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
-  sys_corr_29: -0.0
+  sys_corr_29: 0.0
   sys_corr_30: 0.0
-  sys_corr_31: -0.0
+  sys_corr_31: 0.0
   sys_corr_32: 0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
   sys_corr_54: 0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
   sys_corr_58: 0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
+  sys_corr_62: 0.0
   sys_corr_63: 0.0
-  sys_corr_64: -0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: 7.56145650e-03
   sys_corr_67: 5.04097100e-04
@@ -11452,54 +11452,54 @@ bins:
   sys_corr_15: -1.06365042e-02
   sys_corr_16: -4.33339060e-03
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
+  sys_corr_28: 0.0
   sys_corr_29: 0.0
   sys_corr_30: 0.0
-  sys_corr_31: -0.0
+  sys_corr_31: 0.0
   sys_corr_32: 0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
   sys_corr_55: 0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
+  sys_corr_65: 0.0
   sys_corr_66: -3.93944600e-04
   sys_corr_67: -1.18183380e-02
   sys_corr_68: -2.95458450e-02
@@ -11555,54 +11555,54 @@ bins:
   sys_corr_15: -3.78708980e-03
   sys_corr_16: -2.33051680e-03
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
+  sys_corr_22: 0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
   sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
+  sys_corr_28: 0.0
   sys_corr_29: 0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
   sys_corr_32: 0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
   sys_corr_54: 0.0
   sys_corr_55: 0.0
-  sys_corr_56: -0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
   sys_corr_58: 0.0
   sys_corr_59: 0.0
-  sys_corr_60: -0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
+  sys_corr_62: 0.0
   sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
+  sys_corr_65: 0.0
   sys_corr_66: -9.90469640e-03
   sys_corr_67: -2.21399096e-02
   sys_corr_68: -3.55403812e-02
@@ -11658,54 +11658,54 @@ bins:
   sys_corr_15: -4.05914670e-03
   sys_corr_16: -4.91370390e-03
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
   sys_corr_32: 0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
   sys_corr_54: 0.0
   sys_corr_55: 0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
   sys_corr_58: 0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
+  sys_corr_62: 0.0
   sys_corr_63: 0.0
-  sys_corr_64: -0.0
-  sys_corr_65: -0.0
+  sys_corr_64: 0.0
+  sys_corr_65: 0.0
   sys_corr_66: -1.04683257e-02
   sys_corr_67: -6.83645760e-03
   sys_corr_68: -1.68775047e-02
@@ -11761,54 +11761,54 @@ bins:
   sys_corr_15: -6.50386380e-03
   sys_corr_16: -6.03930210e-03
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
-  sys_corr_20: -0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
-  sys_corr_29: -0.0
+  sys_corr_29: 0.0
   sys_corr_30: 0.0
-  sys_corr_31: -0.0
+  sys_corr_31: 0.0
   sys_corr_32: 0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
   sys_corr_54: 0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
   sys_corr_58: 0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
+  sys_corr_62: 0.0
   sys_corr_63: 0.0
-  sys_corr_64: -0.0
-  sys_corr_65: -0.0
+  sys_corr_64: 0.0
+  sys_corr_65: 0.0
   sys_corr_66: -3.87134750e-03
   sys_corr_67: -3.09707800e-03
   sys_corr_68: -9.29123400e-04
@@ -11864,49 +11864,49 @@ bins:
   sys_corr_15: -4.38633600e-03
   sys_corr_16: -1.31590080e-03
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
   sys_corr_29: 0.0
   sys_corr_30: 0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
   sys_corr_58: 0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0
@@ -11967,53 +11967,53 @@ bins:
   sys_corr_15: -2.65825872e-03
   sys_corr_16: -3.10130184e-03
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
-  sys_corr_20: -0.0
-  sys_corr_21: -0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
+  sys_corr_20: 0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
   sys_corr_23: 0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
-  sys_corr_29: -0.0
+  sys_corr_29: 0.0
   sys_corr_30: 0.0
-  sys_corr_31: -0.0
+  sys_corr_31: 0.0
   sys_corr_32: 0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
   sys_corr_54: 0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
   sys_corr_58: 0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
+  sys_corr_62: 0.0
   sys_corr_63: 0.0
-  sys_corr_64: -0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: -5.46419848e-03
   sys_corr_67: 2.36289664e-03
@@ -12069,55 +12069,55 @@ bins:
   sys_corr_14: 2.13689274e-03
   sys_corr_15: 2.48475900e-04
   sys_corr_16: 1.49085540e-04
-  sys_corr_17: -0.0
+  sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
   sys_corr_25: 0.0
-  sys_corr_26: -0.0
-  sys_corr_27: -0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
+  sys_corr_26: 0.0
+  sys_corr_27: 0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
   sys_corr_31: 0.0
   sys_corr_32: 0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
   sys_corr_55: 0.0
-  sys_corr_56: -0.0
+  sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
   sys_corr_64: 0.0
-  sys_corr_65: -0.0
+  sys_corr_65: 0.0
   sys_corr_66: -3.18049152e-03
   sys_corr_67: -2.83262526e-03
   sys_corr_68: -5.21799390e-03
@@ -12170,56 +12170,56 @@ bins:
   sys_corr_12: 4.71347568e-03
   sys_corr_13: 4.13236224e-03
   sys_corr_14: -3.03470352e-03
-  sys_corr_15: -0.0
+  sys_corr_15: 0.0
   sys_corr_16: -5.81113440e-04
   sys_corr_17: 0.0
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
   sys_corr_31: 0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
   sys_corr_54: 0.0
-  sys_corr_55: -0.0
+  sys_corr_55: 0.0
   sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
   sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0
-  sys_corr_64: -0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: 2.51815824e-03
   sys_corr_67: 2.25988560e-03
@@ -12276,54 +12276,54 @@ bins:
   sys_corr_15: -5.79160530e-04
   sys_corr_16: -7.50763650e-04
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
-  sys_corr_19: -0.0
-  sys_corr_20: -0.0
-  sys_corr_21: -0.0
+  sys_corr_18: 0.0
+  sys_corr_19: 0.0
+  sys_corr_20: 0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
-  sys_corr_31: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
+  sys_corr_31: 0.0
   sys_corr_32: 0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
   sys_corr_54: 0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
   sys_corr_58: 0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
-  sys_corr_62: -0.0
+  sys_corr_62: 0.0
   sys_corr_63: 0.0
-  sys_corr_64: -0.0
-  sys_corr_65: -0.0
+  sys_corr_64: 0.0
+  sys_corr_65: 0.0
   sys_corr_66: -2.20939017e-03
   sys_corr_67: -6.22061310e-04
   sys_corr_68: 7.93664430e-04
@@ -12373,59 +12373,59 @@ bins:
   sys_corr_9: -7.62082002e-03
   sys_corr_10: -4.11337839e-03
   sys_corr_11: -8.27336730e-04
-  sys_corr_12: -0.0
+  sys_corr_12: 0.0
   sys_corr_13: -1.40996823e-03
   sys_corr_14: -4.31147310e-04
   sys_corr_15: 1.16526300e-05
   sys_corr_16: -3.49578900e-04
   sys_corr_17: 0.0
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
   sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
   sys_corr_31: 0.0
   sys_corr_32: 0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
   sys_corr_54: 0.0
   sys_corr_55: 0.0
   sys_corr_56: 0.0
   sys_corr_57: 0.0
   sys_corr_58: 0.0
-  sys_corr_59: -0.0
+  sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
   sys_corr_63: 0.0
-  sys_corr_64: -0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: -8.50641990e-04
   sys_corr_67: -1.04873670e-04
@@ -12483,52 +12483,52 @@ bins:
   sys_corr_16: -1.05252025e-04
   sys_corr_17: 0.0
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
-  sys_corr_24: -0.0
+  sys_corr_23: 0.0
+  sys_corr_24: 0.0
   sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
   sys_corr_31: 0.0
   sys_corr_32: 0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
   sys_corr_54: 0.0
   sys_corr_55: 0.0
   sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
+  sys_corr_58: 0.0
   sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
   sys_corr_63: 0.0
-  sys_corr_64: -0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: 1.17882268e-04
   sys_corr_67: 9.26217820e-05
@@ -12585,49 +12585,49 @@ bins:
   sys_corr_15: -5.43456000e-05
   sys_corr_16: -1.93228800e-05
   sys_corr_17: 0.0
-  sys_corr_18: -0.0
+  sys_corr_18: 0.0
   sys_corr_19: 0.0
-  sys_corr_20: -0.0
+  sys_corr_20: 0.0
   sys_corr_21: 0.0
-  sys_corr_22: -0.0
+  sys_corr_22: 0.0
   sys_corr_23: 0.0
-  sys_corr_24: -0.0
-  sys_corr_25: -0.0
+  sys_corr_24: 0.0
+  sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
   sys_corr_28: 0.0
   sys_corr_29: 0.0
   sys_corr_30: 0.0
-  sys_corr_31: -0.0
-  sys_corr_32: -0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
-  sys_corr_54: -0.0
-  sys_corr_55: -0.0
-  sys_corr_56: -0.0
-  sys_corr_57: -0.0
+  sys_corr_31: 0.0
+  sys_corr_32: 0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
+  sys_corr_54: 0.0
+  sys_corr_55: 0.0
+  sys_corr_56: 0.0
+  sys_corr_57: 0.0
   sys_corr_58: 0.0
-  sys_corr_59: -0.0
-  sys_corr_60: -0.0
+  sys_corr_59: 0.0
+  sys_corr_60: 0.0
   sys_corr_61: 0.0
   sys_corr_62: 0.0
   sys_corr_63: 0.0
@@ -12689,52 +12689,52 @@ bins:
   sys_corr_16: -5.19808800e-07
   sys_corr_17: 0.0
   sys_corr_18: 0.0
-  sys_corr_19: -0.0
+  sys_corr_19: 0.0
   sys_corr_20: 0.0
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 0.0
-  sys_corr_23: -0.0
+  sys_corr_23: 0.0
   sys_corr_24: 0.0
   sys_corr_25: 0.0
   sys_corr_26: 0.0
   sys_corr_27: 0.0
-  sys_corr_28: -0.0
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
+  sys_corr_28: 0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
   sys_corr_31: 0.0
   sys_corr_32: 0.0
-  sys_corr_33: -0.0
-  sys_corr_34: -0.0
-  sys_corr_35: -0.0
-  sys_corr_36: -0.0
-  sys_corr_37: -0.0
-  sys_corr_38: -0.0
-  sys_corr_39: -0.0
-  sys_corr_40: -0.0
-  sys_corr_41: -0.0
-  sys_corr_42: -0.0
-  sys_corr_43: -0.0
-  sys_corr_44: -0.0
-  sys_corr_45: -0.0
-  sys_corr_46: -0.0
-  sys_corr_47: -0.0
-  sys_corr_48: -0.0
-  sys_corr_49: -0.0
-  sys_corr_50: -0.0
-  sys_corr_51: -0.0
-  sys_corr_52: -0.0
-  sys_corr_53: -0.0
+  sys_corr_33: 0.0
+  sys_corr_34: 0.0
+  sys_corr_35: 0.0
+  sys_corr_36: 0.0
+  sys_corr_37: 0.0
+  sys_corr_38: 0.0
+  sys_corr_39: 0.0
+  sys_corr_40: 0.0
+  sys_corr_41: 0.0
+  sys_corr_42: 0.0
+  sys_corr_43: 0.0
+  sys_corr_44: 0.0
+  sys_corr_45: 0.0
+  sys_corr_46: 0.0
+  sys_corr_47: 0.0
+  sys_corr_48: 0.0
+  sys_corr_49: 0.0
+  sys_corr_50: 0.0
+  sys_corr_51: 0.0
+  sys_corr_52: 0.0
+  sys_corr_53: 0.0
   sys_corr_54: 0.0
   sys_corr_55: 0.0
   sys_corr_56: 0.0
   sys_corr_57: 0.0
-  sys_corr_58: -0.0
-  sys_corr_59: -0.0
+  sys_corr_58: 0.0
+  sys_corr_59: 0.0
   sys_corr_60: 0.0
-  sys_corr_61: -0.0
-  sys_corr_62: -0.0
-  sys_corr_63: -0.0
-  sys_corr_64: -0.0
+  sys_corr_61: 0.0
+  sys_corr_62: 0.0
+  sys_corr_63: 0.0
+  sys_corr_64: 0.0
   sys_corr_65: 0.0
   sys_corr_66: -1.15100520e-06
   sys_corr_67: -3.15598200e-06

--- a/nnpdf_data/nnpdf_data/commondata/ATLAS_Z0_7TEV_46FB/uncertainties_cc.yaml
+++ b/nnpdf_data/nnpdf_data/commondata/ATLAS_Z0_7TEV_46FB/uncertainties_cc.yaml
@@ -587,7 +587,7 @@ bins:
   sys_corr_48: -5.99080000e-01
   sys_corr_49: 1.05720000e-01
   sys_corr_50: -0.31716
-  sys_corr_51: -0.0
+  sys_corr_51: 0.0
   sys_corr_52: 0.63432
   sys_corr_53: 0.38764
   sys_corr_54: 2.92139600e+01
@@ -629,20 +629,20 @@ bins:
   sys_corr_90: -0.56384
   sys_corr_91: -2.46680000e-01
   sys_corr_92: 0.0
-  sys_corr_93: -0.0
+  sys_corr_93: 0.0
   sys_corr_94: 0.0
   sys_corr_95: 0.0
   sys_corr_96: 0.0
   sys_corr_97: 0.0
-  sys_corr_98: -0.0
-  sys_corr_99: -0.0
+  sys_corr_98: 0.0
+  sys_corr_99: 0.0
   sys_corr_100: 0.0
   sys_corr_101: 0.56384
   sys_corr_102: -3.52400000e-01
   sys_corr_103: 0.07048
-  sys_corr_104: -0.0
+  sys_corr_104: 0.0
   sys_corr_105: -2.46680000e-01
-  sys_corr_106: -0.0
+  sys_corr_106: 0.0
   sys_corr_107: 1.76200000e-01
   sys_corr_108: -2.46680000e-01
   sys_corr_109: 1.05720000e-01
@@ -703,7 +703,7 @@ bins:
   sys_corr_30: -1.06470000e-01
   sys_corr_31: -0.07098
   sys_corr_32: -0.03549
-  sys_corr_33: -0.0
+  sys_corr_33: 0.0
   sys_corr_34: -1.06470000e-01
   sys_corr_35: 0.07098
   sys_corr_36: -0.07098
@@ -722,7 +722,7 @@ bins:
   sys_corr_49: 1.06470000e-01
   sys_corr_50: -3.90390000e-01
   sys_corr_51: 0.0
-  sys_corr_52: -0.0
+  sys_corr_52: 0.0
   sys_corr_53: 0.56784
   sys_corr_54: 2.72563200e+01
   sys_corr_55: -2.20038
@@ -763,13 +763,13 @@ bins:
   sys_corr_90: 0.03549
   sys_corr_91: -0.53235
   sys_corr_92: 0.0
-  sys_corr_93: -0.0
-  sys_corr_94: -0.0
+  sys_corr_93: 0.0
+  sys_corr_94: 0.0
   sys_corr_95: 0.0
   sys_corr_96: 0.0
   sys_corr_97: 0.0
-  sys_corr_98: -0.0
-  sys_corr_99: -0.0
+  sys_corr_98: 0.0
+  sys_corr_99: 0.0
   sys_corr_100: 0.0
   sys_corr_101: 0.53235
   sys_corr_102: -0.14196
@@ -831,12 +831,12 @@ bins:
   sys_corr_24: -0.10233
   sys_corr_25: -0.03411
   sys_corr_26: -0.13644
-  sys_corr_27: -0.0
+  sys_corr_27: 0.0
   sys_corr_28: -2.38770000e-01
   sys_corr_29: 0.17055
   sys_corr_30: -0.10233
   sys_corr_31: -2.38770000e-01
-  sys_corr_32: -0.0
+  sys_corr_32: 0.0
   sys_corr_33: -0.17055
   sys_corr_34: -0.20466
   sys_corr_35: 0.06822
@@ -897,13 +897,13 @@ bins:
   sys_corr_90: 0.06822
   sys_corr_91: -0.30699
   sys_corr_92: 0.0
-  sys_corr_93: -0.0
+  sys_corr_93: 0.0
   sys_corr_94: 0.0
   sys_corr_95: 0.0
   sys_corr_96: 0.0
   sys_corr_97: 0.0
-  sys_corr_98: -0.0
-  sys_corr_99: -0.0
+  sys_corr_98: 0.0
+  sys_corr_99: 0.0
   sys_corr_100: 0.13644
   sys_corr_101: 5.11650000e-01
   sys_corr_102: 0.10233
@@ -923,7 +923,7 @@ bins:
   sys_corr_116: 0.10233
   sys_corr_117: 0.03411
   sys_corr_118: 2.38770000e-01
-  sys_corr_119: -0.0
+  sys_corr_119: 0.0
   sys_corr_120: 1.22796
   sys_corr_121: 1.39851
   sys_corr_122: 0.57987
@@ -1031,13 +1031,13 @@ bins:
   sys_corr_90: -0.37653
   sys_corr_91: -0.20538
   sys_corr_92: 0.0
-  sys_corr_93: -0.0
-  sys_corr_94: -0.0
+  sys_corr_93: 0.0
+  sys_corr_94: 0.0
   sys_corr_95: 0.0
   sys_corr_96: 0.0
   sys_corr_97: 0.0
-  sys_corr_98: -0.0
-  sys_corr_99: -0.0
+  sys_corr_98: 0.0
+  sys_corr_99: 0.0
   sys_corr_100: -5.47680000e-01
   sys_corr_101: 0.51345
   sys_corr_102: 3.42300000e-01
@@ -1119,7 +1119,7 @@ bins:
   sys_corr_44: 0.08826
   sys_corr_45: -0.1471
   sys_corr_46: -0.70608
-  sys_corr_47: -0.0
+  sys_corr_47: 0.0
   sys_corr_48: -0.82376
   sys_corr_49: 0.23536
   sys_corr_50: -0.70608
@@ -1165,13 +1165,13 @@ bins:
   sys_corr_90: -0.23536
   sys_corr_91: -5.58980000e-01
   sys_corr_92: 0.0
-  sys_corr_93: -0.0
-  sys_corr_94: -0.0
+  sys_corr_93: 0.0
+  sys_corr_94: 0.0
   sys_corr_95: 0.0
   sys_corr_96: 0.0
   sys_corr_97: 0.0
-  sys_corr_98: -0.0
-  sys_corr_99: -0.0
+  sys_corr_98: 0.0
+  sys_corr_99: 0.0
   sys_corr_100: -3.23620000e-01
   sys_corr_101: 4.41300000e-01
   sys_corr_102: 0.47072
@@ -1299,13 +1299,13 @@ bins:
   sys_corr_90: -2.00330000e-01
   sys_corr_91: -3.54430000e-01
   sys_corr_92: 0.0
-  sys_corr_93: -0.0
-  sys_corr_94: -0.0
+  sys_corr_93: 0.0
+  sys_corr_94: 0.0
   sys_corr_95: 0.0
   sys_corr_96: 0.0
   sys_corr_97: 0.0
-  sys_corr_98: -0.0
-  sys_corr_99: -0.0
+  sys_corr_98: 0.0
+  sys_corr_99: 0.0
   sys_corr_100: -0.29279
   sys_corr_101: 0.18492
   sys_corr_102: 3.54430000e-01
@@ -1346,7 +1346,7 @@ bins:
   sys_corr_3: 63.5534
   sys_corr_4: 27.044
   sys_corr_5: 5.4088
-  sys_corr_6: -0.0
+  sys_corr_6: 0.0
   sys_corr_7: -39.2138
   sys_corr_8: 4.0566
   sys_corr_9: -13.522
@@ -1354,7 +1354,7 @@ bins:
   sys_corr_11: -1.33867800e+02
   sys_corr_12: -5.4088
   sys_corr_13: 1.75786000e+01
-  sys_corr_14: -0.0
+  sys_corr_14: 0.0
   sys_corr_15: 6.761
   sys_corr_16: 4.0566
   sys_corr_17: 13.522
@@ -1367,10 +1367,10 @@ bins:
   sys_corr_24: -5.4088
   sys_corr_25: -1.3522
   sys_corr_26: 4.0566
-  sys_corr_27: -0.0
+  sys_corr_27: 0.0
   sys_corr_28: 5.4088
   sys_corr_29: -2.7044
-  sys_corr_30: -0.0
+  sys_corr_30: 0.0
   sys_corr_31: 1.3522
   sys_corr_32: -4.0566
   sys_corr_33: 4.0566
@@ -1433,20 +1433,20 @@ bins:
   sys_corr_90: 12.1698
   sys_corr_91: -12.1698
   sys_corr_92: 0.0
-  sys_corr_93: -0.0
+  sys_corr_93: 0.0
   sys_corr_94: 0.0
-  sys_corr_95: -0.0
+  sys_corr_95: 0.0
   sys_corr_96: 0.0
-  sys_corr_97: -0.0
-  sys_corr_98: -0.0
-  sys_corr_99: -0.0
+  sys_corr_97: 0.0
+  sys_corr_98: 0.0
+  sys_corr_99: 0.0
   sys_corr_100: 8.1132
   sys_corr_101: 1.48742000e+01
   sys_corr_102: -2.7044
   sys_corr_103: 0.0
   sys_corr_104: -1.3522
   sys_corr_105: -8.1132
-  sys_corr_106: -0.0
+  sys_corr_106: 0.0
   sys_corr_107: 5.4088
   sys_corr_108: 0.0
   sys_corr_109: 1.3522
@@ -1463,7 +1463,7 @@ bins:
   sys_corr_120: 43.2704
   sys_corr_121: 5.94968000e+01
   sys_corr_122: 40.566
-  sys_corr_123: -0.0
+  sys_corr_123: 0.0
   sys_corr_124: -10.8176
   sys_corr_125: -22.9874
   sys_corr_126: -36.5094
@@ -1488,7 +1488,7 @@ bins:
   sys_corr_11: -1.37434800e+02
   sys_corr_12: -1.07792000e+01
   sys_corr_13: 16.1688
-  sys_corr_14: -0.0
+  sys_corr_14: 0.0
   sys_corr_15: 6.737
   sys_corr_16: 4.0422
   sys_corr_17: 13.474
@@ -1567,13 +1567,13 @@ bins:
   sys_corr_90: 6.737
   sys_corr_91: -5.38960000e+00
   sys_corr_92: 0.0
-  sys_corr_93: -0.0
-  sys_corr_94: -0.0
-  sys_corr_95: -0.0
+  sys_corr_93: 0.0
+  sys_corr_94: 0.0
+  sys_corr_95: 0.0
   sys_corr_96: 0.0
-  sys_corr_97: -0.0
-  sys_corr_98: -0.0
-  sys_corr_99: -0.0
+  sys_corr_97: 0.0
+  sys_corr_98: 0.0
+  sys_corr_99: 0.0
   sys_corr_100: 5.38960000e+00
   sys_corr_101: 1.48214000e+01
   sys_corr_102: -1.34740000e+00
@@ -1597,14 +1597,14 @@ bins:
   sys_corr_120: 44.4642
   sys_corr_121: 60.633
   sys_corr_122: 40.422
-  sys_corr_123: -0.0
+  sys_corr_123: 0.0
   sys_corr_124: -9.4318
   sys_corr_125: -20.211
   sys_corr_126: -3.90746000e+01
   sys_corr_127: -1.21266000e+01
   sys_corr_128: -66.0226
   sys_corr_129: -33.685
-  sys_corr_130: -0.0
+  sys_corr_130: 0.0
   sys_corr_131: 51.2012
   sys_corr_132: 2425.32
   sys_corr_133: 79.4966
@@ -1616,26 +1616,26 @@ bins:
   sys_corr_5: 5.3696
   sys_corr_6: 5.3696
   sys_corr_7: -36.2448
-  sys_corr_8: -0.0
+  sys_corr_8: 0.0
   sys_corr_9: -6.71200000e+00
   sys_corr_10: 115.4464
   sys_corr_11: -1.36924800e+02
   sys_corr_12: -10.7392
   sys_corr_13: 1.61088000e+01
-  sys_corr_14: -0.0
+  sys_corr_14: 0.0
   sys_corr_15: 6.71200000e+00
   sys_corr_16: 4.02720000e+00
   sys_corr_17: 1.34240000e+01
   sys_corr_18: 2.6848
   sys_corr_19: -1.3424
   sys_corr_20: 8.05440000e+00
-  sys_corr_21: -0.0
+  sys_corr_21: 0.0
   sys_corr_22: 5.3696
   sys_corr_23: 5.3696
   sys_corr_24: -2.6848
   sys_corr_25: -1.3424
   sys_corr_26: 4.02720000e+00
-  sys_corr_27: -0.0
+  sys_corr_27: 0.0
   sys_corr_28: 2.6848
   sys_corr_29: -1.3424
   sys_corr_30: 1.3424
@@ -1644,7 +1644,7 @@ bins:
   sys_corr_33: 2.6848
   sys_corr_34: -1.3424
   sys_corr_35: -1.3424
-  sys_corr_36: -0.0
+  sys_corr_36: 0.0
   sys_corr_37: 10.7392
   sys_corr_38: -6.71200000e+00
   sys_corr_39: -4.02720000e+00
@@ -1658,7 +1658,7 @@ bins:
   sys_corr_47: 1.3424
   sys_corr_48: -1.20816000e+01
   sys_corr_49: 4.02720000e+00
-  sys_corr_50: -0.0
+  sys_corr_50: 0.0
   sys_corr_51: 2.6848
   sys_corr_52: 42.9568
   sys_corr_53: -5.3696
@@ -1701,20 +1701,20 @@ bins:
   sys_corr_90: -2.6848
   sys_corr_91: 4.02720000e+00
   sys_corr_92: 0.0
-  sys_corr_93: -0.0
+  sys_corr_93: 0.0
   sys_corr_94: 0.0
-  sys_corr_95: -0.0
+  sys_corr_95: 0.0
   sys_corr_96: 0.0
-  sys_corr_97: -0.0
-  sys_corr_98: -0.0
-  sys_corr_99: -0.0
+  sys_corr_97: 0.0
+  sys_corr_98: 0.0
+  sys_corr_99: 0.0
   sys_corr_100: 6.71200000e+00
   sys_corr_101: 1.47664000e+01
   sys_corr_102: -1.3424
   sys_corr_103: 1.3424
   sys_corr_104: -1.3424
   sys_corr_105: -5.3696
-  sys_corr_106: -0.0
+  sys_corr_106: 0.0
   sys_corr_107: 5.3696
   sys_corr_108: 2.6848
   sys_corr_109: 1.3424
@@ -1738,7 +1738,7 @@ bins:
   sys_corr_127: -1.20816000e+01
   sys_corr_128: -63.0928
   sys_corr_129: -33.56
-  sys_corr_130: -0.0
+  sys_corr_130: 0.0
   sys_corr_131: 4.96688000e+01
   sys_corr_132: 2416.32
   sys_corr_133: 80.544
@@ -1756,7 +1756,7 @@ bins:
   sys_corr_11: -1.38403200e+02
   sys_corr_12: -18.6312
   sys_corr_13: 1.46388000e+01
-  sys_corr_14: -0.0
+  sys_corr_14: 0.0
   sys_corr_15: 6.654
   sys_corr_16: 3.9924
   sys_corr_17: 13.308
@@ -1767,26 +1767,26 @@ bins:
   sys_corr_22: 3.9924
   sys_corr_23: 6.654
   sys_corr_24: -2.66160000e+00
-  sys_corr_25: -0.0
+  sys_corr_25: 0.0
   sys_corr_26: 3.9924
   sys_corr_27: -1.33080000e+00
   sys_corr_28: 2.66160000e+00
-  sys_corr_29: -0.0
-  sys_corr_30: -0.0
+  sys_corr_29: 0.0
+  sys_corr_30: 0.0
   sys_corr_31: 0.0
   sys_corr_32: -1.33080000e+00
   sys_corr_33: 1.33080000e+00
   sys_corr_34: -1.33080000e+00
-  sys_corr_35: -0.0
+  sys_corr_35: 0.0
   sys_corr_36: 1.33080000e+00
   sys_corr_37: 1.06464000e+01
   sys_corr_38: -7.9848
   sys_corr_39: -5.32320000e+00
   sys_corr_40: -5.32320000e+00
-  sys_corr_41: -0.0
+  sys_corr_41: 0.0
   sys_corr_42: 3.9924
   sys_corr_43: -5.32320000e+00
-  sys_corr_44: -0.0
+  sys_corr_44: 0.0
   sys_corr_45: 2.66160000e+00
   sys_corr_46: -3.9924
   sys_corr_47: -1.33080000e+00
@@ -1835,20 +1835,20 @@ bins:
   sys_corr_90: -13.308
   sys_corr_91: 7.9848
   sys_corr_92: 0.0
-  sys_corr_93: -0.0
-  sys_corr_94: -0.0
-  sys_corr_95: -0.0
+  sys_corr_93: 0.0
+  sys_corr_94: 0.0
+  sys_corr_95: 0.0
   sys_corr_96: 0.0
-  sys_corr_97: -0.0
-  sys_corr_98: -0.0
-  sys_corr_99: -0.0
+  sys_corr_97: 0.0
+  sys_corr_98: 0.0
+  sys_corr_99: 0.0
   sys_corr_100: 1.33080000e+00
   sys_corr_101: 1.46388000e+01
   sys_corr_102: -2.66160000e+00
   sys_corr_103: 0.0
   sys_corr_104: -1.33080000e+00
   sys_corr_105: -5.32320000e+00
-  sys_corr_106: -0.0
+  sys_corr_106: 0.0
   sys_corr_107: 1.33080000e+00
   sys_corr_108: 2.66160000e+00
   sys_corr_109: 0.0
@@ -1890,7 +1890,7 @@ bins:
   sys_corr_11: -1.43078400e+02
   sys_corr_12: -23.8464
   sys_corr_13: 13.248
-  sys_corr_14: -0.0
+  sys_corr_14: 0.0
   sys_corr_15: 5.2992
   sys_corr_16: 2.6496
   sys_corr_17: 13.248
@@ -1907,12 +1907,12 @@ bins:
   sys_corr_28: -1.3248
   sys_corr_29: 1.3248
   sys_corr_30: 2.6496
-  sys_corr_31: -0.0
+  sys_corr_31: 0.0
   sys_corr_32: -2.6496
   sys_corr_33: 1.3248
   sys_corr_34: -2.6496
   sys_corr_35: 1.3248
-  sys_corr_36: -0.0
+  sys_corr_36: 0.0
   sys_corr_37: 11.9232
   sys_corr_38: -3.9744
   sys_corr_39: -2.6496
@@ -1959,7 +1959,7 @@ bins:
   sys_corr_80: 164.2752
   sys_corr_81: -46.368
   sys_corr_82: -5.2992
-  sys_corr_83: -0.0
+  sys_corr_83: 0.0
   sys_corr_84: 15.8976
   sys_corr_85: 5.2992
   sys_corr_86: -1.45728000e+01
@@ -1967,22 +1967,22 @@ bins:
   sys_corr_88: 41.0688
   sys_corr_89: 2.6496
   sys_corr_90: -15.8976
-  sys_corr_91: -0.0
+  sys_corr_91: 0.0
   sys_corr_92: 0.0
-  sys_corr_93: -0.0
+  sys_corr_93: 0.0
   sys_corr_94: 0.0
-  sys_corr_95: -0.0
+  sys_corr_95: 0.0
   sys_corr_96: 0.0
-  sys_corr_97: -0.0
-  sys_corr_98: -0.0
-  sys_corr_99: -0.0
+  sys_corr_97: 0.0
+  sys_corr_98: 0.0
+  sys_corr_99: 0.0
   sys_corr_100: -3.9744
   sys_corr_101: 13.248
   sys_corr_102: -1.3248
   sys_corr_103: -1.3248
-  sys_corr_104: -0.0
+  sys_corr_104: 0.0
   sys_corr_105: -2.6496
-  sys_corr_106: -0.0
+  sys_corr_106: 0.0
   sys_corr_107: -2.6496
   sys_corr_108: 2.6496
   sys_corr_109: -2.6496
@@ -1999,7 +1999,7 @@ bins:
   sys_corr_120: 42.3936
   sys_corr_121: 5.69664000e+01
   sys_corr_122: 35.7696
-  sys_corr_123: -0.0
+  sys_corr_123: 0.0
   sys_corr_124: -7.9488
   sys_corr_125: -15.8976
   sys_corr_126: -35.7696
@@ -2024,7 +2024,7 @@ bins:
   sys_corr_11: -1.40675400e+02
   sys_corr_12: -30.9744
   sys_corr_13: 10.3248
-  sys_corr_14: -0.0
+  sys_corr_14: 0.0
   sys_corr_15: 5.1624
   sys_corr_16: 2.5812
   sys_corr_17: 11.6154
@@ -2038,7 +2038,7 @@ bins:
   sys_corr_25: 1.2906
   sys_corr_26: 1.2906
   sys_corr_27: -1.2906
-  sys_corr_28: -0.0
+  sys_corr_28: 0.0
   sys_corr_29: 2.5812
   sys_corr_30: 0.0
   sys_corr_31: -2.5812
@@ -2046,7 +2046,7 @@ bins:
   sys_corr_33: 0.0
   sys_corr_34: -3.8718
   sys_corr_35: 1.2906
-  sys_corr_36: -0.0
+  sys_corr_36: 0.0
   sys_corr_37: 9.0342
   sys_corr_38: -3.8718
   sys_corr_39: -1.2906
@@ -2057,7 +2057,7 @@ bins:
   sys_corr_44: -2.5812
   sys_corr_45: -1.2906
   sys_corr_46: -9.0342
-  sys_corr_47: -0.0
+  sys_corr_47: 0.0
   sys_corr_48: -12.906
   sys_corr_49: 3.8718
   sys_corr_50: -6.453
@@ -2103,20 +2103,20 @@ bins:
   sys_corr_90: -6.453
   sys_corr_91: -1.41966000e+01
   sys_corr_92: 0.0
-  sys_corr_93: -0.0
+  sys_corr_93: 0.0
   sys_corr_94: 0.0
-  sys_corr_95: -0.0
+  sys_corr_95: 0.0
   sys_corr_96: 0.0
-  sys_corr_97: -0.0
-  sys_corr_98: -0.0
-  sys_corr_99: -0.0
+  sys_corr_97: 0.0
+  sys_corr_98: 0.0
+  sys_corr_99: 0.0
   sys_corr_100: -5.1624
   sys_corr_101: 12.906
-  sys_corr_102: -0.0
+  sys_corr_102: 0.0
   sys_corr_103: -2.5812
-  sys_corr_104: -0.0
+  sys_corr_104: 0.0
   sys_corr_105: -2.5812
-  sys_corr_106: -0.0
+  sys_corr_106: 0.0
   sys_corr_107: -3.8718
   sys_corr_108: 2.5812
   sys_corr_109: -3.8718
@@ -2158,7 +2158,7 @@ bins:
   sys_corr_11: -131.912
   sys_corr_12: -38.3744
   sys_corr_13: 8.39440000e+00
-  sys_corr_14: -0.0
+  sys_corr_14: 0.0
   sys_corr_15: 5.996
   sys_corr_16: 3.5976
   sys_corr_17: 10.7928
@@ -2170,7 +2170,7 @@ bins:
   sys_corr_23: 9.5936
   sys_corr_24: -3.5976
   sys_corr_25: 2.3984
-  sys_corr_26: -0.0
+  sys_corr_26: 0.0
   sys_corr_27: -2.3984
   sys_corr_28: 1.1992
   sys_corr_29: 3.5976
@@ -2189,7 +2189,7 @@ bins:
   sys_corr_42: 0.0
   sys_corr_43: -3.5976
   sys_corr_44: -3.5976
-  sys_corr_45: -0.0
+  sys_corr_45: 0.0
   sys_corr_46: -9.5936
   sys_corr_47: 1.1992
   sys_corr_48: -10.7928
@@ -2238,12 +2238,12 @@ bins:
   sys_corr_91: -9.5936
   sys_corr_92: 0.0
   sys_corr_93: 0.0
-  sys_corr_94: -0.0
-  sys_corr_95: -0.0
+  sys_corr_94: 0.0
+  sys_corr_95: 0.0
   sys_corr_96: 0.0
-  sys_corr_97: -0.0
-  sys_corr_98: -0.0
-  sys_corr_99: -0.0
+  sys_corr_97: 0.0
+  sys_corr_98: 0.0
+  sys_corr_99: 0.0
   sys_corr_100: -4.7968
   sys_corr_101: 1.31912000e+01
   sys_corr_102: 1.1992
@@ -2292,7 +2292,7 @@ bins:
   sys_corr_11: -1.19125200e+02
   sys_corr_12: -40.7816
   sys_corr_13: 6.4392
-  sys_corr_14: -0.0
+  sys_corr_14: 0.0
   sys_corr_15: 4.29280000e+00
   sys_corr_16: 3.2196
   sys_corr_17: 9.6588
@@ -2308,7 +2308,7 @@ bins:
   sys_corr_27: -3.2196
   sys_corr_28: -2.14640000e+00
   sys_corr_29: 4.29280000e+00
-  sys_corr_30: -0.0
+  sys_corr_30: 0.0
   sys_corr_31: -3.2196
   sys_corr_32: -1.07320000e+00
   sys_corr_33: -2.14640000e+00
@@ -2343,7 +2343,7 @@ bins:
   sys_corr_62: 1.71712000e+01
   sys_corr_63: -4.29280000e+00
   sys_corr_64: 2.14640000e+00
-  sys_corr_65: -0.0
+  sys_corr_65: 0.0
   sys_corr_66: -1.07320000e+01
   sys_corr_67: 2.14640000e+00
   sys_corr_68: -7.5124
@@ -2371,13 +2371,13 @@ bins:
   sys_corr_90: 15.0248
   sys_corr_91: 2.14640000e+00
   sys_corr_92: 0.0
-  sys_corr_93: -0.0
-  sys_corr_94: -0.0
-  sys_corr_95: -0.0
+  sys_corr_93: 0.0
+  sys_corr_94: 0.0
+  sys_corr_95: 0.0
   sys_corr_96: 0.0
-  sys_corr_97: -0.0
-  sys_corr_98: -0.0
-  sys_corr_99: -0.0
+  sys_corr_97: 0.0
+  sys_corr_98: 0.0
+  sys_corr_99: 0.0
   sys_corr_100: -4.29280000e+00
   sys_corr_101: 1.07320000e+01
   sys_corr_102: 1.07320000e+00
@@ -2389,7 +2389,7 @@ bins:
   sys_corr_108: 5.36600000e+00
   sys_corr_109: -2.14640000e+00
   sys_corr_110: -7.5124
-  sys_corr_111: -0.0
+  sys_corr_111: 0.0
   sys_corr_112: -4.29280000e+00
   sys_corr_113: -63.3188
   sys_corr_114: -2.89764000e+01
@@ -2414,7 +2414,7 @@ bins:
   sys_corr_133: 79.4168
 - stat: 2.23048353e+02
   sys_corr_1: 1.01651957e+02
-  sys_corr_2: -0.0
+  sys_corr_2: 0.0
   sys_corr_3: 80.883
   sys_corr_4: -3.14545000e+01
   sys_corr_5: -2.6961
@@ -2426,7 +2426,7 @@ bins:
   sys_corr_11: -1.05147900e+02
   sys_corr_12: -4.40363000e+01
   sys_corr_13: 4.4935
-  sys_corr_14: -0.0
+  sys_corr_14: 0.0
   sys_corr_15: 3.5948
   sys_corr_16: 2.6961
   sys_corr_17: 8.08830000e+00
@@ -2459,7 +2459,7 @@ bins:
   sys_corr_44: -1.7974
   sys_corr_45: -0.8987
   sys_corr_46: -4.4935
-  sys_corr_47: -0.0
+  sys_corr_47: 0.0
   sys_corr_48: -8.987
   sys_corr_49: 1.7974
   sys_corr_50: -4.4935
@@ -2506,12 +2506,12 @@ bins:
   sys_corr_91: 3.5948
   sys_corr_92: 0.0
   sys_corr_93: 0.0
-  sys_corr_94: -0.0
-  sys_corr_95: -0.0
+  sys_corr_94: 0.0
+  sys_corr_95: 0.0
   sys_corr_96: 0.0
-  sys_corr_97: -0.0
-  sys_corr_98: -0.0
-  sys_corr_99: -0.0
+  sys_corr_97: 0.0
+  sys_corr_98: 0.0
+  sys_corr_99: 0.0
   sys_corr_100: -1.7974
   sys_corr_101: 9.8857
   sys_corr_102: 3.5948
@@ -2521,7 +2521,7 @@ bins:
   sys_corr_106: 1.7974
   sys_corr_107: -4.4935
   sys_corr_108: 1.25818000e+01
-  sys_corr_109: -0.0
+  sys_corr_109: 0.0
   sys_corr_110: -5.3922
   sys_corr_111: 0.8987
   sys_corr_112: -2.6961
@@ -2560,7 +2560,7 @@ bins:
   sys_corr_11: -79.808
   sys_corr_12: -38.528
   sys_corr_13: 3.44
-  sys_corr_14: -0.0
+  sys_corr_14: 0.0
   sys_corr_15: 3.44
   sys_corr_16: 2.752
   sys_corr_17: 6.19200000e+00
@@ -2586,14 +2586,14 @@ bins:
   sys_corr_37: 2.752
   sys_corr_38: -4.128
   sys_corr_39: -1.376
-  sys_corr_40: -0.0
+  sys_corr_40: 0.0
   sys_corr_41: -2.752
   sys_corr_42: -0.688
-  sys_corr_43: -0.0
+  sys_corr_43: 0.0
   sys_corr_44: -1.376
   sys_corr_45: 0.0
   sys_corr_46: -3.44
-  sys_corr_47: -0.0
+  sys_corr_47: 0.0
   sys_corr_48: -6.88
   sys_corr_49: 1.376
   sys_corr_50: -3.44
@@ -2616,7 +2616,7 @@ bins:
   sys_corr_67: 4.128
   sys_corr_68: -6.19200000e+00
   sys_corr_69: -0.688
-  sys_corr_70: -0.0
+  sys_corr_70: 0.0
   sys_corr_71: 0.0
   sys_corr_72: 8.66880000e+01
   sys_corr_73: 6.19200000e+00
@@ -2640,24 +2640,24 @@ bins:
   sys_corr_91: 2.064
   sys_corr_92: 0.0
   sys_corr_93: 0.0
-  sys_corr_94: -0.0
-  sys_corr_95: -0.0
+  sys_corr_94: 0.0
+  sys_corr_95: 0.0
   sys_corr_96: 0.0
-  sys_corr_97: -0.0
-  sys_corr_98: -0.0
-  sys_corr_99: -0.0
+  sys_corr_97: 0.0
+  sys_corr_98: 0.0
+  sys_corr_99: 0.0
   sys_corr_100: -1.376
   sys_corr_101: 7.568
   sys_corr_102: 2.752
   sys_corr_103: -0.688
   sys_corr_104: -1.376
-  sys_corr_105: -0.0
+  sys_corr_105: 0.0
   sys_corr_106: 0.688
   sys_corr_107: -2.064
   sys_corr_108: 7.568
   sys_corr_109: -2.064
   sys_corr_110: -4.816
-  sys_corr_111: -0.0
+  sys_corr_111: 0.0
   sys_corr_112: -2.064
   sys_corr_113: -39.904
   sys_corr_114: -1.78880000e+01
@@ -2694,7 +2694,7 @@ bins:
   sys_corr_11: -49.7258
   sys_corr_12: -2.50910000e+01
   sys_corr_13: 1.3686
-  sys_corr_14: -0.0
+  sys_corr_14: 0.0
   sys_corr_15: 2.281
   sys_corr_16: 1.8248
   sys_corr_17: 3.6496
@@ -2711,7 +2711,7 @@ bins:
   sys_corr_28: -3.19340000e+00
   sys_corr_29: 4.10580000e+00
   sys_corr_30: -1.8248
-  sys_corr_31: -0.0
+  sys_corr_31: 0.0
   sys_corr_32: 0.0
   sys_corr_33: 1.3686
   sys_corr_34: -2.281
@@ -2772,20 +2772,20 @@ bins:
   sys_corr_89: 8.21160000e+00
   sys_corr_90: -3.19340000e+00
   sys_corr_91: -1.8248
-  sys_corr_92: -0.0
-  sys_corr_93: -0.0
+  sys_corr_92: 0.0
+  sys_corr_93: 0.0
   sys_corr_94: 0.0
-  sys_corr_95: -0.0
+  sys_corr_95: 0.0
   sys_corr_96: 0.0
-  sys_corr_97: -0.0
-  sys_corr_98: -0.0
-  sys_corr_99: -0.0
+  sys_corr_97: 0.0
+  sys_corr_98: 0.0
+  sys_corr_99: 0.0
   sys_corr_100: 1.8248
   sys_corr_101: 5.0182
   sys_corr_102: 2.281
   sys_corr_103: -0.4562
   sys_corr_104: -0.4562
-  sys_corr_105: -0.0
+  sys_corr_105: 0.0
   sys_corr_106: 0.4562
   sys_corr_107: 0.9124
   sys_corr_108: 5.4744
@@ -2805,7 +2805,7 @@ bins:
   sys_corr_122: 11.405
   sys_corr_123: -0.4562
   sys_corr_124: -4.562
-  sys_corr_125: -0.0
+  sys_corr_125: 0.0
   sys_corr_126: -1.64232000e+01
   sys_corr_127: -4.10580000e+00
   sys_corr_128: -24.6348
@@ -2816,7 +2816,7 @@ bins:
   sys_corr_133: 58.8498
 - stat: 1.32232932e+02
   sys_corr_1: 8.19642330e+01
-  sys_corr_2: -0.0
+  sys_corr_2: 0.0
   sys_corr_3: 21.7854
   sys_corr_4: -13.338
   sys_corr_5: 0.4446
@@ -2828,7 +2828,7 @@ bins:
   sys_corr_11: -25.1199
   sys_corr_12: -11.7819
   sys_corr_13: 0.4446
-  sys_corr_14: -0.0
+  sys_corr_14: 0.0
   sys_corr_15: 1.11150000e+00
   sys_corr_16: 0.8892
   sys_corr_17: 1.7784
@@ -2877,7 +2877,7 @@ bins:
   sys_corr_60: 7.5582
   sys_corr_61: 0.4446
   sys_corr_62: 1.5561
-  sys_corr_63: -0.0
+  sys_corr_63: 0.0
   sys_corr_64: 2.22300000e+00
   sys_corr_65: 0.4446
   sys_corr_66: -1.7784
@@ -2906,14 +2906,14 @@ bins:
   sys_corr_89: 12.4488
   sys_corr_90: -10.4481
   sys_corr_91: -8.4474
-  sys_corr_92: -0.0
-  sys_corr_93: -0.0
+  sys_corr_92: 0.0
+  sys_corr_93: 0.0
   sys_corr_94: 0.0
-  sys_corr_95: -0.0
-  sys_corr_96: -0.0
-  sys_corr_97: -0.0
+  sys_corr_95: 0.0
+  sys_corr_96: 0.0
+  sys_corr_97: 0.0
   sys_corr_98: 0.0
-  sys_corr_99: -0.0
+  sys_corr_99: 0.0
   sys_corr_100: 0.2223
   sys_corr_101: 2.22300000e+00
   sys_corr_102: 1.5561
@@ -3014,7 +3014,7 @@ bins:
   sys_corr_63: 0.0151
   sys_corr_64: -0.4228
   sys_corr_65: -5.28500000e-01
-  sys_corr_66: -0.0
+  sys_corr_66: 0.0
   sys_corr_67: 0.3322
   sys_corr_68: 4.98300000e-01
   sys_corr_69: 0.4228
@@ -3040,14 +3040,14 @@ bins:
   sys_corr_89: 2.56700000e-01
   sys_corr_90: 0.0151
   sys_corr_91: -0.0906
-  sys_corr_92: -0.0
-  sys_corr_93: -0.0
-  sys_corr_94: -0.0
-  sys_corr_95: -0.0
+  sys_corr_92: 0.0
+  sys_corr_93: 0.0
+  sys_corr_94: 0.0
+  sys_corr_95: 0.0
   sys_corr_96: 0.0
   sys_corr_97: 0.0
   sys_corr_98: 0.0
-  sys_corr_99: -0.0
+  sys_corr_99: 0.0
   sys_corr_100: -0.8003
   sys_corr_101: -0.5587
   sys_corr_102: 0.1963
@@ -3112,7 +3112,7 @@ bins:
   sys_corr_27: 8.74800000e-02
   sys_corr_28: -4.37400000e-02
   sys_corr_29: 0.05832
-  sys_corr_30: -0.0
+  sys_corr_30: 0.0
   sys_corr_31: 0.02916
   sys_corr_32: 4.37400000e-02
   sys_corr_33: -0.0729
@@ -3141,7 +3141,7 @@ bins:
   sys_corr_56: 2.42028
   sys_corr_57: 6.99840000e-01
   sys_corr_58: -3.64500000e-01
-  sys_corr_59: -0.0
+  sys_corr_59: 0.0
   sys_corr_60: 0.55404
   sys_corr_61: 0.81648
   sys_corr_62: 6.26940000e-01
@@ -3174,14 +3174,14 @@ bins:
   sys_corr_89: 0.1458
   sys_corr_90: 0.01458
   sys_corr_91: -0.11664
-  sys_corr_92: -0.0
-  sys_corr_93: -0.0
-  sys_corr_94: -0.0
-  sys_corr_95: -0.0
+  sys_corr_92: 0.0
+  sys_corr_93: 0.0
+  sys_corr_94: 0.0
+  sys_corr_95: 0.0
   sys_corr_96: 0.0
   sys_corr_97: 0.0
   sys_corr_98: 0.0
-  sys_corr_99: -0.0
+  sys_corr_99: 0.0
   sys_corr_100: -1.1664
   sys_corr_101: -0.52488
   sys_corr_102: 1.74960000e-01
@@ -3191,7 +3191,7 @@ bins:
   sys_corr_106: -0.11664
   sys_corr_107: -6.70680000e-01
   sys_corr_108: -0.26244
-  sys_corr_109: -0.0
+  sys_corr_109: 0.0
   sys_corr_110: -0.10206
   sys_corr_111: 0.11664
   sys_corr_112: 3.49920000e-01
@@ -3241,7 +3241,7 @@ bins:
   sys_corr_22: -0.0405
   sys_corr_23: -1.35000000e-02
   sys_corr_24: -2.70000000e-02
-  sys_corr_25: -0.0
+  sys_corr_25: 0.0
   sys_corr_26: -9.45000000e-02
   sys_corr_27: 9.45000000e-02
   sys_corr_28: -9.45000000e-02
@@ -3252,7 +3252,7 @@ bins:
   sys_corr_33: -2.70000000e-02
   sys_corr_34: -0.0405
   sys_corr_35: -2.70000000e-02
-  sys_corr_36: -0.0
+  sys_corr_36: 0.0
   sys_corr_37: -2.16000000e-01
   sys_corr_38: -0.2565
   sys_corr_39: 3.91500000e-01
@@ -3308,14 +3308,14 @@ bins:
   sys_corr_89: 0.135
   sys_corr_90: -0.0675
   sys_corr_91: 0.0675
-  sys_corr_92: -0.0
-  sys_corr_93: -0.0
-  sys_corr_94: -0.0
-  sys_corr_95: -0.0
-  sys_corr_96: -0.0
+  sys_corr_92: 0.0
+  sys_corr_93: 0.0
+  sys_corr_94: 0.0
+  sys_corr_95: 0.0
+  sys_corr_96: 0.0
   sys_corr_97: 0.0
   sys_corr_98: 0.0
-  sys_corr_99: -0.0
+  sys_corr_99: 0.0
   sys_corr_100: -9.58500000e-01
   sys_corr_101: -4.86000000e-01
   sys_corr_102: 0.2025
@@ -3332,7 +3332,7 @@ bins:
   sys_corr_113: 3.22650000e+00
   sys_corr_114: 8.64000000e-01
   sys_corr_115: 1.7955
-  sys_corr_116: -0.0
+  sys_corr_116: 0.0
   sys_corr_117: 0.2565
   sys_corr_118: 5.40000000e-02
   sys_corr_119: -4.99500000e-01
@@ -3442,14 +3442,14 @@ bins:
   sys_corr_89: 0.05915
   sys_corr_90: -0.04732
   sys_corr_91: 0.03549
-  sys_corr_92: -0.0
-  sys_corr_93: -0.0
+  sys_corr_92: 0.0
+  sys_corr_93: 0.0
   sys_corr_94: 0.0
-  sys_corr_95: -0.0
-  sys_corr_96: -0.0
+  sys_corr_95: 0.0
+  sys_corr_96: 0.0
   sys_corr_97: 0.0
   sys_corr_98: 0.0
-  sys_corr_99: -0.0
+  sys_corr_99: 0.0
   sys_corr_100: -0.89908
   sys_corr_101: -0.44954
   sys_corr_102: 1.53790000e-01
@@ -3527,7 +3527,7 @@ bins:
   sys_corr_40: -1.00165000e-01
   sys_corr_41: -3.46725000e-01
   sys_corr_42: -0.27738
-  sys_corr_43: -0.0
+  sys_corr_43: 0.0
   sys_corr_44: 0.13869
   sys_corr_45: -5.39350000e-02
   sys_corr_46: -1.15575000e-01
@@ -3577,13 +3577,13 @@ bins:
   sys_corr_90: -1.46395000e-01
   sys_corr_91: -6.93450000e-02
   sys_corr_92: 0.0
-  sys_corr_93: -0.0
-  sys_corr_94: -0.0
-  sys_corr_95: -0.0
+  sys_corr_93: 0.0
+  sys_corr_94: 0.0
+  sys_corr_95: 0.0
   sys_corr_96: 0.0
   sys_corr_97: 0.0
   sys_corr_98: 0.0
-  sys_corr_99: -0.0
+  sys_corr_99: 0.0
   sys_corr_100: -6.39515000e-01
   sys_corr_101: -0.27738
   sys_corr_102: 0.146395
@@ -3632,7 +3632,7 @@ bins:
   sys_corr_11: -3.08978000e-01
   sys_corr_12: -1.24906000e-01
   sys_corr_13: 0.128193
-  sys_corr_14: -0.0
+  sys_corr_14: 0.0
   sys_corr_15: -7.23140000e-02
   sys_corr_16: 1.64350000e-02
   sys_corr_17: 0.052592
@@ -3711,13 +3711,13 @@ bins:
   sys_corr_90: -2.07081000e-01
   sys_corr_91: -6.57400000e-02
   sys_corr_92: 0.0
-  sys_corr_93: -0.0
+  sys_corr_93: 0.0
   sys_corr_94: 0.0
-  sys_corr_95: -0.0
-  sys_corr_96: -0.0
+  sys_corr_95: 0.0
+  sys_corr_96: 0.0
   sys_corr_97: 0.0
   sys_corr_98: 0.0
-  sys_corr_99: -0.0
+  sys_corr_99: 0.0
   sys_corr_100: -0.3287
   sys_corr_101: -1.15045000e-01
   sys_corr_102: 5.91660000e-02

--- a/nnpdf_data/nnpdf_data/commondata/ATLAS_Z0_7TEV_46FB/uncertainties_cf.yaml
+++ b/nnpdf_data/nnpdf_data/commondata/ATLAS_Z0_7TEV_46FB/uncertainties_cf.yaml
@@ -538,21 +538,21 @@ definitions:
 bins:
 - stat: 1.35919590e+02
   sys_corr_1: 1.41594150e+02
-  sys_corr_2: -0.0
+  sys_corr_2: 0.0
   sys_corr_3: 0.0
-  sys_corr_4: -0.0
+  sys_corr_4: 0.0
   sys_corr_5: 0.0
-  sys_corr_6: -0.0
+  sys_corr_6: 0.0
   sys_corr_7: 0.0
-  sys_corr_8: -0.0
+  sys_corr_8: 0.0
   sys_corr_9: 2.19735000e+01
   sys_corr_10: 4.2405
   sys_corr_11: -19.1208
   sys_corr_12: -3.39240000e+00
   sys_corr_13: 0.1542
-  sys_corr_14: -0.0
+  sys_corr_14: 0.0
   sys_corr_15: 0.6168
-  sys_corr_16: -0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: -0.1542
@@ -575,12 +575,12 @@ bins:
   sys_corr_36: -0.5397
   sys_corr_37: 1.77330000e+00
   sys_corr_38: -1.0023
-  sys_corr_39: -0.0
+  sys_corr_39: 0.0
   sys_corr_40: -0.0771
   sys_corr_41: -1.0794
   sys_corr_42: -3.85500000e-01
   sys_corr_43: -1.3878
-  sys_corr_44: -0.0
+  sys_corr_44: 0.0
   sys_corr_45: -0.5397
   sys_corr_46: -1.2336
   sys_corr_47: 0.1542
@@ -626,12 +626,12 @@ bins:
   sys_corr_87: 2.1588
   sys_corr_88: -7.71000000e-01
   sys_corr_89: 1.31070000e+00
-  sys_corr_90: -0.0
+  sys_corr_90: 0.0
   sys_corr_91: 0.3084
-  sys_corr_92: -0.0
-  sys_corr_93: -0.0
+  sys_corr_92: 0.0
+  sys_corr_93: 0.0
   sys_corr_94: 25.1346
-  sys_corr_95: -0.0
+  sys_corr_95: 0.0
   sys_corr_96: 6.78480000e+00
   sys_corr_97: 29.7606
   sys_corr_98: -2.20506000e+02
@@ -655,7 +655,7 @@ bins:
   sys_corr_116: -1.6191
   sys_corr_117: 0.0771
   sys_corr_118: 7.71000000e-01
-  sys_corr_119: -0.0
+  sys_corr_119: 0.0
   sys_corr_120: 7.1703
   sys_corr_121: 7.2474
   sys_corr_122: 5.62830000e+00
@@ -672,11 +672,11 @@ bins:
   sys_corr_133: 40.2462
 - stat: 1.82832210e+02
   sys_corr_1: 1.98951280e+02
-  sys_corr_2: -0.0
+  sys_corr_2: 0.0
   sys_corr_3: 0.0
-  sys_corr_4: -0.0
+  sys_corr_4: 0.0
   sys_corr_5: 0.0
-  sys_corr_6: -0.0
+  sys_corr_6: 0.0
   sys_corr_7: 0.0
   sys_corr_8: 0.0
   sys_corr_9: 18.6472
@@ -684,9 +684,9 @@ bins:
   sys_corr_11: -45.0043
   sys_corr_12: -10.3994
   sys_corr_13: 0.3586
-  sys_corr_14: -0.0
+  sys_corr_14: 0.0
   sys_corr_15: 1.61370000e+00
-  sys_corr_16: -0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: -0.3586
@@ -695,7 +695,7 @@ bins:
   sys_corr_22: -0.7172
   sys_corr_23: 1.4344
   sys_corr_24: -0.3586
-  sys_corr_25: -0.0
+  sys_corr_25: 0.0
   sys_corr_26: -0.7172
   sys_corr_27: 0.7172
   sys_corr_28: -8.96500000e-01
@@ -762,10 +762,10 @@ bins:
   sys_corr_89: 8.96500000e-01
   sys_corr_90: -0.5379
   sys_corr_91: 8.96500000e-01
-  sys_corr_92: -0.0
-  sys_corr_93: -0.0
+  sys_corr_92: 0.0
+  sys_corr_93: 0.0
   sys_corr_94: -35.86
-  sys_corr_95: -0.0
+  sys_corr_95: 0.0
   sys_corr_96: 7.53060000e+00
   sys_corr_97: 58.2725
   sys_corr_98: -4.83392800e+02
@@ -793,7 +793,7 @@ bins:
   sys_corr_120: 1.52405000e+01
   sys_corr_121: 1.30889000e+01
   sys_corr_122: 11.4752
-  sys_corr_123: -0.0
+  sys_corr_123: 0.0
   sys_corr_124: 2.8688
   sys_corr_125: -8.965
   sys_corr_126: -7.70990000e+00
@@ -806,11 +806,11 @@ bins:
   sys_corr_133: 46.9766
 - stat: 2.37581364e+02
   sys_corr_1: 2.27174964e+02
-  sys_corr_2: -0.0
+  sys_corr_2: 0.0
   sys_corr_3: 0.0
-  sys_corr_4: -0.0
+  sys_corr_4: 0.0
   sys_corr_5: 0.0
-  sys_corr_6: -0.0
+  sys_corr_6: 0.0
   sys_corr_7: 0.0
   sys_corr_8: 0.0
   sys_corr_9: 2.27640000e+01
@@ -818,9 +818,9 @@ bins:
   sys_corr_11: -81.6252
   sys_corr_12: -1.98372000e+01
   sys_corr_13: 6.50400000e-01
-  sys_corr_14: -0.0
+  sys_corr_14: 0.0
   sys_corr_15: 2.9268
-  sys_corr_16: -0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.0
   sys_corr_18: 0.0
   sys_corr_19: -6.50400000e-01
@@ -829,7 +829,7 @@ bins:
   sys_corr_22: -1.62600000e+00
   sys_corr_23: 2.9268
   sys_corr_24: -3.25200000e-01
-  sys_corr_25: -0.0
+  sys_corr_25: 0.0
   sys_corr_26: -1.30080000e+00
   sys_corr_27: 1.30080000e+00
   sys_corr_28: -1.62600000e+00
@@ -896,10 +896,10 @@ bins:
   sys_corr_89: -3.25200000e-01
   sys_corr_90: -1.62600000e+00
   sys_corr_91: -3.25200000e-01
-  sys_corr_92: -0.0
-  sys_corr_93: -0.0
+  sys_corr_92: 0.0
+  sys_corr_93: 0.0
   sys_corr_94: -3.64224000e+01
-  sys_corr_95: -0.0
+  sys_corr_95: 0.0
   sys_corr_96: 4.55280000e+00
   sys_corr_97: 6.40644000e+01
   sys_corr_98: -8.14300800e+02
@@ -921,13 +921,13 @@ bins:
   sys_corr_114: -2.27640000e+01
   sys_corr_115: -23.7396
   sys_corr_116: 6.50400000e-01
-  sys_corr_117: -0.0
+  sys_corr_117: 0.0
   sys_corr_118: 2.9268
   sys_corr_119: 4.22760000e+00
   sys_corr_120: 2.63412000e+01
   sys_corr_121: 30.2436
   sys_corr_122: 2.21136000e+01
-  sys_corr_123: -0.0
+  sys_corr_123: 0.0
   sys_corr_124: 3.90240000e+00
   sys_corr_125: -1.36584000e+01
   sys_corr_126: -21.138
@@ -940,21 +940,21 @@ bins:
   sys_corr_133: 5.23572000e+01
 - stat: 3.00555135e+02
   sys_corr_1: 894.735
-  sys_corr_2: -0.0
+  sys_corr_2: 0.0
   sys_corr_3: 0.0
-  sys_corr_4: -0.0
+  sys_corr_4: 0.0
   sys_corr_5: 0.0
   sys_corr_6: 0.0
   sys_corr_7: 0.0
-  sys_corr_8: -0.0
+  sys_corr_8: 0.0
   sys_corr_9: 5.05500000e-01
   sys_corr_10: 25.275
   sys_corr_11: -1.27386000e+02
   sys_corr_12: -3.38685000e+01
   sys_corr_13: 1.01100000e+00
-  sys_corr_14: -0.0
+  sys_corr_14: 0.0
   sys_corr_15: 4.5495
-  sys_corr_16: -0.0
+  sys_corr_16: 0.0
   sys_corr_17: 5.05500000e-01
   sys_corr_18: 0.0
   sys_corr_19: -1.01100000e+00
@@ -974,7 +974,7 @@ bins:
   sys_corr_33: -5.05500000e-01
   sys_corr_34: -3.53850000e+00
   sys_corr_35: 1.5165
-  sys_corr_36: -0.0
+  sys_corr_36: 0.0
   sys_corr_37: 8.08800000e+00
   sys_corr_38: -9.6045
   sys_corr_39: -1.5165
@@ -1031,9 +1031,9 @@ bins:
   sys_corr_90: 1.01100000e+00
   sys_corr_91: -4.04400000e+00
   sys_corr_92: 0.0
-  sys_corr_93: -0.0
+  sys_corr_93: 0.0
   sys_corr_94: 18.7035
-  sys_corr_95: -0.0
+  sys_corr_95: 0.0
   sys_corr_96: 5.055
   sys_corr_97: 82.3965
   sys_corr_98: -1.17124350e+03
@@ -1044,7 +1044,7 @@ bins:
   sys_corr_103: -1.5165
   sys_corr_104: 0.0
   sys_corr_105: 4.5495
-  sys_corr_106: -0.0
+  sys_corr_106: 0.0
   sys_corr_107: -1.31430000e+01
   sys_corr_108: 9.6045
   sys_corr_109: -4.04400000e+00
@@ -1074,21 +1074,21 @@ bins:
   sys_corr_133: 59.1435
 - stat: 3.98484576e+02
   sys_corr_1: 1.83138144e+03
-  sys_corr_2: -0.0
+  sys_corr_2: 0.0
   sys_corr_3: 0.0
-  sys_corr_4: -0.0
+  sys_corr_4: 0.0
   sys_corr_5: 0.0
   sys_corr_6: 0.0
   sys_corr_7: 0.0
-  sys_corr_8: -0.0
+  sys_corr_8: 0.0
   sys_corr_9: -5.44152000e+01
   sys_corr_10: 3.30624000e+01
   sys_corr_11: -1.74955200e+02
   sys_corr_12: -5.02824000e+01
   sys_corr_13: 1.3776
-  sys_corr_14: -0.0
+  sys_corr_14: 0.0
   sys_corr_15: 6.19920000e+00
-  sys_corr_16: -0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.6888
   sys_corr_18: 0.0
   sys_corr_19: -2.06640000e+00
@@ -1114,7 +1114,7 @@ bins:
   sys_corr_39: -2.06640000e+00
   sys_corr_40: -5.5104
   sys_corr_41: -8.26560000e+00
-  sys_corr_42: -0.0
+  sys_corr_42: 0.0
   sys_corr_43: -6.88800000e+00
   sys_corr_44: -1.3776
   sys_corr_45: 0.0
@@ -1165,9 +1165,9 @@ bins:
   sys_corr_90: 0.0
   sys_corr_91: -2.06640000e+00
   sys_corr_92: 0.0
-  sys_corr_93: -0.0
+  sys_corr_93: 0.0
   sys_corr_94: 97.1208
-  sys_corr_95: -0.0
+  sys_corr_95: 0.0
   sys_corr_96: 10.332
   sys_corr_97: 1.07452800e+02
   sys_corr_98: -1.28667840e+03
@@ -1208,21 +1208,21 @@ bins:
   sys_corr_133: 77.8344
 - stat: 4.32101418e+02
   sys_corr_1: 1.64720157e+03
-  sys_corr_2: -0.0
+  sys_corr_2: 0.0
   sys_corr_3: 0.0
-  sys_corr_4: -0.0
+  sys_corr_4: 0.0
   sys_corr_5: 0.0
-  sys_corr_6: -0.0
+  sys_corr_6: 0.0
   sys_corr_7: 0.0
-  sys_corr_8: -0.0
+  sys_corr_8: 0.0
   sys_corr_9: 6.9272
   sys_corr_10: 43.295
   sys_corr_11: -2.18206800e+02
   sys_corr_12: -5.71494000e+01
   sys_corr_13: 1.7318
-  sys_corr_14: -0.0
+  sys_corr_14: 0.0
   sys_corr_15: 7.79310000e+00
-  sys_corr_16: -0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.8659
   sys_corr_18: 0.0
   sys_corr_19: -1.7318
@@ -1231,7 +1231,7 @@ bins:
   sys_corr_22: -4.32950000e+00
   sys_corr_23: 7.79310000e+00
   sys_corr_24: 0.0
-  sys_corr_25: -0.0
+  sys_corr_25: 0.0
   sys_corr_26: -3.4636
   sys_corr_27: 3.4636
   sys_corr_28: -4.32950000e+00
@@ -1242,7 +1242,7 @@ bins:
   sys_corr_33: -0.8659
   sys_corr_34: -6.0613
   sys_corr_35: 2.59770000e+00
-  sys_corr_36: -0.0
+  sys_corr_36: 0.0
   sys_corr_37: 13.8544
   sys_corr_38: -16.4521
   sys_corr_39: -1.7318
@@ -1299,9 +1299,9 @@ bins:
   sys_corr_90: 1.7318
   sys_corr_91: -3.4636
   sys_corr_92: 0.0
-  sys_corr_93: -0.0
+  sys_corr_93: 0.0
   sys_corr_94: 7.70651000e+01
-  sys_corr_95: -0.0
+  sys_corr_95: 0.0
   sys_corr_96: 3.4636
   sys_corr_97: 1.14298800e+02
   sys_corr_98: -1.27027530e+03
@@ -1344,19 +1344,19 @@ bins:
   sys_corr_1: 2.60888702e+03
   sys_corr_2: 0.0
   sys_corr_3: 0.0
-  sys_corr_4: -0.0
-  sys_corr_5: -0.0
-  sys_corr_6: -0.0
-  sys_corr_7: -0.0
-  sys_corr_8: -0.0
+  sys_corr_4: 0.0
+  sys_corr_5: 0.0
+  sys_corr_6: 0.0
+  sys_corr_7: 0.0
+  sys_corr_8: 0.0
   sys_corr_9: -25.0009
   sys_corr_10: 42.2429
   sys_corr_11: -2.17249200e+02
   sys_corr_12: -5.94849000e+01
   sys_corr_13: 1.72420000e+00
-  sys_corr_14: -0.0
+  sys_corr_14: 0.0
   sys_corr_15: 7.7589
-  sys_corr_16: -0.0
+  sys_corr_16: 0.0
   sys_corr_17: 8.62100000e-01
   sys_corr_18: 0.0
   sys_corr_19: -2.5863
@@ -1417,7 +1417,7 @@ bins:
   sys_corr_74: -4.3105
   sys_corr_75: -1.29315000e+01
   sys_corr_76: -18.9662
-  sys_corr_77: -0.0
+  sys_corr_77: 0.0
   sys_corr_78: -5.1726
   sys_corr_79: -1.72420000e+00
   sys_corr_80: 31.0356
@@ -1432,8 +1432,8 @@ bins:
   sys_corr_89: -2.5863
   sys_corr_90: 8.62100000e-01
   sys_corr_91: 0.0
-  sys_corr_92: -0.0
-  sys_corr_93: -0.0
+  sys_corr_92: 0.0
+  sys_corr_93: 0.0
   sys_corr_94: 1.18107700e+02
   sys_corr_95: 0.0
   sys_corr_96: 5.1726
@@ -1477,20 +1477,20 @@ bins:
 - stat: 2.01053359e+02
   sys_corr_1: 2.60619450e+02
   sys_corr_2: 0.0
-  sys_corr_3: -0.0
+  sys_corr_3: 0.0
   sys_corr_4: 0.0
-  sys_corr_5: -0.0
-  sys_corr_6: -0.0
-  sys_corr_7: -0.0
-  sys_corr_8: -0.0
+  sys_corr_5: 0.0
+  sys_corr_6: 0.0
+  sys_corr_7: 0.0
+  sys_corr_8: 0.0
   sys_corr_9: 0.4069
   sys_corr_10: 20.345
   sys_corr_11: -1.02538800e+02
   sys_corr_12: -26.8554
   sys_corr_13: 0.8138
-  sys_corr_14: -0.0
+  sys_corr_14: 0.0
   sys_corr_15: 3.66210000e+00
-  sys_corr_16: -0.0
+  sys_corr_16: 0.0
   sys_corr_17: 0.4069
   sys_corr_18: 0.0
   sys_corr_19: -0.8138
@@ -1510,7 +1510,7 @@ bins:
   sys_corr_33: -0.4069
   sys_corr_34: -2.8483
   sys_corr_35: 1.22070000e+00
-  sys_corr_36: -0.0
+  sys_corr_36: 0.0
   sys_corr_37: 6.5104
   sys_corr_38: -7.73110000e+00
   sys_corr_39: -1.22070000e+00
@@ -1566,8 +1566,8 @@ bins:
   sys_corr_89: 2.44140000e+00
   sys_corr_90: -3.66210000e+00
   sys_corr_91: 2.44140000e+00
-  sys_corr_92: -0.0
-  sys_corr_93: -0.0
+  sys_corr_92: 0.0
+  sys_corr_93: 0.0
   sys_corr_94: 162.76
   sys_corr_95: 0.0
   sys_corr_96: 3.66210000e+00
@@ -1611,20 +1611,20 @@ bins:
 - stat: 1.34652150e+02
   sys_corr_1: 4.03518450e+02
   sys_corr_2: 0.0
-  sys_corr_3: -0.0
+  sys_corr_3: 0.0
   sys_corr_4: 0.0
-  sys_corr_5: -0.0
+  sys_corr_5: 0.0
   sys_corr_6: 0.0
-  sys_corr_7: -0.0
-  sys_corr_8: -0.0
+  sys_corr_7: 0.0
+  sys_corr_8: 0.0
   sys_corr_9: 0.3285
   sys_corr_10: 5.475
   sys_corr_11: -27.594
   sys_corr_12: -7.227
   sys_corr_13: 2.19000000e-01
-  sys_corr_14: -0.0
+  sys_corr_14: 0.0
   sys_corr_15: 9.85500000e-01
-  sys_corr_16: -0.0
+  sys_corr_16: 0.0
   sys_corr_17: 1.09500000e-01
   sys_corr_18: 0.0
   sys_corr_19: -2.19000000e-01
@@ -1644,7 +1644,7 @@ bins:
   sys_corr_33: -1.09500000e-01
   sys_corr_34: -7.66500000e-01
   sys_corr_35: 0.3285
-  sys_corr_36: -0.0
+  sys_corr_36: 0.0
   sys_corr_37: 1.75200000e+00
   sys_corr_38: -2.0805
   sys_corr_39: -2.19000000e-01
@@ -1700,8 +1700,8 @@ bins:
   sys_corr_89: 1.09500000e-01
   sys_corr_90: -7.66500000e-01
   sys_corr_91: 8.76000000e-01
-  sys_corr_92: -0.0
-  sys_corr_93: -0.0
+  sys_corr_92: 0.0
+  sys_corr_93: 0.0
   sys_corr_94: 2.18124000e+02
   sys_corr_95: 0.0
   sys_corr_96: 1.86150000e+00
@@ -1746,11 +1746,11 @@ bins:
   sys_corr_1: 19.746
   sys_corr_2: 0.0
   sys_corr_3: 0.0
-  sys_corr_4: -0.0
-  sys_corr_5: -0.0
-  sys_corr_6: -0.0
+  sys_corr_4: 0.0
+  sys_corr_5: 0.0
+  sys_corr_6: 0.0
   sys_corr_7: 0.0
-  sys_corr_8: -0.0
+  sys_corr_8: 0.0
   sys_corr_9: 6.66000000e-01
   sys_corr_10: 6.66000000e-01
   sys_corr_11: 2.394
@@ -1835,7 +1835,7 @@ bins:
   sys_corr_90: -9.00000000e-03
   sys_corr_91: 0.042
   sys_corr_92: 0.0
-  sys_corr_93: -0.0
+  sys_corr_93: 0.0
   sys_corr_94: 4.13400000e+00
   sys_corr_95: 0.0
   sys_corr_96: -0.633
@@ -1880,11 +1880,11 @@ bins:
   sys_corr_1: 4.26579640e+01
   sys_corr_2: 0.0
   sys_corr_3: 0.0
-  sys_corr_4: -0.0
-  sys_corr_5: -0.0
-  sys_corr_6: -0.0
+  sys_corr_4: 0.0
+  sys_corr_5: 0.0
+  sys_corr_6: 0.0
   sys_corr_7: 0.0
-  sys_corr_8: -0.0
+  sys_corr_8: 0.0
   sys_corr_9: 5.91840000e-01
   sys_corr_10: 1.12888000e+00
   sys_corr_11: 4.0826
@@ -1896,7 +1896,7 @@ bins:
   sys_corr_17: -5.48000000e-03
   sys_corr_18: -5.48000000e-03
   sys_corr_19: 0.0274
-  sys_corr_20: -0.0
+  sys_corr_20: 0.0
   sys_corr_21: -4.60320000e-01
   sys_corr_22: 0.0822
   sys_corr_23: -1.53440000e-01
@@ -1923,7 +1923,7 @@ bins:
   sys_corr_44: -0.07124
   sys_corr_45: 4.38400000e-02
   sys_corr_46: 0.37264
-  sys_corr_47: -0.0
+  sys_corr_47: 0.0
   sys_corr_48: 4.82240000e-01
   sys_corr_49: -0.18084
   sys_corr_50: 3.34280000e-01
@@ -2012,13 +2012,13 @@ bins:
   sys_corr_133: 8.49400000e-01
 - stat: 3.69435750e+01
   sys_corr_1: 125.023
-  sys_corr_2: -0.0
-  sys_corr_3: -0.0
+  sys_corr_2: 0.0
+  sys_corr_3: 0.0
   sys_corr_4: 0.0
-  sys_corr_5: -0.0
-  sys_corr_6: -0.0
-  sys_corr_7: -0.0
-  sys_corr_8: -0.0
+  sys_corr_5: 0.0
+  sys_corr_6: 0.0
+  sys_corr_7: 0.0
+  sys_corr_8: 0.0
   sys_corr_9: -0.7215
   sys_corr_10: 1.41525000e+00
   sys_corr_11: 5.18925
@@ -2027,7 +2027,7 @@ bins:
   sys_corr_14: 9.25000000e-03
   sys_corr_15: -3.70000000e-02
   sys_corr_16: 1.85000000e-02
-  sys_corr_17: -0.0
+  sys_corr_17: 0.0
   sys_corr_18: -9.25000000e-03
   sys_corr_19: 3.70000000e-02
   sys_corr_20: -1.85000000e-02
@@ -2035,7 +2035,7 @@ bins:
   sys_corr_22: 0.0925
   sys_corr_23: -0.19425
   sys_corr_24: -9.25000000e-03
-  sys_corr_25: -0.0
+  sys_corr_25: 0.0
   sys_corr_26: 1.48000000e-01
   sys_corr_27: -0.13875
   sys_corr_28: 0.15725
@@ -2147,12 +2147,12 @@ bins:
 - stat: 3.63021910e+01
   sys_corr_1: 1.95495680e+02
   sys_corr_2: 0.0
-  sys_corr_3: -0.0
+  sys_corr_3: 0.0
   sys_corr_4: 0.0
-  sys_corr_5: -0.0
-  sys_corr_6: -0.0
-  sys_corr_7: -0.0
-  sys_corr_8: -0.0
+  sys_corr_5: 0.0
+  sys_corr_6: 0.0
+  sys_corr_7: 0.0
+  sys_corr_8: 0.0
   sys_corr_9: 0.66527
   sys_corr_10: 1.67723000e+00
   sys_corr_11: 6.08113000e+00
@@ -2161,10 +2161,10 @@ bins:
   sys_corr_14: 0.00937
   sys_corr_15: -0.04685
   sys_corr_16: 0.01874
-  sys_corr_17: -0.0
+  sys_corr_17: 0.0
   sys_corr_18: -0.00937
   sys_corr_19: 0.03748
-  sys_corr_20: -0.0
+  sys_corr_20: 0.0
   sys_corr_21: -0.68401
   sys_corr_22: 1.21810000e-01
   sys_corr_23: -0.23425
@@ -2191,7 +2191,7 @@ bins:
   sys_corr_44: -1.03070000e-01
   sys_corr_45: 0.06559
   sys_corr_46: 5.52830000e-01
-  sys_corr_47: -0.0
+  sys_corr_47: 0.0
   sys_corr_48: 0.72149
   sys_corr_49: -0.27173
   sys_corr_50: 0.49661
@@ -2236,8 +2236,8 @@ bins:
   sys_corr_89: 0.26236
   sys_corr_90: -0.03748
   sys_corr_91: 0.14055
-  sys_corr_92: -0.0
-  sys_corr_93: -0.0
+  sys_corr_92: 0.0
+  sys_corr_93: 0.0
   sys_corr_94: 18.31835
   sys_corr_95: 0.0
   sys_corr_96: -0.1874
@@ -2281,11 +2281,11 @@ bins:
 - stat: 2.31557560e+01
   sys_corr_1: 62.94985
   sys_corr_2: 0.0
-  sys_corr_3: -0.0
+  sys_corr_3: 0.0
   sys_corr_4: 0.0
-  sys_corr_5: -0.0
-  sys_corr_6: -0.0
-  sys_corr_7: -0.0
+  sys_corr_5: 0.0
+  sys_corr_6: 0.0
+  sys_corr_7: 0.0
   sys_corr_8: 0.0
   sys_corr_9: 4.50110000e-01
   sys_corr_10: 7.73490000e-01
@@ -2298,7 +2298,7 @@ bins:
   sys_corr_17: -0.00437
   sys_corr_18: -0.00437
   sys_corr_19: 0.01748
-  sys_corr_20: -0.0
+  sys_corr_20: 0.0
   sys_corr_21: -3.19010000e-01
   sys_corr_22: 0.05681
   sys_corr_23: -1.09250000e-01
@@ -2325,7 +2325,7 @@ bins:
   sys_corr_44: -4.80700000e-02
   sys_corr_45: 0.02622
   sys_corr_46: 0.25783
-  sys_corr_47: -0.0
+  sys_corr_47: 0.0
   sys_corr_48: 3.32120000e-01
   sys_corr_49: -0.12673
   sys_corr_50: 0.22724
@@ -2349,7 +2349,7 @@ bins:
   sys_corr_68: 7.21050000e-01
   sys_corr_69: 1.02258
   sys_corr_70: -4.05536
-  sys_corr_71: -0.0
+  sys_corr_71: 0.0
   sys_corr_72: 0.11362
   sys_corr_73: -1.82666
   sys_corr_74: 6.38020000e-01
@@ -2370,11 +2370,11 @@ bins:
   sys_corr_89: 2.14130000e-01
   sys_corr_90: -0.11799
   sys_corr_91: 0.20976
-  sys_corr_92: -0.0
-  sys_corr_93: -0.0
+  sys_corr_92: 0.0
+  sys_corr_93: 0.0
   sys_corr_94: 1.04705200e+01
   sys_corr_95: 0.0
-  sys_corr_96: -0.0
+  sys_corr_96: 0.0
   sys_corr_97: 5.17408
   sys_corr_98: 18.76915
   sys_corr_99: -13.5907
@@ -2415,12 +2415,12 @@ bins:
 - stat: 1.02037760e+01
   sys_corr_1: 8.165696
   sys_corr_2: 0.0
-  sys_corr_3: -0.0
+  sys_corr_3: 0.0
   sys_corr_4: 0.0
-  sys_corr_5: -0.0
+  sys_corr_5: 0.0
   sys_corr_6: 0.0
-  sys_corr_7: -0.0
-  sys_corr_8: -0.0
+  sys_corr_7: 0.0
+  sys_corr_8: 0.0
   sys_corr_9: -6.12480000e-02
   sys_corr_10: 1.41504000e-01
   sys_corr_11: 5.26592000e-01
@@ -2429,7 +2429,7 @@ bins:
   sys_corr_14: 7.04000000e-04
   sys_corr_15: -3.52000000e-03
   sys_corr_16: 1.40800000e-03
-  sys_corr_17: -0.0
+  sys_corr_17: 0.0
   sys_corr_18: -7.04000000e-04
   sys_corr_19: 3.52000000e-03
   sys_corr_20: -1.40800000e-03
@@ -2504,12 +2504,12 @@ bins:
   sys_corr_89: 0.041536
   sys_corr_90: -1.12640000e-02
   sys_corr_91: 1.40800000e-03
-  sys_corr_92: -0.0
+  sys_corr_92: 0.0
   sys_corr_93: 0.0
   sys_corr_94: 1.701568
   sys_corr_95: 0.0
   sys_corr_96: 0.0
-  sys_corr_97: -0.0
+  sys_corr_97: 0.0
   sys_corr_98: 3.74809600e+00
   sys_corr_99: -2.26476800e+00
   sys_corr_100: 0.02112

--- a/nnpdf_data/nnpdf_data/commondata/ATLAS_Z0_8TEV_LOWMASS/uncertainties.yaml
+++ b/nnpdf_data/nnpdf_data/commondata/ATLAS_Z0_8TEV_LOWMASS/uncertainties.yaml
@@ -1132,89 +1132,89 @@ bins:
   sysZ3D1017: 0.0
   sysZ3D1018: 0.0
   sysZ3D1019: 0.0
-  sysZ3D1020: -0.0
-  sysZ3D1021: -0.0
+  sysZ3D1020: 0.0
+  sysZ3D1021: 0.0
   sysZ3D1022: 0.0
-  sysZ3D1023: -0.0
+  sysZ3D1023: 0.0
   sysZ3D1024: 0.0
   sysZ3D1025: -1.84960000e-02
   sysZ3D1026: 0.0
-  sysZ3D1027: -0.0
+  sysZ3D1027: 0.0
   sysZ3D1028: 0.0
   sysZ3D1029: 0.0
-  sysZ3D1030: -0.0
-  sysZ3D1031: -0.0
-  sysZ3D1032: -0.0
+  sysZ3D1030: 0.0
+  sysZ3D1031: 0.0
+  sysZ3D1032: 0.0
   sysZ3D1033: 0.0
   sysZ3D1034: 0.0
   sysZ3D1035: 0.0
   sysZ3D1036: 0.0
   sysZ3D1037: 0.0
-  sysZ3D1038: -0.0
-  sysZ3D1039: -0.0
+  sysZ3D1038: 0.0
+  sysZ3D1039: 0.0
   sysZ3D1040: 0.0
-  sysZ3D1041: -0.0
+  sysZ3D1041: 0.0
   sysZ3D1042: 0.0
   sysZ3D1043: 0.0
-  sysZ3D1044: -0.0
-  sysZ3D1045: -0.0
-  sysZ3D1046: -0.0
-  sysZ3D1047: -0.0
+  sysZ3D1044: 0.0
+  sysZ3D1045: 0.0
+  sysZ3D1046: 0.0
+  sysZ3D1047: 0.0
   sysZ3D1048: 0.0
   sysZ3D1049: 0.0
   sysZ3D1050: 0.0
   sysZ3D1051: 0.0
-  sysZ3D1052: -0.0
+  sysZ3D1052: 0.0
   sysZ3D1053: 0.0
-  sysZ3D1054: -0.0
-  sysZ3D1055: -0.0
+  sysZ3D1054: 0.0
+  sysZ3D1055: 0.0
   sysZ3D1056: 0.0
   sysZ3D1057: 0.0
-  sysZ3D1058: -0.0
-  sysZ3D1059: -0.0
-  sysZ3D1060: -0.0
-  sysZ3D1061: -0.0
+  sysZ3D1058: 0.0
+  sysZ3D1059: 0.0
+  sysZ3D1060: 0.0
+  sysZ3D1061: 0.0
   sysZ3D1062: 0.0
   sysZ3D1063: 0.0
   sysZ3D1064: 0.0
-  sysZ3D1065: -0.0
-  sysZ3D1066: -0.0
+  sysZ3D1065: 0.0
+  sysZ3D1066: 0.0
   sysZ3D1067: 0.0
-  sysZ3D1068: -0.0
-  sysZ3D1069: -0.0
-  sysZ3D1070: -0.0
+  sysZ3D1068: 0.0
+  sysZ3D1069: 0.0
+  sysZ3D1070: 0.0
   sysZ3D1071: 0.0
   sysZ3D1072: 0.0
   sysZ3D1073: 0.0
-  sysZ3D1074: -0.0
-  sysZ3D1075: -0.0
+  sysZ3D1074: 0.0
+  sysZ3D1075: 0.0
   sysZ3D1076: 0.0
   sysZ3D1077: 0.0
   sysZ3D1078: 0.0
-  sysZ3D1079: -0.0
-  sysZ3D1080: -0.0
-  sysZ3D1081: -0.0
+  sysZ3D1079: 0.0
+  sysZ3D1080: 0.0
+  sysZ3D1081: 0.0
   sysZ3D1082: 0.0
-  sysZ3D1083: -0.0
-  sysZ3D1084: -0.0
-  sysZ3D1085: -0.0
+  sysZ3D1083: 0.0
+  sysZ3D1084: 0.0
+  sysZ3D1085: 0.0
   sysZ3D1086: 0.0
   sysZ3D1087: 0.0
-  sysZ3D1088: -0.0
+  sysZ3D1088: 0.0
   sysZ3D1089: 0.0
-  sysZ3D1090: -0.0
+  sysZ3D1090: 0.0
   sysZ3D1091: 0.0
-  sysZ3D1092: -0.0
+  sysZ3D1092: 0.0
   sysZ3D1093: 0.0
   sysZ3D1094: 0.0
-  sysZ3D1095: -0.0
-  sysZ3D1096: -0.0
-  sysZ3D1097: -0.0
+  sysZ3D1095: 0.0
+  sysZ3D1096: 0.0
+  sysZ3D1097: 0.0
   sysZ3D1098: 0.0
   sysZ3D1099: 0.0
-  sysZ3D1100: -0.0
+  sysZ3D1100: 0.0
   sysZ3D1101: 0.0
-  sysZ3D1102: -0.0
+  sysZ3D1102: 0.0
   sysZ3D1103: 0.0
   sysZ3D1104: -3.51424000e-01
   sysZ3D1105: -1.53516800e+00
@@ -1227,7 +1227,7 @@ bins:
   sysZ3D1112: 3.69920000e-02
   sysZ3D1113: 0.110976
   sysZ3D1114: -0.09248
-  sysZ3D1115: -0.0
+  sysZ3D1115: 0.0
   sysZ3D1116: -1.84960000e-02
   sysZ3D1117: -1.84960000e-02
   sysZ3D1118: 0.0
@@ -1235,7 +1235,7 @@ bins:
   sysZ3D1120: 0.055488
   sysZ3D1121: -7.39840000e-02
   sysZ3D1122: -1.84960000e-02
-  sysZ3D1123: -0.0
+  sysZ3D1123: 0.0
   sysZ3D1124: -1.84960000e-02
   sysZ3D1125: -1.84960000e-02
   sysZ3D1126: 1.84960000e-02
@@ -1243,41 +1243,41 @@ bins:
   sysZ3D1128: 0.0
   sysZ3D1129: 0.0
   sysZ3D1130: 0.0
-  sysZ3D1131: -0.0
+  sysZ3D1131: 0.0
   sysZ3D1132: 0.0
-  sysZ3D1133: -0.0
+  sysZ3D1133: 0.0
   sysZ3D1134: 0.0
   sysZ3D1135: 0.0
-  sysZ3D1136: -0.0
-  sysZ3D1137: -0.0
+  sysZ3D1136: 0.0
+  sysZ3D1137: 0.0
   sysZ3D1138: 1.84960000e-02
   sysZ3D1139: 0.0
   sysZ3D1140: -1.84960000e-02
-  sysZ3D1141: -0.0
-  sysZ3D1142: -0.0
-  sysZ3D1143: -0.0
-  sysZ3D1144: -0.0
-  sysZ3D1145: -0.0
-  sysZ3D1146: -0.0
+  sysZ3D1141: 0.0
+  sysZ3D1142: 0.0
+  sysZ3D1143: 0.0
+  sysZ3D1144: 0.0
+  sysZ3D1145: 0.0
+  sysZ3D1146: 0.0
   sysZ3D1147: 0.0
-  sysZ3D1148: -0.0
+  sysZ3D1148: 0.0
   sysZ3D1149: 0.0
   sysZ3D1150: 1.84960000e-02
-  sysZ3D1151: -0.0
+  sysZ3D1151: 0.0
   sysZ3D1152: 1.84960000e-02
-  sysZ3D1153: -0.0
+  sysZ3D1153: 0.0
   sysZ3D1154: 1.84960000e-02
   sysZ3D1155: 1.84960000e-02
-  sysZ3D1156: -0.0
-  sysZ3D1157: -0.0
+  sysZ3D1156: 0.0
+  sysZ3D1157: 0.0
   sysZ3D1158: 0.0
   sysZ3D1159: 0.0
   sysZ3D1160: 0.0
   sysZ3D1161: 0.0
-  sysZ3D1162: -0.0
-  sysZ3D1163: -0.0
+  sysZ3D1162: 0.0
+  sysZ3D1163: 0.0
   sysZ3D1164: -1.84960000e-02
-  sysZ3D1165: -0.0
+  sysZ3D1165: 0.0
   sysZ3D1166: 0.0
   sysZ3D1167: 1.84960000e-02
   sysZ3D1168: 3.69920000e-02
@@ -1287,18 +1287,18 @@ bins:
   sysZ3D1172: 1.84960000e-02
   sysZ3D1173: 1.84960000e-02
   sysZ3D1174: 1.47968000e-01
-  sysZ3D1175: -0.0
+  sysZ3D1175: 0.0
   sysZ3D1176: 3.69920000e-02
-  sysZ3D1177: -0.0
+  sysZ3D1177: 0.0
   sysZ3D1178: -3.69920000e-02
   sysZ3D1179: -5.54880000e-02
-  sysZ3D1180: -0.0
-  sysZ3D1181: -0.0
+  sysZ3D1180: 0.0
+  sysZ3D1181: 0.0
   sysZ3D1182: 1.84960000e-02
   sysZ3D1183: -1.84960000e-02
   sysZ3D1184: 1.84960000e-02
   sysZ3D1185: -1.84960000e-02
-  sysZ3D1186: -0.0
+  sysZ3D1186: 0.0
   sysZ3D1187: -3.69920000e-02
   sysZ3D1188: 0.0
   sysZ3D1189: 1.84960000e-02
@@ -1306,14 +1306,14 @@ bins:
   sysZ3D1191: -7.39840000e-02
   sysZ3D1192: -1.84960000e-02
   sysZ3D1193: -1.84960000e-02
-  sysZ3D1194: -0.0
+  sysZ3D1194: 0.0
   sysZ3D1195: -3.69920000e-02
   sysZ3D1196: -1.84960000e-02
   sysZ3D1197: -1.84960000e-02
   sysZ3D1198: 0.0
   sysZ3D1199: 0.0
-  sysZ3D1200: -0.0
-  sysZ3D1201: -0.0
+  sysZ3D1200: 0.0
+  sysZ3D1201: 0.0
   sysZ3D1202: 0.0
   sysZ3D1203: 3.69920000e-02
   sysZ3D1204: -3.69920000e-02
@@ -1321,7 +1321,7 @@ bins:
   sysZ3D1206: -1.84960000e-02
   sysZ3D1207: -1.84960000e-02
   sysZ3D1208: 0.0
-  sysZ3D1209: -0.0
+  sysZ3D1209: 0.0
   sysZ3D1210: 0.0
   sysZ3D1211: 0.0
   sysZ3D1212: 0.0
@@ -1331,41 +1331,41 @@ bins:
   sysZ3D1216: -1.84960000e-02
   sysZ3D1217: 0.0
   sysZ3D1218: -3.69920000e-02
-  sysZ3D1219: -0.0
+  sysZ3D1219: 0.0
   sysZ3D1220: 1.84960000e-02
   sysZ3D1221: 1.84960000e-02
   sysZ3D1222: 1.84960000e-02
   sysZ3D1223: 1.84960000e-02
-  sysZ3D1224: -0.0
+  sysZ3D1224: 0.0
   sysZ3D1225: 1.84960000e-02
-  sysZ3D1226: -0.0
+  sysZ3D1226: 0.0
   sysZ3D1227: -3.69920000e-02
   sysZ3D1228: -3.69920000e-02
-  sysZ3D1229: -0.0
-  sysZ3D1230: -0.0
-  sysZ3D1231: -0.0
+  sysZ3D1229: 0.0
+  sysZ3D1230: 0.0
+  sysZ3D1231: 0.0
   sysZ3D1232: 1.84960000e-02
   sysZ3D1233: 1.84960000e-02
   sysZ3D1234: -1.84960000e-02
-  sysZ3D1235: -0.0
+  sysZ3D1235: 0.0
   sysZ3D1236: 0.0
   sysZ3D1237: 0.0
-  sysZ3D1238: -0.0
-  sysZ3D1239: -0.0
-  sysZ3D1240: -0.0
-  sysZ3D1241: -0.0
+  sysZ3D1238: 0.0
+  sysZ3D1239: 0.0
+  sysZ3D1240: 0.0
+  sysZ3D1241: 0.0
   sysZ3D1242: 0.0
   sysZ3D1243: 0.0
   sysZ3D1244: -5.54880000e-02
   sysZ3D1245: 3.69920000e-02
   sysZ3D1246: 0.0
-  sysZ3D1247: -0.0
-  sysZ3D1248: -0.0
-  sysZ3D1249: -0.0
-  sysZ3D1250: -0.0
+  sysZ3D1247: 0.0
+  sysZ3D1248: 0.0
+  sysZ3D1249: 0.0
+  sysZ3D1250: 0.0
   sysZ3D1251: 1.84960000e-02
   sysZ3D1252: 1.84960000e-02
-  sysZ3D1253: -0.0
+  sysZ3D1253: 0.0
   sysZ3D1254: -3.69920000e-02
   sysZ3D1255: 0.055488
   sysZ3D1256: 1.84960000e-02
@@ -1373,7 +1373,7 @@ bins:
   sysZ3D1258: -1.84960000e-02
   sysZ3D1259: 1.84960000e-02
   sysZ3D1260: -1.84960000e-02
-  sysZ3D1261: -0.0
+  sysZ3D1261: 0.0
   sysZ3D1262: 0.09248
   sysZ3D1263: 1.84960000e-02
   sysZ3D1264: -1.10976000e-01
@@ -1381,7 +1381,7 @@ bins:
   sysZ3D1266: -2.03456000e-01
   sysZ3D1267: -3.69920000e-02
   sysZ3D1268: 1.84960000e-02
-  sysZ3D1269: -0.0
+  sysZ3D1269: 0.0
   sysZ3D1270: -3.69920000e-02
   sysZ3D1271: 0.09248
   sysZ3D1272: 0.0
@@ -1410,89 +1410,89 @@ bins:
   sysZ3D1017: 0.0
   sysZ3D1018: 0.0
   sysZ3D1019: 0.0
-  sysZ3D1020: -0.0
-  sysZ3D1021: -0.0
-  sysZ3D1022: -0.0
-  sysZ3D1023: -0.0
+  sysZ3D1020: 0.0
+  sysZ3D1021: 0.0
+  sysZ3D1022: 0.0
+  sysZ3D1023: 0.0
   sysZ3D1024: 0.0
   sysZ3D1025: -1.86960000e-02
   sysZ3D1026: 0.0
-  sysZ3D1027: -0.0
+  sysZ3D1027: 0.0
   sysZ3D1028: 0.0
-  sysZ3D1029: -0.0
+  sysZ3D1029: 0.0
   sysZ3D1030: 0.0
-  sysZ3D1031: -0.0
+  sysZ3D1031: 0.0
   sysZ3D1032: 0.0
-  sysZ3D1033: -0.0
+  sysZ3D1033: 0.0
   sysZ3D1034: 0.0
-  sysZ3D1035: -0.0
+  sysZ3D1035: 0.0
   sysZ3D1036: 0.0
   sysZ3D1037: 0.0
-  sysZ3D1038: -0.0
-  sysZ3D1039: -0.0
+  sysZ3D1038: 0.0
+  sysZ3D1039: 0.0
   sysZ3D1040: 0.0
   sysZ3D1041: 0.0
-  sysZ3D1042: -0.0
+  sysZ3D1042: 0.0
   sysZ3D1043: 0.0
-  sysZ3D1044: -0.0
-  sysZ3D1045: -0.0
-  sysZ3D1046: -0.0
+  sysZ3D1044: 0.0
+  sysZ3D1045: 0.0
+  sysZ3D1046: 0.0
   sysZ3D1047: 0.0
   sysZ3D1048: 0.0
-  sysZ3D1049: -0.0
-  sysZ3D1050: -0.0
-  sysZ3D1051: -0.0
-  sysZ3D1052: -0.0
+  sysZ3D1049: 0.0
+  sysZ3D1050: 0.0
+  sysZ3D1051: 0.0
+  sysZ3D1052: 0.0
   sysZ3D1053: 0.0
-  sysZ3D1054: -0.0
+  sysZ3D1054: 0.0
   sysZ3D1055: 0.0
-  sysZ3D1056: -0.0
-  sysZ3D1057: -0.0
-  sysZ3D1058: -0.0
+  sysZ3D1056: 0.0
+  sysZ3D1057: 0.0
+  sysZ3D1058: 0.0
   sysZ3D1059: 0.0
-  sysZ3D1060: -0.0
-  sysZ3D1061: -0.0
+  sysZ3D1060: 0.0
+  sysZ3D1061: 0.0
   sysZ3D1062: 0.0
   sysZ3D1063: 0.0
   sysZ3D1064: 0.0
   sysZ3D1065: 0.0
-  sysZ3D1066: -0.0
+  sysZ3D1066: 0.0
   sysZ3D1067: 0.0
   sysZ3D1068: 0.0
   sysZ3D1069: 0.0
-  sysZ3D1070: -0.0
+  sysZ3D1070: 0.0
   sysZ3D1071: 0.0
   sysZ3D1072: 0.0
   sysZ3D1073: 0.0
   sysZ3D1074: 0.0
-  sysZ3D1075: -0.0
+  sysZ3D1075: 0.0
   sysZ3D1076: 0.0
-  sysZ3D1077: -0.0
-  sysZ3D1078: -0.0
-  sysZ3D1079: -0.0
-  sysZ3D1080: -0.0
+  sysZ3D1077: 0.0
+  sysZ3D1078: 0.0
+  sysZ3D1079: 0.0
+  sysZ3D1080: 0.0
   sysZ3D1081: 0.0
-  sysZ3D1082: -0.0
+  sysZ3D1082: 0.0
   sysZ3D1083: 0.0
   sysZ3D1084: 0.0
   sysZ3D1085: 0.0
   sysZ3D1086: 0.0
   sysZ3D1087: 0.0
-  sysZ3D1088: -0.0
-  sysZ3D1089: -0.0
-  sysZ3D1090: -0.0
-  sysZ3D1091: -0.0
-  sysZ3D1092: -0.0
-  sysZ3D1093: -0.0
+  sysZ3D1088: 0.0
+  sysZ3D1089: 0.0
+  sysZ3D1090: 0.0
+  sysZ3D1091: 0.0
+  sysZ3D1092: 0.0
+  sysZ3D1093: 0.0
   sysZ3D1094: 0.0
-  sysZ3D1095: -0.0
-  sysZ3D1096: -0.0
-  sysZ3D1097: -0.0
-  sysZ3D1098: -0.0
+  sysZ3D1095: 0.0
+  sysZ3D1096: 0.0
+  sysZ3D1097: 0.0
+  sysZ3D1098: 0.0
   sysZ3D1099: 0.0
-  sysZ3D1100: -0.0
-  sysZ3D1101: -0.0
-  sysZ3D1102: -0.0
+  sysZ3D1100: 0.0
+  sysZ3D1101: 0.0
+  sysZ3D1102: 0.0
   sysZ3D1103: 0.0
   sysZ3D1104: -3.36528000e-01
   sysZ3D1105: -1.55176800e+00
@@ -1505,11 +1505,11 @@ bins:
   sysZ3D1112: 3.73920000e-02
   sysZ3D1113: 0.09348
   sysZ3D1114: -7.47840000e-02
-  sysZ3D1115: -0.0
+  sysZ3D1115: 0.0
   sysZ3D1116: -1.86960000e-02
   sysZ3D1117: -3.73920000e-02
   sysZ3D1118: -7.47840000e-02
-  sysZ3D1119: -0.0
+  sysZ3D1119: 0.0
   sysZ3D1120: -1.86960000e-02
   sysZ3D1121: 3.73920000e-02
   sysZ3D1122: 1.86960000e-02
@@ -1521,41 +1521,41 @@ bins:
   sysZ3D1128: 0.0
   sysZ3D1129: 0.0
   sysZ3D1130: 0.0
-  sysZ3D1131: -0.0
+  sysZ3D1131: 0.0
   sysZ3D1132: 0.0
-  sysZ3D1133: -0.0
+  sysZ3D1133: 0.0
   sysZ3D1134: 0.0
-  sysZ3D1135: -0.0
-  sysZ3D1136: -0.0
-  sysZ3D1137: -0.0
+  sysZ3D1135: 0.0
+  sysZ3D1136: 0.0
+  sysZ3D1137: 0.0
   sysZ3D1138: 1.86960000e-02
   sysZ3D1139: 0.0
   sysZ3D1140: 0.0
-  sysZ3D1141: -0.0
-  sysZ3D1142: -0.0
-  sysZ3D1143: -0.0
+  sysZ3D1141: 0.0
+  sysZ3D1142: 0.0
+  sysZ3D1143: 0.0
   sysZ3D1144: -1.86960000e-02
   sysZ3D1145: 3.73920000e-02
   sysZ3D1146: 0.0
   sysZ3D1147: 1.86960000e-02
-  sysZ3D1148: -0.0
+  sysZ3D1148: 0.0
   sysZ3D1149: -1.86960000e-02
   sysZ3D1150: 1.86960000e-02
   sysZ3D1151: 0.0
   sysZ3D1152: -3.73920000e-02
-  sysZ3D1153: -0.0
+  sysZ3D1153: 0.0
   sysZ3D1154: -1.86960000e-02
   sysZ3D1155: 1.86960000e-02
-  sysZ3D1156: -0.0
-  sysZ3D1157: -0.0
-  sysZ3D1158: -0.0
+  sysZ3D1156: 0.0
+  sysZ3D1157: 0.0
+  sysZ3D1158: 0.0
   sysZ3D1159: 1.86960000e-02
   sysZ3D1160: 0.0
   sysZ3D1161: 0.0
-  sysZ3D1162: -0.0
-  sysZ3D1163: -0.0
+  sysZ3D1162: 0.0
+  sysZ3D1163: 0.0
   sysZ3D1164: -1.86960000e-02
-  sysZ3D1165: -0.0
+  sysZ3D1165: 0.0
   sysZ3D1166: 0.0
   sysZ3D1167: 1.86960000e-02
   sysZ3D1168: 5.60880000e-02
@@ -1565,18 +1565,18 @@ bins:
   sysZ3D1172: 3.73920000e-02
   sysZ3D1173: 1.86960000e-02
   sysZ3D1174: 1.49568000e-01
-  sysZ3D1175: -0.0
+  sysZ3D1175: 0.0
   sysZ3D1176: 0.0
   sysZ3D1177: -1.86960000e-02
   sysZ3D1178: -1.86960000e-02
   sysZ3D1179: -3.73920000e-02
-  sysZ3D1180: -0.0
+  sysZ3D1180: 0.0
   sysZ3D1181: 0.0
   sysZ3D1182: 0.0
   sysZ3D1183: 0.0
   sysZ3D1184: 1.86960000e-02
   sysZ3D1185: -1.86960000e-02
-  sysZ3D1186: -0.0
+  sysZ3D1186: 0.0
   sysZ3D1187: -3.73920000e-02
   sysZ3D1188: 0.0
   sysZ3D1189: 1.86960000e-02
@@ -1588,59 +1588,59 @@ bins:
   sysZ3D1195: -1.86960000e-02
   sysZ3D1196: -1.86960000e-02
   sysZ3D1197: -1.86960000e-02
-  sysZ3D1198: -0.0
+  sysZ3D1198: 0.0
   sysZ3D1199: -1.86960000e-02
   sysZ3D1200: 0.0
   sysZ3D1201: -1.86960000e-02
   sysZ3D1202: 0.0
   sysZ3D1203: 3.73920000e-02
   sysZ3D1204: -1.86960000e-02
-  sysZ3D1205: -0.0
+  sysZ3D1205: 0.0
   sysZ3D1206: -1.86960000e-02
-  sysZ3D1207: -0.0
+  sysZ3D1207: 0.0
   sysZ3D1208: -1.86960000e-02
-  sysZ3D1209: -0.0
-  sysZ3D1210: -0.0
-  sysZ3D1211: -0.0
+  sysZ3D1209: 0.0
+  sysZ3D1210: 0.0
+  sysZ3D1211: 0.0
   sysZ3D1212: 0.0
   sysZ3D1213: 1.86960000e-02
   sysZ3D1214: 1.86960000e-02
-  sysZ3D1215: -0.0
+  sysZ3D1215: 0.0
   sysZ3D1216: -1.86960000e-02
   sysZ3D1217: 1.86960000e-02
   sysZ3D1218: -3.73920000e-02
-  sysZ3D1219: -0.0
+  sysZ3D1219: 0.0
   sysZ3D1220: 1.86960000e-02
   sysZ3D1221: 0.0
   sysZ3D1222: 1.86960000e-02
-  sysZ3D1223: -0.0
+  sysZ3D1223: 0.0
   sysZ3D1224: 0.0
   sysZ3D1225: 1.86960000e-02
-  sysZ3D1226: -0.0
+  sysZ3D1226: 0.0
   sysZ3D1227: -3.73920000e-02
   sysZ3D1228: -3.73920000e-02
-  sysZ3D1229: -0.0
-  sysZ3D1230: -0.0
+  sysZ3D1229: 0.0
+  sysZ3D1230: 0.0
   sysZ3D1231: 0.0
   sysZ3D1232: 1.86960000e-02
-  sysZ3D1233: -0.0
+  sysZ3D1233: 0.0
   sysZ3D1234: 0.0
   sysZ3D1235: 0.0
   sysZ3D1236: 1.86960000e-02
   sysZ3D1237: 0.0
-  sysZ3D1238: -0.0
-  sysZ3D1239: -0.0
-  sysZ3D1240: -0.0
-  sysZ3D1241: -0.0
+  sysZ3D1238: 0.0
+  sysZ3D1239: 0.0
+  sysZ3D1240: 0.0
+  sysZ3D1241: 0.0
   sysZ3D1242: 0.0
   sysZ3D1243: 0.0
   sysZ3D1244: -3.73920000e-02
   sysZ3D1245: 1.86960000e-02
   sysZ3D1246: 3.73920000e-02
-  sysZ3D1247: -0.0
-  sysZ3D1248: -0.0
-  sysZ3D1249: -0.0
-  sysZ3D1250: -0.0
+  sysZ3D1247: 0.0
+  sysZ3D1248: 0.0
+  sysZ3D1249: 0.0
+  sysZ3D1250: 0.0
   sysZ3D1251: 0.0
   sysZ3D1252: 0.0
   sysZ3D1253: 1.86960000e-02
@@ -1659,7 +1659,7 @@ bins:
   sysZ3D1266: -0.18696
   sysZ3D1267: -3.73920000e-02
   sysZ3D1268: 3.73920000e-02
-  sysZ3D1269: -0.0
+  sysZ3D1269: 0.0
   sysZ3D1270: -3.73920000e-02
   sysZ3D1271: 1.30872000e-01
   sysZ3D1272: 0.0
@@ -1688,36 +1688,36 @@ bins:
   sysZ3D1017: 0.0
   sysZ3D1018: 0.0
   sysZ3D1019: 0.0
-  sysZ3D1020: -0.0
-  sysZ3D1021: -0.0
-  sysZ3D1022: -0.0
+  sysZ3D1020: 0.0
+  sysZ3D1021: 0.0
+  sysZ3D1022: 0.0
   sysZ3D1023: -1.85780000e-02
   sysZ3D1024: 0.018578
   sysZ3D1025: -3.71560000e-02
   sysZ3D1026: 0.0
   sysZ3D1027: -1.85780000e-02
-  sysZ3D1028: -0.0
-  sysZ3D1029: -0.0
-  sysZ3D1030: -0.0
-  sysZ3D1031: -0.0
+  sysZ3D1028: 0.0
+  sysZ3D1029: 0.0
+  sysZ3D1030: 0.0
+  sysZ3D1031: 0.0
   sysZ3D1032: 0.0
   sysZ3D1033: 0.0
-  sysZ3D1034: -0.0
-  sysZ3D1035: -0.0
-  sysZ3D1036: -0.0
-  sysZ3D1037: -0.0
+  sysZ3D1034: 0.0
+  sysZ3D1035: 0.0
+  sysZ3D1036: 0.0
+  sysZ3D1037: 0.0
   sysZ3D1038: 0.0
-  sysZ3D1039: -0.0
-  sysZ3D1040: -0.0
+  sysZ3D1039: 0.0
+  sysZ3D1040: 0.0
   sysZ3D1041: 0.0
-  sysZ3D1042: -0.0
-  sysZ3D1043: -0.0
-  sysZ3D1044: -0.0
+  sysZ3D1042: 0.0
+  sysZ3D1043: 0.0
+  sysZ3D1044: 0.0
   sysZ3D1045: 0.0
-  sysZ3D1046: -0.0
+  sysZ3D1046: 0.0
   sysZ3D1047: 0.0
-  sysZ3D1048: -0.0
-  sysZ3D1049: -0.0
+  sysZ3D1048: 0.0
+  sysZ3D1049: 0.0
   sysZ3D1050: 0.0
   sysZ3D1051: 0.0
   sysZ3D1052: 0.0
@@ -1726,50 +1726,50 @@ bins:
   sysZ3D1055: 0.0
   sysZ3D1056: 0.0
   sysZ3D1057: 0.0
-  sysZ3D1058: -0.0
-  sysZ3D1059: -0.0
+  sysZ3D1058: 0.0
+  sysZ3D1059: 0.0
   sysZ3D1060: 0.0
-  sysZ3D1061: -0.0
-  sysZ3D1062: -0.0
-  sysZ3D1063: -0.0
-  sysZ3D1064: -0.0
-  sysZ3D1065: -0.0
+  sysZ3D1061: 0.0
+  sysZ3D1062: 0.0
+  sysZ3D1063: 0.0
+  sysZ3D1064: 0.0
+  sysZ3D1065: 0.0
   sysZ3D1066: 0.0
-  sysZ3D1067: -0.0
+  sysZ3D1067: 0.0
   sysZ3D1068: 0.0
   sysZ3D1069: 0.0
-  sysZ3D1070: -0.0
+  sysZ3D1070: 0.0
   sysZ3D1071: 0.0
-  sysZ3D1072: -0.0
-  sysZ3D1073: -0.0
-  sysZ3D1074: -0.0
-  sysZ3D1075: -0.0
-  sysZ3D1076: -0.0
+  sysZ3D1072: 0.0
+  sysZ3D1073: 0.0
+  sysZ3D1074: 0.0
+  sysZ3D1075: 0.0
+  sysZ3D1076: 0.0
   sysZ3D1077: 0.0
-  sysZ3D1078: -0.0
+  sysZ3D1078: 0.0
   sysZ3D1079: 0.0
   sysZ3D1080: 0.0
   sysZ3D1081: 0.0
-  sysZ3D1082: -0.0
+  sysZ3D1082: 0.0
   sysZ3D1083: 0.0
   sysZ3D1084: 0.0
   sysZ3D1085: 0.0
   sysZ3D1086: 0.0
-  sysZ3D1087: -0.0
-  sysZ3D1088: -0.0
-  sysZ3D1089: -0.0
+  sysZ3D1087: 0.0
+  sysZ3D1088: 0.0
+  sysZ3D1089: 0.0
   sysZ3D1090: 0.0
   sysZ3D1091: 0.0
-  sysZ3D1092: -0.0
-  sysZ3D1093: -0.0
-  sysZ3D1094: -0.0
+  sysZ3D1092: 0.0
+  sysZ3D1093: 0.0
+  sysZ3D1094: 0.0
   sysZ3D1095: 0.0
   sysZ3D1096: 0.0
-  sysZ3D1097: -0.0
-  sysZ3D1098: -0.0
-  sysZ3D1099: -0.0
-  sysZ3D1100: -0.0
-  sysZ3D1101: -0.0
+  sysZ3D1097: 0.0
+  sysZ3D1098: 0.0
+  sysZ3D1099: 0.0
+  sysZ3D1100: 0.0
+  sysZ3D1101: 0.0
   sysZ3D1102: 0.0
   sysZ3D1103: 0.0
   sysZ3D1104: -3.34404000e-01
@@ -1783,36 +1783,36 @@ bins:
   sysZ3D1112: 0.037156
   sysZ3D1113: 0.09289
   sysZ3D1114: -7.43120000e-02
-  sysZ3D1115: -0.0
+  sysZ3D1115: 0.0
   sysZ3D1116: -1.85780000e-02
   sysZ3D1117: -3.71560000e-02
-  sysZ3D1118: -0.0
+  sysZ3D1118: 0.0
   sysZ3D1119: -3.71560000e-02
   sysZ3D1120: 0.018578
   sysZ3D1121: -0.09289
   sysZ3D1122: 0.037156
   sysZ3D1123: 0.018578
-  sysZ3D1124: -0.0
+  sysZ3D1124: 0.0
   sysZ3D1125: -1.85780000e-02
   sysZ3D1126: 0.037156
   sysZ3D1127: -5.57340000e-02
   sysZ3D1128: 0.0
   sysZ3D1129: 0.0
   sysZ3D1130: 0.0
-  sysZ3D1131: -0.0
+  sysZ3D1131: 0.0
   sysZ3D1132: 0.0
-  sysZ3D1133: -0.0
+  sysZ3D1133: 0.0
   sysZ3D1134: 0.018578
-  sysZ3D1135: -0.0
-  sysZ3D1136: -0.0
-  sysZ3D1137: -0.0
-  sysZ3D1138: -0.0
+  sysZ3D1135: 0.0
+  sysZ3D1136: 0.0
+  sysZ3D1137: 0.0
+  sysZ3D1138: 0.0
   sysZ3D1139: 0.018578
   sysZ3D1140: -3.71560000e-02
   sysZ3D1141: -1.85780000e-02
-  sysZ3D1142: -0.0
+  sysZ3D1142: 0.0
   sysZ3D1143: 0.018578
-  sysZ3D1144: -0.0
+  sysZ3D1144: 0.0
   sysZ3D1145: 0.018578
   sysZ3D1146: 0.0
   sysZ3D1147: -3.71560000e-02
@@ -1821,19 +1821,19 @@ bins:
   sysZ3D1150: 0.0
   sysZ3D1151: 0.018578
   sysZ3D1152: 0.018578
-  sysZ3D1153: -0.0
+  sysZ3D1153: 0.0
   sysZ3D1154: 0.018578
   sysZ3D1155: -1.85780000e-02
   sysZ3D1156: 0.018578
-  sysZ3D1157: -0.0
-  sysZ3D1158: -0.0
+  sysZ3D1157: 0.0
+  sysZ3D1158: 0.0
   sysZ3D1159: 0.0
-  sysZ3D1160: -0.0
-  sysZ3D1161: -0.0
-  sysZ3D1162: -0.0
-  sysZ3D1163: -0.0
-  sysZ3D1164: -0.0
-  sysZ3D1165: -0.0
+  sysZ3D1160: 0.0
+  sysZ3D1161: 0.0
+  sysZ3D1162: 0.0
+  sysZ3D1163: 0.0
+  sysZ3D1164: 0.0
+  sysZ3D1165: 0.0
   sysZ3D1166: 0.0
   sysZ3D1167: 0.0
   sysZ3D1168: 0.037156
@@ -1843,18 +1843,18 @@ bins:
   sysZ3D1172: 0.018578
   sysZ3D1173: 0.018578
   sysZ3D1174: 0.130046
-  sysZ3D1175: -0.0
+  sysZ3D1175: 0.0
   sysZ3D1176: -7.43120000e-02
   sysZ3D1177: -1.11468000e-01
   sysZ3D1178: -5.57340000e-02
   sysZ3D1179: -5.57340000e-02
-  sysZ3D1180: -0.0
+  sysZ3D1180: 0.0
   sysZ3D1181: 0.018578
   sysZ3D1182: 0.018578
   sysZ3D1183: -1.85780000e-02
   sysZ3D1184: 0.037156
   sysZ3D1185: -1.85780000e-02
-  sysZ3D1186: -0.0
+  sysZ3D1186: 0.0
   sysZ3D1187: -5.57340000e-02
   sysZ3D1188: 0.037156
   sysZ3D1189: 0.018578
@@ -1865,7 +1865,7 @@ bins:
   sysZ3D1194: 0.018578
   sysZ3D1195: -1.85780000e-02
   sysZ3D1196: -1.85780000e-02
-  sysZ3D1197: -0.0
+  sysZ3D1197: 0.0
   sysZ3D1198: -1.85780000e-02
   sysZ3D1199: -1.85780000e-02
   sysZ3D1200: -1.85780000e-02
@@ -1873,52 +1873,52 @@ bins:
   sysZ3D1202: 0.0
   sysZ3D1203: 0.037156
   sysZ3D1204: -1.85780000e-02
-  sysZ3D1205: -0.0
-  sysZ3D1206: -0.0
-  sysZ3D1207: -0.0
-  sysZ3D1208: -0.0
-  sysZ3D1209: -0.0
+  sysZ3D1205: 0.0
+  sysZ3D1206: 0.0
+  sysZ3D1207: 0.0
+  sysZ3D1208: 0.0
+  sysZ3D1209: 0.0
   sysZ3D1210: 0.0
   sysZ3D1211: 0.0
   sysZ3D1212: 0.0
   sysZ3D1213: 0.018578
   sysZ3D1214: 0.018578
   sysZ3D1215: 0.0
-  sysZ3D1216: -0.0
-  sysZ3D1217: -0.0
+  sysZ3D1216: 0.0
+  sysZ3D1217: 0.0
   sysZ3D1218: -3.71560000e-02
-  sysZ3D1219: -0.0
+  sysZ3D1219: 0.0
   sysZ3D1220: 0.018578
   sysZ3D1221: 0.018578
   sysZ3D1222: 0.0
   sysZ3D1223: 0.018578
-  sysZ3D1224: -0.0
-  sysZ3D1225: -0.0
+  sysZ3D1224: 0.0
+  sysZ3D1225: 0.0
   sysZ3D1226: -1.85780000e-02
   sysZ3D1227: -3.71560000e-02
   sysZ3D1228: -3.71560000e-02
-  sysZ3D1229: -0.0
-  sysZ3D1230: -0.0
+  sysZ3D1229: 0.0
+  sysZ3D1230: 0.0
   sysZ3D1231: 0.0
-  sysZ3D1232: -0.0
+  sysZ3D1232: 0.0
   sysZ3D1233: 0.0
   sysZ3D1234: 0.0
   sysZ3D1235: 0.0
-  sysZ3D1236: -0.0
+  sysZ3D1236: 0.0
   sysZ3D1237: 0.0
-  sysZ3D1238: -0.0
+  sysZ3D1238: 0.0
   sysZ3D1239: 0.0
   sysZ3D1240: 0.0
-  sysZ3D1241: -0.0
+  sysZ3D1241: 0.0
   sysZ3D1242: 0.0
   sysZ3D1243: 0.0
   sysZ3D1244: -3.71560000e-02
   sysZ3D1245: 0.037156
   sysZ3D1246: -1.85780000e-02
-  sysZ3D1247: -0.0
+  sysZ3D1247: 0.0
   sysZ3D1248: -1.85780000e-02
   sysZ3D1249: 0.0
-  sysZ3D1250: -0.0
+  sysZ3D1250: 0.0
   sysZ3D1251: 0.0
   sysZ3D1252: 0.018578
   sysZ3D1253: -1.85780000e-02
@@ -1970,101 +1970,101 @@ bins:
   sysZ3D1021: 0.0
   sysZ3D1022: 0.0
   sysZ3D1023: 0.0
-  sysZ3D1024: -0.0
+  sysZ3D1024: 0.0
   sysZ3D1025: 0.0
-  sysZ3D1026: -0.0
+  sysZ3D1026: 0.0
   sysZ3D1027: 0.0
   sysZ3D1028: 0.0
   sysZ3D1029: 0.0
-  sysZ3D1030: -0.0
+  sysZ3D1030: 0.0
   sysZ3D1031: 0.0
   sysZ3D1032: 0.0
   sysZ3D1033: 0.0
   sysZ3D1034: -1.87320000e-02
   sysZ3D1035: 0.0
   sysZ3D1036: 0.0
-  sysZ3D1037: -0.0
+  sysZ3D1037: 0.0
   sysZ3D1038: 0.0
   sysZ3D1039: 0.0
-  sysZ3D1040: -0.0
-  sysZ3D1041: -0.0
-  sysZ3D1042: -0.0
+  sysZ3D1040: 0.0
+  sysZ3D1041: 0.0
+  sysZ3D1042: 0.0
   sysZ3D1043: 0.0
-  sysZ3D1044: -0.0
-  sysZ3D1045: -0.0
+  sysZ3D1044: 0.0
+  sysZ3D1045: 0.0
   sysZ3D1046: 0.0
   sysZ3D1047: 0.0
   sysZ3D1048: 0.0
   sysZ3D1049: 0.0
   sysZ3D1050: 0.0
-  sysZ3D1051: -0.0
+  sysZ3D1051: 0.0
   sysZ3D1052: 0.0
-  sysZ3D1053: -0.0
+  sysZ3D1053: 0.0
   sysZ3D1054: 0.0
-  sysZ3D1055: -0.0
+  sysZ3D1055: 0.0
   sysZ3D1056: 0.0
-  sysZ3D1057: -0.0
+  sysZ3D1057: 0.0
   sysZ3D1058: -1.87320000e-02
   sysZ3D1059: 0.0
-  sysZ3D1060: -0.0
+  sysZ3D1060: 0.0
   sysZ3D1061: 0.0
   sysZ3D1062: 0.0
   sysZ3D1063: 0.0
-  sysZ3D1064: -0.0
+  sysZ3D1064: 0.0
   sysZ3D1065: 0.0
   sysZ3D1066: 0.0
   sysZ3D1067: 0.0
-  sysZ3D1068: -0.0
+  sysZ3D1068: 0.0
   sysZ3D1069: 0.0
-  sysZ3D1070: -0.0
-  sysZ3D1071: -0.0
-  sysZ3D1072: -0.0
-  sysZ3D1073: -0.0
+  sysZ3D1070: 0.0
+  sysZ3D1071: 0.0
+  sysZ3D1072: 0.0
+  sysZ3D1073: 0.0
   sysZ3D1074: 0.0
   sysZ3D1075: 0.0
-  sysZ3D1076: -0.0
-  sysZ3D1077: -0.0
-  sysZ3D1078: -0.0
+  sysZ3D1076: 0.0
+  sysZ3D1077: 0.0
+  sysZ3D1078: 0.0
   sysZ3D1079: 0.0
-  sysZ3D1080: -0.0
+  sysZ3D1080: 0.0
   sysZ3D1081: 0.0
   sysZ3D1082: 0.0
-  sysZ3D1083: -0.0
-  sysZ3D1084: -0.0
+  sysZ3D1083: 0.0
+  sysZ3D1084: 0.0
   sysZ3D1085: 0.0
-  sysZ3D1086: -0.0
+  sysZ3D1086: 0.0
   sysZ3D1087: 0.0
   sysZ3D1088: 0.0
-  sysZ3D1089: -0.0
+  sysZ3D1089: 0.0
   sysZ3D1090: 0.0
-  sysZ3D1091: -0.0
+  sysZ3D1091: 0.0
   sysZ3D1092: 0.0
   sysZ3D1093: 0.0
   sysZ3D1094: 0.0
-  sysZ3D1095: -0.0
+  sysZ3D1095: 0.0
   sysZ3D1096: 0.0
   sysZ3D1097: 0.0
   sysZ3D1098: 0.0
   sysZ3D1099: 0.0
   sysZ3D1100: 0.0
   sysZ3D1101: 0.0
-  sysZ3D1102: -0.0
-  sysZ3D1103: -0.0
+  sysZ3D1102: 0.0
+  sysZ3D1103: 0.0
   sysZ3D1104: -3.18444000e-01
   sysZ3D1105: -1.51729200e+00
   sysZ3D1106: -0.09366
   sysZ3D1107: -1.87320000e-02
   sysZ3D1108: -5.43228000e-01
-  sysZ3D1109: -0.0
+  sysZ3D1109: 0.0
   sysZ3D1110: 0.0
   sysZ3D1111: 0.0
   sysZ3D1112: 0.037464
   sysZ3D1113: 0.09366
   sysZ3D1114: -0.09366
-  sysZ3D1115: -0.0
+  sysZ3D1115: 0.0
   sysZ3D1116: 0.037464
   sysZ3D1117: -3.74640000e-02
-  sysZ3D1118: -0.0
+  sysZ3D1118: 0.0
   sysZ3D1119: -3.74640000e-02
   sysZ3D1120: 0.037464
   sysZ3D1121: -3.74640000e-02
@@ -2077,12 +2077,12 @@ bins:
   sysZ3D1128: 0.0
   sysZ3D1129: 0.0
   sysZ3D1130: 0.0
-  sysZ3D1131: -0.0
+  sysZ3D1131: 0.0
   sysZ3D1132: 0.0
-  sysZ3D1133: -0.0
+  sysZ3D1133: 0.0
   sysZ3D1134: 0.0
   sysZ3D1135: 0.018732
-  sysZ3D1136: -0.0
+  sysZ3D1136: 0.0
   sysZ3D1137: 0.0
   sysZ3D1138: 0.0
   sysZ3D1139: 0.0
@@ -2108,65 +2108,65 @@ bins:
   sysZ3D1159: -5.61960000e-02
   sysZ3D1160: -1.87320000e-02
   sysZ3D1161: -1.87320000e-02
-  sysZ3D1162: -0.0
-  sysZ3D1163: -0.0
-  sysZ3D1164: -0.0
-  sysZ3D1165: -0.0
+  sysZ3D1162: 0.0
+  sysZ3D1163: 0.0
+  sysZ3D1164: 0.0
+  sysZ3D1165: 0.0
   sysZ3D1166: 0.0
   sysZ3D1167: 0.018732
   sysZ3D1168: 0.037464
   sysZ3D1169: 0.0
-  sysZ3D1170: -0.0
+  sysZ3D1170: 0.0
   sysZ3D1171: 0.018732
   sysZ3D1172: 0.018732
   sysZ3D1173: 0.018732
   sysZ3D1174: 0.09366
-  sysZ3D1175: -0.0
-  sysZ3D1176: -0.0
+  sysZ3D1175: 0.0
+  sysZ3D1176: 0.0
   sysZ3D1177: -1.87320000e-02
   sysZ3D1178: -1.87320000e-02
   sysZ3D1179: -3.74640000e-02
-  sysZ3D1180: -0.0
+  sysZ3D1180: 0.0
   sysZ3D1181: 0.0
   sysZ3D1182: 0.018732
-  sysZ3D1183: -0.0
+  sysZ3D1183: 0.0
   sysZ3D1184: 0.018732
-  sysZ3D1185: -0.0
-  sysZ3D1186: -0.0
+  sysZ3D1185: 0.0
+  sysZ3D1186: 0.0
   sysZ3D1187: -1.87320000e-02
   sysZ3D1188: 0.0
   sysZ3D1189: 0.0
-  sysZ3D1190: -0.0
+  sysZ3D1190: 0.0
   sysZ3D1191: -5.61960000e-02
   sysZ3D1192: -1.87320000e-02
   sysZ3D1193: -1.87320000e-02
-  sysZ3D1194: -0.0
+  sysZ3D1194: 0.0
   sysZ3D1195: -1.87320000e-02
   sysZ3D1196: -1.87320000e-02
-  sysZ3D1197: -0.0
-  sysZ3D1198: -0.0
+  sysZ3D1197: 0.0
+  sysZ3D1198: 0.0
   sysZ3D1199: -1.87320000e-02
-  sysZ3D1200: -0.0
+  sysZ3D1200: 0.0
   sysZ3D1201: -1.87320000e-02
   sysZ3D1202: 0.0
   sysZ3D1203: 0.037464
-  sysZ3D1204: -0.0
-  sysZ3D1205: -0.0
-  sysZ3D1206: -0.0
+  sysZ3D1204: 0.0
+  sysZ3D1205: 0.0
+  sysZ3D1206: 0.0
   sysZ3D1207: 0.0
-  sysZ3D1208: -0.0
+  sysZ3D1208: 0.0
   sysZ3D1209: 0.0
-  sysZ3D1210: -0.0
+  sysZ3D1210: 0.0
   sysZ3D1211: 0.0
   sysZ3D1212: 0.0
   sysZ3D1213: 0.0
   sysZ3D1214: 0.018732
-  sysZ3D1215: -0.0
-  sysZ3D1216: -0.0
+  sysZ3D1215: 0.0
+  sysZ3D1216: 0.0
   sysZ3D1217: 0.037464
   sysZ3D1218: -3.74640000e-02
   sysZ3D1219: 0.0
-  sysZ3D1220: -0.0
+  sysZ3D1220: 0.0
   sysZ3D1221: 0.018732
   sysZ3D1222: 0.0
   sysZ3D1223: 0.0
@@ -2175,39 +2175,39 @@ bins:
   sysZ3D1226: 0.0
   sysZ3D1227: -1.87320000e-02
   sysZ3D1228: -1.87320000e-02
-  sysZ3D1229: -0.0
-  sysZ3D1230: -0.0
+  sysZ3D1229: 0.0
+  sysZ3D1230: 0.0
   sysZ3D1231: 0.0
   sysZ3D1232: 0.0
   sysZ3D1233: 0.018732
-  sysZ3D1234: -0.0
-  sysZ3D1235: -0.0
+  sysZ3D1234: 0.0
+  sysZ3D1235: 0.0
   sysZ3D1236: 0.018732
   sysZ3D1237: 0.0
-  sysZ3D1238: -0.0
-  sysZ3D1239: -0.0
-  sysZ3D1240: -0.0
+  sysZ3D1238: 0.0
+  sysZ3D1239: 0.0
+  sysZ3D1240: 0.0
   sysZ3D1241: 0.0
   sysZ3D1242: 0.0
   sysZ3D1243: 0.0
   sysZ3D1244: -1.87320000e-02
   sysZ3D1245: 0.018732
   sysZ3D1246: 0.018732
-  sysZ3D1247: -0.0
-  sysZ3D1248: -0.0
+  sysZ3D1247: 0.0
+  sysZ3D1248: 0.0
   sysZ3D1249: 0.0
   sysZ3D1250: 0.0
-  sysZ3D1251: -0.0
-  sysZ3D1252: -0.0
+  sysZ3D1251: 0.0
+  sysZ3D1252: 0.0
   sysZ3D1253: 0.018732
   sysZ3D1254: -1.87320000e-02
   sysZ3D1255: 5.61960000e-02
   sysZ3D1256: 5.61960000e-02
   sysZ3D1257: -3.74640000e-02
-  sysZ3D1258: -0.0
+  sysZ3D1258: 0.0
   sysZ3D1259: -3.74640000e-02
   sysZ3D1260: -1.87320000e-02
-  sysZ3D1261: -0.0
+  sysZ3D1261: 0.0
   sysZ3D1262: 0.09366
   sysZ3D1263: 5.61960000e-02
   sysZ3D1264: -5.61960000e-02
@@ -2244,96 +2244,96 @@ bins:
   sysZ3D1017: 0.0
   sysZ3D1018: 0.0
   sysZ3D1019: 0.0
-  sysZ3D1020: -0.0
-  sysZ3D1021: -0.0
+  sysZ3D1020: 0.0
+  sysZ3D1021: 0.0
   sysZ3D1022: 0.0
   sysZ3D1023: -0.01856
   sysZ3D1024: 0.0
   sysZ3D1025: -0.01856
   sysZ3D1026: 0.01856
-  sysZ3D1027: -0.0
-  sysZ3D1028: -0.0
-  sysZ3D1029: -0.0
+  sysZ3D1027: 0.0
+  sysZ3D1028: 0.0
+  sysZ3D1029: 0.0
   sysZ3D1030: 0.0
-  sysZ3D1031: -0.0
+  sysZ3D1031: 0.0
   sysZ3D1032: 0.0
-  sysZ3D1033: -0.0
-  sysZ3D1034: -0.0
-  sysZ3D1035: -0.0
+  sysZ3D1033: 0.0
+  sysZ3D1034: 0.0
+  sysZ3D1035: 0.0
   sysZ3D1036: 0.0
   sysZ3D1037: 0.0
-  sysZ3D1038: -0.0
-  sysZ3D1039: -0.0
-  sysZ3D1040: -0.0
+  sysZ3D1038: 0.0
+  sysZ3D1039: 0.0
+  sysZ3D1040: 0.0
   sysZ3D1041: 0.0
   sysZ3D1042: 0.0
   sysZ3D1043: 0.0
   sysZ3D1044: 0.0
   sysZ3D1045: 0.0
-  sysZ3D1046: -0.0
+  sysZ3D1046: 0.0
   sysZ3D1047: 0.0
-  sysZ3D1048: -0.0
-  sysZ3D1049: -0.0
+  sysZ3D1048: 0.0
+  sysZ3D1049: 0.0
   sysZ3D1050: 0.0
-  sysZ3D1051: -0.0
+  sysZ3D1051: 0.0
   sysZ3D1052: 0.0
-  sysZ3D1053: -0.0
+  sysZ3D1053: 0.0
   sysZ3D1054: 0.0
   sysZ3D1055: 0.0
-  sysZ3D1056: -0.0
-  sysZ3D1057: -0.0
-  sysZ3D1058: -0.0
-  sysZ3D1059: -0.0
+  sysZ3D1056: 0.0
+  sysZ3D1057: 0.0
+  sysZ3D1058: 0.0
+  sysZ3D1059: 0.0
   sysZ3D1060: 0.0
   sysZ3D1061: 0.0
   sysZ3D1062: 0.0
-  sysZ3D1063: -0.0
+  sysZ3D1063: 0.0
   sysZ3D1064: 0.0
   sysZ3D1065: 0.0
   sysZ3D1066: 0.0
   sysZ3D1067: 0.0
-  sysZ3D1068: -0.0
-  sysZ3D1069: -0.0
-  sysZ3D1070: -0.0
+  sysZ3D1068: 0.0
+  sysZ3D1069: 0.0
+  sysZ3D1070: 0.0
   sysZ3D1071: 0.0
   sysZ3D1072: 0.0
-  sysZ3D1073: -0.0
-  sysZ3D1074: -0.0
+  sysZ3D1073: 0.0
+  sysZ3D1074: 0.0
   sysZ3D1075: 0.0
   sysZ3D1076: 0.0
-  sysZ3D1077: -0.0
+  sysZ3D1077: 0.0
   sysZ3D1078: 0.0
-  sysZ3D1079: -0.0
+  sysZ3D1079: 0.0
   sysZ3D1080: 0.0
-  sysZ3D1081: -0.0
+  sysZ3D1081: 0.0
   sysZ3D1082: 0.0
-  sysZ3D1083: -0.0
-  sysZ3D1084: -0.0
-  sysZ3D1085: -0.0
+  sysZ3D1083: 0.0
+  sysZ3D1084: 0.0
+  sysZ3D1085: 0.0
   sysZ3D1086: 0.01856
-  sysZ3D1087: -0.0
+  sysZ3D1087: 0.0
   sysZ3D1088: 0.0
-  sysZ3D1089: -0.0
-  sysZ3D1090: -0.0
+  sysZ3D1089: 0.0
+  sysZ3D1090: 0.0
   sysZ3D1091: 0.0
   sysZ3D1092: 0.0
   sysZ3D1093: 0.0
-  sysZ3D1094: -0.0
+  sysZ3D1094: 0.0
   sysZ3D1095: 0.0
-  sysZ3D1096: -0.0
-  sysZ3D1097: -0.0
+  sysZ3D1096: 0.0
+  sysZ3D1097: 0.0
   sysZ3D1098: 0.01856
   sysZ3D1099: 0.0
   sysZ3D1100: 0.0
-  sysZ3D1101: -0.0
-  sysZ3D1102: -0.0
-  sysZ3D1103: -0.0
+  sysZ3D1101: 0.0
+  sysZ3D1102: 0.0
+  sysZ3D1103: 0.0
   sysZ3D1104: -0.2784
   sysZ3D1105: -1.52192000e+00
   sysZ3D1106: -0.0928
   sysZ3D1107: -0.01856
   sysZ3D1108: -5.38240000e-01
-  sysZ3D1109: -0.0
+  sysZ3D1109: 0.0
   sysZ3D1110: 0.0
   sysZ3D1111: 5.56800000e-02
   sysZ3D1112: 0.03712
@@ -2341,7 +2341,7 @@ bins:
   sysZ3D1114: -0.07424
   sysZ3D1115: -0.01856
   sysZ3D1116: 0.03712
-  sysZ3D1117: -0.0
+  sysZ3D1117: 0.0
   sysZ3D1118: -0.03712
   sysZ3D1119: 0.01856
   sysZ3D1120: 5.56800000e-02
@@ -2359,19 +2359,19 @@ bins:
   sysZ3D1132: 0.01856
   sysZ3D1133: 0.0
   sysZ3D1134: -5.56800000e-02
-  sysZ3D1135: -0.0
+  sysZ3D1135: 0.0
   sysZ3D1136: 0.0
-  sysZ3D1137: -0.0
+  sysZ3D1137: 0.0
   sysZ3D1138: 0.01856
   sysZ3D1139: -0.01856
   sysZ3D1140: 0.0
   sysZ3D1141: 0.0
-  sysZ3D1142: -0.0
+  sysZ3D1142: 0.0
   sysZ3D1143: 0.0
-  sysZ3D1144: -0.0
+  sysZ3D1144: 0.0
   sysZ3D1145: -0.01856
-  sysZ3D1146: -0.0
-  sysZ3D1147: -0.0
+  sysZ3D1146: 0.0
+  sysZ3D1147: 0.0
   sysZ3D1148: 0.0
   sysZ3D1149: 0.0
   sysZ3D1150: 0.01856
@@ -2384,12 +2384,12 @@ bins:
   sysZ3D1157: 0.03712
   sysZ3D1158: 0.0
   sysZ3D1159: 0.0
-  sysZ3D1160: -0.0
+  sysZ3D1160: 0.0
   sysZ3D1161: 0.0
   sysZ3D1162: 0.01856
   sysZ3D1163: -0.03712
-  sysZ3D1164: -0.0
-  sysZ3D1165: -0.0
+  sysZ3D1164: 0.0
+  sysZ3D1165: 0.0
   sysZ3D1166: 0.0
   sysZ3D1167: 0.0
   sysZ3D1168: 0.03712
@@ -2399,12 +2399,12 @@ bins:
   sysZ3D1172: 0.01856
   sysZ3D1173: 0.01856
   sysZ3D1174: 0.0928
-  sysZ3D1175: -0.0
+  sysZ3D1175: 0.0
   sysZ3D1176: 0.03712
   sysZ3D1177: 0.01856
   sysZ3D1178: 0.01856
   sysZ3D1179: -0.03712
-  sysZ3D1180: -0.0
+  sysZ3D1180: 0.0
   sysZ3D1181: -0.01856
   sysZ3D1182: 0.01856
   sysZ3D1183: 0.0
@@ -2413,33 +2413,33 @@ bins:
   sysZ3D1186: 0.01856
   sysZ3D1187: -0.03712
   sysZ3D1188: -0.01856
-  sysZ3D1189: -0.0
+  sysZ3D1189: 0.0
   sysZ3D1190: 0.0
   sysZ3D1191: -5.56800000e-02
   sysZ3D1192: 0.01856
   sysZ3D1193: -0.01856
   sysZ3D1194: -0.01856
-  sysZ3D1195: -0.0
+  sysZ3D1195: 0.0
   sysZ3D1196: 0.0
   sysZ3D1197: 0.01856
-  sysZ3D1198: -0.0
+  sysZ3D1198: 0.0
   sysZ3D1199: -0.01856
   sysZ3D1200: -0.03712
   sysZ3D1201: -0.01856
   sysZ3D1202: 0.0
   sysZ3D1203: 0.01856
-  sysZ3D1204: -0.0
+  sysZ3D1204: 0.0
   sysZ3D1205: 0.0
   sysZ3D1206: 0.0
-  sysZ3D1207: -0.0
-  sysZ3D1208: -0.0
+  sysZ3D1207: 0.0
+  sysZ3D1208: 0.0
   sysZ3D1209: -0.01856
   sysZ3D1210: -0.01856
   sysZ3D1211: 0.0
   sysZ3D1212: 0.0
   sysZ3D1213: 0.0
   sysZ3D1214: 0.01856
-  sysZ3D1215: -0.0
+  sysZ3D1215: 0.0
   sysZ3D1216: 0.0
   sysZ3D1217: 0.01856
   sysZ3D1218: -0.03712
@@ -2450,15 +2450,15 @@ bins:
   sysZ3D1223: 0.0
   sysZ3D1224: 0.0
   sysZ3D1225: 0.01856
-  sysZ3D1226: -0.0
+  sysZ3D1226: 0.0
   sysZ3D1227: -0.01856
   sysZ3D1228: -0.01856
-  sysZ3D1229: -0.0
-  sysZ3D1230: -0.0
+  sysZ3D1229: 0.0
+  sysZ3D1230: 0.0
   sysZ3D1231: 0.0
   sysZ3D1232: 0.0
-  sysZ3D1233: -0.0
-  sysZ3D1234: -0.0
+  sysZ3D1233: 0.0
+  sysZ3D1234: 0.0
   sysZ3D1235: 0.0
   sysZ3D1236: 0.0
   sysZ3D1237: 0.0
@@ -2474,15 +2474,15 @@ bins:
   sysZ3D1247: 0.0
   sysZ3D1248: 0.0
   sysZ3D1249: 0.01856
-  sysZ3D1250: -0.0
+  sysZ3D1250: 0.0
   sysZ3D1251: -0.01856
   sysZ3D1252: -0.01856
   sysZ3D1253: 0.0
-  sysZ3D1254: -0.0
+  sysZ3D1254: 0.0
   sysZ3D1255: 0.03712
   sysZ3D1256: 5.56800000e-02
-  sysZ3D1257: -0.0
-  sysZ3D1258: -0.0
+  sysZ3D1257: 0.0
+  sysZ3D1258: 0.0
   sysZ3D1259: -5.56800000e-02
   sysZ3D1260: 0.0
   sysZ3D1261: 0.01856
@@ -2493,7 +2493,7 @@ bins:
   sysZ3D1266: -0.14848
   sysZ3D1267: -5.56800000e-02
   sysZ3D1268: 0.03712
-  sysZ3D1269: -0.0
+  sysZ3D1269: 0.0
   sysZ3D1270: -0.03712
   sysZ3D1271: 0.0928
   sysZ3D1272: 0.0
@@ -2525,44 +2525,44 @@ bins:
   sysZ3D1020: 0.0
   sysZ3D1021: 0.0
   sysZ3D1022: 0.0
-  sysZ3D1023: -0.0
+  sysZ3D1023: 0.0
   sysZ3D1024: 0.0
-  sysZ3D1025: -0.0
+  sysZ3D1025: 0.0
   sysZ3D1026: 0.0
-  sysZ3D1027: -0.0
-  sysZ3D1028: -0.0
-  sysZ3D1029: -0.0
+  sysZ3D1027: 0.0
+  sysZ3D1028: 0.0
+  sysZ3D1029: 0.0
   sysZ3D1030: 0.0
   sysZ3D1031: 0.0
   sysZ3D1032: 0.0
-  sysZ3D1033: -0.0
+  sysZ3D1033: 0.0
   sysZ3D1034: 0.0
   sysZ3D1035: 0.0
-  sysZ3D1036: -0.0
-  sysZ3D1037: -0.0
-  sysZ3D1038: -0.0
-  sysZ3D1039: -0.0
+  sysZ3D1036: 0.0
+  sysZ3D1037: 0.0
+  sysZ3D1038: 0.0
+  sysZ3D1039: 0.0
   sysZ3D1040: 0.0
-  sysZ3D1041: -0.0
+  sysZ3D1041: 0.0
   sysZ3D1042: 0.0
-  sysZ3D1043: -0.0
+  sysZ3D1043: 0.0
   sysZ3D1044: 0.0
-  sysZ3D1045: -0.0
+  sysZ3D1045: 0.0
   sysZ3D1046: 0.0
-  sysZ3D1047: -0.0
-  sysZ3D1048: -0.0
+  sysZ3D1047: 0.0
+  sysZ3D1048: 0.0
   sysZ3D1049: 0.0
   sysZ3D1050: 0.0
-  sysZ3D1051: -0.0
-  sysZ3D1052: -0.0
-  sysZ3D1053: -0.0
+  sysZ3D1051: 0.0
+  sysZ3D1052: 0.0
+  sysZ3D1053: 0.0
   sysZ3D1054: -1.87640000e-02
-  sysZ3D1055: -0.0
+  sysZ3D1055: 0.0
   sysZ3D1056: 0.0
-  sysZ3D1057: -0.0
-  sysZ3D1058: -0.0
-  sysZ3D1059: -0.0
-  sysZ3D1060: -0.0
+  sysZ3D1057: 0.0
+  sysZ3D1058: 0.0
+  sysZ3D1059: 0.0
+  sysZ3D1060: 0.0
   sysZ3D1061: 0.0
   sysZ3D1062: 0.0
   sysZ3D1063: 0.0
@@ -2573,36 +2573,36 @@ bins:
   sysZ3D1068: 0.0
   sysZ3D1069: 0.0
   sysZ3D1070: 0.0
-  sysZ3D1071: -0.0
-  sysZ3D1072: -0.0
-  sysZ3D1073: -0.0
+  sysZ3D1071: 0.0
+  sysZ3D1072: 0.0
+  sysZ3D1073: 0.0
   sysZ3D1074: 0.0
-  sysZ3D1075: -0.0
-  sysZ3D1076: -0.0
-  sysZ3D1077: -0.0
-  sysZ3D1078: -0.0
-  sysZ3D1079: -0.0
+  sysZ3D1075: 0.0
+  sysZ3D1076: 0.0
+  sysZ3D1077: 0.0
+  sysZ3D1078: 0.0
+  sysZ3D1079: 0.0
   sysZ3D1080: 0.0
-  sysZ3D1081: -0.0
+  sysZ3D1081: 0.0
   sysZ3D1082: 1.87640000e-02
-  sysZ3D1083: -0.0
-  sysZ3D1084: -0.0
+  sysZ3D1083: 0.0
+  sysZ3D1084: 0.0
   sysZ3D1085: 0.0
   sysZ3D1086: 0.0
-  sysZ3D1087: -0.0
+  sysZ3D1087: 0.0
   sysZ3D1088: -1.87640000e-02
   sysZ3D1089: 0.0
   sysZ3D1090: 0.0
-  sysZ3D1091: -0.0
+  sysZ3D1091: 0.0
   sysZ3D1092: 0.0
-  sysZ3D1093: -0.0
-  sysZ3D1094: -0.0
+  sysZ3D1093: 0.0
+  sysZ3D1094: 0.0
   sysZ3D1095: 0.0
-  sysZ3D1096: -0.0
+  sysZ3D1096: 0.0
   sysZ3D1097: 0.0
-  sysZ3D1098: -0.0
-  sysZ3D1099: -0.0
-  sysZ3D1100: -0.0
+  sysZ3D1098: 0.0
+  sysZ3D1099: 0.0
+  sysZ3D1100: 0.0
   sysZ3D1101: 0.0
   sysZ3D1102: 0.0
   sysZ3D1103: 0.0
@@ -2611,7 +2611,7 @@ bins:
   sysZ3D1106: -0.09382
   sysZ3D1107: -1.87640000e-02
   sysZ3D1108: -5.25392000e-01
-  sysZ3D1109: -0.0
+  sysZ3D1109: 0.0
   sysZ3D1110: 0.0
   sysZ3D1111: -0.18764
   sysZ3D1112: 3.75280000e-02
@@ -2626,7 +2626,7 @@ bins:
   sysZ3D1121: -3.75280000e-02
   sysZ3D1122: -3.75280000e-02
   sysZ3D1123: -3.75280000e-02
-  sysZ3D1124: -0.0
+  sysZ3D1124: 0.0
   sysZ3D1125: 0.0
   sysZ3D1126: -1.87640000e-02
   sysZ3D1127: -3.75280000e-02
@@ -2641,16 +2641,16 @@ bins:
   sysZ3D1136: 3.75280000e-02
   sysZ3D1137: 0.0
   sysZ3D1138: 1.87640000e-02
-  sysZ3D1139: -0.0
+  sysZ3D1139: 0.0
   sysZ3D1140: -3.75280000e-02
-  sysZ3D1141: -0.0
-  sysZ3D1142: -0.0
+  sysZ3D1141: 0.0
+  sysZ3D1142: 0.0
   sysZ3D1143: 0.0
   sysZ3D1144: 0.0
   sysZ3D1145: 0.0
   sysZ3D1146: 0.0
   sysZ3D1147: 0.0
-  sysZ3D1148: -0.0
+  sysZ3D1148: 0.0
   sysZ3D1149: 0.0
   sysZ3D1150: 1.87640000e-02
   sysZ3D1151: 3.75280000e-02
@@ -2668,7 +2668,7 @@ bins:
   sysZ3D1163: -1.87640000e-02
   sysZ3D1164: 0.0
   sysZ3D1165: 1.87640000e-02
-  sysZ3D1166: -0.0
+  sysZ3D1166: 0.0
   sysZ3D1167: 0.0
   sysZ3D1168: 5.62920000e-02
   sysZ3D1169: 0.0
@@ -2677,9 +2677,9 @@ bins:
   sysZ3D1172: 1.87640000e-02
   sysZ3D1173: 1.87640000e-02
   sysZ3D1174: 7.50560000e-02
-  sysZ3D1175: -0.0
+  sysZ3D1175: 0.0
   sysZ3D1176: -1.87640000e-02
-  sysZ3D1177: -0.0
+  sysZ3D1177: 0.0
   sysZ3D1178: 1.87640000e-02
   sysZ3D1179: -5.62920000e-02
   sysZ3D1180: -1.87640000e-02
@@ -2688,92 +2688,92 @@ bins:
   sysZ3D1183: 1.87640000e-02
   sysZ3D1184: 1.87640000e-02
   sysZ3D1185: 1.87640000e-02
-  sysZ3D1186: -0.0
+  sysZ3D1186: 0.0
   sysZ3D1187: -3.75280000e-02
-  sysZ3D1188: -0.0
+  sysZ3D1188: 0.0
   sysZ3D1189: 0.0
-  sysZ3D1190: -0.0
+  sysZ3D1190: 0.0
   sysZ3D1191: -3.75280000e-02
   sysZ3D1192: 0.0
   sysZ3D1193: -3.75280000e-02
-  sysZ3D1194: -0.0
+  sysZ3D1194: 0.0
   sysZ3D1195: 0.0
   sysZ3D1196: 0.0
   sysZ3D1197: 1.87640000e-02
-  sysZ3D1198: -0.0
+  sysZ3D1198: 0.0
   sysZ3D1199: -1.87640000e-02
   sysZ3D1200: -1.87640000e-02
   sysZ3D1201: 0.0
   sysZ3D1202: 0.0
   sysZ3D1203: 1.87640000e-02
-  sysZ3D1204: -0.0
+  sysZ3D1204: 0.0
   sysZ3D1205: 0.0
   sysZ3D1206: 0.0
-  sysZ3D1207: -0.0
-  sysZ3D1208: -0.0
-  sysZ3D1209: -0.0
+  sysZ3D1207: 0.0
+  sysZ3D1208: 0.0
+  sysZ3D1209: 0.0
   sysZ3D1210: 1.87640000e-02
-  sysZ3D1211: -0.0
-  sysZ3D1212: -0.0
+  sysZ3D1211: 0.0
+  sysZ3D1212: 0.0
   sysZ3D1213: 0.0
   sysZ3D1214: 1.87640000e-02
-  sysZ3D1215: -0.0
+  sysZ3D1215: 0.0
   sysZ3D1216: 0.0
   sysZ3D1217: 3.75280000e-02
   sysZ3D1218: -3.75280000e-02
   sysZ3D1219: 0.0
-  sysZ3D1220: -0.0
-  sysZ3D1221: -0.0
-  sysZ3D1222: -0.0
+  sysZ3D1220: 0.0
+  sysZ3D1221: 0.0
+  sysZ3D1222: 0.0
   sysZ3D1223: 0.0
   sysZ3D1224: 0.0
   sysZ3D1225: 0.0
-  sysZ3D1226: -0.0
+  sysZ3D1226: 0.0
   sysZ3D1227: -1.87640000e-02
   sysZ3D1228: -1.87640000e-02
-  sysZ3D1229: -0.0
+  sysZ3D1229: 0.0
   sysZ3D1230: 0.0
   sysZ3D1231: 0.0
   sysZ3D1232: 0.0
-  sysZ3D1233: -0.0
-  sysZ3D1234: -0.0
-  sysZ3D1235: -0.0
+  sysZ3D1233: 0.0
+  sysZ3D1234: 0.0
+  sysZ3D1235: 0.0
   sysZ3D1236: 1.87640000e-02
   sysZ3D1237: 0.0
-  sysZ3D1238: -0.0
-  sysZ3D1239: -0.0
+  sysZ3D1238: 0.0
+  sysZ3D1239: 0.0
   sysZ3D1240: 0.0
-  sysZ3D1241: -0.0
+  sysZ3D1241: 0.0
   sysZ3D1242: 0.0
   sysZ3D1243: 0.0
   sysZ3D1244: 0.0
   sysZ3D1245: 0.0
-  sysZ3D1246: -0.0
-  sysZ3D1247: -0.0
-  sysZ3D1248: -0.0
+  sysZ3D1246: 0.0
+  sysZ3D1247: 0.0
+  sysZ3D1248: 0.0
   sysZ3D1249: 0.0
   sysZ3D1250: 0.0
   sysZ3D1251: -1.87640000e-02
-  sysZ3D1252: -0.0
+  sysZ3D1252: 0.0
   sysZ3D1253: 0.0
   sysZ3D1254: -1.87640000e-02
-  sysZ3D1255: -0.0
+  sysZ3D1255: 0.0
   sysZ3D1256: -0.09382
   sysZ3D1257: -5.62920000e-02
   sysZ3D1258: -1.87640000e-02
   sysZ3D1259: -0.09382
   sysZ3D1260: -3.75280000e-02
-  sysZ3D1261: -0.0
+  sysZ3D1261: 0.0
   sysZ3D1262: 7.50560000e-02
   sysZ3D1263: 5.62920000e-02
-  sysZ3D1264: -0.0
+  sysZ3D1264: 0.0
   sysZ3D1265: 2.62696000e-01
   sysZ3D1266: -1.50112000e-01
   sysZ3D1267: -5.62920000e-02
   sysZ3D1268: 1.87640000e-02
   sysZ3D1269: -1.87640000e-02
   sysZ3D1270: 0.0
-  sysZ3D1271: -0.0
+  sysZ3D1271: 0.0
   sysZ3D1272: 0.0
   sysZ3D1273: 0.0
   sysZ3D1274: 3.75280000e-02
@@ -2800,96 +2800,96 @@ bins:
   sysZ3D1017: 0.0
   sysZ3D1018: 0.0
   sysZ3D1019: 0.0
-  sysZ3D1020: -0.0
+  sysZ3D1020: 0.0
   sysZ3D1021: 0.0
-  sysZ3D1022: -0.0
+  sysZ3D1022: 0.0
   sysZ3D1023: 0.018598
   sysZ3D1024: -1.85980000e-02
   sysZ3D1025: 5.57940000e-02
   sysZ3D1026: -1.85980000e-02
   sysZ3D1027: 0.018598
-  sysZ3D1028: -0.0
-  sysZ3D1029: -0.0
-  sysZ3D1030: -0.0
-  sysZ3D1031: -0.0
-  sysZ3D1032: -0.0
+  sysZ3D1028: 0.0
+  sysZ3D1029: 0.0
+  sysZ3D1030: 0.0
+  sysZ3D1031: 0.0
+  sysZ3D1032: 0.0
   sysZ3D1033: 0.0
   sysZ3D1034: 0.018598
   sysZ3D1035: 0.018598
-  sysZ3D1036: -0.0
-  sysZ3D1037: -0.0
+  sysZ3D1036: 0.0
+  sysZ3D1037: 0.0
   sysZ3D1038: 0.0
-  sysZ3D1039: -0.0
+  sysZ3D1039: 0.0
   sysZ3D1040: 0.0
-  sysZ3D1041: -0.0
-  sysZ3D1042: -0.0
-  sysZ3D1043: -0.0
+  sysZ3D1041: 0.0
+  sysZ3D1042: 0.0
+  sysZ3D1043: 0.0
   sysZ3D1044: 0.0
-  sysZ3D1045: -0.0
+  sysZ3D1045: 0.0
   sysZ3D1046: 0.0
-  sysZ3D1047: -0.0
+  sysZ3D1047: 0.0
   sysZ3D1048: 0.0
-  sysZ3D1049: -0.0
+  sysZ3D1049: 0.0
   sysZ3D1050: 0.0
   sysZ3D1051: 0.0
   sysZ3D1052: 0.0
-  sysZ3D1053: -0.0
-  sysZ3D1054: -0.0
+  sysZ3D1053: 0.0
+  sysZ3D1054: 0.0
   sysZ3D1055: 0.0
-  sysZ3D1056: -0.0
+  sysZ3D1056: 0.0
   sysZ3D1057: 0.0
-  sysZ3D1058: -0.0
-  sysZ3D1059: -0.0
-  sysZ3D1060: -0.0
-  sysZ3D1061: -0.0
+  sysZ3D1058: 0.0
+  sysZ3D1059: 0.0
+  sysZ3D1060: 0.0
+  sysZ3D1061: 0.0
   sysZ3D1062: -1.85980000e-02
-  sysZ3D1063: -0.0
+  sysZ3D1063: 0.0
   sysZ3D1064: 0.0
-  sysZ3D1065: -0.0
+  sysZ3D1065: 0.0
   sysZ3D1066: 0.0
   sysZ3D1067: 0.0
-  sysZ3D1068: -0.0
+  sysZ3D1068: 0.0
   sysZ3D1069: 0.0
-  sysZ3D1070: -0.0
-  sysZ3D1071: -0.0
-  sysZ3D1072: -0.0
-  sysZ3D1073: -0.0
-  sysZ3D1074: -0.0
-  sysZ3D1075: -0.0
-  sysZ3D1076: -0.0
+  sysZ3D1070: 0.0
+  sysZ3D1071: 0.0
+  sysZ3D1072: 0.0
+  sysZ3D1073: 0.0
+  sysZ3D1074: 0.0
+  sysZ3D1075: 0.0
+  sysZ3D1076: 0.0
   sysZ3D1077: 0.0
-  sysZ3D1078: -0.0
-  sysZ3D1079: -0.0
-  sysZ3D1080: -0.0
-  sysZ3D1081: -0.0
-  sysZ3D1082: -0.0
+  sysZ3D1078: 0.0
+  sysZ3D1079: 0.0
+  sysZ3D1080: 0.0
+  sysZ3D1081: 0.0
+  sysZ3D1082: 0.0
   sysZ3D1083: 0.0
   sysZ3D1084: -1.85980000e-02
-  sysZ3D1085: -0.0
+  sysZ3D1085: 0.0
   sysZ3D1086: 0.0
   sysZ3D1087: 0.0
-  sysZ3D1088: -0.0
-  sysZ3D1089: -0.0
-  sysZ3D1090: -0.0
-  sysZ3D1091: -0.0
-  sysZ3D1092: -0.0
-  sysZ3D1093: -0.0
-  sysZ3D1094: -0.0
-  sysZ3D1095: -0.0
+  sysZ3D1088: 0.0
+  sysZ3D1089: 0.0
+  sysZ3D1090: 0.0
+  sysZ3D1091: 0.0
+  sysZ3D1092: 0.0
+  sysZ3D1093: 0.0
+  sysZ3D1094: 0.0
+  sysZ3D1095: 0.0
   sysZ3D1096: 0.0
-  sysZ3D1097: -0.0
+  sysZ3D1097: 0.0
   sysZ3D1098: 0.0
-  sysZ3D1099: -0.0
+  sysZ3D1099: 0.0
   sysZ3D1100: 0.0
   sysZ3D1101: 0.0
-  sysZ3D1102: -0.0
+  sysZ3D1102: 0.0
   sysZ3D1103: 0.0
   sysZ3D1104: -0.18598
   sysZ3D1105: -1.50643800e+00
   sysZ3D1106: -0.09299
   sysZ3D1107: -1.85980000e-02
   sysZ3D1108: -5.02146000e-01
-  sysZ3D1109: -0.0
+  sysZ3D1109: 0.0
   sysZ3D1110: 0.0
   sysZ3D1111: -0.18598
   sysZ3D1112: 0.018598
@@ -2897,43 +2897,43 @@ bins:
   sysZ3D1114: -7.43920000e-02
   sysZ3D1115: 0.018598
   sysZ3D1116: 0.0
-  sysZ3D1117: -0.0
-  sysZ3D1118: -0.0
-  sysZ3D1119: -0.0
+  sysZ3D1117: 0.0
+  sysZ3D1118: 0.0
+  sysZ3D1119: 0.0
   sysZ3D1120: 0.0
   sysZ3D1121: -1.85980000e-02
-  sysZ3D1122: -0.0
+  sysZ3D1122: 0.0
   sysZ3D1123: 0.018598
   sysZ3D1124: -7.43920000e-02
   sysZ3D1125: -3.71960000e-02
   sysZ3D1126: -1.85980000e-02
   sysZ3D1127: -5.57940000e-02
   sysZ3D1128: 0.0
-  sysZ3D1129: -0.0
+  sysZ3D1129: 0.0
   sysZ3D1130: 0.018598
   sysZ3D1131: 0.018598
-  sysZ3D1132: -0.0
+  sysZ3D1132: 0.0
   sysZ3D1133: 0.018598
   sysZ3D1134: -1.85980000e-02
-  sysZ3D1135: -0.0
+  sysZ3D1135: 0.0
   sysZ3D1136: -1.85980000e-02
   sysZ3D1137: -1.85980000e-02
   sysZ3D1138: -1.85980000e-02
   sysZ3D1139: -1.85980000e-02
   sysZ3D1140: -1.85980000e-02
   sysZ3D1141: -1.85980000e-02
-  sysZ3D1142: -0.0
+  sysZ3D1142: 0.0
   sysZ3D1143: 0.018598
-  sysZ3D1144: -0.0
+  sysZ3D1144: 0.0
   sysZ3D1145: -1.85980000e-02
   sysZ3D1146: 0.0
-  sysZ3D1147: -0.0
-  sysZ3D1148: -0.0
+  sysZ3D1147: 0.0
+  sysZ3D1148: 0.0
   sysZ3D1149: 0.0
   sysZ3D1150: 0.0
   sysZ3D1151: 0.018598
-  sysZ3D1152: -0.0
-  sysZ3D1153: -0.0
+  sysZ3D1152: 0.0
+  sysZ3D1153: 0.0
   sysZ3D1154: 0.0
   sysZ3D1155: 0.0
   sysZ3D1156: 0.018598
@@ -2955,7 +2955,7 @@ bins:
   sysZ3D1172: 0.018598
   sysZ3D1173: 0.018598
   sysZ3D1174: 0.037196
-  sysZ3D1175: -0.0
+  sysZ3D1175: 0.0
   sysZ3D1176: -3.71960000e-02
   sysZ3D1177: -3.71960000e-02
   sysZ3D1178: 0.018598
@@ -2968,7 +2968,7 @@ bins:
   sysZ3D1185: 0.037196
   sysZ3D1186: -1.85980000e-02
   sysZ3D1187: -3.71960000e-02
-  sysZ3D1188: -0.0
+  sysZ3D1188: 0.0
   sysZ3D1189: 0.0
   sysZ3D1190: -1.85980000e-02
   sysZ3D1191: 5.57940000e-02
@@ -2979,49 +2979,49 @@ bins:
   sysZ3D1196: 0.018598
   sysZ3D1197: 0.0
   sysZ3D1198: 0.0
-  sysZ3D1199: -0.0
+  sysZ3D1199: 0.0
   sysZ3D1200: 0.0
   sysZ3D1201: -1.85980000e-02
   sysZ3D1202: 0.0
   sysZ3D1203: 0.018598
-  sysZ3D1204: -0.0
+  sysZ3D1204: 0.0
   sysZ3D1205: 0.0
   sysZ3D1206: 0.0
   sysZ3D1207: 0.0
   sysZ3D1208: 0.0
-  sysZ3D1209: -0.0
-  sysZ3D1210: -0.0
-  sysZ3D1211: -0.0
+  sysZ3D1209: 0.0
+  sysZ3D1210: 0.0
+  sysZ3D1211: 0.0
   sysZ3D1212: 0.0
   sysZ3D1213: 0.0
   sysZ3D1214: 0.0
-  sysZ3D1215: -0.0
-  sysZ3D1216: -0.0
+  sysZ3D1215: 0.0
+  sysZ3D1216: 0.0
   sysZ3D1217: 0.018598
   sysZ3D1218: -1.85980000e-02
   sysZ3D1219: 0.018598
-  sysZ3D1220: -0.0
+  sysZ3D1220: 0.0
   sysZ3D1221: -1.85980000e-02
-  sysZ3D1222: -0.0
+  sysZ3D1222: 0.0
   sysZ3D1223: 0.0
   sysZ3D1224: 0.0
-  sysZ3D1225: -0.0
+  sysZ3D1225: 0.0
   sysZ3D1226: 0.0
   sysZ3D1227: -1.85980000e-02
   sysZ3D1228: -1.85980000e-02
   sysZ3D1229: -1.85980000e-02
   sysZ3D1230: 0.018598
   sysZ3D1231: 0.0
-  sysZ3D1232: -0.0
-  sysZ3D1233: -0.0
-  sysZ3D1234: -0.0
+  sysZ3D1232: 0.0
+  sysZ3D1233: 0.0
+  sysZ3D1234: 0.0
   sysZ3D1235: -1.85980000e-02
   sysZ3D1236: 0.018598
   sysZ3D1237: 0.0
   sysZ3D1238: 0.0
   sysZ3D1239: 0.0
   sysZ3D1240: 0.018598
-  sysZ3D1241: -0.0
+  sysZ3D1241: 0.0
   sysZ3D1242: 0.0
   sysZ3D1243: 0.0
   sysZ3D1244: 0.037196
@@ -3034,8 +3034,8 @@ bins:
   sysZ3D1251: -3.71960000e-02
   sysZ3D1252: 0.018598
   sysZ3D1253: 0.0
-  sysZ3D1254: -0.0
-  sysZ3D1255: -0.0
+  sysZ3D1254: 0.0
+  sysZ3D1255: 0.0
   sysZ3D1256: 0.0
   sysZ3D1257: -1.85980000e-02
   sysZ3D1258: 0.018598
@@ -3078,80 +3078,80 @@ bins:
   sysZ3D1017: 0.0
   sysZ3D1018: 0.0
   sysZ3D1019: 0.0
-  sysZ3D1020: -0.0
-  sysZ3D1021: -0.0
+  sysZ3D1020: 0.0
+  sysZ3D1021: 0.0
   sysZ3D1022: 0.0
   sysZ3D1023: -1.81960000e-02
   sysZ3D1024: 1.81960000e-02
   sysZ3D1025: -1.81960000e-02
   sysZ3D1026: 0.0
-  sysZ3D1027: -0.0
+  sysZ3D1027: 0.0
   sysZ3D1028: 0.0
-  sysZ3D1029: -0.0
+  sysZ3D1029: 0.0
   sysZ3D1030: 0.0
-  sysZ3D1031: -0.0
-  sysZ3D1032: -0.0
+  sysZ3D1031: 0.0
+  sysZ3D1032: 0.0
   sysZ3D1033: 1.81960000e-02
-  sysZ3D1034: -0.0
-  sysZ3D1035: -0.0
+  sysZ3D1034: 0.0
+  sysZ3D1035: 0.0
   sysZ3D1036: 0.0
   sysZ3D1037: 0.0
-  sysZ3D1038: -0.0
+  sysZ3D1038: 0.0
   sysZ3D1039: 0.0
-  sysZ3D1040: -0.0
+  sysZ3D1040: 0.0
   sysZ3D1041: 0.0
-  sysZ3D1042: -0.0
+  sysZ3D1042: 0.0
   sysZ3D1043: 0.0
   sysZ3D1044: 0.0
   sysZ3D1045: 0.0
-  sysZ3D1046: -0.0
+  sysZ3D1046: 0.0
   sysZ3D1047: 0.0
-  sysZ3D1048: -0.0
+  sysZ3D1048: 0.0
   sysZ3D1049: 0.0
   sysZ3D1050: -1.81960000e-02
   sysZ3D1051: 0.0
   sysZ3D1052: 0.0
-  sysZ3D1053: -0.0
+  sysZ3D1053: 0.0
   sysZ3D1054: -1.81960000e-02
-  sysZ3D1055: -0.0
-  sysZ3D1056: -0.0
+  sysZ3D1055: 0.0
+  sysZ3D1056: 0.0
   sysZ3D1057: 0.0
   sysZ3D1058: 0.0
   sysZ3D1059: 0.0
-  sysZ3D1060: -0.0
+  sysZ3D1060: 0.0
   sysZ3D1061: 0.0
-  sysZ3D1062: -0.0
-  sysZ3D1063: -0.0
+  sysZ3D1062: 0.0
+  sysZ3D1063: 0.0
   sysZ3D1064: -1.81960000e-02
-  sysZ3D1065: -0.0
-  sysZ3D1066: -0.0
+  sysZ3D1065: 0.0
+  sysZ3D1066: 0.0
   sysZ3D1067: 0.0
   sysZ3D1068: 0.0
-  sysZ3D1069: -0.0
-  sysZ3D1070: -0.0
+  sysZ3D1069: 0.0
+  sysZ3D1070: 0.0
   sysZ3D1071: 0.0
-  sysZ3D1072: -0.0
+  sysZ3D1072: 0.0
   sysZ3D1073: 0.0
   sysZ3D1074: 0.0
-  sysZ3D1075: -0.0
+  sysZ3D1075: 0.0
   sysZ3D1076: 0.0
-  sysZ3D1077: -0.0
-  sysZ3D1078: -0.0
+  sysZ3D1077: 0.0
+  sysZ3D1078: 0.0
   sysZ3D1079: 0.0
-  sysZ3D1080: -0.0
-  sysZ3D1081: -0.0
+  sysZ3D1080: 0.0
+  sysZ3D1081: 0.0
   sysZ3D1082: 0.0
-  sysZ3D1083: -0.0
+  sysZ3D1083: 0.0
   sysZ3D1084: 0.0
   sysZ3D1085: 0.0
   sysZ3D1086: 0.0
   sysZ3D1087: 0.0
   sysZ3D1088: 0.0
-  sysZ3D1089: -0.0
+  sysZ3D1089: 0.0
   sysZ3D1090: 0.0
-  sysZ3D1091: -0.0
+  sysZ3D1091: 0.0
   sysZ3D1092: 1.81960000e-02
-  sysZ3D1093: -0.0
+  sysZ3D1093: 0.0
   sysZ3D1094: 1.81960000e-02
   sysZ3D1095: 0.0
   sysZ3D1096: 1.81960000e-02
@@ -3160,14 +3160,14 @@ bins:
   sysZ3D1099: 0.0
   sysZ3D1100: 0.0
   sysZ3D1101: 0.0
-  sysZ3D1102: -0.0
-  sysZ3D1103: -0.0
+  sysZ3D1102: 0.0
+  sysZ3D1103: 0.0
   sysZ3D1104: -1.45568000e-01
   sysZ3D1105: -1.3647
   sysZ3D1106: -7.27840000e-02
   sysZ3D1107: -1.81960000e-02
   sysZ3D1108: -5.09488000e-01
-  sysZ3D1109: -0.0
+  sysZ3D1109: 0.0
   sysZ3D1110: 0.0
   sysZ3D1111: -3.27528000e-01
   sysZ3D1112: 1.81960000e-02
@@ -3177,40 +3177,40 @@ bins:
   sysZ3D1116: -3.63920000e-02
   sysZ3D1117: 7.27840000e-02
   sysZ3D1118: -3.63920000e-02
-  sysZ3D1119: -0.0
-  sysZ3D1120: -0.0
+  sysZ3D1119: 0.0
+  sysZ3D1120: 0.0
   sysZ3D1121: -3.63920000e-02
   sysZ3D1122: -1.81960000e-02
   sysZ3D1123: 1.81960000e-02
-  sysZ3D1124: -0.0
+  sysZ3D1124: 0.0
   sysZ3D1125: 1.81960000e-02
   sysZ3D1126: -1.81960000e-02
   sysZ3D1127: -9.09800000e-02
   sysZ3D1128: 0.0
   sysZ3D1129: 1.81960000e-02
-  sysZ3D1130: -0.0
+  sysZ3D1130: 0.0
   sysZ3D1131: -1.81960000e-02
   sysZ3D1132: 1.81960000e-02
   sysZ3D1133: 1.81960000e-02
-  sysZ3D1134: -0.0
+  sysZ3D1134: 0.0
   sysZ3D1135: 0.0
   sysZ3D1136: 1.81960000e-02
-  sysZ3D1137: -0.0
+  sysZ3D1137: 0.0
   sysZ3D1138: 1.81960000e-02
-  sysZ3D1139: -0.0
+  sysZ3D1139: 0.0
   sysZ3D1140: -1.81960000e-02
-  sysZ3D1141: -0.0
-  sysZ3D1142: -0.0
+  sysZ3D1141: 0.0
+  sysZ3D1142: 0.0
   sysZ3D1143: -1.81960000e-02
   sysZ3D1144: 0.0
   sysZ3D1145: 0.0
   sysZ3D1146: 0.0
   sysZ3D1147: 0.0
-  sysZ3D1148: -0.0
+  sysZ3D1148: 0.0
   sysZ3D1149: 0.0
   sysZ3D1150: 0.0
   sysZ3D1151: 0.0
-  sysZ3D1152: -0.0
+  sysZ3D1152: 0.0
   sysZ3D1153: 0.0
   sysZ3D1154: -1.81960000e-02
   sysZ3D1155: 1.81960000e-02
@@ -3220,7 +3220,7 @@ bins:
   sysZ3D1159: -3.63920000e-02
   sysZ3D1160: 0.0
   sysZ3D1161: 0.0
-  sysZ3D1162: -0.0
+  sysZ3D1162: 0.0
   sysZ3D1163: 1.81960000e-02
   sysZ3D1164: 1.81960000e-02
   sysZ3D1165: 0.054588
@@ -3233,7 +3233,7 @@ bins:
   sysZ3D1172: 0.0
   sysZ3D1173: 0.0
   sysZ3D1174: 1.81960000e-02
-  sysZ3D1175: -0.0
+  sysZ3D1175: 0.0
   sysZ3D1176: 0.054588
   sysZ3D1177: 7.27840000e-02
   sysZ3D1178: 7.27840000e-02
@@ -3252,7 +3252,7 @@ bins:
   sysZ3D1191: 3.63920000e-02
   sysZ3D1192: 1.81960000e-02
   sysZ3D1193: 1.81960000e-02
-  sysZ3D1194: -0.0
+  sysZ3D1194: 0.0
   sysZ3D1195: 0.0
   sysZ3D1196: 1.81960000e-02
   sysZ3D1197: 1.81960000e-02
@@ -3262,27 +3262,27 @@ bins:
   sysZ3D1201: 0.0
   sysZ3D1202: 0.0
   sysZ3D1203: 1.81960000e-02
-  sysZ3D1204: -0.0
+  sysZ3D1204: 0.0
   sysZ3D1205: 1.81960000e-02
   sysZ3D1206: 0.0
   sysZ3D1207: 0.0
-  sysZ3D1208: -0.0
-  sysZ3D1209: -0.0
+  sysZ3D1208: 0.0
+  sysZ3D1209: 0.0
   sysZ3D1210: 0.0
   sysZ3D1211: 0.0
-  sysZ3D1212: -0.0
+  sysZ3D1212: 0.0
   sysZ3D1213: 0.0
   sysZ3D1214: 1.81960000e-02
   sysZ3D1215: 0.0
   sysZ3D1216: 0.0
   sysZ3D1217: 3.63920000e-02
-  sysZ3D1218: -0.0
+  sysZ3D1218: 0.0
   sysZ3D1219: 0.0
-  sysZ3D1220: -0.0
+  sysZ3D1220: 0.0
   sysZ3D1221: -1.81960000e-02
-  sysZ3D1222: -0.0
+  sysZ3D1222: 0.0
   sysZ3D1223: -3.63920000e-02
-  sysZ3D1224: -0.0
+  sysZ3D1224: 0.0
   sysZ3D1225: 0.0
   sysZ3D1226: 0.0
   sysZ3D1227: -1.81960000e-02
@@ -3290,27 +3290,27 @@ bins:
   sysZ3D1229: 0.0
   sysZ3D1230: 0.0
   sysZ3D1231: 0.0
-  sysZ3D1232: -0.0
-  sysZ3D1233: -0.0
-  sysZ3D1234: -0.0
-  sysZ3D1235: -0.0
+  sysZ3D1232: 0.0
+  sysZ3D1233: 0.0
+  sysZ3D1234: 0.0
+  sysZ3D1235: 0.0
   sysZ3D1236: 1.81960000e-02
   sysZ3D1237: 0.0
   sysZ3D1238: 0.0
   sysZ3D1239: 0.0
   sysZ3D1240: 0.0
-  sysZ3D1241: -0.0
+  sysZ3D1241: 0.0
   sysZ3D1242: 0.0
   sysZ3D1243: 0.0
   sysZ3D1244: 1.81960000e-02
-  sysZ3D1245: -0.0
+  sysZ3D1245: 0.0
   sysZ3D1246: 0.0
   sysZ3D1247: 0.0
   sysZ3D1248: 0.0
-  sysZ3D1249: -0.0
+  sysZ3D1249: 0.0
   sysZ3D1250: 1.81960000e-02
   sysZ3D1251: -3.63920000e-02
-  sysZ3D1252: -0.0
+  sysZ3D1252: 0.0
   sysZ3D1253: 0.0
   sysZ3D1254: 1.81960000e-02
   sysZ3D1255: -5.45880000e-02
@@ -3327,10 +3327,10 @@ bins:
   sysZ3D1266: -1.63764000e-01
   sysZ3D1267: -5.45880000e-02
   sysZ3D1268: 1.81960000e-02
-  sysZ3D1269: -0.0
+  sysZ3D1269: 0.0
   sysZ3D1270: 3.63920000e-02
   sysZ3D1271: -5.45880000e-02
-  sysZ3D1272: -0.0
+  sysZ3D1272: 0.0
   sysZ3D1273: 0.0
   sysZ3D1274: 0.054588
   sysZ3D1275: 9.09800000e-02
@@ -3339,7 +3339,7 @@ bins:
 - stat: 1.014552
   sysZ3D1001: -6.65280000e-02
   sysZ3D1002: -9.97920000e-02
-  sysZ3D1003: -0.0
+  sysZ3D1003: 0.0
   sysZ3D1004: 0.0
   sysZ3D1005: 0.0
   sysZ3D1006: 0.0
@@ -3356,96 +3356,96 @@ bins:
   sysZ3D1017: 0.0
   sysZ3D1018: 0.0
   sysZ3D1019: 0.0
-  sysZ3D1020: -0.0
-  sysZ3D1021: -0.0
-  sysZ3D1022: -0.0
+  sysZ3D1020: 0.0
+  sysZ3D1021: 0.0
+  sysZ3D1022: 0.0
   sysZ3D1023: -1.66320000e-02
   sysZ3D1024: 0.016632
   sysZ3D1025: -3.32640000e-02
   sysZ3D1026: 0.0
-  sysZ3D1027: -0.0
+  sysZ3D1027: 0.0
   sysZ3D1028: -1.66320000e-02
   sysZ3D1029: 0.0
   sysZ3D1030: 0.0
   sysZ3D1031: 0.016632
-  sysZ3D1032: -0.0
-  sysZ3D1033: -0.0
+  sysZ3D1032: 0.0
+  sysZ3D1033: 0.0
   sysZ3D1034: 0.0
   sysZ3D1035: 0.0
   sysZ3D1036: -1.66320000e-02
   sysZ3D1037: 0.016632
   sysZ3D1038: 0.0
-  sysZ3D1039: -0.0
-  sysZ3D1040: -0.0
+  sysZ3D1039: 0.0
+  sysZ3D1040: 0.0
   sysZ3D1041: 0.0
-  sysZ3D1042: -0.0
-  sysZ3D1043: -0.0
-  sysZ3D1044: -0.0
+  sysZ3D1042: 0.0
+  sysZ3D1043: 0.0
+  sysZ3D1044: 0.0
   sysZ3D1045: 0.0
-  sysZ3D1046: -0.0
+  sysZ3D1046: 0.0
   sysZ3D1047: 0.0
   sysZ3D1048: 0.0
-  sysZ3D1049: -0.0
+  sysZ3D1049: 0.0
   sysZ3D1050: 0.0
-  sysZ3D1051: -0.0
+  sysZ3D1051: 0.0
   sysZ3D1052: 0.0
   sysZ3D1053: 0.0
   sysZ3D1054: 0.0
   sysZ3D1055: 0.0
-  sysZ3D1056: -0.0
+  sysZ3D1056: 0.0
   sysZ3D1057: 0.0
   sysZ3D1058: 0.0
-  sysZ3D1059: -0.0
-  sysZ3D1060: -0.0
+  sysZ3D1059: 0.0
+  sysZ3D1060: 0.0
   sysZ3D1061: 0.0
   sysZ3D1062: 0.0
   sysZ3D1063: 0.0
   sysZ3D1064: 0.0
   sysZ3D1065: -1.66320000e-02
-  sysZ3D1066: -0.0
+  sysZ3D1066: 0.0
   sysZ3D1067: 0.0
   sysZ3D1068: -1.66320000e-02
-  sysZ3D1069: -0.0
-  sysZ3D1070: -0.0
+  sysZ3D1069: 0.0
+  sysZ3D1070: 0.0
   sysZ3D1071: -1.66320000e-02
   sysZ3D1072: 0.0
   sysZ3D1073: 0.0
   sysZ3D1074: 0.0
-  sysZ3D1075: -0.0
+  sysZ3D1075: 0.0
   sysZ3D1076: 0.0
   sysZ3D1077: 0.0
   sysZ3D1078: 0.016632
-  sysZ3D1079: -0.0
+  sysZ3D1079: 0.0
   sysZ3D1080: 0.0
-  sysZ3D1081: -0.0
-  sysZ3D1082: -0.0
-  sysZ3D1083: -0.0
+  sysZ3D1081: 0.0
+  sysZ3D1082: 0.0
+  sysZ3D1083: 0.0
   sysZ3D1084: 0.0
   sysZ3D1085: -1.66320000e-02
-  sysZ3D1086: -0.0
+  sysZ3D1086: 0.0
   sysZ3D1087: 0.016632
-  sysZ3D1088: -0.0
+  sysZ3D1088: 0.0
   sysZ3D1089: 0.016632
   sysZ3D1090: -1.66320000e-02
-  sysZ3D1091: -0.0
+  sysZ3D1091: 0.0
   sysZ3D1092: 0.0
-  sysZ3D1093: -0.0
+  sysZ3D1093: 0.0
   sysZ3D1094: 0.0
-  sysZ3D1095: -0.0
+  sysZ3D1095: 0.0
   sysZ3D1096: 0.0
   sysZ3D1097: 0.0
   sysZ3D1098: 0.0
-  sysZ3D1099: -0.0
-  sysZ3D1100: -0.0
+  sysZ3D1099: 0.0
+  sysZ3D1100: 0.0
   sysZ3D1101: 0.0
   sysZ3D1102: 0.0
   sysZ3D1103: 0.0
   sysZ3D1104: -9.97920000e-02
   sysZ3D1105: -1.24740000e+00
   sysZ3D1106: -6.65280000e-02
-  sysZ3D1107: -0.0
+  sysZ3D1107: 0.0
   sysZ3D1108: -4.82328000e-01
-  sysZ3D1109: -0.0
+  sysZ3D1109: 0.0
   sysZ3D1110: 0.0
   sysZ3D1111: -2.99376000e-01
   sysZ3D1112: 0.016632
@@ -3455,20 +3455,20 @@ bins:
   sysZ3D1116: 4.98960000e-02
   sysZ3D1117: -1.66320000e-02
   sysZ3D1118: -1.66320000e-02
-  sysZ3D1119: -0.0
+  sysZ3D1119: 0.0
   sysZ3D1120: 0.0
   sysZ3D1121: -3.32640000e-02
   sysZ3D1122: 0.0
   sysZ3D1123: -3.32640000e-02
   sysZ3D1124: 0.08316
   sysZ3D1125: 0.033264
-  sysZ3D1126: -0.0
+  sysZ3D1126: 0.0
   sysZ3D1127: -9.97920000e-02
   sysZ3D1128: -1.66320000e-02
   sysZ3D1129: -3.32640000e-02
   sysZ3D1130: 0.033264
   sysZ3D1131: 0.016632
-  sysZ3D1132: -0.0
+  sysZ3D1132: 0.0
   sysZ3D1133: -3.32640000e-02
   sysZ3D1134: 0.066528
   sysZ3D1135: 0.0
@@ -3476,20 +3476,20 @@ bins:
   sysZ3D1137: -1.66320000e-02
   sysZ3D1138: -1.66320000e-02
   sysZ3D1139: 0.033264
-  sysZ3D1140: -0.0
-  sysZ3D1141: -0.0
-  sysZ3D1142: -0.0
-  sysZ3D1143: -0.0
-  sysZ3D1144: -0.0
-  sysZ3D1145: -0.0
+  sysZ3D1140: 0.0
+  sysZ3D1141: 0.0
+  sysZ3D1142: 0.0
+  sysZ3D1143: 0.0
+  sysZ3D1144: 0.0
+  sysZ3D1145: 0.0
   sysZ3D1146: 0.0
-  sysZ3D1147: -0.0
-  sysZ3D1148: -0.0
+  sysZ3D1147: 0.0
+  sysZ3D1148: 0.0
   sysZ3D1149: 0.0
   sysZ3D1150: 0.0
   sysZ3D1151: 0.0
   sysZ3D1152: -1.66320000e-02
-  sysZ3D1153: -0.0
+  sysZ3D1153: 0.0
   sysZ3D1154: 0.0
   sysZ3D1155: -1.66320000e-02
   sysZ3D1156: 0.016632
@@ -3508,7 +3508,7 @@ bins:
   sysZ3D1169: 0.016632
   sysZ3D1170: 0.033264
   sysZ3D1171: 9.97920000e-02
-  sysZ3D1172: -0.0
+  sysZ3D1172: 0.0
   sysZ3D1173: 0.0
   sysZ3D1174: -1.66320000e-02
   sysZ3D1175: 0.0
@@ -3522,7 +3522,7 @@ bins:
   sysZ3D1183: 0.016632
   sysZ3D1184: 0.016632
   sysZ3D1185: 0.066528
-  sysZ3D1186: -0.0
+  sysZ3D1186: 0.0
   sysZ3D1187: -0.08316
   sysZ3D1188: -4.98960000e-02
   sysZ3D1189: -1.66320000e-02
@@ -3535,53 +3535,53 @@ bins:
   sysZ3D1196: 0.016632
   sysZ3D1197: 0.016632
   sysZ3D1198: 0.016632
-  sysZ3D1199: -0.0
-  sysZ3D1200: -0.0
+  sysZ3D1199: 0.0
+  sysZ3D1200: 0.0
   sysZ3D1201: 0.0
   sysZ3D1202: 0.0
   sysZ3D1203: 0.0
-  sysZ3D1204: -0.0
+  sysZ3D1204: 0.0
   sysZ3D1205: 0.0
   sysZ3D1206: 0.016632
   sysZ3D1207: 0.0
-  sysZ3D1208: -0.0
-  sysZ3D1209: -0.0
-  sysZ3D1210: -0.0
+  sysZ3D1208: 0.0
+  sysZ3D1209: 0.0
+  sysZ3D1210: 0.0
   sysZ3D1211: 0.0
   sysZ3D1212: 0.0
-  sysZ3D1213: -0.0
-  sysZ3D1214: -0.0
-  sysZ3D1215: -0.0
+  sysZ3D1213: 0.0
+  sysZ3D1214: 0.0
+  sysZ3D1215: 0.0
   sysZ3D1216: -1.66320000e-02
   sysZ3D1217: 0.016632
   sysZ3D1218: -1.66320000e-02
   sysZ3D1219: 0.016632
-  sysZ3D1220: -0.0
+  sysZ3D1220: 0.0
   sysZ3D1221: -1.66320000e-02
-  sysZ3D1222: -0.0
+  sysZ3D1222: 0.0
   sysZ3D1223: -1.66320000e-02
   sysZ3D1224: -1.66320000e-02
   sysZ3D1225: -1.66320000e-02
-  sysZ3D1226: -0.0
-  sysZ3D1227: -0.0
+  sysZ3D1226: 0.0
+  sysZ3D1227: 0.0
   sysZ3D1228: 0.0
-  sysZ3D1229: -0.0
+  sysZ3D1229: 0.0
   sysZ3D1230: 0.016632
   sysZ3D1231: 0.0
-  sysZ3D1232: -0.0
-  sysZ3D1233: -0.0
-  sysZ3D1234: -0.0
-  sysZ3D1235: -0.0
+  sysZ3D1232: 0.0
+  sysZ3D1233: 0.0
+  sysZ3D1234: 0.0
+  sysZ3D1235: 0.0
   sysZ3D1236: 0.0
   sysZ3D1237: 0.0
   sysZ3D1238: 0.0
   sysZ3D1239: 0.0
-  sysZ3D1240: -0.0
-  sysZ3D1241: -0.0
+  sysZ3D1240: 0.0
+  sysZ3D1241: 0.0
   sysZ3D1242: 0.0
   sysZ3D1243: 0.0
   sysZ3D1244: 0.016632
-  sysZ3D1245: -0.0
+  sysZ3D1245: 0.0
   sysZ3D1246: 0.016632
   sysZ3D1247: 0.0
   sysZ3D1248: -1.66320000e-02
@@ -3608,8 +3608,8 @@ bins:
   sysZ3D1269: -1.66320000e-02
   sysZ3D1270: 0.066528
   sysZ3D1271: -9.97920000e-02
-  sysZ3D1272: -0.0
-  sysZ3D1273: -0.0
+  sysZ3D1272: 0.0
+  sysZ3D1273: 0.0
   sysZ3D1274: 4.98960000e-02
   sysZ3D1275: 9.97920000e-02
   sys,uncor: 0.765072
@@ -3617,7 +3617,7 @@ bins:
 - stat: 8.89548000e-01
   sysZ3D1001: -0.06739
   sysZ3D1002: -5.39120000e-02
-  sysZ3D1003: -0.0
+  sysZ3D1003: 0.0
   sysZ3D1004: 0.0
   sysZ3D1005: 0.0
   sysZ3D1006: 0.0
@@ -3635,19 +3635,19 @@ bins:
   sysZ3D1018: 0.0
   sysZ3D1019: 0.0
   sysZ3D1020: 0.0
-  sysZ3D1021: -0.0
-  sysZ3D1022: -0.0
-  sysZ3D1023: -0.0
+  sysZ3D1021: 0.0
+  sysZ3D1022: 0.0
+  sysZ3D1023: 0.0
   sysZ3D1024: 1.34780000e-02
   sysZ3D1025: -1.34780000e-02
   sysZ3D1026: 0.0
-  sysZ3D1027: -0.0
+  sysZ3D1027: 0.0
   sysZ3D1028: 1.34780000e-02
   sysZ3D1029: 0.0
   sysZ3D1030: 0.0
   sysZ3D1031: -1.34780000e-02
-  sysZ3D1032: -0.0
-  sysZ3D1033: -0.0
+  sysZ3D1032: 0.0
+  sysZ3D1033: 0.0
   sysZ3D1034: 0.0
   sysZ3D1035: 0.0
   sysZ3D1036: 0.0
@@ -3657,36 +3657,36 @@ bins:
   sysZ3D1040: 1.34780000e-02
   sysZ3D1041: 0.0
   sysZ3D1042: 0.0
-  sysZ3D1043: -0.0
-  sysZ3D1044: -0.0
+  sysZ3D1043: 0.0
+  sysZ3D1044: 0.0
   sysZ3D1045: -1.34780000e-02
   sysZ3D1046: 1.34780000e-02
-  sysZ3D1047: -0.0
-  sysZ3D1048: -0.0
+  sysZ3D1047: 0.0
+  sysZ3D1048: 0.0
   sysZ3D1049: 0.0
   sysZ3D1050: 0.0
   sysZ3D1051: -1.34780000e-02
   sysZ3D1052: 0.0
-  sysZ3D1053: -0.0
-  sysZ3D1054: -0.0
+  sysZ3D1053: 0.0
+  sysZ3D1054: 0.0
   sysZ3D1055: 1.34780000e-02
-  sysZ3D1056: -0.0
+  sysZ3D1056: 0.0
   sysZ3D1057: 0.0
-  sysZ3D1058: -0.0
-  sysZ3D1059: -0.0
+  sysZ3D1058: 0.0
+  sysZ3D1059: 0.0
   sysZ3D1060: 0.0
-  sysZ3D1061: -0.0
+  sysZ3D1061: 0.0
   sysZ3D1062: 0.0
   sysZ3D1063: 0.0
   sysZ3D1064: -1.34780000e-02
   sysZ3D1065: 1.34780000e-02
-  sysZ3D1066: -0.0
+  sysZ3D1066: 0.0
   sysZ3D1067: 0.0
   sysZ3D1068: 0.0
-  sysZ3D1069: -0.0
+  sysZ3D1069: 0.0
   sysZ3D1070: 1.34780000e-02
-  sysZ3D1071: -0.0
-  sysZ3D1072: -0.0
+  sysZ3D1071: 0.0
+  sysZ3D1072: 0.0
   sysZ3D1073: 0.0
   sysZ3D1074: 0.0
   sysZ3D1075: -1.34780000e-02
@@ -3700,18 +3700,18 @@ bins:
   sysZ3D1083: 0.0
   sysZ3D1084: 0.0
   sysZ3D1085: 0.0
-  sysZ3D1086: -0.0
-  sysZ3D1087: -0.0
-  sysZ3D1088: -0.0
-  sysZ3D1089: -0.0
+  sysZ3D1086: 0.0
+  sysZ3D1087: 0.0
+  sysZ3D1088: 0.0
+  sysZ3D1089: 0.0
   sysZ3D1090: 0.0
-  sysZ3D1091: -0.0
-  sysZ3D1092: -0.0
+  sysZ3D1091: 0.0
+  sysZ3D1092: 0.0
   sysZ3D1093: 0.0
-  sysZ3D1094: -0.0
+  sysZ3D1094: 0.0
   sysZ3D1095: 1.34780000e-02
-  sysZ3D1096: -0.0
-  sysZ3D1097: -0.0
+  sysZ3D1096: 0.0
+  sysZ3D1097: 0.0
   sysZ3D1098: 0.0
   sysZ3D1099: -1.34780000e-02
   sysZ3D1100: -1.34780000e-02
@@ -3721,9 +3721,9 @@ bins:
   sysZ3D1104: -0.06739
   sysZ3D1105: -9.03026000e-01
   sysZ3D1106: -5.39120000e-02
-  sysZ3D1107: -0.0
+  sysZ3D1107: 0.0
   sysZ3D1108: -3.63906000e-01
-  sysZ3D1109: -0.0
+  sysZ3D1109: 0.0
   sysZ3D1110: 0.0
   sysZ3D1111: -1.88692000e-01
   sysZ3D1112: 1.34780000e-02
@@ -3733,14 +3733,14 @@ bins:
   sysZ3D1116: -1.34780000e-02
   sysZ3D1117: -1.34780000e-02
   sysZ3D1118: -1.34780000e-02
-  sysZ3D1119: -0.0
+  sysZ3D1119: 0.0
   sysZ3D1120: 0.0
   sysZ3D1121: -2.69560000e-02
   sysZ3D1122: -1.34780000e-02
   sysZ3D1123: 1.34780000e-02
   sysZ3D1124: 0.06739
   sysZ3D1125: -1.21302000e-01
-  sysZ3D1126: -0.0
+  sysZ3D1126: 0.0
   sysZ3D1127: -9.43460000e-02
   sysZ3D1128: -1.34780000e-02
   sysZ3D1129: 1.34780000e-02
@@ -3750,25 +3750,25 @@ bins:
   sysZ3D1133: 0.0
   sysZ3D1134: 1.34780000e-02
   sysZ3D1135: 1.34780000e-02
-  sysZ3D1136: -0.0
-  sysZ3D1137: -0.0
+  sysZ3D1136: 0.0
+  sysZ3D1137: 0.0
   sysZ3D1138: 1.34780000e-02
   sysZ3D1139: -1.34780000e-02
   sysZ3D1140: -1.34780000e-02
   sysZ3D1141: -1.34780000e-02
-  sysZ3D1142: -0.0
+  sysZ3D1142: 0.0
   sysZ3D1143: 0.0
-  sysZ3D1144: -0.0
+  sysZ3D1144: 0.0
   sysZ3D1145: 0.0
   sysZ3D1146: 0.0
   sysZ3D1147: 0.0
   sysZ3D1148: 0.0
   sysZ3D1149: 0.0
-  sysZ3D1150: -0.0
+  sysZ3D1150: 0.0
   sysZ3D1151: 0.0
-  sysZ3D1152: -0.0
-  sysZ3D1153: -0.0
-  sysZ3D1154: -0.0
+  sysZ3D1152: 0.0
+  sysZ3D1153: 0.0
+  sysZ3D1154: 0.0
   sysZ3D1155: 0.0
   sysZ3D1156: 0.0
   sysZ3D1157: -1.34780000e-02
@@ -3777,7 +3777,7 @@ bins:
   sysZ3D1160: -4.04340000e-02
   sysZ3D1161: -2.69560000e-02
   sysZ3D1162: 0.0
-  sysZ3D1163: -0.0
+  sysZ3D1163: 0.0
   sysZ3D1164: 1.34780000e-02
   sysZ3D1165: -1.34780000e-02
   sysZ3D1166: 2.69560000e-02
@@ -3787,9 +3787,9 @@ bins:
   sysZ3D1170: 1.34780000e-02
   sysZ3D1171: 9.43460000e-02
   sysZ3D1172: -1.34780000e-02
-  sysZ3D1173: -0.0
+  sysZ3D1173: 0.0
   sysZ3D1174: -5.39120000e-02
-  sysZ3D1175: -0.0
+  sysZ3D1175: 0.0
   sysZ3D1176: 0.06739
   sysZ3D1177: 0.080868
   sysZ3D1178: 0.06739
@@ -3809,7 +3809,7 @@ bins:
   sysZ3D1192: 1.34780000e-02
   sysZ3D1193: 5.39120000e-02
   sysZ3D1194: -2.69560000e-02
-  sysZ3D1195: -0.0
+  sysZ3D1195: 0.0
   sysZ3D1196: 1.34780000e-02
   sysZ3D1197: 1.34780000e-02
   sysZ3D1198: 1.34780000e-02
@@ -3818,37 +3818,37 @@ bins:
   sysZ3D1201: 0.0
   sysZ3D1202: 0.0
   sysZ3D1203: 0.0
-  sysZ3D1204: -0.0
+  sysZ3D1204: 0.0
   sysZ3D1205: 0.0
   sysZ3D1206: 0.0
   sysZ3D1207: 0.0
   sysZ3D1208: 0.0
-  sysZ3D1209: -0.0
-  sysZ3D1210: -0.0
-  sysZ3D1211: -0.0
-  sysZ3D1212: -0.0
+  sysZ3D1209: 0.0
+  sysZ3D1210: 0.0
+  sysZ3D1211: 0.0
+  sysZ3D1212: 0.0
   sysZ3D1213: -1.34780000e-02
   sysZ3D1214: 0.0
-  sysZ3D1215: -0.0
-  sysZ3D1216: -0.0
+  sysZ3D1215: 0.0
+  sysZ3D1216: 0.0
   sysZ3D1217: 1.34780000e-02
   sysZ3D1218: 0.0
   sysZ3D1219: 0.0
-  sysZ3D1220: -0.0
+  sysZ3D1220: 0.0
   sysZ3D1221: -1.34780000e-02
-  sysZ3D1222: -0.0
+  sysZ3D1222: 0.0
   sysZ3D1223: -1.34780000e-02
-  sysZ3D1224: -0.0
-  sysZ3D1225: -0.0
-  sysZ3D1226: -0.0
+  sysZ3D1224: 0.0
+  sysZ3D1225: 0.0
+  sysZ3D1226: 0.0
   sysZ3D1227: 1.34780000e-02
   sysZ3D1228: 1.34780000e-02
   sysZ3D1229: 1.34780000e-02
   sysZ3D1230: 0.0
   sysZ3D1231: 0.0
-  sysZ3D1232: -0.0
-  sysZ3D1233: -0.0
-  sysZ3D1234: -0.0
+  sysZ3D1232: 0.0
+  sysZ3D1233: 0.0
+  sysZ3D1234: 0.0
   sysZ3D1235: -1.34780000e-02
   sysZ3D1236: 0.0
   sysZ3D1237: 0.0
@@ -3861,7 +3861,7 @@ bins:
   sysZ3D1244: 1.34780000e-02
   sysZ3D1245: 0.0
   sysZ3D1246: 0.0
-  sysZ3D1247: -0.0
+  sysZ3D1247: 0.0
   sysZ3D1248: 0.0
   sysZ3D1249: -1.34780000e-02
   sysZ3D1250: 2.69560000e-02
@@ -3872,9 +3872,9 @@ bins:
   sysZ3D1255: -4.04340000e-02
   sysZ3D1256: -1.34780000e-02
   sysZ3D1257: 0.0
-  sysZ3D1258: -0.0
+  sysZ3D1258: 0.0
   sysZ3D1259: -2.69560000e-02
-  sysZ3D1260: -0.0
+  sysZ3D1260: 0.0
   sysZ3D1261: 0.0
   sysZ3D1262: 0.040434
   sysZ3D1263: 5.39120000e-02
@@ -3887,7 +3887,7 @@ bins:
   sysZ3D1270: 0.06739
   sysZ3D1271: -1.07824000e-01
   sysZ3D1272: -1.34780000e-02
-  sysZ3D1273: -0.0
+  sysZ3D1273: 0.0
   sysZ3D1274: -8.08680000e-02
   sysZ3D1275: 0.06739
   sys,uncor: 0.6739
@@ -3895,7 +3895,7 @@ bins:
 - stat: 0.713634
   sysZ3D1001: -0.04299
   sysZ3D1002: -1.71960000e-02
-  sysZ3D1003: -0.0
+  sysZ3D1003: 0.0
   sysZ3D1004: 0.0
   sysZ3D1005: 0.0
   sysZ3D1006: 0.0
@@ -3912,11 +3912,11 @@ bins:
   sysZ3D1017: 0.0
   sysZ3D1018: 0.0
   sysZ3D1019: 0.0
-  sysZ3D1020: -0.0
-  sysZ3D1021: -0.0
-  sysZ3D1022: -0.0
+  sysZ3D1020: 0.0
+  sysZ3D1021: 0.0
+  sysZ3D1022: 0.0
   sysZ3D1023: 0.008598
-  sysZ3D1024: -0.0
+  sysZ3D1024: 0.0
   sysZ3D1025: 0.008598
   sysZ3D1026: 0.008598
   sysZ3D1027: -8.59800000e-03
@@ -3924,84 +3924,84 @@ bins:
   sysZ3D1029: -8.59800000e-03
   sysZ3D1030: 0.0
   sysZ3D1031: -8.59800000e-03
-  sysZ3D1032: -0.0
-  sysZ3D1033: -0.0
+  sysZ3D1032: 0.0
+  sysZ3D1033: 0.0
   sysZ3D1034: 0.0
   sysZ3D1035: 0.0
-  sysZ3D1036: -0.0
+  sysZ3D1036: 0.0
   sysZ3D1037: 0.0
-  sysZ3D1038: -0.0
-  sysZ3D1039: -0.0
+  sysZ3D1038: 0.0
+  sysZ3D1039: 0.0
   sysZ3D1040: 0.0
-  sysZ3D1041: -0.0
+  sysZ3D1041: 0.0
   sysZ3D1042: 0.0
   sysZ3D1043: 0.0
-  sysZ3D1044: -0.0
-  sysZ3D1045: -0.0
+  sysZ3D1044: 0.0
+  sysZ3D1045: 0.0
   sysZ3D1046: 0.0
   sysZ3D1047: -8.59800000e-03
   sysZ3D1048: -8.59800000e-03
   sysZ3D1049: 0.0
   sysZ3D1050: 0.0
-  sysZ3D1051: -0.0
-  sysZ3D1052: -0.0
-  sysZ3D1053: -0.0
+  sysZ3D1051: 0.0
+  sysZ3D1052: 0.0
+  sysZ3D1053: 0.0
   sysZ3D1054: 0.0
   sysZ3D1055: -8.59800000e-03
-  sysZ3D1056: -0.0
-  sysZ3D1057: -0.0
-  sysZ3D1058: -0.0
+  sysZ3D1056: 0.0
+  sysZ3D1057: 0.0
+  sysZ3D1058: 0.0
   sysZ3D1059: -8.59800000e-03
   sysZ3D1060: -8.59800000e-03
   sysZ3D1061: -8.59800000e-03
   sysZ3D1062: -8.59800000e-03
   sysZ3D1063: 0.0
-  sysZ3D1064: -0.0
+  sysZ3D1064: 0.0
   sysZ3D1065: 0.0
-  sysZ3D1066: -0.0
+  sysZ3D1066: 0.0
   sysZ3D1067: -8.59800000e-03
   sysZ3D1068: 0.0
   sysZ3D1069: -8.59800000e-03
   sysZ3D1070: 0.008598
-  sysZ3D1071: -0.0
-  sysZ3D1072: -0.0
+  sysZ3D1071: 0.0
+  sysZ3D1072: 0.0
   sysZ3D1073: 0.008598
-  sysZ3D1074: -0.0
-  sysZ3D1075: -0.0
-  sysZ3D1076: -0.0
-  sysZ3D1077: -0.0
+  sysZ3D1074: 0.0
+  sysZ3D1075: 0.0
+  sysZ3D1076: 0.0
+  sysZ3D1077: 0.0
   sysZ3D1078: 0.0
   sysZ3D1079: -8.59800000e-03
   sysZ3D1080: 0.0
-  sysZ3D1081: -0.0
+  sysZ3D1081: 0.0
   sysZ3D1082: 0.0
   sysZ3D1083: 0.0
   sysZ3D1084: 0.0
   sysZ3D1085: 0.008598
   sysZ3D1086: 0.008598
   sysZ3D1087: 0.008598
-  sysZ3D1088: -0.0
+  sysZ3D1088: 0.0
   sysZ3D1089: -8.59800000e-03
-  sysZ3D1090: -0.0
+  sysZ3D1090: 0.0
   sysZ3D1091: 0.008598
-  sysZ3D1092: -0.0
+  sysZ3D1092: 0.0
   sysZ3D1093: -8.59800000e-03
   sysZ3D1094: 0.008598
   sysZ3D1095: 0.008598
   sysZ3D1096: 0.0
   sysZ3D1097: -8.59800000e-03
   sysZ3D1098: 0.0
-  sysZ3D1099: -0.0
+  sysZ3D1099: 0.0
   sysZ3D1100: 0.0
   sysZ3D1101: 0.008598
-  sysZ3D1102: -0.0
+  sysZ3D1102: 0.0
   sysZ3D1103: 0.0
   sysZ3D1104: -2.57940000e-02
   sysZ3D1105: -5.33076000e-01
   sysZ3D1106: -3.43920000e-02
-  sysZ3D1107: -0.0
+  sysZ3D1107: 0.0
   sysZ3D1108: -2.49342000e-01
-  sysZ3D1109: -0.0
+  sysZ3D1109: 0.0
   sysZ3D1110: 0.0
   sysZ3D1111: -0.12897
   sysZ3D1112: 0.008598
@@ -4011,11 +4011,11 @@ bins:
   sysZ3D1116: -0.04299
   sysZ3D1117: -8.59800000e-03
   sysZ3D1118: -8.59800000e-03
-  sysZ3D1119: -0.0
+  sysZ3D1119: 0.0
   sysZ3D1120: 0.0
   sysZ3D1121: -1.71960000e-02
   sysZ3D1122: -8.59800000e-03
-  sysZ3D1123: -0.0
+  sysZ3D1123: 0.0
   sysZ3D1124: 0.008598
   sysZ3D1125: 0.008598
   sysZ3D1126: 0.008598
@@ -4029,28 +4029,28 @@ bins:
   sysZ3D1134: 0.008598
   sysZ3D1135: -8.59800000e-03
   sysZ3D1136: 0.008598
-  sysZ3D1137: -0.0
-  sysZ3D1138: -0.0
+  sysZ3D1137: 0.0
+  sysZ3D1138: 0.0
   sysZ3D1139: 0.0
-  sysZ3D1140: -0.0
-  sysZ3D1141: -0.0
-  sysZ3D1142: -0.0
+  sysZ3D1140: 0.0
+  sysZ3D1141: 0.0
+  sysZ3D1142: 0.0
   sysZ3D1143: 0.0
   sysZ3D1144: 0.0
-  sysZ3D1145: -0.0
-  sysZ3D1146: -0.0
-  sysZ3D1147: -0.0
-  sysZ3D1148: -0.0
-  sysZ3D1149: -0.0
-  sysZ3D1150: -0.0
+  sysZ3D1145: 0.0
+  sysZ3D1146: 0.0
+  sysZ3D1147: 0.0
+  sysZ3D1148: 0.0
+  sysZ3D1149: 0.0
+  sysZ3D1150: 0.0
   sysZ3D1151: 0.0
   sysZ3D1152: -8.59800000e-03
-  sysZ3D1153: -0.0
+  sysZ3D1153: 0.0
   sysZ3D1154: 0.0
   sysZ3D1155: 0.0
   sysZ3D1156: 0.0
-  sysZ3D1157: -0.0
-  sysZ3D1158: -0.0
+  sysZ3D1157: 0.0
+  sysZ3D1158: 0.0
   sysZ3D1159: 0.008598
   sysZ3D1160: 0.008598
   sysZ3D1161: -8.59800000e-03
@@ -4067,7 +4067,7 @@ bins:
   sysZ3D1172: -1.71960000e-02
   sysZ3D1173: 0.0
   sysZ3D1174: -5.15880000e-02
-  sysZ3D1175: -0.0
+  sysZ3D1175: 0.0
   sysZ3D1176: 0.034392
   sysZ3D1177: 5.15880000e-02
   sysZ3D1178: 0.04299
@@ -4078,7 +4078,7 @@ bins:
   sysZ3D1183: 0.008598
   sysZ3D1184: 0.017196
   sysZ3D1185: 0.04299
-  sysZ3D1186: -0.0
+  sysZ3D1186: 0.0
   sysZ3D1187: -0.04299
   sysZ3D1188: -3.43920000e-02
   sysZ3D1189: -1.71960000e-02
@@ -4087,61 +4087,61 @@ bins:
   sysZ3D1192: 0.017196
   sysZ3D1193: 5.15880000e-02
   sysZ3D1194: 0.008598
-  sysZ3D1195: -0.0
+  sysZ3D1195: 0.0
   sysZ3D1196: 0.008598
   sysZ3D1197: 0.008598
   sysZ3D1198: 0.008598
-  sysZ3D1199: -0.0
+  sysZ3D1199: 0.0
   sysZ3D1200: 0.0
   sysZ3D1201: 0.008598
   sysZ3D1202: 0.0
   sysZ3D1203: 0.008598
-  sysZ3D1204: -0.0
+  sysZ3D1204: 0.0
   sysZ3D1205: 0.0
   sysZ3D1206: 0.0
   sysZ3D1207: 0.0
-  sysZ3D1208: -0.0
-  sysZ3D1209: -0.0
+  sysZ3D1208: 0.0
+  sysZ3D1209: 0.0
   sysZ3D1210: 0.0
   sysZ3D1211: 0.0
   sysZ3D1212: 0.0
   sysZ3D1213: 0.0
   sysZ3D1214: -8.59800000e-03
   sysZ3D1215: -8.59800000e-03
-  sysZ3D1216: -0.0
-  sysZ3D1217: -0.0
-  sysZ3D1218: -0.0
+  sysZ3D1216: 0.0
+  sysZ3D1217: 0.0
+  sysZ3D1218: 0.0
   sysZ3D1219: 0.008598
-  sysZ3D1220: -0.0
+  sysZ3D1220: 0.0
   sysZ3D1221: -8.59800000e-03
-  sysZ3D1222: -0.0
+  sysZ3D1222: 0.0
   sysZ3D1223: -8.59800000e-03
-  sysZ3D1224: -0.0
-  sysZ3D1225: -0.0
-  sysZ3D1226: -0.0
+  sysZ3D1224: 0.0
+  sysZ3D1225: 0.0
+  sysZ3D1226: 0.0
   sysZ3D1227: -1.71960000e-02
   sysZ3D1228: 0.0
   sysZ3D1229: 0.0
   sysZ3D1230: 0.0
   sysZ3D1231: 0.008598
-  sysZ3D1232: -0.0
-  sysZ3D1233: -0.0
-  sysZ3D1234: -0.0
-  sysZ3D1235: -0.0
+  sysZ3D1232: 0.0
+  sysZ3D1233: 0.0
+  sysZ3D1234: 0.0
+  sysZ3D1235: 0.0
   sysZ3D1236: 0.0
   sysZ3D1237: 0.0
-  sysZ3D1238: -0.0
-  sysZ3D1239: -0.0
-  sysZ3D1240: -0.0
-  sysZ3D1241: -0.0
+  sysZ3D1238: 0.0
+  sysZ3D1239: 0.0
+  sysZ3D1240: 0.0
+  sysZ3D1241: 0.0
   sysZ3D1242: 0.0
   sysZ3D1243: 0.0
   sysZ3D1244: 0.008598
   sysZ3D1245: -8.59800000e-03
-  sysZ3D1246: -0.0
-  sysZ3D1247: -0.0
+  sysZ3D1246: 0.0
+  sysZ3D1247: 0.0
   sysZ3D1248: 0.008598
-  sysZ3D1249: -0.0
+  sysZ3D1249: 0.0
   sysZ3D1250: 0.017196
   sysZ3D1251: -0.04299
   sysZ3D1252: 0.0
@@ -4149,7 +4149,7 @@ bins:
   sysZ3D1254: 0.008598
   sysZ3D1255: -2.57940000e-02
   sysZ3D1256: -1.71960000e-02
-  sysZ3D1257: -0.0
+  sysZ3D1257: 0.0
   sysZ3D1258: -8.59800000e-03
   sysZ3D1259: -3.43920000e-02
   sysZ3D1260: -1.71960000e-02
@@ -4161,11 +4161,11 @@ bins:
   sysZ3D1266: -7.73820000e-02
   sysZ3D1267: -3.43920000e-02
   sysZ3D1268: 0.0
-  sysZ3D1269: -0.0
+  sysZ3D1269: 0.0
   sysZ3D1270: 0.04299
   sysZ3D1271: -6.01860000e-02
   sysZ3D1272: -8.59800000e-03
-  sysZ3D1273: -0.0
+  sysZ3D1273: 0.0
   sysZ3D1274: -2.57940000e-02
   sysZ3D1275: 5.15880000e-02
   sys,uncor: 0.533076
@@ -4199,17 +4199,17 @@ bins:
   sysZ3D1026: 0.00586
   sysZ3D1027: -0.00586
   sysZ3D1028: -0.00293
-  sysZ3D1029: -0.0
-  sysZ3D1030: -0.0
-  sysZ3D1031: -0.0
+  sysZ3D1029: 0.0
+  sysZ3D1030: 0.0
+  sysZ3D1031: 0.0
   sysZ3D1032: 0.0
   sysZ3D1033: -0.00293
-  sysZ3D1034: -0.0
+  sysZ3D1034: 0.0
   sysZ3D1035: 0.00293
-  sysZ3D1036: -0.0
+  sysZ3D1036: 0.0
   sysZ3D1037: 0.00293
-  sysZ3D1038: -0.0
-  sysZ3D1039: -0.0
+  sysZ3D1038: 0.0
+  sysZ3D1039: 0.0
   sysZ3D1040: -0.00293
   sysZ3D1041: -0.00293
   sysZ3D1042: 0.00293
@@ -4225,51 +4225,51 @@ bins:
   sysZ3D1052: -0.00293
   sysZ3D1053: -0.00293
   sysZ3D1054: 0.0
-  sysZ3D1055: -0.0
+  sysZ3D1055: 0.0
   sysZ3D1056: 0.00293
   sysZ3D1057: -0.00293
   sysZ3D1058: -0.00586
   sysZ3D1059: 0.0
   sysZ3D1060: 0.0
   sysZ3D1061: -0.00293
-  sysZ3D1062: -0.0
+  sysZ3D1062: 0.0
   sysZ3D1063: -0.00293
   sysZ3D1064: 0.0
-  sysZ3D1065: -0.0
+  sysZ3D1065: 0.0
   sysZ3D1066: -0.00586
-  sysZ3D1067: -0.0
+  sysZ3D1067: 0.0
   sysZ3D1068: 0.0
   sysZ3D1069: 0.00293
   sysZ3D1070: -0.00293
   sysZ3D1071: -0.00293
   sysZ3D1072: -0.00293
-  sysZ3D1073: -0.0
+  sysZ3D1073: 0.0
   sysZ3D1074: 0.00293
   sysZ3D1075: 0.00293
-  sysZ3D1076: -0.0
+  sysZ3D1076: 0.0
   sysZ3D1077: -0.00586
   sysZ3D1078: -0.00293
   sysZ3D1079: 0.00293
-  sysZ3D1080: -0.0
+  sysZ3D1080: 0.0
   sysZ3D1081: 0.00293
-  sysZ3D1082: -0.0
+  sysZ3D1082: 0.0
   sysZ3D1083: 0.00293
   sysZ3D1084: 0.00586
-  sysZ3D1085: -0.0
+  sysZ3D1085: 0.0
   sysZ3D1086: 0.0
   sysZ3D1087: 0.00293
   sysZ3D1088: 0.0
-  sysZ3D1089: -0.0
-  sysZ3D1090: -0.0
+  sysZ3D1089: 0.0
+  sysZ3D1090: 0.0
   sysZ3D1091: 0.00586
   sysZ3D1092: -0.00293
-  sysZ3D1093: -0.0
+  sysZ3D1093: 0.0
   sysZ3D1094: 0.00879
   sysZ3D1095: 0.00586
-  sysZ3D1096: -0.0
+  sysZ3D1096: 0.0
   sysZ3D1097: 0.0
   sysZ3D1098: -0.00293
-  sysZ3D1099: -0.0
+  sysZ3D1099: 0.0
   sysZ3D1100: -0.00293
   sysZ3D1101: -0.00293
   sysZ3D1102: 0.0
@@ -4277,19 +4277,19 @@ bins:
   sysZ3D1104: -0.00879
   sysZ3D1105: -0.16408
   sysZ3D1106: -0.01172
-  sysZ3D1107: -0.0
+  sysZ3D1107: 0.0
   sysZ3D1108: -0.07911
-  sysZ3D1109: -0.0
+  sysZ3D1109: 0.0
   sysZ3D1110: 0.0
   sysZ3D1111: -0.04102
   sysZ3D1112: 0.0
   sysZ3D1113: 0.01465
   sysZ3D1114: -0.01758
   sysZ3D1115: 0.00879
-  sysZ3D1116: -0.0
+  sysZ3D1116: 0.0
   sysZ3D1117: -0.00293
   sysZ3D1118: -0.00293
-  sysZ3D1119: -0.0
+  sysZ3D1119: 0.0
   sysZ3D1120: 0.0
   sysZ3D1121: -0.00586
   sysZ3D1122: -0.00293
@@ -4307,31 +4307,31 @@ bins:
   sysZ3D1134: -0.00293
   sysZ3D1135: 0.0
   sysZ3D1136: 0.0
-  sysZ3D1137: -0.0
+  sysZ3D1137: 0.0
   sysZ3D1138: 0.00293
   sysZ3D1139: 0.00293
   sysZ3D1140: -0.00293
   sysZ3D1141: -0.00293
   sysZ3D1142: 0.0
-  sysZ3D1143: -0.0
+  sysZ3D1143: 0.0
   sysZ3D1144: 0.00293
   sysZ3D1145: 0.0
   sysZ3D1146: 0.0
-  sysZ3D1147: -0.0
-  sysZ3D1148: -0.0
-  sysZ3D1149: -0.0
+  sysZ3D1147: 0.0
+  sysZ3D1148: 0.0
+  sysZ3D1149: 0.0
   sysZ3D1150: 0.0
   sysZ3D1151: 0.0
-  sysZ3D1152: -0.0
-  sysZ3D1153: -0.0
+  sysZ3D1152: 0.0
+  sysZ3D1153: 0.0
   sysZ3D1154: -0.00293
   sysZ3D1155: 0.00293
-  sysZ3D1156: -0.0
-  sysZ3D1157: -0.0
-  sysZ3D1158: -0.0
-  sysZ3D1159: -0.0
-  sysZ3D1160: -0.0
-  sysZ3D1161: -0.0
+  sysZ3D1156: 0.0
+  sysZ3D1157: 0.0
+  sysZ3D1158: 0.0
+  sysZ3D1159: 0.0
+  sysZ3D1160: 0.0
+  sysZ3D1161: 0.0
   sysZ3D1162: 0.00586
   sysZ3D1163: 0.00293
   sysZ3D1164: -0.03223
@@ -4345,7 +4345,7 @@ bins:
   sysZ3D1172: -0.00879
   sysZ3D1173: -0.00293
   sysZ3D1174: -0.02637
-  sysZ3D1175: -0.0
+  sysZ3D1175: 0.0
   sysZ3D1176: 0.0293
   sysZ3D1177: 0.02637
   sysZ3D1178: 0.02051
@@ -4357,7 +4357,7 @@ bins:
   sysZ3D1184: 0.00586
   sysZ3D1185: 0.02637
   sysZ3D1186: 0.00293
-  sysZ3D1187: -0.0
+  sysZ3D1187: 0.0
   sysZ3D1188: -0.01758
   sysZ3D1189: -0.01172
   sysZ3D1190: 0.02051
@@ -4369,8 +4369,8 @@ bins:
   sysZ3D1196: 0.00293
   sysZ3D1197: 0.00293
   sysZ3D1198: 0.00293
-  sysZ3D1199: -0.0
-  sysZ3D1200: -0.0
+  sysZ3D1199: 0.0
+  sysZ3D1200: 0.0
   sysZ3D1201: 0.0
   sysZ3D1202: 0.0
   sysZ3D1203: 0.00293
@@ -4379,11 +4379,11 @@ bins:
   sysZ3D1206: 0.00293
   sysZ3D1207: 0.0
   sysZ3D1208: 0.0
-  sysZ3D1209: -0.0
+  sysZ3D1209: 0.0
   sysZ3D1210: 0.0
   sysZ3D1211: 0.0
-  sysZ3D1212: -0.0
-  sysZ3D1213: -0.0
+  sysZ3D1212: 0.0
+  sysZ3D1213: 0.0
   sysZ3D1214: -0.00586
   sysZ3D1215: -0.01465
   sysZ3D1216: 0.0
@@ -4394,31 +4394,31 @@ bins:
   sysZ3D1221: -0.00586
   sysZ3D1222: -0.00293
   sysZ3D1223: -0.00293
-  sysZ3D1224: -0.0
-  sysZ3D1225: -0.0
-  sysZ3D1226: -0.0
+  sysZ3D1224: 0.0
+  sysZ3D1225: 0.0
+  sysZ3D1226: 0.0
   sysZ3D1227: 0.0
   sysZ3D1228: 0.00293
-  sysZ3D1229: -0.0
+  sysZ3D1229: 0.0
   sysZ3D1230: 0.00293
   sysZ3D1231: 0.00586
   sysZ3D1232: -0.00293
   sysZ3D1233: -0.00293
-  sysZ3D1234: -0.0
+  sysZ3D1234: 0.0
   sysZ3D1235: -0.00293
   sysZ3D1236: 0.0
   sysZ3D1237: 0.0
-  sysZ3D1238: -0.0
+  sysZ3D1238: 0.0
   sysZ3D1239: 0.0
   sysZ3D1240: 0.0
-  sysZ3D1241: -0.0
+  sysZ3D1241: 0.0
   sysZ3D1242: 0.0
   sysZ3D1243: 0.0
   sysZ3D1244: 0.00879
   sysZ3D1245: -0.00293
-  sysZ3D1246: -0.0
-  sysZ3D1247: -0.0
-  sysZ3D1248: -0.0
+  sysZ3D1246: 0.0
+  sysZ3D1247: 0.0
+  sysZ3D1248: 0.0
   sysZ3D1249: -0.00293
   sysZ3D1250: 0.00879
   sysZ3D1251: -0.01758
@@ -4451,7 +4451,7 @@ bins:
 - stat: 1.279488
   sysZ3D1001: -9.13920000e-02
   sysZ3D1002: -9.13920000e-02
-  sysZ3D1003: -0.0
+  sysZ3D1003: 0.0
   sysZ3D1004: 0.0
   sysZ3D1005: 0.0
   sysZ3D1006: 0.0
@@ -4468,87 +4468,87 @@ bins:
   sysZ3D1017: 0.0
   sysZ3D1018: 0.0
   sysZ3D1019: 0.0
-  sysZ3D1020: -0.0
+  sysZ3D1020: 0.0
   sysZ3D1021: 0.0
   sysZ3D1022: 0.0
   sysZ3D1023: 0.0
-  sysZ3D1024: -0.0
+  sysZ3D1024: 0.0
   sysZ3D1025: 0.0
   sysZ3D1026: 0.0
-  sysZ3D1027: -0.0
+  sysZ3D1027: 0.0
   sysZ3D1028: 0.0
-  sysZ3D1029: -0.0
-  sysZ3D1030: -0.0
+  sysZ3D1029: 0.0
+  sysZ3D1030: 0.0
   sysZ3D1031: 0.0
   sysZ3D1032: 0.0
-  sysZ3D1033: -0.0
+  sysZ3D1033: 0.0
   sysZ3D1034: 0.0
-  sysZ3D1035: -0.0
-  sysZ3D1036: -0.0
+  sysZ3D1035: 0.0
+  sysZ3D1036: 0.0
   sysZ3D1037: 0.0
   sysZ3D1038: 0.0
   sysZ3D1039: 0.0
-  sysZ3D1040: -0.0
-  sysZ3D1041: -0.0
+  sysZ3D1040: 0.0
+  sysZ3D1041: 0.0
   sysZ3D1042: 0.0
   sysZ3D1043: 0.0
   sysZ3D1044: 0.0
   sysZ3D1045: 0.0
-  sysZ3D1046: -0.0
+  sysZ3D1046: 0.0
   sysZ3D1047: 0.0
   sysZ3D1048: 0.0
   sysZ3D1049: 0.0
   sysZ3D1050: 0.0
-  sysZ3D1051: -0.0
+  sysZ3D1051: 0.0
   sysZ3D1052: 0.0
-  sysZ3D1053: -0.0
-  sysZ3D1054: -0.0
-  sysZ3D1055: -0.0
-  sysZ3D1056: -0.0
-  sysZ3D1057: -0.0
+  sysZ3D1053: 0.0
+  sysZ3D1054: 0.0
+  sysZ3D1055: 0.0
+  sysZ3D1056: 0.0
+  sysZ3D1057: 0.0
   sysZ3D1058: 0.0
-  sysZ3D1059: -0.0
+  sysZ3D1059: 0.0
   sysZ3D1060: 0.0
-  sysZ3D1061: -0.0
+  sysZ3D1061: 0.0
   sysZ3D1062: 0.0
   sysZ3D1063: 0.0
-  sysZ3D1064: -0.0
-  sysZ3D1065: -0.0
-  sysZ3D1066: -0.0
-  sysZ3D1067: -0.0
+  sysZ3D1064: 0.0
+  sysZ3D1065: 0.0
+  sysZ3D1066: 0.0
+  sysZ3D1067: 0.0
   sysZ3D1068: 0.0
   sysZ3D1069: 0.0
-  sysZ3D1070: -0.0
+  sysZ3D1070: 0.0
   sysZ3D1071: 0.0
-  sysZ3D1072: -0.0
-  sysZ3D1073: -0.0
+  sysZ3D1072: 0.0
+  sysZ3D1073: 0.0
   sysZ3D1074: 0.0
   sysZ3D1075: 0.0
-  sysZ3D1076: -0.0
+  sysZ3D1076: 0.0
   sysZ3D1077: 0.0
   sysZ3D1078: 0.0
   sysZ3D1079: 0.0
-  sysZ3D1080: -0.0
-  sysZ3D1081: -0.0
+  sysZ3D1080: 0.0
+  sysZ3D1081: 0.0
   sysZ3D1082: 0.0
-  sysZ3D1083: -0.0
-  sysZ3D1084: -0.0
+  sysZ3D1083: 0.0
+  sysZ3D1084: 0.0
   sysZ3D1085: 0.0
-  sysZ3D1086: -0.0
+  sysZ3D1086: 0.0
   sysZ3D1087: 0.0
   sysZ3D1088: 0.0
   sysZ3D1089: 0.0
   sysZ3D1090: 0.0
-  sysZ3D1091: -0.0
-  sysZ3D1092: -0.0
+  sysZ3D1091: 0.0
+  sysZ3D1092: 0.0
   sysZ3D1093: 0.0
-  sysZ3D1094: -0.0
-  sysZ3D1095: -0.0
-  sysZ3D1096: -0.0
+  sysZ3D1094: 0.0
+  sysZ3D1095: 0.0
+  sysZ3D1096: 0.0
   sysZ3D1097: 0.0
-  sysZ3D1098: -0.0
+  sysZ3D1098: 0.0
   sysZ3D1099: 0.0
-  sysZ3D1100: -0.0
+  sysZ3D1100: 0.0
   sysZ3D1101: 0.0
   sysZ3D1102: 0.0
   sysZ3D1103: 0.0
@@ -4557,13 +4557,13 @@ bins:
   sysZ3D1106: -9.13920000e-02
   sysZ3D1107: -3.04640000e-02
   sysZ3D1108: -0.15232
-  sysZ3D1109: -0.0
+  sysZ3D1109: 0.0
   sysZ3D1110: 0.0
   sysZ3D1111: -0.15232
   sysZ3D1112: 0.0
   sysZ3D1113: 0.091392
   sysZ3D1114: -6.09280000e-02
-  sysZ3D1115: -0.0
+  sysZ3D1115: 0.0
   sysZ3D1116: -3.04640000e-02
   sysZ3D1117: -6.09280000e-02
   sysZ3D1118: 0.0
@@ -4572,31 +4572,31 @@ bins:
   sysZ3D1121: 0.0
   sysZ3D1122: 0.0
   sysZ3D1123: 0.0
-  sysZ3D1124: -0.0
-  sysZ3D1125: -0.0
+  sysZ3D1124: 0.0
+  sysZ3D1125: 0.0
   sysZ3D1126: 3.04640000e-02
   sysZ3D1127: -1.21856000e-01
   sysZ3D1128: 0.0
   sysZ3D1129: 0.0
-  sysZ3D1130: -0.0
-  sysZ3D1131: -0.0
+  sysZ3D1130: 0.0
+  sysZ3D1131: 0.0
   sysZ3D1132: 0.0
   sysZ3D1133: 0.0
   sysZ3D1134: 0.0
-  sysZ3D1135: -0.0
-  sysZ3D1136: -0.0
+  sysZ3D1135: 0.0
+  sysZ3D1136: 0.0
   sysZ3D1137: 0.0
-  sysZ3D1138: -0.0
-  sysZ3D1139: -0.0
+  sysZ3D1138: 0.0
+  sysZ3D1139: 0.0
   sysZ3D1140: -6.09280000e-02
-  sysZ3D1141: -0.0
-  sysZ3D1142: -0.0
+  sysZ3D1141: 0.0
+  sysZ3D1142: 0.0
   sysZ3D1143: 3.04640000e-02
-  sysZ3D1144: -0.0
+  sysZ3D1144: 0.0
   sysZ3D1145: 0.0
   sysZ3D1146: 0.0
-  sysZ3D1147: -0.0
-  sysZ3D1148: -0.0
+  sysZ3D1147: 0.0
+  sysZ3D1148: 0.0
   sysZ3D1149: 0.0
   sysZ3D1150: -3.04640000e-02
   sysZ3D1151: 6.09280000e-02
@@ -4604,22 +4604,22 @@ bins:
   sysZ3D1153: 0.0
   sysZ3D1154: -3.04640000e-02
   sysZ3D1155: -3.04640000e-02
-  sysZ3D1156: -0.0
+  sysZ3D1156: 0.0
   sysZ3D1157: 0.0
   sysZ3D1158: 0.0
   sysZ3D1159: -3.04640000e-02
-  sysZ3D1160: -0.0
-  sysZ3D1161: -0.0
+  sysZ3D1160: 0.0
+  sysZ3D1161: 0.0
   sysZ3D1162: 0.0
   sysZ3D1163: 0.0
-  sysZ3D1164: -0.0
-  sysZ3D1165: -0.0
+  sysZ3D1164: 0.0
+  sysZ3D1165: 0.0
   sysZ3D1166: 0.0
   sysZ3D1167: 0.0
   sysZ3D1168: 0.0
-  sysZ3D1169: -0.0
+  sysZ3D1169: 0.0
   sysZ3D1170: 0.0
-  sysZ3D1171: -0.0
+  sysZ3D1171: 0.0
   sysZ3D1172: 0.0
   sysZ3D1173: 0.0
   sysZ3D1174: 6.09280000e-02
@@ -4627,24 +4627,24 @@ bins:
   sysZ3D1176: -9.13920000e-02
   sysZ3D1177: -9.13920000e-02
   sysZ3D1178: -6.09280000e-02
-  sysZ3D1179: -0.0
+  sysZ3D1179: 0.0
   sysZ3D1180: 0.0
   sysZ3D1181: 3.04640000e-02
   sysZ3D1182: 0.0
   sysZ3D1183: 0.0
   sysZ3D1184: 3.04640000e-02
   sysZ3D1185: -3.04640000e-02
-  sysZ3D1186: -0.0
+  sysZ3D1186: 0.0
   sysZ3D1187: 3.04640000e-02
   sysZ3D1188: 6.09280000e-02
   sysZ3D1189: 3.04640000e-02
   sysZ3D1190: -6.09280000e-02
   sysZ3D1191: -3.04640000e-02
   sysZ3D1192: -3.04640000e-02
-  sysZ3D1193: -0.0
+  sysZ3D1193: 0.0
   sysZ3D1194: 1.21856000e-01
-  sysZ3D1195: -0.0
-  sysZ3D1196: -0.0
+  sysZ3D1195: 0.0
+  sysZ3D1196: 0.0
   sysZ3D1197: 0.0
   sysZ3D1198: 3.04640000e-02
   sysZ3D1199: 6.09280000e-02
@@ -4652,9 +4652,9 @@ bins:
   sysZ3D1201: 3.04640000e-02
   sysZ3D1202: 0.0
   sysZ3D1203: 6.09280000e-02
-  sysZ3D1204: -0.0
-  sysZ3D1205: -0.0
-  sysZ3D1206: -0.0
+  sysZ3D1204: 0.0
+  sysZ3D1205: 0.0
+  sysZ3D1206: 0.0
   sysZ3D1207: 0.0
   sysZ3D1208: 0.0
   sysZ3D1209: 0.0
@@ -4667,7 +4667,7 @@ bins:
   sysZ3D1216: -6.09280000e-02
   sysZ3D1217: -3.04640000e-02
   sysZ3D1218: -3.04640000e-02
-  sysZ3D1219: -0.0
+  sysZ3D1219: 0.0
   sysZ3D1220: 0.0
   sysZ3D1221: 0.0
   sysZ3D1222: 3.04640000e-02
@@ -4677,16 +4677,16 @@ bins:
   sysZ3D1226: -3.04640000e-02
   sysZ3D1227: -3.04640000e-02
   sysZ3D1228: -3.04640000e-02
-  sysZ3D1229: -0.0
-  sysZ3D1230: -0.0
-  sysZ3D1231: -0.0
+  sysZ3D1229: 0.0
+  sysZ3D1230: 0.0
+  sysZ3D1231: 0.0
   sysZ3D1232: 0.0
   sysZ3D1233: 0.0
   sysZ3D1234: 0.0
-  sysZ3D1235: -0.0
-  sysZ3D1236: -0.0
+  sysZ3D1235: 0.0
+  sysZ3D1236: 0.0
   sysZ3D1237: -3.04640000e-02
-  sysZ3D1238: -0.0
+  sysZ3D1238: 0.0
   sysZ3D1239: 0.0
   sysZ3D1240: 0.0
   sysZ3D1241: 0.0
@@ -4707,7 +4707,7 @@ bins:
   sysZ3D1256: -3.04640000e-02
   sysZ3D1257: -6.09280000e-02
   sysZ3D1258: 6.09280000e-02
-  sysZ3D1259: -0.0
+  sysZ3D1259: 0.0
   sysZ3D1260: 3.04640000e-02
   sysZ3D1261: 6.09280000e-02
   sysZ3D1262: 0.274176
@@ -4717,7 +4717,7 @@ bins:
   sysZ3D1266: -3.35104000e-01
   sysZ3D1267: 3.04640000e-02
   sysZ3D1268: 3.04640000e-02
-  sysZ3D1269: -0.0
+  sysZ3D1269: 0.0
   sysZ3D1270: 3.04640000e-02
   sysZ3D1271: -3.04640000e-02
   sysZ3D1272: 0.0
@@ -4729,7 +4729,7 @@ bins:
 - stat: 1.268232
   sysZ3D1001: -9.05880000e-02
   sysZ3D1002: -6.03920000e-02
-  sysZ3D1003: -0.0
+  sysZ3D1003: 0.0
   sysZ3D1004: 0.0
   sysZ3D1005: 0.0
   sysZ3D1006: 0.0
@@ -4746,96 +4746,96 @@ bins:
   sysZ3D1017: 0.0
   sysZ3D1018: 0.0
   sysZ3D1019: 0.0
-  sysZ3D1020: -0.0
-  sysZ3D1021: -0.0
-  sysZ3D1022: -0.0
+  sysZ3D1020: 0.0
+  sysZ3D1021: 0.0
+  sysZ3D1022: 0.0
   sysZ3D1023: -3.01960000e-02
   sysZ3D1024: 0.0
   sysZ3D1025: -3.01960000e-02
   sysZ3D1026: 0.0
-  sysZ3D1027: -0.0
-  sysZ3D1028: -0.0
-  sysZ3D1029: -0.0
+  sysZ3D1027: 0.0
+  sysZ3D1028: 0.0
+  sysZ3D1029: 0.0
   sysZ3D1030: 0.0
-  sysZ3D1031: -0.0
-  sysZ3D1032: -0.0
+  sysZ3D1031: 0.0
+  sysZ3D1032: 0.0
   sysZ3D1033: 0.0
-  sysZ3D1034: -0.0
+  sysZ3D1034: 0.0
   sysZ3D1035: 0.0
   sysZ3D1036: 0.0
-  sysZ3D1037: -0.0
+  sysZ3D1037: 0.0
   sysZ3D1038: 0.0
-  sysZ3D1039: -0.0
-  sysZ3D1040: -0.0
+  sysZ3D1039: 0.0
+  sysZ3D1040: 0.0
   sysZ3D1041: 0.0
   sysZ3D1042: 0.0
   sysZ3D1043: 0.0
-  sysZ3D1044: -0.0
+  sysZ3D1044: 0.0
   sysZ3D1045: 0.0
-  sysZ3D1046: -0.0
+  sysZ3D1046: 0.0
   sysZ3D1047: 0.0
-  sysZ3D1048: -0.0
+  sysZ3D1048: 0.0
   sysZ3D1049: 0.0
-  sysZ3D1050: -0.0
-  sysZ3D1051: -0.0
+  sysZ3D1050: 0.0
+  sysZ3D1051: 0.0
   sysZ3D1052: 0.0
-  sysZ3D1053: -0.0
-  sysZ3D1054: -0.0
-  sysZ3D1055: -0.0
-  sysZ3D1056: -0.0
-  sysZ3D1057: -0.0
-  sysZ3D1058: -0.0
-  sysZ3D1059: -0.0
+  sysZ3D1053: 0.0
+  sysZ3D1054: 0.0
+  sysZ3D1055: 0.0
+  sysZ3D1056: 0.0
+  sysZ3D1057: 0.0
+  sysZ3D1058: 0.0
+  sysZ3D1059: 0.0
   sysZ3D1060: 0.0
-  sysZ3D1061: -0.0
-  sysZ3D1062: -0.0
-  sysZ3D1063: -0.0
-  sysZ3D1064: -0.0
-  sysZ3D1065: -0.0
-  sysZ3D1066: -0.0
+  sysZ3D1061: 0.0
+  sysZ3D1062: 0.0
+  sysZ3D1063: 0.0
+  sysZ3D1064: 0.0
+  sysZ3D1065: 0.0
+  sysZ3D1066: 0.0
   sysZ3D1067: 0.0
-  sysZ3D1068: -0.0
+  sysZ3D1068: 0.0
   sysZ3D1069: 0.0
   sysZ3D1070: 0.0
   sysZ3D1071: 0.0
-  sysZ3D1072: -0.0
+  sysZ3D1072: 0.0
   sysZ3D1073: 0.0
   sysZ3D1074: 0.0
-  sysZ3D1075: -0.0
-  sysZ3D1076: -0.0
-  sysZ3D1077: -0.0
+  sysZ3D1075: 0.0
+  sysZ3D1076: 0.0
+  sysZ3D1077: 0.0
   sysZ3D1078: 0.0
   sysZ3D1079: 0.0
   sysZ3D1080: 0.0
   sysZ3D1081: 0.0
   sysZ3D1082: 0.0
   sysZ3D1083: 0.0
-  sysZ3D1084: -0.0
+  sysZ3D1084: 0.0
   sysZ3D1085: 0.0
-  sysZ3D1086: -0.0
-  sysZ3D1087: -0.0
+  sysZ3D1086: 0.0
+  sysZ3D1087: 0.0
   sysZ3D1088: 0.0
-  sysZ3D1089: -0.0
-  sysZ3D1090: -0.0
-  sysZ3D1091: -0.0
+  sysZ3D1089: 0.0
+  sysZ3D1090: 0.0
+  sysZ3D1091: 0.0
   sysZ3D1092: 0.0
-  sysZ3D1093: -0.0
-  sysZ3D1094: -0.0
-  sysZ3D1095: -0.0
-  sysZ3D1096: -0.0
+  sysZ3D1093: 0.0
+  sysZ3D1094: 0.0
+  sysZ3D1095: 0.0
+  sysZ3D1096: 0.0
   sysZ3D1097: 0.0
-  sysZ3D1098: -0.0
-  sysZ3D1099: -0.0
+  sysZ3D1098: 0.0
+  sysZ3D1099: 0.0
   sysZ3D1100: 0.0
-  sysZ3D1101: -0.0
-  sysZ3D1102: -0.0
+  sysZ3D1101: 0.0
+  sysZ3D1102: 0.0
   sysZ3D1103: 0.0
   sysZ3D1104: -2.71764000e-01
   sysZ3D1105: -8.15292000e-01
   sysZ3D1106: -9.05880000e-02
   sysZ3D1107: -3.01960000e-02
   sysZ3D1108: -2.11372000e-01
-  sysZ3D1109: -0.0
+  sysZ3D1109: 0.0
   sysZ3D1110: 0.0
   sysZ3D1111: -1.20784000e-01
   sysZ3D1112: 0.0
@@ -4849,34 +4849,34 @@ bins:
   sysZ3D1120: -3.01960000e-02
   sysZ3D1121: -1.20784000e-01
   sysZ3D1122: -6.03920000e-02
-  sysZ3D1123: -0.0
-  sysZ3D1124: -0.0
-  sysZ3D1125: -0.0
+  sysZ3D1123: 0.0
+  sysZ3D1124: 0.0
+  sysZ3D1125: 0.0
   sysZ3D1126: 6.03920000e-02
   sysZ3D1127: -9.05880000e-02
   sysZ3D1128: 0.0
   sysZ3D1129: 0.0
   sysZ3D1130: 0.0
-  sysZ3D1131: -0.0
+  sysZ3D1131: 0.0
   sysZ3D1132: 0.0
   sysZ3D1133: 0.0
   sysZ3D1134: 0.0
   sysZ3D1135: 0.0
-  sysZ3D1136: -0.0
+  sysZ3D1136: 0.0
   sysZ3D1137: 0.0
   sysZ3D1138: -3.01960000e-02
   sysZ3D1139: 3.01960000e-02
   sysZ3D1140: -3.01960000e-02
   sysZ3D1141: 0.0
   sysZ3D1142: -3.01960000e-02
-  sysZ3D1143: -0.0
-  sysZ3D1144: -0.0
-  sysZ3D1145: -0.0
-  sysZ3D1146: -0.0
-  sysZ3D1147: -0.0
+  sysZ3D1143: 0.0
+  sysZ3D1144: 0.0
+  sysZ3D1145: 0.0
+  sysZ3D1146: 0.0
+  sysZ3D1147: 0.0
   sysZ3D1148: 0.0
   sysZ3D1149: 3.01960000e-02
-  sysZ3D1150: -0.0
+  sysZ3D1150: 0.0
   sysZ3D1151: 3.01960000e-02
   sysZ3D1152: -3.01960000e-02
   sysZ3D1153: 0.0
@@ -4884,46 +4884,46 @@ bins:
   sysZ3D1155: -3.01960000e-02
   sysZ3D1156: 0.0
   sysZ3D1157: 0.0
-  sysZ3D1158: -0.0
+  sysZ3D1158: 0.0
   sysZ3D1159: 3.01960000e-02
-  sysZ3D1160: -0.0
-  sysZ3D1161: -0.0
+  sysZ3D1160: 0.0
+  sysZ3D1161: 0.0
   sysZ3D1162: 0.0
-  sysZ3D1163: -0.0
-  sysZ3D1164: -0.0
+  sysZ3D1163: 0.0
+  sysZ3D1164: 0.0
   sysZ3D1165: 0.0
   sysZ3D1166: 0.0
-  sysZ3D1167: -0.0
+  sysZ3D1167: 0.0
   sysZ3D1168: 0.0
-  sysZ3D1169: -0.0
+  sysZ3D1169: 0.0
   sysZ3D1170: 0.0
-  sysZ3D1171: -0.0
+  sysZ3D1171: 0.0
   sysZ3D1172: 0.0
   sysZ3D1173: 0.0
   sysZ3D1174: 6.03920000e-02
   sysZ3D1175: 0.0
   sysZ3D1176: 0.0
-  sysZ3D1177: -0.0
-  sysZ3D1178: -0.0
-  sysZ3D1179: -0.0
-  sysZ3D1180: -0.0
+  sysZ3D1177: 0.0
+  sysZ3D1178: 0.0
+  sysZ3D1179: 0.0
+  sysZ3D1180: 0.0
   sysZ3D1181: 0.0
   sysZ3D1182: 0.0
-  sysZ3D1183: -0.0
+  sysZ3D1183: 0.0
   sysZ3D1184: 0.0
-  sysZ3D1185: -0.0
-  sysZ3D1186: -0.0
-  sysZ3D1187: -0.0
+  sysZ3D1185: 0.0
+  sysZ3D1186: 0.0
+  sysZ3D1187: 0.0
   sysZ3D1188: 0.0
   sysZ3D1189: 0.0
-  sysZ3D1190: -0.0
+  sysZ3D1190: 0.0
   sysZ3D1191: -3.01960000e-02
-  sysZ3D1192: -0.0
-  sysZ3D1193: -0.0
+  sysZ3D1192: 0.0
+  sysZ3D1193: 0.0
   sysZ3D1194: 1.81176000e-01
   sysZ3D1195: -3.01960000e-02
-  sysZ3D1196: -0.0
-  sysZ3D1197: -0.0
+  sysZ3D1196: 0.0
+  sysZ3D1197: 0.0
   sysZ3D1198: 0.0
   sysZ3D1199: 3.01960000e-02
   sysZ3D1200: 6.03920000e-02
@@ -4932,8 +4932,8 @@ bins:
   sysZ3D1203: 6.03920000e-02
   sysZ3D1204: -3.01960000e-02
   sysZ3D1205: 0.0
-  sysZ3D1206: -0.0
-  sysZ3D1207: -0.0
+  sysZ3D1206: 0.0
+  sysZ3D1207: 0.0
   sysZ3D1208: 0.0
   sysZ3D1209: 0.0
   sysZ3D1210: 3.01960000e-02
@@ -4945,27 +4945,27 @@ bins:
   sysZ3D1216: -3.01960000e-02
   sysZ3D1217: -9.05880000e-02
   sysZ3D1218: -6.03920000e-02
-  sysZ3D1219: -0.0
+  sysZ3D1219: 0.0
   sysZ3D1220: 0.0
-  sysZ3D1221: -0.0
+  sysZ3D1221: 0.0
   sysZ3D1222: 0.0
   sysZ3D1223: -6.03920000e-02
   sysZ3D1224: -3.01960000e-02
   sysZ3D1225: -3.01960000e-02
   sysZ3D1226: -3.01960000e-02
   sysZ3D1227: -3.01960000e-02
-  sysZ3D1228: -0.0
-  sysZ3D1229: -0.0
-  sysZ3D1230: -0.0
-  sysZ3D1231: -0.0
+  sysZ3D1228: 0.0
+  sysZ3D1229: 0.0
+  sysZ3D1230: 0.0
+  sysZ3D1231: 0.0
   sysZ3D1232: 0.0
   sysZ3D1233: 0.0
   sysZ3D1234: 0.0
   sysZ3D1235: -3.01960000e-02
-  sysZ3D1236: -0.0
+  sysZ3D1236: 0.0
   sysZ3D1237: 0.0
   sysZ3D1238: -3.01960000e-02
-  sysZ3D1239: -0.0
+  sysZ3D1239: 0.0
   sysZ3D1240: 0.0
   sysZ3D1241: 0.0
   sysZ3D1242: 0.0
@@ -4995,11 +4995,11 @@ bins:
   sysZ3D1266: -0.30196
   sysZ3D1267: 3.01960000e-02
   sysZ3D1268: 3.01960000e-02
-  sysZ3D1269: -0.0
+  sysZ3D1269: 0.0
   sysZ3D1270: 3.01960000e-02
-  sysZ3D1271: -0.0
+  sysZ3D1271: 0.0
   sysZ3D1272: 0.0
-  sysZ3D1273: -0.0
+  sysZ3D1273: 0.0
   sysZ3D1274: -3.01960000e-02
   sysZ3D1275: 0.15098
   sys,uncor: 0.694508
@@ -5007,7 +5007,7 @@ bins:
 - stat: 1.269828
   sysZ3D1001: -9.07020000e-02
   sysZ3D1002: -6.04680000e-02
-  sysZ3D1003: -0.0
+  sysZ3D1003: 0.0
   sysZ3D1004: 0.0
   sysZ3D1005: 0.0
   sysZ3D1006: 0.0
@@ -5024,86 +5024,86 @@ bins:
   sysZ3D1017: 0.0
   sysZ3D1018: 0.0
   sysZ3D1019: 0.0
-  sysZ3D1020: -0.0
-  sysZ3D1021: -0.0
+  sysZ3D1020: 0.0
+  sysZ3D1021: 0.0
   sysZ3D1022: 0.0
-  sysZ3D1023: -0.0
+  sysZ3D1023: 0.0
   sysZ3D1024: 0.0
   sysZ3D1025: -3.02340000e-02
   sysZ3D1026: 0.0
-  sysZ3D1027: -0.0
-  sysZ3D1028: -0.0
-  sysZ3D1029: -0.0
+  sysZ3D1027: 0.0
+  sysZ3D1028: 0.0
+  sysZ3D1029: 0.0
   sysZ3D1030: 0.0
   sysZ3D1031: 0.0
   sysZ3D1032: 0.0
-  sysZ3D1033: -0.0
-  sysZ3D1034: -0.0
+  sysZ3D1033: 0.0
+  sysZ3D1034: 0.0
   sysZ3D1035: 0.0
   sysZ3D1036: 0.0
   sysZ3D1037: 0.0
-  sysZ3D1038: -0.0
+  sysZ3D1038: 0.0
   sysZ3D1039: 0.0
   sysZ3D1040: 0.0
-  sysZ3D1041: -0.0
-  sysZ3D1042: -0.0
-  sysZ3D1043: -0.0
+  sysZ3D1041: 0.0
+  sysZ3D1042: 0.0
+  sysZ3D1043: 0.0
   sysZ3D1044: 0.0
   sysZ3D1045: 0.0
   sysZ3D1046: 0.0
   sysZ3D1047: 0.0
   sysZ3D1048: 0.0
-  sysZ3D1049: -0.0
-  sysZ3D1050: -0.0
-  sysZ3D1051: -0.0
-  sysZ3D1052: -0.0
+  sysZ3D1049: 0.0
+  sysZ3D1050: 0.0
+  sysZ3D1051: 0.0
+  sysZ3D1052: 0.0
   sysZ3D1053: 0.0
   sysZ3D1054: 0.0
-  sysZ3D1055: -0.0
-  sysZ3D1056: -0.0
-  sysZ3D1057: -0.0
+  sysZ3D1055: 0.0
+  sysZ3D1056: 0.0
+  sysZ3D1057: 0.0
   sysZ3D1058: 0.0
-  sysZ3D1059: -0.0
-  sysZ3D1060: -0.0
+  sysZ3D1059: 0.0
+  sysZ3D1060: 0.0
   sysZ3D1061: 0.0
   sysZ3D1062: 0.0
-  sysZ3D1063: -0.0
+  sysZ3D1063: 0.0
   sysZ3D1064: 0.0
   sysZ3D1065: 0.0
-  sysZ3D1066: -0.0
-  sysZ3D1067: -0.0
-  sysZ3D1068: -0.0
+  sysZ3D1066: 0.0
+  sysZ3D1067: 0.0
+  sysZ3D1068: 0.0
   sysZ3D1069: 0.0
   sysZ3D1070: 0.0
   sysZ3D1071: 0.0
-  sysZ3D1072: -0.0
+  sysZ3D1072: 0.0
   sysZ3D1073: 0.0
   sysZ3D1074: 0.0
-  sysZ3D1075: -0.0
+  sysZ3D1075: 0.0
   sysZ3D1076: 0.0
   sysZ3D1077: 0.0
-  sysZ3D1078: -0.0
+  sysZ3D1078: 0.0
   sysZ3D1079: 0.0
-  sysZ3D1080: -0.0
-  sysZ3D1081: -0.0
-  sysZ3D1082: -0.0
+  sysZ3D1080: 0.0
+  sysZ3D1081: 0.0
+  sysZ3D1082: 0.0
   sysZ3D1083: 0.0
   sysZ3D1084: 0.0
   sysZ3D1085: 0.0
-  sysZ3D1086: -0.0
+  sysZ3D1086: 0.0
   sysZ3D1087: 0.0
   sysZ3D1088: 0.0
-  sysZ3D1089: -0.0
+  sysZ3D1089: 0.0
   sysZ3D1090: 0.0
-  sysZ3D1091: -0.0
+  sysZ3D1091: 0.0
   sysZ3D1092: 0.0
   sysZ3D1093: 0.0
   sysZ3D1094: 0.0
-  sysZ3D1095: -0.0
+  sysZ3D1095: 0.0
   sysZ3D1096: 0.0
   sysZ3D1097: -3.02340000e-02
   sysZ3D1098: 0.0
-  sysZ3D1099: -0.0
+  sysZ3D1099: 0.0
   sysZ3D1100: 0.0
   sysZ3D1101: 0.0
   sysZ3D1102: 0.0
@@ -5113,13 +5113,13 @@ bins:
   sysZ3D1106: -9.07020000e-02
   sysZ3D1107: -3.02340000e-02
   sysZ3D1108: -1.81404000e-01
-  sysZ3D1109: -0.0
+  sysZ3D1109: 0.0
   sysZ3D1110: 0.0
   sysZ3D1111: -9.07020000e-02
   sysZ3D1112: 0.0
   sysZ3D1113: 9.07020000e-02
   sysZ3D1114: -3.02340000e-02
-  sysZ3D1115: -0.0
+  sysZ3D1115: 0.0
   sysZ3D1116: -3.02340000e-02
   sysZ3D1117: -6.04680000e-02
   sysZ3D1118: -3.02340000e-02
@@ -5129,21 +5129,21 @@ bins:
   sysZ3D1122: -3.02340000e-02
   sysZ3D1123: -9.07020000e-02
   sysZ3D1124: 0.0
-  sysZ3D1125: -0.0
+  sysZ3D1125: 0.0
   sysZ3D1126: 6.04680000e-02
   sysZ3D1127: -9.07020000e-02
   sysZ3D1128: 0.0
   sysZ3D1129: 0.0
-  sysZ3D1130: -0.0
-  sysZ3D1131: -0.0
-  sysZ3D1132: -0.0
+  sysZ3D1130: 0.0
+  sysZ3D1131: 0.0
+  sysZ3D1132: 0.0
   sysZ3D1133: 0.0
   sysZ3D1134: 3.02340000e-02
   sysZ3D1135: -3.02340000e-02
   sysZ3D1136: 0.0
   sysZ3D1137: 3.02340000e-02
-  sysZ3D1138: -0.0
-  sysZ3D1139: -0.0
+  sysZ3D1138: 0.0
+  sysZ3D1139: 0.0
   sysZ3D1140: -3.02340000e-02
   sysZ3D1141: 0.0
   sysZ3D1142: 0.0
@@ -5152,15 +5152,15 @@ bins:
   sysZ3D1145: 0.0
   sysZ3D1146: 0.0
   sysZ3D1147: -3.02340000e-02
-  sysZ3D1148: -0.0
+  sysZ3D1148: 0.0
   sysZ3D1149: 0.0
-  sysZ3D1150: -0.0
-  sysZ3D1151: -0.0
+  sysZ3D1150: 0.0
+  sysZ3D1151: 0.0
   sysZ3D1152: -3.02340000e-02
   sysZ3D1153: 0.0
   sysZ3D1154: 0.0
   sysZ3D1155: 0.0
-  sysZ3D1156: -0.0
+  sysZ3D1156: 0.0
   sysZ3D1157: 3.02340000e-02
   sysZ3D1158: 0.0
   sysZ3D1159: 0.0
@@ -5168,29 +5168,29 @@ bins:
   sysZ3D1161: 3.02340000e-02
   sysZ3D1162: 0.0
   sysZ3D1163: 0.0
-  sysZ3D1164: -0.0
-  sysZ3D1165: -0.0
+  sysZ3D1164: 0.0
+  sysZ3D1165: 0.0
   sysZ3D1166: 0.0
   sysZ3D1167: 0.0
   sysZ3D1168: 0.0
-  sysZ3D1169: -0.0
+  sysZ3D1169: 0.0
   sysZ3D1170: 0.0
-  sysZ3D1171: -0.0
+  sysZ3D1171: 0.0
   sysZ3D1172: 0.0
-  sysZ3D1173: -0.0
+  sysZ3D1173: 0.0
   sysZ3D1174: 3.02340000e-02
   sysZ3D1175: 0.0
   sysZ3D1176: -6.04680000e-02
   sysZ3D1177: -9.07020000e-02
   sysZ3D1178: -3.02340000e-02
-  sysZ3D1179: -0.0
+  sysZ3D1179: 0.0
   sysZ3D1180: 0.0
   sysZ3D1181: 3.02340000e-02
-  sysZ3D1182: -0.0
-  sysZ3D1183: -0.0
+  sysZ3D1182: 0.0
+  sysZ3D1183: 0.0
   sysZ3D1184: 0.0
-  sysZ3D1185: -0.0
-  sysZ3D1186: -0.0
+  sysZ3D1185: 0.0
+  sysZ3D1186: 0.0
   sysZ3D1187: 3.02340000e-02
   sysZ3D1188: 3.02340000e-02
   sysZ3D1189: 3.02340000e-02
@@ -5203,49 +5203,49 @@ bins:
   sysZ3D1196: -3.02340000e-02
   sysZ3D1197: 0.0
   sysZ3D1198: 0.0
-  sysZ3D1199: -0.0
+  sysZ3D1199: 0.0
   sysZ3D1200: 6.04680000e-02
   sysZ3D1201: 3.02340000e-02
   sysZ3D1202: 0.0
   sysZ3D1203: 1.20936000e-01
   sysZ3D1204: 0.0
-  sysZ3D1205: -0.0
-  sysZ3D1206: -0.0
-  sysZ3D1207: -0.0
-  sysZ3D1208: -0.0
+  sysZ3D1205: 0.0
+  sysZ3D1206: 0.0
+  sysZ3D1207: 0.0
+  sysZ3D1208: 0.0
   sysZ3D1209: 0.0
   sysZ3D1210: 0.0
   sysZ3D1211: 0.0
-  sysZ3D1212: -0.0
+  sysZ3D1212: 0.0
   sysZ3D1213: 0.0
   sysZ3D1214: 0.0
   sysZ3D1215: 3.02340000e-02
-  sysZ3D1216: -0.0
+  sysZ3D1216: 0.0
   sysZ3D1217: -9.07020000e-02
   sysZ3D1218: -9.07020000e-02
-  sysZ3D1219: -0.0
-  sysZ3D1220: -0.0
+  sysZ3D1219: 0.0
+  sysZ3D1220: 0.0
   sysZ3D1221: -3.02340000e-02
-  sysZ3D1222: -0.0
+  sysZ3D1222: 0.0
   sysZ3D1223: 3.02340000e-02
   sysZ3D1224: 0.0
   sysZ3D1225: -3.02340000e-02
-  sysZ3D1226: -0.0
+  sysZ3D1226: 0.0
   sysZ3D1227: -9.07020000e-02
-  sysZ3D1228: -0.0
+  sysZ3D1228: 0.0
   sysZ3D1229: 0.0
-  sysZ3D1230: -0.0
-  sysZ3D1231: -0.0
+  sysZ3D1230: 0.0
+  sysZ3D1231: 0.0
   sysZ3D1232: 0.0
-  sysZ3D1233: -0.0
+  sysZ3D1233: 0.0
   sysZ3D1234: 0.0
-  sysZ3D1235: -0.0
+  sysZ3D1235: 0.0
   sysZ3D1236: 0.0
   sysZ3D1237: -3.02340000e-02
-  sysZ3D1238: -0.0
-  sysZ3D1239: -0.0
+  sysZ3D1238: 0.0
+  sysZ3D1239: 0.0
   sysZ3D1240: 0.0
-  sysZ3D1241: -0.0
+  sysZ3D1241: 0.0
   sysZ3D1242: 0.0
   sysZ3D1243: 0.0
   sysZ3D1244: -6.04680000e-02
@@ -5277,7 +5277,7 @@ bins:
   sysZ3D1270: 3.02340000e-02
   sysZ3D1271: 0.0
   sysZ3D1272: 0.0
-  sysZ3D1273: -0.0
+  sysZ3D1273: 0.0
   sysZ3D1274: -3.02340000e-02
   sysZ3D1275: 0.15117
   sys,uncor: 6.65148000e-01
@@ -5285,7 +5285,7 @@ bins:
 - stat: 1.292838
   sysZ3D1001: -9.01980000e-02
   sysZ3D1002: -3.00660000e-02
-  sysZ3D1003: -0.0
+  sysZ3D1003: 0.0
   sysZ3D1004: 0.0
   sysZ3D1005: 0.0
   sysZ3D1006: 0.0
@@ -5303,95 +5303,95 @@ bins:
   sysZ3D1018: 0.0
   sysZ3D1019: 0.0
   sysZ3D1020: 0.0
-  sysZ3D1021: -0.0
+  sysZ3D1021: 0.0
   sysZ3D1022: 0.0
   sysZ3D1023: -3.00660000e-02
   sysZ3D1024: 0.0
   sysZ3D1025: -3.00660000e-02
   sysZ3D1026: 0.0
-  sysZ3D1027: -0.0
+  sysZ3D1027: 0.0
   sysZ3D1028: 0.0
-  sysZ3D1029: -0.0
-  sysZ3D1030: -0.0
-  sysZ3D1031: -0.0
-  sysZ3D1032: -0.0
+  sysZ3D1029: 0.0
+  sysZ3D1030: 0.0
+  sysZ3D1031: 0.0
+  sysZ3D1032: 0.0
   sysZ3D1033: 0.0
-  sysZ3D1034: -0.0
-  sysZ3D1035: -0.0
-  sysZ3D1036: -0.0
+  sysZ3D1034: 0.0
+  sysZ3D1035: 0.0
+  sysZ3D1036: 0.0
   sysZ3D1037: 0.0
   sysZ3D1038: 0.0
-  sysZ3D1039: -0.0
+  sysZ3D1039: 0.0
   sysZ3D1040: 0.0
-  sysZ3D1041: -0.0
+  sysZ3D1041: 0.0
   sysZ3D1042: 0.0
   sysZ3D1043: 0.0
-  sysZ3D1044: -0.0
+  sysZ3D1044: 0.0
   sysZ3D1045: 0.0
-  sysZ3D1046: -0.0
+  sysZ3D1046: 0.0
   sysZ3D1047: 0.0
   sysZ3D1048: 0.0
-  sysZ3D1049: -0.0
+  sysZ3D1049: 0.0
   sysZ3D1050: 0.0
   sysZ3D1051: 0.0
   sysZ3D1052: 0.0
   sysZ3D1053: 0.0
   sysZ3D1054: 0.0
-  sysZ3D1055: -0.0
-  sysZ3D1056: -0.0
+  sysZ3D1055: 0.0
+  sysZ3D1056: 0.0
   sysZ3D1057: 0.0
-  sysZ3D1058: -0.0
+  sysZ3D1058: 0.0
   sysZ3D1059: 0.0
-  sysZ3D1060: -0.0
+  sysZ3D1060: 0.0
   sysZ3D1061: 0.0
-  sysZ3D1062: -0.0
+  sysZ3D1062: 0.0
   sysZ3D1063: 0.0
-  sysZ3D1064: -0.0
+  sysZ3D1064: 0.0
   sysZ3D1065: 0.0
   sysZ3D1066: 0.0
-  sysZ3D1067: -0.0
+  sysZ3D1067: 0.0
   sysZ3D1068: 0.0
   sysZ3D1069: 0.0
   sysZ3D1070: 0.0
   sysZ3D1071: 0.0
   sysZ3D1072: 0.0
-  sysZ3D1073: -0.0
+  sysZ3D1073: 0.0
   sysZ3D1074: 0.0
   sysZ3D1075: 0.0
-  sysZ3D1076: -0.0
-  sysZ3D1077: -0.0
+  sysZ3D1076: 0.0
+  sysZ3D1077: 0.0
   sysZ3D1078: 0.030066
   sysZ3D1079: 0.0
   sysZ3D1080: 0.0
   sysZ3D1081: 0.0
-  sysZ3D1082: -0.0
+  sysZ3D1082: 0.0
   sysZ3D1083: 0.0
-  sysZ3D1084: -0.0
-  sysZ3D1085: -0.0
-  sysZ3D1086: -0.0
-  sysZ3D1087: -0.0
+  sysZ3D1084: 0.0
+  sysZ3D1085: 0.0
+  sysZ3D1086: 0.0
+  sysZ3D1087: 0.0
   sysZ3D1088: 0.0
-  sysZ3D1089: -0.0
+  sysZ3D1089: 0.0
   sysZ3D1090: 0.0
   sysZ3D1091: 0.0
   sysZ3D1092: 0.0
-  sysZ3D1093: -0.0
-  sysZ3D1094: -0.0
-  sysZ3D1095: -0.0
+  sysZ3D1093: 0.0
+  sysZ3D1094: 0.0
+  sysZ3D1095: 0.0
   sysZ3D1096: 0.0
   sysZ3D1097: 0.0
   sysZ3D1098: 0.0
   sysZ3D1099: 0.0
-  sysZ3D1100: -0.0
-  sysZ3D1101: -0.0
-  sysZ3D1102: -0.0
-  sysZ3D1103: -0.0
+  sysZ3D1100: 0.0
+  sysZ3D1101: 0.0
+  sysZ3D1102: 0.0
+  sysZ3D1103: 0.0
   sysZ3D1104: -2.40528000e-01
   sysZ3D1105: -7.81716000e-01
   sysZ3D1106: -9.01980000e-02
   sysZ3D1107: -3.00660000e-02
   sysZ3D1108: -1.80396000e-01
-  sysZ3D1109: -0.0
+  sysZ3D1109: 0.0
   sysZ3D1110: 0.0
   sysZ3D1111: -1.50330000e-01
   sysZ3D1112: 0.0
@@ -5399,59 +5399,59 @@ bins:
   sysZ3D1114: -3.00660000e-02
   sysZ3D1115: -3.00660000e-02
   sysZ3D1116: -6.01320000e-02
-  sysZ3D1117: -0.0
+  sysZ3D1117: 0.0
   sysZ3D1118: -3.00660000e-02
   sysZ3D1119: -3.00660000e-02
   sysZ3D1120: -9.01980000e-02
   sysZ3D1121: -1.20264000e-01
   sysZ3D1122: 0.030066
   sysZ3D1123: 0.030066
-  sysZ3D1124: -0.0
-  sysZ3D1125: -0.0
+  sysZ3D1124: 0.0
+  sysZ3D1125: 0.0
   sysZ3D1126: 0.060132
   sysZ3D1127: -9.01980000e-02
   sysZ3D1128: 0.0
   sysZ3D1129: 0.0
-  sysZ3D1130: -0.0
-  sysZ3D1131: -0.0
+  sysZ3D1130: 0.0
+  sysZ3D1131: 0.0
   sysZ3D1132: 0.0
-  sysZ3D1133: -0.0
-  sysZ3D1134: -0.0
-  sysZ3D1135: -0.0
-  sysZ3D1136: -0.0
-  sysZ3D1137: -0.0
+  sysZ3D1133: 0.0
+  sysZ3D1134: 0.0
+  sysZ3D1135: 0.0
+  sysZ3D1136: 0.0
+  sysZ3D1137: 0.0
   sysZ3D1138: -3.00660000e-02
   sysZ3D1139: 0.030066
   sysZ3D1140: 0.030066
   sysZ3D1141: 0.0
-  sysZ3D1142: -0.0
+  sysZ3D1142: 0.0
   sysZ3D1143: 0.0
-  sysZ3D1144: -0.0
+  sysZ3D1144: 0.0
   sysZ3D1145: 0.0
   sysZ3D1146: 0.0
   sysZ3D1147: 0.030066
   sysZ3D1148: -3.00660000e-02
-  sysZ3D1149: -0.0
+  sysZ3D1149: 0.0
   sysZ3D1150: 0.030066
-  sysZ3D1151: -0.0
+  sysZ3D1151: 0.0
   sysZ3D1152: 0.030066
   sysZ3D1153: 0.0
-  sysZ3D1154: -0.0
+  sysZ3D1154: 0.0
   sysZ3D1155: 0.030066
   sysZ3D1156: 0.0
-  sysZ3D1157: -0.0
+  sysZ3D1157: 0.0
   sysZ3D1158: 0.030066
   sysZ3D1159: -3.00660000e-02
   sysZ3D1160: 0.030066
   sysZ3D1161: 0.0
   sysZ3D1162: -3.00660000e-02
   sysZ3D1163: -3.00660000e-02
-  sysZ3D1164: -0.0
-  sysZ3D1165: -0.0
+  sysZ3D1164: 0.0
+  sysZ3D1165: 0.0
   sysZ3D1166: 0.0
-  sysZ3D1167: -0.0
+  sysZ3D1167: 0.0
   sysZ3D1168: 0.030066
-  sysZ3D1169: -0.0
+  sysZ3D1169: 0.0
   sysZ3D1170: 0.030066
   sysZ3D1171: 0.0
   sysZ3D1172: 0.030066
@@ -5461,23 +5461,23 @@ bins:
   sysZ3D1176: -6.01320000e-02
   sysZ3D1177: -6.01320000e-02
   sysZ3D1178: -3.00660000e-02
-  sysZ3D1179: -0.0
+  sysZ3D1179: 0.0
   sysZ3D1180: 0.0
   sysZ3D1181: 0.030066
-  sysZ3D1182: -0.0
+  sysZ3D1182: 0.0
   sysZ3D1183: 0.0
   sysZ3D1184: 0.0
   sysZ3D1185: 0.0
-  sysZ3D1186: -0.0
+  sysZ3D1186: 0.0
   sysZ3D1187: 0.0
   sysZ3D1188: 0.030066
   sysZ3D1189: 0.0
   sysZ3D1190: -3.00660000e-02
   sysZ3D1191: -3.00660000e-02
-  sysZ3D1192: -0.0
-  sysZ3D1193: -0.0
+  sysZ3D1192: 0.0
+  sysZ3D1193: 0.0
   sysZ3D1194: 0.240528
-  sysZ3D1195: -0.0
+  sysZ3D1195: 0.0
   sysZ3D1196: 0.0
   sysZ3D1197: 0.0
   sysZ3D1198: -3.00660000e-02
@@ -5486,11 +5486,11 @@ bins:
   sysZ3D1201: 0.030066
   sysZ3D1202: 0.0
   sysZ3D1203: 1.50330000e-01
-  sysZ3D1204: -0.0
-  sysZ3D1205: -0.0
+  sysZ3D1204: 0.0
+  sysZ3D1205: 0.0
   sysZ3D1206: 0.0
-  sysZ3D1207: -0.0
-  sysZ3D1208: -0.0
+  sysZ3D1207: 0.0
+  sysZ3D1208: 0.0
   sysZ3D1209: 0.0
   sysZ3D1210: 0.030066
   sysZ3D1211: 0.0
@@ -5501,34 +5501,34 @@ bins:
   sysZ3D1216: 0.0
   sysZ3D1217: -6.01320000e-02
   sysZ3D1218: -1.20264000e-01
-  sysZ3D1219: -0.0
-  sysZ3D1220: -0.0
+  sysZ3D1219: 0.0
+  sysZ3D1220: 0.0
   sysZ3D1221: -3.00660000e-02
   sysZ3D1222: 0.0
   sysZ3D1223: 0.030066
   sysZ3D1224: 0.0
-  sysZ3D1225: -0.0
+  sysZ3D1225: 0.0
   sysZ3D1226: -3.00660000e-02
   sysZ3D1227: -9.01980000e-02
   sysZ3D1228: -6.01320000e-02
-  sysZ3D1229: -0.0
-  sysZ3D1230: -0.0
-  sysZ3D1231: -0.0
-  sysZ3D1232: -0.0
-  sysZ3D1233: -0.0
+  sysZ3D1229: 0.0
+  sysZ3D1230: 0.0
+  sysZ3D1231: 0.0
+  sysZ3D1232: 0.0
+  sysZ3D1233: 0.0
   sysZ3D1234: 0.0
   sysZ3D1235: 0.0
   sysZ3D1236: 0.0
   sysZ3D1237: 0.0
   sysZ3D1238: -3.00660000e-02
-  sysZ3D1239: -0.0
-  sysZ3D1240: -0.0
+  sysZ3D1239: 0.0
+  sysZ3D1240: 0.0
   sysZ3D1241: 0.0
   sysZ3D1242: 0.0
   sysZ3D1243: 0.0
-  sysZ3D1244: -0.0
+  sysZ3D1244: 0.0
   sysZ3D1245: 0.0
-  sysZ3D1246: -0.0
+  sysZ3D1246: 0.0
   sysZ3D1247: 0.0
   sysZ3D1248: 0.030066
   sysZ3D1249: 0.030066
@@ -5543,7 +5543,7 @@ bins:
   sysZ3D1258: -6.01320000e-02
   sysZ3D1259: -1.50330000e-01
   sysZ3D1260: -6.01320000e-02
-  sysZ3D1261: -0.0
+  sysZ3D1261: 0.0
   sysZ3D1262: 1.50330000e-01
   sysZ3D1263: 1.80396000e-01
   sysZ3D1264: 1.80396000e-01
@@ -5555,7 +5555,7 @@ bins:
   sysZ3D1270: 0.030066
   sysZ3D1271: 0.030066
   sysZ3D1272: 0.0
-  sysZ3D1273: -0.0
+  sysZ3D1273: 0.0
   sysZ3D1274: -6.01320000e-02
   sysZ3D1275: 1.50330000e-01
   sys,uncor: 7.21584000e-01
@@ -5563,7 +5563,7 @@ bins:
 - stat: 1.26824200e+00
   sysZ3D1001: -8.84820000e-02
   sysZ3D1002: -2.94940000e-02
-  sysZ3D1003: -0.0
+  sysZ3D1003: 0.0
   sysZ3D1004: 0.0
   sysZ3D1005: 0.0
   sysZ3D1006: 0.0
@@ -5580,108 +5580,108 @@ bins:
   sysZ3D1017: 0.0
   sysZ3D1018: 0.0
   sysZ3D1019: 0.0
-  sysZ3D1020: -0.0
-  sysZ3D1021: -0.0
+  sysZ3D1020: 0.0
+  sysZ3D1021: 0.0
   sysZ3D1022: 0.0
   sysZ3D1023: -2.94940000e-02
   sysZ3D1024: 0.029494
   sysZ3D1025: -5.89880000e-02
   sysZ3D1026: 0.029494
   sysZ3D1027: -2.94940000e-02
-  sysZ3D1028: -0.0
+  sysZ3D1028: 0.0
   sysZ3D1029: 0.0
-  sysZ3D1030: -0.0
+  sysZ3D1030: 0.0
   sysZ3D1031: 0.0
-  sysZ3D1032: -0.0
+  sysZ3D1032: 0.0
   sysZ3D1033: 0.0
   sysZ3D1034: 0.0
-  sysZ3D1035: -0.0
+  sysZ3D1035: 0.0
   sysZ3D1036: 0.0
-  sysZ3D1037: -0.0
-  sysZ3D1038: -0.0
+  sysZ3D1037: 0.0
+  sysZ3D1038: 0.0
   sysZ3D1039: 0.0
-  sysZ3D1040: -0.0
-  sysZ3D1041: -0.0
+  sysZ3D1040: 0.0
+  sysZ3D1041: 0.0
   sysZ3D1042: 0.0
-  sysZ3D1043: -0.0
-  sysZ3D1044: -0.0
+  sysZ3D1043: 0.0
+  sysZ3D1044: 0.0
   sysZ3D1045: 0.0
-  sysZ3D1046: -0.0
-  sysZ3D1047: -0.0
+  sysZ3D1046: 0.0
+  sysZ3D1047: 0.0
   sysZ3D1048: 0.0
   sysZ3D1049: 0.0
-  sysZ3D1050: -0.0
+  sysZ3D1050: 0.0
   sysZ3D1051: 0.0
-  sysZ3D1052: -0.0
+  sysZ3D1052: 0.0
   sysZ3D1053: 0.029494
   sysZ3D1054: 0.0
-  sysZ3D1055: -0.0
-  sysZ3D1056: -0.0
-  sysZ3D1057: -0.0
+  sysZ3D1055: 0.0
+  sysZ3D1056: 0.0
+  sysZ3D1057: 0.0
   sysZ3D1058: 0.0
-  sysZ3D1059: -0.0
-  sysZ3D1060: -0.0
-  sysZ3D1061: -0.0
-  sysZ3D1062: -0.0
+  sysZ3D1059: 0.0
+  sysZ3D1060: 0.0
+  sysZ3D1061: 0.0
+  sysZ3D1062: 0.0
   sysZ3D1063: 0.0
-  sysZ3D1064: -0.0
-  sysZ3D1065: -0.0
-  sysZ3D1066: -0.0
-  sysZ3D1067: -0.0
-  sysZ3D1068: -0.0
+  sysZ3D1064: 0.0
+  sysZ3D1065: 0.0
+  sysZ3D1066: 0.0
+  sysZ3D1067: 0.0
+  sysZ3D1068: 0.0
   sysZ3D1069: 0.0
   sysZ3D1070: 0.0
   sysZ3D1071: 0.0
-  sysZ3D1072: -0.0
+  sysZ3D1072: 0.0
   sysZ3D1073: 0.0
   sysZ3D1074: 0.0
-  sysZ3D1075: -0.0
-  sysZ3D1076: -0.0
+  sysZ3D1075: 0.0
+  sysZ3D1076: 0.0
   sysZ3D1077: 0.0
-  sysZ3D1078: -0.0
+  sysZ3D1078: 0.0
   sysZ3D1079: 0.0
-  sysZ3D1080: -0.0
+  sysZ3D1080: 0.0
   sysZ3D1081: 0.0
-  sysZ3D1082: -0.0
-  sysZ3D1083: -0.0
+  sysZ3D1082: 0.0
+  sysZ3D1083: 0.0
   sysZ3D1084: 0.0
-  sysZ3D1085: -0.0
+  sysZ3D1085: 0.0
   sysZ3D1086: 0.0
   sysZ3D1087: 0.0
   sysZ3D1088: 0.0
   sysZ3D1089: 0.0
-  sysZ3D1090: -0.0
-  sysZ3D1091: -0.0
-  sysZ3D1092: -0.0
+  sysZ3D1090: 0.0
+  sysZ3D1091: 0.0
+  sysZ3D1092: 0.0
   sysZ3D1093: -2.94940000e-02
   sysZ3D1094: 0.0
-  sysZ3D1095: -0.0
+  sysZ3D1095: 0.0
   sysZ3D1096: 0.0
   sysZ3D1097: 0.0
-  sysZ3D1098: -0.0
+  sysZ3D1098: 0.0
   sysZ3D1099: 0.0
-  sysZ3D1100: -0.0
+  sysZ3D1100: 0.0
   sysZ3D1101: 0.0
-  sysZ3D1102: -0.0
-  sysZ3D1103: -0.0
+  sysZ3D1102: 0.0
+  sysZ3D1103: 0.0
   sysZ3D1104: -2.06458000e-01
   sysZ3D1105: -7.66844000e-01
   sysZ3D1106: -8.84820000e-02
   sysZ3D1107: -2.94940000e-02
   sysZ3D1108: -1.76964000e-01
-  sysZ3D1109: -0.0
+  sysZ3D1109: 0.0
   sysZ3D1110: 0.0
   sysZ3D1111: -0.14747
   sysZ3D1112: 0.0
   sysZ3D1113: 8.84820000e-02
-  sysZ3D1114: -0.0
+  sysZ3D1114: 0.0
   sysZ3D1115: -2.94940000e-02
   sysZ3D1116: -1.17976000e-01
   sysZ3D1117: -8.84820000e-02
   sysZ3D1118: -2.94940000e-02
   sysZ3D1119: -8.84820000e-02
   sysZ3D1120: -2.94940000e-02
-  sysZ3D1121: -0.0
+  sysZ3D1121: 0.0
   sysZ3D1122: -5.89880000e-02
   sysZ3D1123: -5.89880000e-02
   sysZ3D1124: -5.89880000e-02
@@ -5694,9 +5694,9 @@ bins:
   sysZ3D1131: -2.94940000e-02
   sysZ3D1132: -2.94940000e-02
   sysZ3D1133: 0.058988
-  sysZ3D1134: -0.0
-  sysZ3D1135: -0.0
-  sysZ3D1136: -0.0
+  sysZ3D1134: 0.0
+  sysZ3D1135: 0.0
+  sysZ3D1136: 0.0
   sysZ3D1137: 0.0
   sysZ3D1138: 0.029494
   sysZ3D1139: 0.0
@@ -5704,7 +5704,7 @@ bins:
   sysZ3D1141: -2.94940000e-02
   sysZ3D1142: 0.029494
   sysZ3D1143: 0.0
-  sysZ3D1144: -0.0
+  sysZ3D1144: 0.0
   sysZ3D1145: 0.029494
   sysZ3D1146: 0.0
   sysZ3D1147: -2.94940000e-02
@@ -5713,21 +5713,21 @@ bins:
   sysZ3D1150: 0.0
   sysZ3D1151: 0.0
   sysZ3D1152: 0.029494
-  sysZ3D1153: -0.0
+  sysZ3D1153: 0.0
   sysZ3D1154: 0.0
   sysZ3D1155: -2.94940000e-02
-  sysZ3D1156: -0.0
+  sysZ3D1156: 0.0
   sysZ3D1157: -2.94940000e-02
-  sysZ3D1158: -0.0
+  sysZ3D1158: 0.0
   sysZ3D1159: 0.0
   sysZ3D1160: 0.029494
   sysZ3D1161: 0.029494
   sysZ3D1162: 0.0
-  sysZ3D1163: -0.0
+  sysZ3D1163: 0.0
   sysZ3D1164: 0.0
-  sysZ3D1165: -0.0
+  sysZ3D1165: 0.0
   sysZ3D1166: 0.0
-  sysZ3D1167: -0.0
+  sysZ3D1167: 0.0
   sysZ3D1168: 0.0
   sysZ3D1169: 0.0
   sysZ3D1170: 0.0
@@ -5736,29 +5736,29 @@ bins:
   sysZ3D1173: 0.0
   sysZ3D1174: 0.029494
   sysZ3D1175: 0.0
-  sysZ3D1176: -0.0
+  sysZ3D1176: 0.0
   sysZ3D1177: -2.94940000e-02
-  sysZ3D1178: -0.0
+  sysZ3D1178: 0.0
   sysZ3D1179: -2.94940000e-02
   sysZ3D1180: 0.0
   sysZ3D1181: 0.0
-  sysZ3D1182: -0.0
-  sysZ3D1183: -0.0
+  sysZ3D1182: 0.0
+  sysZ3D1183: 0.0
   sysZ3D1184: 0.0
   sysZ3D1185: 0.0
-  sysZ3D1186: -0.0
-  sysZ3D1187: -0.0
+  sysZ3D1186: 0.0
+  sysZ3D1187: 0.0
   sysZ3D1188: 0.029494
   sysZ3D1189: 0.0
-  sysZ3D1190: -0.0
+  sysZ3D1190: 0.0
   sysZ3D1191: -2.94940000e-02
-  sysZ3D1192: -0.0
-  sysZ3D1193: -0.0
+  sysZ3D1192: 0.0
+  sysZ3D1193: 0.0
   sysZ3D1194: 0.235952
   sysZ3D1195: 0.029494
-  sysZ3D1196: -0.0
-  sysZ3D1197: -0.0
-  sysZ3D1198: -0.0
+  sysZ3D1196: 0.0
+  sysZ3D1197: 0.0
+  sysZ3D1198: 0.0
   sysZ3D1199: 0.0
   sysZ3D1200: 0.058988
   sysZ3D1201: 0.029494
@@ -5767,47 +5767,47 @@ bins:
   sysZ3D1204: 0.029494
   sysZ3D1205: -2.94940000e-02
   sysZ3D1206: -2.94940000e-02
-  sysZ3D1207: -0.0
-  sysZ3D1208: -0.0
+  sysZ3D1207: 0.0
+  sysZ3D1208: 0.0
   sysZ3D1209: 0.0
   sysZ3D1210: 0.029494
   sysZ3D1211: 0.0
   sysZ3D1212: 0.0
-  sysZ3D1213: -0.0
+  sysZ3D1213: 0.0
   sysZ3D1214: 0.029494
   sysZ3D1215: 0.029494
   sysZ3D1216: 0.0
   sysZ3D1217: -5.89880000e-02
   sysZ3D1218: -1.17976000e-01
   sysZ3D1219: 0.0
-  sysZ3D1220: -0.0
+  sysZ3D1220: 0.0
   sysZ3D1221: -2.94940000e-02
   sysZ3D1222: 0.0
   sysZ3D1223: 0.058988
   sysZ3D1224: 0.0
   sysZ3D1225: -2.94940000e-02
-  sysZ3D1226: -0.0
+  sysZ3D1226: 0.0
   sysZ3D1227: -2.94940000e-02
   sysZ3D1228: -5.89880000e-02
-  sysZ3D1229: -0.0
+  sysZ3D1229: 0.0
   sysZ3D1230: 0.0
-  sysZ3D1231: -0.0
-  sysZ3D1232: -0.0
-  sysZ3D1233: -0.0
+  sysZ3D1231: 0.0
+  sysZ3D1232: 0.0
+  sysZ3D1233: 0.0
   sysZ3D1234: 0.0
   sysZ3D1235: 0.029494
   sysZ3D1236: 0.0
   sysZ3D1237: 0.0
-  sysZ3D1238: -0.0
-  sysZ3D1239: -0.0
+  sysZ3D1238: 0.0
+  sysZ3D1239: 0.0
   sysZ3D1240: 0.0
-  sysZ3D1241: -0.0
+  sysZ3D1241: 0.0
   sysZ3D1242: 0.0
   sysZ3D1243: 0.0
   sysZ3D1244: -2.94940000e-02
   sysZ3D1245: 0.029494
-  sysZ3D1246: -0.0
-  sysZ3D1247: -0.0
+  sysZ3D1246: 0.0
+  sysZ3D1247: 0.0
   sysZ3D1248: 0.029494
   sysZ3D1249: 0.058988
   sysZ3D1250: 0.029494
@@ -5829,7 +5829,7 @@ bins:
   sysZ3D1266: -2.65446000e-01
   sysZ3D1267: -5.89880000e-02
   sysZ3D1268: 0.0
-  sysZ3D1269: -0.0
+  sysZ3D1269: 0.0
   sysZ3D1270: 0.029494
   sysZ3D1271: 0.0
   sysZ3D1272: 0.0
@@ -5841,7 +5841,7 @@ bins:
 - stat: 1.231944
   sysZ3D1001: -8.79960000e-02
   sysZ3D1002: 2.93320000e-02
-  sysZ3D1003: -0.0
+  sysZ3D1003: 0.0
   sysZ3D1004: 0.0
   sysZ3D1005: 0.0
   sysZ3D1006: 0.0
@@ -5858,39 +5858,39 @@ bins:
   sysZ3D1017: 0.0
   sysZ3D1018: 0.0
   sysZ3D1019: 0.0
-  sysZ3D1020: -0.0
-  sysZ3D1021: -0.0
+  sysZ3D1020: 0.0
+  sysZ3D1021: 0.0
   sysZ3D1022: 0.0
   sysZ3D1023: -2.93320000e-02
   sysZ3D1024: 0.0
   sysZ3D1025: -2.93320000e-02
   sysZ3D1026: 0.0
-  sysZ3D1027: -0.0
-  sysZ3D1028: -0.0
+  sysZ3D1027: 0.0
+  sysZ3D1028: 0.0
   sysZ3D1029: 0.0
   sysZ3D1030: 0.0
   sysZ3D1031: 0.0
-  sysZ3D1032: -0.0
-  sysZ3D1033: -0.0
-  sysZ3D1034: -0.0
+  sysZ3D1032: 0.0
+  sysZ3D1033: 0.0
+  sysZ3D1034: 0.0
   sysZ3D1035: 0.0
-  sysZ3D1036: -0.0
+  sysZ3D1036: 0.0
   sysZ3D1037: 0.0
-  sysZ3D1038: -0.0
+  sysZ3D1038: 0.0
   sysZ3D1039: 0.0
   sysZ3D1040: 0.0
   sysZ3D1041: 0.0
-  sysZ3D1042: -0.0
+  sysZ3D1042: 0.0
   sysZ3D1043: 0.0
   sysZ3D1044: 0.0
   sysZ3D1045: 0.0
   sysZ3D1046: 0.0
   sysZ3D1047: 0.0
-  sysZ3D1048: -0.0
-  sysZ3D1049: -0.0
+  sysZ3D1048: 0.0
+  sysZ3D1049: 0.0
   sysZ3D1050: 0.0
   sysZ3D1051: 0.0
-  sysZ3D1052: -0.0
+  sysZ3D1052: 0.0
   sysZ3D1053: 0.0
   sysZ3D1054: 0.0
   sysZ3D1055: 0.0
@@ -5898,56 +5898,56 @@ bins:
   sysZ3D1057: 0.0
   sysZ3D1058: 0.0
   sysZ3D1059: 0.0
-  sysZ3D1060: -0.0
+  sysZ3D1060: 0.0
   sysZ3D1061: 0.0
-  sysZ3D1062: -0.0
-  sysZ3D1063: -0.0
-  sysZ3D1064: -0.0
+  sysZ3D1062: 0.0
+  sysZ3D1063: 0.0
+  sysZ3D1064: 0.0
   sysZ3D1065: 0.0
-  sysZ3D1066: -0.0
-  sysZ3D1067: -0.0
+  sysZ3D1066: 0.0
+  sysZ3D1067: 0.0
   sysZ3D1068: 0.0
-  sysZ3D1069: -0.0
+  sysZ3D1069: 0.0
   sysZ3D1070: 0.0
-  sysZ3D1071: -0.0
+  sysZ3D1071: 0.0
   sysZ3D1072: 0.0
-  sysZ3D1073: -0.0
+  sysZ3D1073: 0.0
   sysZ3D1074: 0.0
   sysZ3D1075: 0.0
   sysZ3D1076: 0.0
   sysZ3D1077: 0.0
   sysZ3D1078: 0.0
-  sysZ3D1079: -0.0
-  sysZ3D1080: -0.0
-  sysZ3D1081: -0.0
+  sysZ3D1079: 0.0
+  sysZ3D1080: 0.0
+  sysZ3D1081: 0.0
   sysZ3D1082: 0.0
   sysZ3D1083: 0.0
   sysZ3D1084: 0.0
-  sysZ3D1085: -0.0
+  sysZ3D1085: 0.0
   sysZ3D1086: -2.93320000e-02
   sysZ3D1087: 0.0
   sysZ3D1088: 0.0
   sysZ3D1089: 0.0
-  sysZ3D1090: -0.0
+  sysZ3D1090: 0.0
   sysZ3D1091: 0.0
-  sysZ3D1092: -0.0
+  sysZ3D1092: 0.0
   sysZ3D1093: 0.0
   sysZ3D1094: 0.0
   sysZ3D1095: -2.93320000e-02
-  sysZ3D1096: -0.0
-  sysZ3D1097: -0.0
+  sysZ3D1096: 0.0
+  sysZ3D1097: 0.0
   sysZ3D1098: 2.93320000e-02
-  sysZ3D1099: -0.0
-  sysZ3D1100: -0.0
+  sysZ3D1099: 0.0
+  sysZ3D1100: 0.0
   sysZ3D1101: 0.0
-  sysZ3D1102: -0.0
+  sysZ3D1102: 0.0
   sysZ3D1103: -2.93320000e-02
   sysZ3D1104: -1.75992000e-01
   sysZ3D1105: -7.33300000e-01
   sysZ3D1106: -8.79960000e-02
   sysZ3D1107: -2.93320000e-02
   sysZ3D1108: -1.75992000e-01
-  sysZ3D1109: -0.0
+  sysZ3D1109: 0.0
   sysZ3D1110: 0.0
   sysZ3D1111: -2.34656000e-01
   sysZ3D1112: 0.0
@@ -5959,38 +5959,38 @@ bins:
   sysZ3D1118: -5.86640000e-02
   sysZ3D1119: 0.0
   sysZ3D1120: -2.93320000e-02
-  sysZ3D1121: -0.0
+  sysZ3D1121: 0.0
   sysZ3D1122: 0.0
   sysZ3D1123: -5.86640000e-02
   sysZ3D1124: -5.86640000e-02
   sysZ3D1125: -5.86640000e-02
   sysZ3D1126: 0.087996
   sysZ3D1127: -5.86640000e-02
-  sysZ3D1128: -0.0
+  sysZ3D1128: 0.0
   sysZ3D1129: 0.0
   sysZ3D1130: 0.0
   sysZ3D1131: -2.93320000e-02
   sysZ3D1132: 0.0
   sysZ3D1133: -2.93320000e-02
-  sysZ3D1134: -0.0
-  sysZ3D1135: -0.0
+  sysZ3D1134: 0.0
+  sysZ3D1135: 0.0
   sysZ3D1136: -2.93320000e-02
   sysZ3D1137: -2.93320000e-02
   sysZ3D1138: -2.93320000e-02
   sysZ3D1139: 2.93320000e-02
   sysZ3D1140: 2.93320000e-02
   sysZ3D1141: -2.93320000e-02
-  sysZ3D1142: -0.0
+  sysZ3D1142: 0.0
   sysZ3D1143: 0.0
-  sysZ3D1144: -0.0
+  sysZ3D1144: 0.0
   sysZ3D1145: -2.93320000e-02
-  sysZ3D1146: -0.0
-  sysZ3D1147: -0.0
-  sysZ3D1148: -0.0
-  sysZ3D1149: -0.0
+  sysZ3D1146: 0.0
+  sysZ3D1147: 0.0
+  sysZ3D1148: 0.0
+  sysZ3D1149: 0.0
   sysZ3D1150: 0.0
   sysZ3D1151: 0.0
-  sysZ3D1152: -0.0
+  sysZ3D1152: 0.0
   sysZ3D1153: 2.93320000e-02
   sysZ3D1154: 0.0
   sysZ3D1155: -2.93320000e-02
@@ -6002,9 +6002,9 @@ bins:
   sysZ3D1161: -2.93320000e-02
   sysZ3D1162: 0.0
   sysZ3D1163: 5.86640000e-02
-  sysZ3D1164: -0.0
+  sysZ3D1164: 0.0
   sysZ3D1165: -5.86640000e-02
-  sysZ3D1166: -0.0
+  sysZ3D1166: 0.0
   sysZ3D1167: -2.93320000e-02
   sysZ3D1168: 2.93320000e-02
   sysZ3D1169: 0.0
@@ -6016,36 +6016,36 @@ bins:
   sysZ3D1175: 0.0
   sysZ3D1176: -5.86640000e-02
   sysZ3D1177: -8.79960000e-02
-  sysZ3D1178: -0.0
-  sysZ3D1179: -0.0
+  sysZ3D1178: 0.0
+  sysZ3D1179: 0.0
   sysZ3D1180: 0.0
   sysZ3D1181: 2.93320000e-02
-  sysZ3D1182: -0.0
-  sysZ3D1183: -0.0
+  sysZ3D1182: 0.0
+  sysZ3D1183: 0.0
   sysZ3D1184: 0.0
   sysZ3D1185: 0.0
   sysZ3D1186: 0.0
-  sysZ3D1187: -0.0
+  sysZ3D1187: 0.0
   sysZ3D1188: 2.93320000e-02
   sysZ3D1189: 0.0
-  sysZ3D1190: -0.0
-  sysZ3D1191: -0.0
-  sysZ3D1192: -0.0
-  sysZ3D1193: -0.0
+  sysZ3D1190: 0.0
+  sysZ3D1191: 0.0
+  sysZ3D1192: 0.0
+  sysZ3D1193: 0.0
   sysZ3D1194: 0.263988
   sysZ3D1195: 0.0
-  sysZ3D1196: -0.0
-  sysZ3D1197: -0.0
-  sysZ3D1198: -0.0
+  sysZ3D1196: 0.0
+  sysZ3D1197: 0.0
+  sysZ3D1198: 0.0
   sysZ3D1199: 2.93320000e-02
   sysZ3D1200: 2.93320000e-02
   sysZ3D1201: 2.93320000e-02
   sysZ3D1202: 0.0
   sysZ3D1203: 1.17328000e-01
   sysZ3D1204: 0.0
-  sysZ3D1205: -0.0
+  sysZ3D1205: 0.0
   sysZ3D1206: -2.93320000e-02
-  sysZ3D1207: -0.0
+  sysZ3D1207: 0.0
   sysZ3D1208: 0.0
   sysZ3D1209: 0.0
   sysZ3D1210: 0.0
@@ -6058,27 +6058,27 @@ bins:
   sysZ3D1217: -5.86640000e-02
   sysZ3D1218: -8.79960000e-02
   sysZ3D1219: -2.93320000e-02
-  sysZ3D1220: -0.0
+  sysZ3D1220: 0.0
   sysZ3D1221: 0.0
   sysZ3D1222: 0.0
   sysZ3D1223: 2.93320000e-02
   sysZ3D1224: -2.93320000e-02
   sysZ3D1225: -2.93320000e-02
-  sysZ3D1226: -0.0
+  sysZ3D1226: 0.0
   sysZ3D1227: -5.86640000e-02
   sysZ3D1228: -8.79960000e-02
-  sysZ3D1229: -0.0
+  sysZ3D1229: 0.0
   sysZ3D1230: -2.93320000e-02
   sysZ3D1231: -2.93320000e-02
-  sysZ3D1232: -0.0
+  sysZ3D1232: 0.0
   sysZ3D1233: 0.0
   sysZ3D1234: 0.0
   sysZ3D1235: 0.0
-  sysZ3D1236: -0.0
-  sysZ3D1237: -0.0
-  sysZ3D1238: -0.0
-  sysZ3D1239: -0.0
-  sysZ3D1240: -0.0
+  sysZ3D1236: 0.0
+  sysZ3D1237: 0.0
+  sysZ3D1238: 0.0
+  sysZ3D1239: 0.0
+  sysZ3D1240: 0.0
   sysZ3D1241: 0.0
   sysZ3D1242: 0.0
   sysZ3D1243: 0.0
@@ -6088,13 +6088,13 @@ bins:
   sysZ3D1247: 2.93320000e-02
   sysZ3D1248: 2.93320000e-02
   sysZ3D1249: 2.93320000e-02
-  sysZ3D1250: -0.0
+  sysZ3D1250: 0.0
   sysZ3D1251: 2.93320000e-02
   sysZ3D1252: 0.087996
-  sysZ3D1253: -0.0
+  sysZ3D1253: 0.0
   sysZ3D1254: 2.93320000e-02
   sysZ3D1255: -3.22652000e-01
-  sysZ3D1256: -0.0
+  sysZ3D1256: 0.0
   sysZ3D1257: -5.86640000e-02
   sysZ3D1258: 5.86640000e-02
   sysZ3D1259: -0.14666
@@ -6109,7 +6109,7 @@ bins:
   sysZ3D1268: 2.93320000e-02
   sysZ3D1269: 2.93320000e-02
   sysZ3D1270: 2.93320000e-02
-  sysZ3D1271: -0.0
+  sysZ3D1271: 0.0
   sysZ3D1272: 0.0
   sysZ3D1273: -2.93320000e-02
   sysZ3D1274: -8.79960000e-02
@@ -6119,7 +6119,7 @@ bins:
 - stat: 1.211482
   sysZ3D1001: -8.45220000e-02
   sysZ3D1002: 0.056348
-  sysZ3D1003: -0.0
+  sysZ3D1003: 0.0
   sysZ3D1004: 0.0
   sysZ3D1005: 0.0
   sysZ3D1006: 0.0
@@ -6137,63 +6137,63 @@ bins:
   sysZ3D1018: 0.0
   sysZ3D1019: 0.0
   sysZ3D1020: -2.81740000e-02
-  sysZ3D1021: -0.0
+  sysZ3D1021: 0.0
   sysZ3D1022: 0.0
   sysZ3D1023: -2.81740000e-02
   sysZ3D1024: 0.028174
   sysZ3D1025: -2.81740000e-02
-  sysZ3D1026: -0.0
-  sysZ3D1027: -0.0
+  sysZ3D1026: 0.0
+  sysZ3D1027: 0.0
   sysZ3D1028: 0.0
-  sysZ3D1029: -0.0
+  sysZ3D1029: 0.0
   sysZ3D1030: 0.0
-  sysZ3D1031: -0.0
+  sysZ3D1031: 0.0
   sysZ3D1032: 0.0
   sysZ3D1033: 0.0
-  sysZ3D1034: -0.0
-  sysZ3D1035: -0.0
+  sysZ3D1034: 0.0
+  sysZ3D1035: 0.0
   sysZ3D1036: 0.0
   sysZ3D1037: 0.0
-  sysZ3D1038: -0.0
+  sysZ3D1038: 0.0
   sysZ3D1039: 0.0
-  sysZ3D1040: -0.0
+  sysZ3D1040: 0.0
   sysZ3D1041: 0.0
-  sysZ3D1042: -0.0
+  sysZ3D1042: 0.0
   sysZ3D1043: 0.0
-  sysZ3D1044: -0.0
-  sysZ3D1045: -0.0
-  sysZ3D1046: -0.0
-  sysZ3D1047: -0.0
-  sysZ3D1048: -0.0
+  sysZ3D1044: 0.0
+  sysZ3D1045: 0.0
+  sysZ3D1046: 0.0
+  sysZ3D1047: 0.0
+  sysZ3D1048: 0.0
   sysZ3D1049: 0.0
   sysZ3D1050: -2.81740000e-02
   sysZ3D1051: 0.0
-  sysZ3D1052: -0.0
-  sysZ3D1053: -0.0
-  sysZ3D1054: -0.0
-  sysZ3D1055: -0.0
+  sysZ3D1052: 0.0
+  sysZ3D1053: 0.0
+  sysZ3D1054: 0.0
+  sysZ3D1055: 0.0
   sysZ3D1056: 0.0
   sysZ3D1057: 0.0
-  sysZ3D1058: -0.0
+  sysZ3D1058: 0.0
   sysZ3D1059: 0.0
-  sysZ3D1060: -0.0
+  sysZ3D1060: 0.0
   sysZ3D1061: 0.0
   sysZ3D1062: 0.0
   sysZ3D1063: -2.81740000e-02
   sysZ3D1064: 0.0
-  sysZ3D1065: -0.0
-  sysZ3D1066: -0.0
-  sysZ3D1067: -0.0
-  sysZ3D1068: -0.0
+  sysZ3D1065: 0.0
+  sysZ3D1066: 0.0
+  sysZ3D1067: 0.0
+  sysZ3D1068: 0.0
   sysZ3D1069: 0.0
-  sysZ3D1070: -0.0
+  sysZ3D1070: 0.0
   sysZ3D1071: 0.0
   sysZ3D1072: 0.0
   sysZ3D1073: 0.0
   sysZ3D1074: 0.0
   sysZ3D1075: 0.0
-  sysZ3D1076: -0.0
-  sysZ3D1077: -0.0
+  sysZ3D1076: 0.0
+  sysZ3D1077: 0.0
   sysZ3D1078: 0.0
   sysZ3D1079: 0.0
   sysZ3D1080: 0.0
@@ -6204,28 +6204,28 @@ bins:
   sysZ3D1085: 0.0
   sysZ3D1086: 0.0
   sysZ3D1087: -2.81740000e-02
-  sysZ3D1088: -0.0
-  sysZ3D1089: -0.0
+  sysZ3D1088: 0.0
+  sysZ3D1089: 0.0
   sysZ3D1090: 0.028174
   sysZ3D1091: -2.81740000e-02
-  sysZ3D1092: -0.0
+  sysZ3D1092: 0.0
   sysZ3D1093: 0.0
-  sysZ3D1094: -0.0
+  sysZ3D1094: 0.0
   sysZ3D1095: 0.0
-  sysZ3D1096: -0.0
-  sysZ3D1097: -0.0
+  sysZ3D1096: 0.0
+  sysZ3D1097: 0.0
   sysZ3D1098: 0.0
-  sysZ3D1099: -0.0
-  sysZ3D1100: -0.0
-  sysZ3D1101: -0.0
+  sysZ3D1099: 0.0
+  sysZ3D1100: 0.0
+  sysZ3D1101: 0.0
   sysZ3D1102: 0.0
-  sysZ3D1103: -0.0
+  sysZ3D1103: 0.0
   sysZ3D1104: -0.14087
   sysZ3D1105: -7.04350000e-01
   sysZ3D1106: -5.63480000e-02
-  sysZ3D1107: -0.0
+  sysZ3D1107: 0.0
   sysZ3D1108: -1.69044000e-01
-  sysZ3D1109: -0.0
+  sysZ3D1109: 0.0
   sysZ3D1110: 0.0
   sysZ3D1111: -1.97218000e-01
   sysZ3D1112: 0.0
@@ -6245,17 +6245,17 @@ bins:
   sysZ3D1126: 0.14087
   sysZ3D1127: 0.0
   sysZ3D1128: 0.0
-  sysZ3D1129: -0.0
+  sysZ3D1129: 0.0
   sysZ3D1130: -2.81740000e-02
-  sysZ3D1131: -0.0
-  sysZ3D1132: -0.0
-  sysZ3D1133: -0.0
+  sysZ3D1131: 0.0
+  sysZ3D1132: 0.0
+  sysZ3D1133: 0.0
   sysZ3D1134: 0.112696
   sysZ3D1135: 0.0
   sysZ3D1136: -2.81740000e-02
-  sysZ3D1137: -0.0
+  sysZ3D1137: 0.0
   sysZ3D1138: 0.056348
-  sysZ3D1139: -0.0
+  sysZ3D1139: 0.0
   sysZ3D1140: -2.81740000e-02
   sysZ3D1141: 0.0
   sysZ3D1142: -2.81740000e-02
@@ -6272,20 +6272,20 @@ bins:
   sysZ3D1153: 0.028174
   sysZ3D1154: -5.63480000e-02
   sysZ3D1155: -2.81740000e-02
-  sysZ3D1156: -0.0
+  sysZ3D1156: 0.0
   sysZ3D1157: -2.81740000e-02
   sysZ3D1158: 0.0
-  sysZ3D1159: -0.0
+  sysZ3D1159: 0.0
   sysZ3D1160: 0.0
   sysZ3D1161: 0.028174
   sysZ3D1162: -5.63480000e-02
-  sysZ3D1163: -0.0
+  sysZ3D1163: 0.0
   sysZ3D1164: 0.028174
   sysZ3D1165: 0.028174
   sysZ3D1166: 0.028174
   sysZ3D1167: 0.0
   sysZ3D1168: 0.028174
-  sysZ3D1169: -0.0
+  sysZ3D1169: 0.0
   sysZ3D1170: 0.028174
   sysZ3D1171: 0.028174
   sysZ3D1172: 0.0
@@ -6294,16 +6294,16 @@ bins:
   sysZ3D1175: 0.0
   sysZ3D1176: -8.45220000e-02
   sysZ3D1177: -1.12696000e-01
-  sysZ3D1178: -0.0
+  sysZ3D1178: 0.0
   sysZ3D1179: -2.81740000e-02
   sysZ3D1180: 0.0
   sysZ3D1181: 0.028174
-  sysZ3D1182: -0.0
-  sysZ3D1183: -0.0
+  sysZ3D1182: 0.0
+  sysZ3D1183: 0.0
   sysZ3D1184: 0.0
   sysZ3D1185: 0.0
-  sysZ3D1186: -0.0
-  sysZ3D1187: -0.0
+  sysZ3D1186: 0.0
+  sysZ3D1187: 0.0
   sysZ3D1188: 0.028174
   sysZ3D1189: 0.0
   sysZ3D1190: -2.81740000e-02
@@ -6313,7 +6313,7 @@ bins:
   sysZ3D1194: 0.309914
   sysZ3D1195: -2.81740000e-02
   sysZ3D1196: 0.0
-  sysZ3D1197: -0.0
+  sysZ3D1197: 0.0
   sysZ3D1198: 0.028174
   sysZ3D1199: 0.0
   sysZ3D1200: 0.028174
@@ -6321,14 +6321,14 @@ bins:
   sysZ3D1202: 0.0
   sysZ3D1203: 8.45220000e-02
   sysZ3D1204: -2.81740000e-02
-  sysZ3D1205: -0.0
-  sysZ3D1206: -0.0
-  sysZ3D1207: -0.0
-  sysZ3D1208: -0.0
+  sysZ3D1205: 0.0
+  sysZ3D1206: 0.0
+  sysZ3D1207: 0.0
+  sysZ3D1208: 0.0
   sysZ3D1209: 0.0
   sysZ3D1210: 0.028174
   sysZ3D1211: 0.0
-  sysZ3D1212: -0.0
+  sysZ3D1212: 0.0
   sysZ3D1213: 0.028174
   sysZ3D1214: 0.028174
   sysZ3D1215: 8.45220000e-02
@@ -6341,7 +6341,7 @@ bins:
   sysZ3D1222: 0.0
   sysZ3D1223: 0.0
   sysZ3D1224: -2.81740000e-02
-  sysZ3D1225: -0.0
+  sysZ3D1225: 0.0
   sysZ3D1226: -2.81740000e-02
   sysZ3D1227: -5.63480000e-02
   sysZ3D1228: -5.63480000e-02
@@ -6354,27 +6354,27 @@ bins:
   sysZ3D1235: 0.0
   sysZ3D1236: -2.81740000e-02
   sysZ3D1237: 0.0
-  sysZ3D1238: -0.0
-  sysZ3D1239: -0.0
-  sysZ3D1240: -0.0
-  sysZ3D1241: -0.0
+  sysZ3D1238: 0.0
+  sysZ3D1239: 0.0
+  sysZ3D1240: 0.0
+  sysZ3D1241: 0.0
   sysZ3D1242: 0.0
   sysZ3D1243: 0.0
   sysZ3D1244: -5.63480000e-02
   sysZ3D1245: 0.056348
   sysZ3D1246: 0.0
-  sysZ3D1247: -0.0
+  sysZ3D1247: 0.0
   sysZ3D1248: 0.056348
   sysZ3D1249: 0.056348
   sysZ3D1250: -2.81740000e-02
   sysZ3D1251: 0.056348
   sysZ3D1252: 0.112696
-  sysZ3D1253: -0.0
+  sysZ3D1253: 0.0
   sysZ3D1254: 0.028174
   sysZ3D1255: -0.28174
   sysZ3D1256: 0.056348
-  sysZ3D1257: -0.0
-  sysZ3D1258: -0.0
+  sysZ3D1257: 0.0
+  sysZ3D1258: 0.0
   sysZ3D1259: -8.45220000e-02
   sysZ3D1260: 0.0
   sysZ3D1261: -2.81740000e-02
@@ -6388,8 +6388,8 @@ bins:
   sysZ3D1269: 0.0
   sysZ3D1270: 0.056348
   sysZ3D1271: 0.0
-  sysZ3D1272: -0.0
-  sysZ3D1273: -0.0
+  sysZ3D1272: 0.0
+  sysZ3D1273: 0.0
   sysZ3D1274: -1.69044000e-01
   sysZ3D1275: 1.97218000e-01
   sys,uncor: 6.76176000e-01
@@ -6397,7 +6397,7 @@ bins:
 - stat: 1.14453
   sysZ3D1001: -7.63020000e-02
   sysZ3D1002: 5.08680000e-02
-  sysZ3D1003: -0.0
+  sysZ3D1003: 0.0
   sysZ3D1004: 0.0
   sysZ3D1005: 0.0
   sysZ3D1006: 0.0
@@ -6414,8 +6414,8 @@ bins:
   sysZ3D1017: 0.0
   sysZ3D1018: 0.0
   sysZ3D1019: 0.0
-  sysZ3D1020: -0.0
-  sysZ3D1021: -0.0
+  sysZ3D1020: 0.0
+  sysZ3D1021: 0.0
   sysZ3D1022: 0.0
   sysZ3D1023: -5.08680000e-02
   sysZ3D1024: 5.08680000e-02
@@ -6423,55 +6423,55 @@ bins:
   sysZ3D1026: 5.08680000e-02
   sysZ3D1027: -2.54340000e-02
   sysZ3D1028: -2.54340000e-02
-  sysZ3D1029: -0.0
+  sysZ3D1029: 0.0
   sysZ3D1030: 0.0
   sysZ3D1031: 0.0
   sysZ3D1032: 0.0
   sysZ3D1033: 2.54340000e-02
-  sysZ3D1034: -0.0
-  sysZ3D1035: -0.0
+  sysZ3D1034: 0.0
+  sysZ3D1035: 0.0
   sysZ3D1036: 0.0
   sysZ3D1037: 0.0
-  sysZ3D1038: -0.0
+  sysZ3D1038: 0.0
   sysZ3D1039: -2.54340000e-02
   sysZ3D1040: 0.0
-  sysZ3D1041: -0.0
+  sysZ3D1041: 0.0
   sysZ3D1042: 0.0
   sysZ3D1043: 0.0
-  sysZ3D1044: -0.0
+  sysZ3D1044: 0.0
   sysZ3D1045: 0.0
-  sysZ3D1046: -0.0
-  sysZ3D1047: -0.0
+  sysZ3D1046: 0.0
+  sysZ3D1047: 0.0
   sysZ3D1048: 0.0
   sysZ3D1049: 0.0
   sysZ3D1050: 2.54340000e-02
   sysZ3D1051: 0.0
   sysZ3D1052: 0.0
-  sysZ3D1053: -0.0
+  sysZ3D1053: 0.0
   sysZ3D1054: 0.0
   sysZ3D1055: 0.0
-  sysZ3D1056: -0.0
+  sysZ3D1056: 0.0
   sysZ3D1057: -2.54340000e-02
   sysZ3D1058: -2.54340000e-02
-  sysZ3D1059: -0.0
+  sysZ3D1059: 0.0
   sysZ3D1060: 0.0
   sysZ3D1061: 0.0
   sysZ3D1062: 0.0
   sysZ3D1063: 2.54340000e-02
-  sysZ3D1064: -0.0
+  sysZ3D1064: 0.0
   sysZ3D1065: 0.0
-  sysZ3D1066: -0.0
-  sysZ3D1067: -0.0
+  sysZ3D1066: 0.0
+  sysZ3D1067: 0.0
   sysZ3D1068: 0.0
-  sysZ3D1069: -0.0
+  sysZ3D1069: 0.0
   sysZ3D1070: 0.0
-  sysZ3D1071: -0.0
+  sysZ3D1071: 0.0
   sysZ3D1072: 0.0
   sysZ3D1073: 0.0
   sysZ3D1074: 0.0
   sysZ3D1075: 0.0
-  sysZ3D1076: -0.0
-  sysZ3D1077: -0.0
+  sysZ3D1076: 0.0
+  sysZ3D1077: 0.0
   sysZ3D1078: -2.54340000e-02
   sysZ3D1079: -2.54340000e-02
   sysZ3D1080: -2.54340000e-02
@@ -6480,30 +6480,30 @@ bins:
   sysZ3D1083: 0.0
   sysZ3D1084: 0.0
   sysZ3D1085: 0.0
-  sysZ3D1086: -0.0
-  sysZ3D1087: -0.0
+  sysZ3D1086: 0.0
+  sysZ3D1087: 0.0
   sysZ3D1088: 0.0
-  sysZ3D1089: -0.0
-  sysZ3D1090: -0.0
+  sysZ3D1089: 0.0
+  sysZ3D1090: 0.0
   sysZ3D1091: 2.54340000e-02
-  sysZ3D1092: -0.0
+  sysZ3D1092: 0.0
   sysZ3D1093: 2.54340000e-02
-  sysZ3D1094: -0.0
-  sysZ3D1095: -0.0
-  sysZ3D1096: -0.0
-  sysZ3D1097: -0.0
+  sysZ3D1094: 0.0
+  sysZ3D1095: 0.0
+  sysZ3D1096: 0.0
+  sysZ3D1097: 0.0
   sysZ3D1098: 2.54340000e-02
   sysZ3D1099: -2.54340000e-02
-  sysZ3D1100: -0.0
+  sysZ3D1100: 0.0
   sysZ3D1101: -2.54340000e-02
   sysZ3D1102: 0.0
   sysZ3D1103: 0.0
   sysZ3D1104: -1.01736000e-01
   sysZ3D1105: -5.59548000e-01
   sysZ3D1106: -7.63020000e-02
-  sysZ3D1107: -0.0
+  sysZ3D1107: 0.0
   sysZ3D1108: -1.52604000e-01
-  sysZ3D1109: -0.0
+  sysZ3D1109: 0.0
   sysZ3D1110: 0.0
   sysZ3D1111: -1.52604000e-01
   sysZ3D1112: 0.0
@@ -6511,18 +6511,18 @@ bins:
   sysZ3D1114: -5.08680000e-02
   sysZ3D1115: -1.01736000e-01
   sysZ3D1116: -7.63020000e-02
-  sysZ3D1117: -0.0
-  sysZ3D1118: -0.0
+  sysZ3D1117: 0.0
+  sysZ3D1118: 0.0
   sysZ3D1119: 0.0
   sysZ3D1120: 0.0
   sysZ3D1121: -5.08680000e-02
   sysZ3D1122: -1.01736000e-01
-  sysZ3D1123: -0.0
+  sysZ3D1123: 0.0
   sysZ3D1124: -5.08680000e-02
   sysZ3D1125: -2.54340000e-02
   sysZ3D1126: 0.12717
-  sysZ3D1127: -0.0
-  sysZ3D1128: -0.0
+  sysZ3D1127: 0.0
+  sysZ3D1128: 0.0
   sysZ3D1129: 0.0
   sysZ3D1130: 2.54340000e-02
   sysZ3D1131: 0.0
@@ -6531,35 +6531,35 @@ bins:
   sysZ3D1134: -2.54340000e-02
   sysZ3D1135: -2.54340000e-02
   sysZ3D1136: 0.0
-  sysZ3D1137: -0.0
+  sysZ3D1137: 0.0
   sysZ3D1138: 2.54340000e-02
-  sysZ3D1139: -0.0
+  sysZ3D1139: 0.0
   sysZ3D1140: -2.54340000e-02
   sysZ3D1141: -2.54340000e-02
   sysZ3D1142: 0.0
-  sysZ3D1143: -0.0
+  sysZ3D1143: 0.0
   sysZ3D1144: 0.0
-  sysZ3D1145: -0.0
+  sysZ3D1145: 0.0
   sysZ3D1146: 0.0
-  sysZ3D1147: -0.0
+  sysZ3D1147: 0.0
   sysZ3D1148: 0.0
-  sysZ3D1149: -0.0
+  sysZ3D1149: 0.0
   sysZ3D1150: 0.0
-  sysZ3D1151: -0.0
+  sysZ3D1151: 0.0
   sysZ3D1152: 0.0
   sysZ3D1153: 0.0
   sysZ3D1154: 2.54340000e-02
   sysZ3D1155: 2.54340000e-02
   sysZ3D1156: 0.0
   sysZ3D1157: 2.54340000e-02
-  sysZ3D1158: -0.0
+  sysZ3D1158: 0.0
   sysZ3D1159: 2.54340000e-02
   sysZ3D1160: 7.63020000e-02
-  sysZ3D1161: -0.0
-  sysZ3D1162: -0.0
+  sysZ3D1161: 0.0
+  sysZ3D1162: 0.0
   sysZ3D1163: -2.54340000e-02
-  sysZ3D1164: -0.0
-  sysZ3D1165: -0.0
+  sysZ3D1164: 0.0
+  sysZ3D1165: 0.0
   sysZ3D1166: -2.54340000e-02
   sysZ3D1167: 2.54340000e-02
   sysZ3D1168: 2.54340000e-02
@@ -6568,7 +6568,7 @@ bins:
   sysZ3D1171: 2.54340000e-02
   sysZ3D1172: 0.0
   sysZ3D1173: 0.0
-  sysZ3D1174: -0.0
+  sysZ3D1174: 0.0
   sysZ3D1175: 0.0
   sysZ3D1176: -2.54340000e-02
   sysZ3D1177: -2.54340000e-02
@@ -6576,7 +6576,7 @@ bins:
   sysZ3D1179: 0.0
   sysZ3D1180: 2.54340000e-02
   sysZ3D1181: 0.0
-  sysZ3D1182: -0.0
+  sysZ3D1182: 0.0
   sysZ3D1183: -2.54340000e-02
   sysZ3D1184: 0.0
   sysZ3D1185: 2.54340000e-02
@@ -6587,11 +6587,11 @@ bins:
   sysZ3D1190: 0.0
   sysZ3D1191: 2.54340000e-02
   sysZ3D1192: 0.0
-  sysZ3D1193: -0.0
+  sysZ3D1193: 0.0
   sysZ3D1194: 3.05208000e-01
   sysZ3D1195: -2.54340000e-02
   sysZ3D1196: -2.54340000e-02
-  sysZ3D1197: -0.0
+  sysZ3D1197: 0.0
   sysZ3D1198: 0.0
   sysZ3D1199: 5.08680000e-02
   sysZ3D1200: 5.08680000e-02
@@ -6600,7 +6600,7 @@ bins:
   sysZ3D1203: 7.63020000e-02
   sysZ3D1204: -2.54340000e-02
   sysZ3D1205: -2.54340000e-02
-  sysZ3D1206: -0.0
+  sysZ3D1206: 0.0
   sysZ3D1207: -2.54340000e-02
   sysZ3D1208: 0.0
   sysZ3D1209: 0.0
@@ -6610,7 +6610,7 @@ bins:
   sysZ3D1213: 0.0
   sysZ3D1214: 2.54340000e-02
   sysZ3D1215: 5.08680000e-02
-  sysZ3D1216: -0.0
+  sysZ3D1216: 0.0
   sysZ3D1217: -5.08680000e-02
   sysZ3D1218: -7.63020000e-02
   sysZ3D1219: -2.54340000e-02
@@ -6619,23 +6619,23 @@ bins:
   sysZ3D1222: 0.0
   sysZ3D1223: 2.54340000e-02
   sysZ3D1224: -2.54340000e-02
-  sysZ3D1225: -0.0
-  sysZ3D1226: -0.0
+  sysZ3D1225: 0.0
+  sysZ3D1226: 0.0
   sysZ3D1227: -2.54340000e-02
   sysZ3D1228: -2.54340000e-02
-  sysZ3D1229: -0.0
-  sysZ3D1230: -0.0
+  sysZ3D1229: 0.0
+  sysZ3D1230: 0.0
   sysZ3D1231: -2.54340000e-02
   sysZ3D1232: 0.0
   sysZ3D1233: 0.0
   sysZ3D1234: 0.0
   sysZ3D1235: 0.0
   sysZ3D1236: -2.54340000e-02
-  sysZ3D1237: -0.0
-  sysZ3D1238: -0.0
+  sysZ3D1237: 0.0
+  sysZ3D1238: 0.0
   sysZ3D1239: 0.0
   sysZ3D1240: 0.0
-  sysZ3D1241: -0.0
+  sysZ3D1241: 0.0
   sysZ3D1242: 0.0
   sysZ3D1243: 0.0
   sysZ3D1244: -5.08680000e-02
@@ -6701,87 +6701,87 @@ bins:
   sysZ3D1026: 2.08320000e-02
   sysZ3D1027: -2.08320000e-02
   sysZ3D1028: 0.0
-  sysZ3D1029: -0.0
-  sysZ3D1030: -0.0
+  sysZ3D1029: 0.0
+  sysZ3D1030: 0.0
   sysZ3D1031: 0.0
-  sysZ3D1032: -0.0
-  sysZ3D1033: -0.0
-  sysZ3D1034: -0.0
-  sysZ3D1035: -0.0
+  sysZ3D1032: 0.0
+  sysZ3D1033: 0.0
+  sysZ3D1034: 0.0
+  sysZ3D1035: 0.0
   sysZ3D1036: 2.08320000e-02
   sysZ3D1037: -2.08320000e-02
-  sysZ3D1038: -0.0
-  sysZ3D1039: -0.0
-  sysZ3D1040: -0.0
+  sysZ3D1038: 0.0
+  sysZ3D1039: 0.0
+  sysZ3D1040: 0.0
   sysZ3D1041: 0.0
   sysZ3D1042: -2.08320000e-02
   sysZ3D1043: 0.0
-  sysZ3D1044: -0.0
-  sysZ3D1045: -0.0
+  sysZ3D1044: 0.0
+  sysZ3D1045: 0.0
   sysZ3D1046: 0.0
   sysZ3D1047: -2.08320000e-02
   sysZ3D1048: 0.0
-  sysZ3D1049: -0.0
+  sysZ3D1049: 0.0
   sysZ3D1050: -2.08320000e-02
   sysZ3D1051: 0.0
   sysZ3D1052: 0.0
   sysZ3D1053: 0.0
-  sysZ3D1054: -0.0
+  sysZ3D1054: 0.0
   sysZ3D1055: 2.08320000e-02
-  sysZ3D1056: -0.0
+  sysZ3D1056: 0.0
   sysZ3D1057: -2.08320000e-02
   sysZ3D1058: 2.08320000e-02
-  sysZ3D1059: -0.0
-  sysZ3D1060: -0.0
+  sysZ3D1059: 0.0
+  sysZ3D1060: 0.0
   sysZ3D1061: 2.08320000e-02
-  sysZ3D1062: -0.0
+  sysZ3D1062: 0.0
   sysZ3D1063: 0.0
-  sysZ3D1064: -0.0
+  sysZ3D1064: 0.0
   sysZ3D1065: 0.0
   sysZ3D1066: 0.0
-  sysZ3D1067: -0.0
+  sysZ3D1067: 0.0
   sysZ3D1068: 0.0
-  sysZ3D1069: -0.0
+  sysZ3D1069: 0.0
   sysZ3D1070: 0.0
   sysZ3D1071: 2.08320000e-02
   sysZ3D1072: 0.0
-  sysZ3D1073: -0.0
+  sysZ3D1073: 0.0
   sysZ3D1074: 2.08320000e-02
-  sysZ3D1075: -0.0
-  sysZ3D1076: -0.0
+  sysZ3D1075: 0.0
+  sysZ3D1076: 0.0
   sysZ3D1077: 0.0
   sysZ3D1078: 0.0
-  sysZ3D1079: -0.0
-  sysZ3D1080: -0.0
+  sysZ3D1079: 0.0
+  sysZ3D1080: 0.0
   sysZ3D1081: 2.08320000e-02
   sysZ3D1082: 0.0
   sysZ3D1083: -2.08320000e-02
   sysZ3D1084: 0.0
   sysZ3D1085: 2.08320000e-02
   sysZ3D1086: 0.0
-  sysZ3D1087: -0.0
+  sysZ3D1087: 0.0
   sysZ3D1088: 0.0
   sysZ3D1089: 2.08320000e-02
   sysZ3D1090: 0.0
   sysZ3D1091: 2.08320000e-02
-  sysZ3D1092: -0.0
+  sysZ3D1092: 0.0
   sysZ3D1093: 2.08320000e-02
   sysZ3D1094: 0.0
-  sysZ3D1095: -0.0
+  sysZ3D1095: 0.0
   sysZ3D1096: -2.08320000e-02
   sysZ3D1097: 0.0
-  sysZ3D1098: -0.0
-  sysZ3D1099: -0.0
+  sysZ3D1098: 0.0
+  sysZ3D1099: 0.0
   sysZ3D1100: 2.08320000e-02
   sysZ3D1101: 0.0
-  sysZ3D1102: -0.0
+  sysZ3D1102: 0.0
   sysZ3D1103: 2.08320000e-02
   sysZ3D1104: -8.33280000e-02
   sysZ3D1105: -0.41664
   sysZ3D1106: -6.24960000e-02
-  sysZ3D1107: -0.0
+  sysZ3D1107: 0.0
   sysZ3D1108: -1.45824000e-01
-  sysZ3D1109: -0.0
+  sysZ3D1109: 0.0
   sysZ3D1110: 0.0
   sysZ3D1111: -1.24992000e-01
   sysZ3D1112: 0.0
@@ -6790,7 +6790,7 @@ bins:
   sysZ3D1115: -4.16640000e-02
   sysZ3D1116: -6.24960000e-02
   sysZ3D1117: -2.08320000e-02
-  sysZ3D1118: -0.0
+  sysZ3D1118: 0.0
   sysZ3D1119: 0.0
   sysZ3D1120: 0.0
   sysZ3D1121: -2.08320000e-02
@@ -6801,10 +6801,10 @@ bins:
   sysZ3D1126: 1.24992000e-01
   sysZ3D1127: 4.16640000e-02
   sysZ3D1128: -2.08320000e-02
-  sysZ3D1129: -0.0
+  sysZ3D1129: 0.0
   sysZ3D1130: 0.0
   sysZ3D1131: -2.08320000e-02
-  sysZ3D1132: -0.0
+  sysZ3D1132: 0.0
   sysZ3D1133: 0.0
   sysZ3D1134: -2.08320000e-02
   sysZ3D1135: -2.08320000e-02
@@ -6814,7 +6814,7 @@ bins:
   sysZ3D1139: -2.08320000e-02
   sysZ3D1140: 0.0
   sysZ3D1141: -2.08320000e-02
-  sysZ3D1142: -0.0
+  sysZ3D1142: 0.0
   sysZ3D1143: 0.0
   sysZ3D1144: 0.0
   sysZ3D1145: 0.0
@@ -6825,16 +6825,16 @@ bins:
   sysZ3D1150: 0.0
   sysZ3D1151: 0.0
   sysZ3D1152: 0.0
-  sysZ3D1153: -0.0
-  sysZ3D1154: -0.0
+  sysZ3D1153: 0.0
+  sysZ3D1154: 0.0
   sysZ3D1155: 0.0
-  sysZ3D1156: -0.0
+  sysZ3D1156: 0.0
   sysZ3D1157: 0.0
   sysZ3D1158: 0.0
-  sysZ3D1159: -0.0
+  sysZ3D1159: 0.0
   sysZ3D1160: -2.08320000e-02
   sysZ3D1161: 0.0
-  sysZ3D1162: -0.0
+  sysZ3D1162: 0.0
   sysZ3D1163: 0.0
   sysZ3D1164: -2.08320000e-02
   sysZ3D1165: 0.0
@@ -6845,7 +6845,7 @@ bins:
   sysZ3D1170: 2.08320000e-02
   sysZ3D1171: 2.08320000e-02
   sysZ3D1172: 2.08320000e-02
-  sysZ3D1173: -0.0
+  sysZ3D1173: 0.0
   sysZ3D1174: -2.08320000e-02
   sysZ3D1175: 0.0
   sysZ3D1176: -4.16640000e-02
@@ -6853,14 +6853,14 @@ bins:
   sysZ3D1178: 0.0
   sysZ3D1179: 0.0
   sysZ3D1180: 0.0
-  sysZ3D1181: -0.0
-  sysZ3D1182: -0.0
+  sysZ3D1181: 0.0
+  sysZ3D1182: 0.0
   sysZ3D1183: -2.08320000e-02
   sysZ3D1184: 0.0
   sysZ3D1185: 0.0
   sysZ3D1186: 0.0
-  sysZ3D1187: -0.0
-  sysZ3D1188: -0.0
+  sysZ3D1187: 0.0
+  sysZ3D1188: 0.0
   sysZ3D1189: 0.0
   sysZ3D1190: 0.0
   sysZ3D1191: 2.08320000e-02
@@ -6870,7 +6870,7 @@ bins:
   sysZ3D1195: -2.08320000e-02
   sysZ3D1196: -2.08320000e-02
   sysZ3D1197: -2.08320000e-02
-  sysZ3D1198: -0.0
+  sysZ3D1198: 0.0
   sysZ3D1199: 2.08320000e-02
   sysZ3D1200: 4.16640000e-02
   sysZ3D1201: 6.24960000e-02
@@ -6879,7 +6879,7 @@ bins:
   sysZ3D1204: -2.08320000e-02
   sysZ3D1205: -2.08320000e-02
   sysZ3D1206: -2.08320000e-02
-  sysZ3D1207: -0.0
+  sysZ3D1207: 0.0
   sysZ3D1208: 0.0
   sysZ3D1209: 0.0
   sysZ3D1210: 4.16640000e-02
@@ -6901,16 +6901,16 @@ bins:
   sysZ3D1226: -2.08320000e-02
   sysZ3D1227: -2.08320000e-02
   sysZ3D1228: -4.16640000e-02
-  sysZ3D1229: -0.0
-  sysZ3D1230: -0.0
+  sysZ3D1229: 0.0
+  sysZ3D1230: 0.0
   sysZ3D1231: -2.08320000e-02
   sysZ3D1232: 0.0
   sysZ3D1233: 2.08320000e-02
   sysZ3D1234: 2.08320000e-02
   sysZ3D1235: 2.08320000e-02
-  sysZ3D1236: -0.0
-  sysZ3D1237: -0.0
-  sysZ3D1238: -0.0
+  sysZ3D1236: 0.0
+  sysZ3D1237: 0.0
+  sysZ3D1238: 0.0
   sysZ3D1239: 0.0
   sysZ3D1240: 0.0
   sysZ3D1241: 0.0
@@ -6918,7 +6918,7 @@ bins:
   sysZ3D1243: 0.0
   sysZ3D1244: -6.24960000e-02
   sysZ3D1245: 6.24960000e-02
-  sysZ3D1246: -0.0
+  sysZ3D1246: 0.0
   sysZ3D1247: 2.08320000e-02
   sysZ3D1248: 6.24960000e-02
   sysZ3D1249: 2.08320000e-02
@@ -6944,7 +6944,7 @@ bins:
   sysZ3D1269: 0.0
   sysZ3D1270: 4.16640000e-02
   sysZ3D1271: 2.08320000e-02
-  sysZ3D1272: -0.0
+  sysZ3D1272: 0.0
   sysZ3D1273: -2.08320000e-02
   sysZ3D1274: -8.33280000e-02
   sysZ3D1275: 0.145824
@@ -6953,7 +6953,7 @@ bins:
 - stat: 8.62512000e-01
   sysZ3D1001: -6.16080000e-02
   sysZ3D1002: 1.54020000e-02
-  sysZ3D1003: -0.0
+  sysZ3D1003: 0.0
   sysZ3D1004: 0.0
   sysZ3D1005: 0.0
   sysZ3D1006: 0.0
@@ -6970,9 +6970,9 @@ bins:
   sysZ3D1017: 0.0
   sysZ3D1018: 0.0
   sysZ3D1019: 0.0
-  sysZ3D1020: -0.0
-  sysZ3D1021: -0.0
-  sysZ3D1022: -0.0
+  sysZ3D1020: 0.0
+  sysZ3D1021: 0.0
+  sysZ3D1022: 0.0
   sysZ3D1023: -3.08040000e-02
   sysZ3D1024: 3.08040000e-02
   sysZ3D1025: -6.16080000e-02
@@ -6987,43 +6987,43 @@ bins:
   sysZ3D1034: 0.0
   sysZ3D1035: 1.54020000e-02
   sysZ3D1036: 0.0
-  sysZ3D1037: -0.0
+  sysZ3D1037: 0.0
   sysZ3D1038: 1.54020000e-02
   sysZ3D1039: 1.54020000e-02
-  sysZ3D1040: -0.0
+  sysZ3D1040: 0.0
   sysZ3D1041: 1.54020000e-02
   sysZ3D1042: 0.0
   sysZ3D1043: 0.0
   sysZ3D1044: 0.0
   sysZ3D1045: 0.0
-  sysZ3D1046: -0.0
-  sysZ3D1047: -0.0
+  sysZ3D1046: 0.0
+  sysZ3D1047: 0.0
   sysZ3D1048: -1.54020000e-02
   sysZ3D1049: 1.54020000e-02
-  sysZ3D1050: -0.0
+  sysZ3D1050: 0.0
   sysZ3D1051: 0.0
   sysZ3D1052: 0.0
-  sysZ3D1053: -0.0
+  sysZ3D1053: 0.0
   sysZ3D1054: 0.0
-  sysZ3D1055: -0.0
+  sysZ3D1055: 0.0
   sysZ3D1056: 0.0
   sysZ3D1057: 0.0
-  sysZ3D1058: -0.0
+  sysZ3D1058: 0.0
   sysZ3D1059: -1.54020000e-02
   sysZ3D1060: -1.54020000e-02
-  sysZ3D1061: -0.0
+  sysZ3D1061: 0.0
   sysZ3D1062: 0.0
   sysZ3D1063: 0.0
   sysZ3D1064: 0.0
-  sysZ3D1065: -0.0
-  sysZ3D1066: -0.0
-  sysZ3D1067: -0.0
+  sysZ3D1065: 0.0
+  sysZ3D1066: 0.0
+  sysZ3D1067: 0.0
   sysZ3D1068: -1.54020000e-02
   sysZ3D1069: 1.54020000e-02
-  sysZ3D1070: -0.0
-  sysZ3D1071: -0.0
-  sysZ3D1072: -0.0
-  sysZ3D1073: -0.0
+  sysZ3D1070: 0.0
+  sysZ3D1071: 0.0
+  sysZ3D1072: 0.0
+  sysZ3D1073: 0.0
   sysZ3D1074: 1.54020000e-02
   sysZ3D1075: -1.54020000e-02
   sysZ3D1076: 0.0
@@ -7031,7 +7031,7 @@ bins:
   sysZ3D1078: 0.0
   sysZ3D1079: 1.54020000e-02
   sysZ3D1080: -1.54020000e-02
-  sysZ3D1081: -0.0
+  sysZ3D1081: 0.0
   sysZ3D1082: 1.54020000e-02
   sysZ3D1083: 0.0
   sysZ3D1084: 0.0
@@ -7039,27 +7039,27 @@ bins:
   sysZ3D1086: 0.0
   sysZ3D1087: 1.54020000e-02
   sysZ3D1088: 1.54020000e-02
-  sysZ3D1089: -0.0
-  sysZ3D1090: -0.0
+  sysZ3D1089: 0.0
+  sysZ3D1090: 0.0
   sysZ3D1091: 0.0
-  sysZ3D1092: -0.0
-  sysZ3D1093: -0.0
-  sysZ3D1094: -0.0
-  sysZ3D1095: -0.0
-  sysZ3D1096: -0.0
+  sysZ3D1092: 0.0
+  sysZ3D1093: 0.0
+  sysZ3D1094: 0.0
+  sysZ3D1095: 0.0
+  sysZ3D1096: 0.0
   sysZ3D1097: 1.54020000e-02
   sysZ3D1098: -1.54020000e-02
   sysZ3D1099: 1.54020000e-02
   sysZ3D1100: -1.54020000e-02
   sysZ3D1101: 1.54020000e-02
   sysZ3D1102: 0.0
-  sysZ3D1103: -0.0
+  sysZ3D1103: 0.0
   sysZ3D1104: -4.62060000e-02
   sysZ3D1105: -2.61834000e-01
   sysZ3D1106: -4.62060000e-02
-  sysZ3D1107: -0.0
+  sysZ3D1107: 0.0
   sysZ3D1108: -9.24120000e-02
-  sysZ3D1109: -0.0
+  sysZ3D1109: 0.0
   sysZ3D1110: 0.0
   sysZ3D1111: -4.62060000e-02
   sysZ3D1112: 0.0
@@ -7071,7 +7071,7 @@ bins:
   sysZ3D1118: 0.0
   sysZ3D1119: 0.0
   sysZ3D1120: 0.0
-  sysZ3D1121: -0.0
+  sysZ3D1121: 0.0
   sysZ3D1122: -1.54020000e-02
   sysZ3D1123: -1.54020000e-02
   sysZ3D1124: -1.07814000e-01
@@ -7080,34 +7080,34 @@ bins:
   sysZ3D1127: 1.54020000e-02
   sysZ3D1128: -3.08040000e-02
   sysZ3D1129: 3.08040000e-02
-  sysZ3D1130: -0.0
-  sysZ3D1131: -0.0
+  sysZ3D1130: 0.0
+  sysZ3D1131: 0.0
   sysZ3D1132: -1.54020000e-02
   sysZ3D1133: -1.54020000e-02
   sysZ3D1134: 6.16080000e-02
   sysZ3D1135: 1.54020000e-02
   sysZ3D1136: -1.54020000e-02
   sysZ3D1137: -1.54020000e-02
-  sysZ3D1138: -0.0
+  sysZ3D1138: 0.0
   sysZ3D1139: 0.0
   sysZ3D1140: 0.0
   sysZ3D1141: 0.0
-  sysZ3D1142: -0.0
-  sysZ3D1143: -0.0
-  sysZ3D1144: -0.0
-  sysZ3D1145: -0.0
+  sysZ3D1142: 0.0
+  sysZ3D1143: 0.0
+  sysZ3D1144: 0.0
+  sysZ3D1145: 0.0
   sysZ3D1146: 0.0
-  sysZ3D1147: -0.0
-  sysZ3D1148: -0.0
-  sysZ3D1149: -0.0
+  sysZ3D1147: 0.0
+  sysZ3D1148: 0.0
+  sysZ3D1149: 0.0
   sysZ3D1150: 0.0
   sysZ3D1151: 0.0
   sysZ3D1152: -1.54020000e-02
-  sysZ3D1153: -0.0
+  sysZ3D1153: 0.0
   sysZ3D1154: 1.54020000e-02
   sysZ3D1155: 1.54020000e-02
   sysZ3D1156: 0.0
-  sysZ3D1157: -0.0
+  sysZ3D1157: 0.0
   sysZ3D1158: 0.0
   sysZ3D1159: 3.08040000e-02
   sysZ3D1160: 1.54020000e-02
@@ -7119,30 +7119,30 @@ bins:
   sysZ3D1166: -6.16080000e-02
   sysZ3D1167: 1.54020000e-02
   sysZ3D1168: 0.0
-  sysZ3D1169: -0.0
+  sysZ3D1169: 0.0
   sysZ3D1170: 1.54020000e-02
   sysZ3D1171: 1.54020000e-02
   sysZ3D1172: 0.0
-  sysZ3D1173: -0.0
+  sysZ3D1173: 0.0
   sysZ3D1174: -1.54020000e-02
   sysZ3D1175: 0.0
   sysZ3D1176: -3.08040000e-02
   sysZ3D1177: -3.08040000e-02
-  sysZ3D1178: -0.0
+  sysZ3D1178: 0.0
   sysZ3D1179: 1.54020000e-02
   sysZ3D1180: 1.54020000e-02
   sysZ3D1181: -1.54020000e-02
-  sysZ3D1182: -0.0
+  sysZ3D1182: 0.0
   sysZ3D1183: -1.54020000e-02
   sysZ3D1184: 0.0
   sysZ3D1185: 0.0
   sysZ3D1186: 0.0
-  sysZ3D1187: -0.0
-  sysZ3D1188: -0.0
+  sysZ3D1187: 0.0
+  sysZ3D1188: 0.0
   sysZ3D1189: 0.0
   sysZ3D1190: 0.0
   sysZ3D1191: 1.54020000e-02
-  sysZ3D1192: -0.0
+  sysZ3D1192: 0.0
   sysZ3D1193: 1.54020000e-02
   sysZ3D1194: 0.277236
   sysZ3D1195: -3.08040000e-02
@@ -7158,7 +7158,7 @@ bins:
   sysZ3D1205: -1.54020000e-02
   sysZ3D1206: -1.54020000e-02
   sysZ3D1207: -1.54020000e-02
-  sysZ3D1208: -0.0
+  sysZ3D1208: 0.0
   sysZ3D1209: 1.54020000e-02
   sysZ3D1210: 3.08040000e-02
   sysZ3D1211: 0.0
@@ -7166,7 +7166,7 @@ bins:
   sysZ3D1213: 1.54020000e-02
   sysZ3D1214: 1.54020000e-02
   sysZ3D1215: 3.08040000e-02
-  sysZ3D1216: -0.0
+  sysZ3D1216: 0.0
   sysZ3D1217: -0.07701
   sysZ3D1218: -0.07701
   sysZ3D1219: -1.54020000e-02
@@ -7174,7 +7174,7 @@ bins:
   sysZ3D1221: 1.54020000e-02
   sysZ3D1222: 1.54020000e-02
   sysZ3D1223: 3.08040000e-02
-  sysZ3D1224: -0.0
+  sysZ3D1224: 0.0
   sysZ3D1225: -3.08040000e-02
   sysZ3D1226: -1.54020000e-02
   sysZ3D1227: -0.07701
@@ -7187,11 +7187,11 @@ bins:
   sysZ3D1234: 1.54020000e-02
   sysZ3D1235: 1.54020000e-02
   sysZ3D1236: 0.0
-  sysZ3D1237: -0.0
+  sysZ3D1237: 0.0
   sysZ3D1238: -1.54020000e-02
   sysZ3D1239: 0.0
   sysZ3D1240: 0.0
-  sysZ3D1241: -0.0
+  sysZ3D1241: 0.0
   sysZ3D1242: 0.0
   sysZ3D1243: 0.0
   sysZ3D1244: -0.07701
@@ -7200,11 +7200,11 @@ bins:
   sysZ3D1247: 1.54020000e-02
   sysZ3D1248: 4.62060000e-02
   sysZ3D1249: 3.08040000e-02
-  sysZ3D1250: -0.0
+  sysZ3D1250: 0.0
   sysZ3D1251: 3.08040000e-02
   sysZ3D1252: 0.07701
   sysZ3D1253: 1.54020000e-02
-  sysZ3D1254: -0.0
+  sysZ3D1254: 0.0
   sysZ3D1255: -2.92638000e-01
   sysZ3D1256: 3.08040000e-02
   sysZ3D1257: -9.24120000e-02
@@ -7222,8 +7222,8 @@ bins:
   sysZ3D1269: 0.0
   sysZ3D1270: 3.08040000e-02
   sysZ3D1271: 1.54020000e-02
-  sysZ3D1272: -0.0
-  sysZ3D1273: -0.0
+  sysZ3D1272: 0.0
+  sysZ3D1273: 0.0
   sysZ3D1274: -1.23216000e-01
   sysZ3D1275: 9.24120000e-02
   sys,uncor: 0.508266
@@ -7231,7 +7231,7 @@ bins:
 - stat: 0.64862
   sysZ3D1001: -0.04633
   sysZ3D1002: 0.0
-  sysZ3D1003: -0.0
+  sysZ3D1003: 0.0
   sysZ3D1004: 0.0
   sysZ3D1005: 0.0
   sysZ3D1006: 0.0
@@ -7258,19 +7258,19 @@ bins:
   sysZ3D1027: -2.77980000e-02
   sysZ3D1028: 0.0
   sysZ3D1029: -9.26600000e-03
-  sysZ3D1030: -0.0
+  sysZ3D1030: 0.0
   sysZ3D1031: 0.009266
-  sysZ3D1032: -0.0
+  sysZ3D1032: 0.0
   sysZ3D1033: -9.26600000e-03
   sysZ3D1034: -9.26600000e-03
   sysZ3D1035: 0.009266
-  sysZ3D1036: -0.0
-  sysZ3D1037: -0.0
+  sysZ3D1036: 0.0
+  sysZ3D1037: 0.0
   sysZ3D1038: 0.0
   sysZ3D1039: 0.0
   sysZ3D1040: 0.009266
-  sysZ3D1041: -0.0
-  sysZ3D1042: -0.0
+  sysZ3D1041: 0.0
+  sysZ3D1042: 0.0
   sysZ3D1043: 0.0
   sysZ3D1044: -9.26600000e-03
   sysZ3D1045: 0.0
@@ -7285,41 +7285,41 @@ bins:
   sysZ3D1054: -9.26600000e-03
   sysZ3D1055: 0.0
   sysZ3D1056: 0.0
-  sysZ3D1057: -0.0
+  sysZ3D1057: 0.0
   sysZ3D1058: 0.018532
   sysZ3D1059: 0.009266
   sysZ3D1060: -9.26600000e-03
-  sysZ3D1061: -0.0
+  sysZ3D1061: 0.0
   sysZ3D1062: 0.0
   sysZ3D1063: 0.0
   sysZ3D1064: -9.26600000e-03
   sysZ3D1065: 0.009266
-  sysZ3D1066: -0.0
-  sysZ3D1067: -0.0
-  sysZ3D1068: -0.0
+  sysZ3D1066: 0.0
+  sysZ3D1067: 0.0
+  sysZ3D1068: 0.0
   sysZ3D1069: 0.009266
-  sysZ3D1070: -0.0
+  sysZ3D1070: 0.0
   sysZ3D1071: 0.009266
   sysZ3D1072: 0.0
   sysZ3D1073: -9.26600000e-03
   sysZ3D1074: 0.0
   sysZ3D1075: 0.0
   sysZ3D1076: 0.009266
-  sysZ3D1077: -0.0
+  sysZ3D1077: 0.0
   sysZ3D1078: 0.009266
   sysZ3D1079: 0.0
   sysZ3D1080: -9.26600000e-03
   sysZ3D1081: 0.0
   sysZ3D1082: 0.0
   sysZ3D1083: -9.26600000e-03
-  sysZ3D1084: -0.0
+  sysZ3D1084: 0.0
   sysZ3D1085: -1.85320000e-02
-  sysZ3D1086: -0.0
-  sysZ3D1087: -0.0
+  sysZ3D1086: 0.0
+  sysZ3D1087: 0.0
   sysZ3D1088: -9.26600000e-03
-  sysZ3D1089: -0.0
+  sysZ3D1089: 0.0
   sysZ3D1090: -9.26600000e-03
-  sysZ3D1091: -0.0
+  sysZ3D1091: 0.0
   sysZ3D1092: -9.26600000e-03
   sysZ3D1093: 0.018532
   sysZ3D1094: -9.26600000e-03
@@ -7335,7 +7335,7 @@ bins:
   sysZ3D1104: -1.85320000e-02
   sysZ3D1105: -1.57522000e-01
   sysZ3D1106: -2.77980000e-02
-  sysZ3D1107: -0.0
+  sysZ3D1107: 0.0
   sysZ3D1108: -5.55960000e-02
   sysZ3D1109: 0.0
   sysZ3D1110: 0.0
@@ -7346,10 +7346,10 @@ bins:
   sysZ3D1115: -5.55960000e-02
   sysZ3D1116: -9.26600000e-03
   sysZ3D1117: 0.0
-  sysZ3D1118: -0.0
-  sysZ3D1119: -0.0
+  sysZ3D1118: 0.0
+  sysZ3D1119: 0.0
   sysZ3D1120: 0.0
-  sysZ3D1121: -0.0
+  sysZ3D1121: 0.0
   sysZ3D1122: 0.0
   sysZ3D1123: -9.26600000e-03
   sysZ3D1124: -3.70640000e-02
@@ -7360,33 +7360,33 @@ bins:
   sysZ3D1129: 0.009266
   sysZ3D1130: -9.26600000e-03
   sysZ3D1131: 0.009266
-  sysZ3D1132: -0.0
+  sysZ3D1132: 0.0
   sysZ3D1133: -1.85320000e-02
-  sysZ3D1134: -0.0
+  sysZ3D1134: 0.0
   sysZ3D1135: 0.009266
   sysZ3D1136: -9.26600000e-03
-  sysZ3D1137: -0.0
+  sysZ3D1137: 0.0
   sysZ3D1138: 0.0
   sysZ3D1139: 0.009266
   sysZ3D1140: 0.0
-  sysZ3D1141: -0.0
+  sysZ3D1141: 0.0
   sysZ3D1142: 0.0
-  sysZ3D1143: -0.0
-  sysZ3D1144: -0.0
+  sysZ3D1143: 0.0
+  sysZ3D1144: 0.0
   sysZ3D1145: 0.0
   sysZ3D1146: 0.0
-  sysZ3D1147: -0.0
-  sysZ3D1148: -0.0
-  sysZ3D1149: -0.0
+  sysZ3D1147: 0.0
+  sysZ3D1148: 0.0
+  sysZ3D1149: 0.0
   sysZ3D1150: 0.0
   sysZ3D1151: 0.0
-  sysZ3D1152: -0.0
-  sysZ3D1153: -0.0
+  sysZ3D1152: 0.0
+  sysZ3D1153: 0.0
   sysZ3D1154: 0.0
   sysZ3D1155: 0.009266
   sysZ3D1156: 0.0
   sysZ3D1157: 0.0
-  sysZ3D1158: -0.0
+  sysZ3D1158: 0.0
   sysZ3D1159: -9.26600000e-03
   sysZ3D1160: 0.009266
   sysZ3D1161: 0.009266
@@ -7412,12 +7412,12 @@ bins:
   sysZ3D1181: -9.26600000e-03
   sysZ3D1182: 0.0
   sysZ3D1183: -9.26600000e-03
-  sysZ3D1184: -0.0
+  sysZ3D1184: 0.0
   sysZ3D1185: 0.009266
   sysZ3D1186: 0.009266
   sysZ3D1187: 0.009266
   sysZ3D1188: -9.26600000e-03
-  sysZ3D1189: -0.0
+  sysZ3D1189: 0.0
   sysZ3D1190: 0.0
   sysZ3D1191: 0.009266
   sysZ3D1192: 0.0
@@ -7436,7 +7436,7 @@ bins:
   sysZ3D1205: -1.85320000e-02
   sysZ3D1206: -1.85320000e-02
   sysZ3D1207: -9.26600000e-03
-  sysZ3D1208: -0.0
+  sysZ3D1208: 0.0
   sysZ3D1209: 0.0
   sysZ3D1210: 0.009266
   sysZ3D1211: 0.009266
@@ -7452,7 +7452,7 @@ bins:
   sysZ3D1221: 0.009266
   sysZ3D1222: 0.009266
   sysZ3D1223: 0.018532
-  sysZ3D1224: -0.0
+  sysZ3D1224: 0.0
   sysZ3D1225: -9.26600000e-03
   sysZ3D1226: -9.26600000e-03
   sysZ3D1227: -0.04633
@@ -7464,12 +7464,12 @@ bins:
   sysZ3D1233: 0.009266
   sysZ3D1234: 0.009266
   sysZ3D1235: 0.009266
-  sysZ3D1236: -0.0
-  sysZ3D1237: -0.0
+  sysZ3D1236: 0.0
+  sysZ3D1237: 0.0
   sysZ3D1238: -9.26600000e-03
   sysZ3D1239: 0.0
   sysZ3D1240: 0.009266
-  sysZ3D1241: -0.0
+  sysZ3D1241: 0.0
   sysZ3D1242: 0.0
   sysZ3D1243: 0.0
   sysZ3D1244: -6.48620000e-02
@@ -7478,7 +7478,7 @@ bins:
   sysZ3D1247: 0.009266
   sysZ3D1248: 0.027798
   sysZ3D1249: 0.027798
-  sysZ3D1250: -0.0
+  sysZ3D1250: 0.0
   sysZ3D1251: 0.018532
   sysZ3D1252: 6.48620000e-02
   sysZ3D1253: 0.009266
@@ -7509,7 +7509,7 @@ bins:
 - stat: 3.59900000e-01
   sysZ3D1001: -1.83000000e-02
   sysZ3D1002: -0.0061
-  sysZ3D1003: -0.0
+  sysZ3D1003: 0.0
   sysZ3D1004: 0.0
   sysZ3D1005: 0.0
   sysZ3D1006: 0.0
@@ -7527,7 +7527,7 @@ bins:
   sysZ3D1018: 0.0
   sysZ3D1019: 0.0
   sysZ3D1020: 0.00305
-  sysZ3D1021: -0.0
+  sysZ3D1021: 0.0
   sysZ3D1022: 0.0
   sysZ3D1023: -2.13500000e-02
   sysZ3D1024: 1.83000000e-02
@@ -7545,7 +7545,7 @@ bins:
   sysZ3D1036: 0.0
   sysZ3D1037: 0.00305
   sysZ3D1038: 0.00305
-  sysZ3D1039: -0.0
+  sysZ3D1039: 0.0
   sysZ3D1040: -0.00305
   sysZ3D1041: -0.00305
   sysZ3D1042: 0.0
@@ -7575,24 +7575,24 @@ bins:
   sysZ3D1066: 0.00305
   sysZ3D1067: -0.00305
   sysZ3D1068: 0.0
-  sysZ3D1069: -0.0
+  sysZ3D1069: 0.0
   sysZ3D1070: -0.00305
   sysZ3D1071: 0.0
-  sysZ3D1072: -0.0
-  sysZ3D1073: -0.0
-  sysZ3D1074: -0.0
+  sysZ3D1072: 0.0
+  sysZ3D1073: 0.0
+  sysZ3D1074: 0.0
   sysZ3D1075: -0.00305
   sysZ3D1076: 0.0
   sysZ3D1077: 0.00305
-  sysZ3D1078: -0.0
+  sysZ3D1078: 0.0
   sysZ3D1079: 0.00305
   sysZ3D1080: -0.0061
   sysZ3D1081: -9.15000000e-03
-  sysZ3D1082: -0.0
+  sysZ3D1082: 0.0
   sysZ3D1083: 0.0061
   sysZ3D1084: -0.0061
   sysZ3D1085: -0.00305
-  sysZ3D1086: -0.0
+  sysZ3D1086: 0.0
   sysZ3D1087: 0.0
   sysZ3D1088: -0.00305
   sysZ3D1089: -0.0061
@@ -7603,17 +7603,17 @@ bins:
   sysZ3D1094: -0.01525
   sysZ3D1095: -0.0061
   sysZ3D1096: 0.0061
-  sysZ3D1097: -0.0
+  sysZ3D1097: 0.0
   sysZ3D1098: 0.0
-  sysZ3D1099: -0.0
+  sysZ3D1099: 0.0
   sysZ3D1100: -0.00305
   sysZ3D1101: -0.00305
-  sysZ3D1102: -0.0
+  sysZ3D1102: 0.0
   sysZ3D1103: 0.00305
   sysZ3D1104: -0.0061
   sysZ3D1105: -0.04575
   sysZ3D1106: -9.15000000e-03
-  sysZ3D1107: -0.0
+  sysZ3D1107: 0.0
   sysZ3D1108: -0.02745
   sysZ3D1109: -0.00305
   sysZ3D1110: 0.0
@@ -7624,10 +7624,10 @@ bins:
   sysZ3D1115: 0.03355
   sysZ3D1116: 0.00305
   sysZ3D1117: 0.0
-  sysZ3D1118: -0.0
-  sysZ3D1119: -0.0
+  sysZ3D1118: 0.0
+  sysZ3D1119: 0.0
   sysZ3D1120: 0.0
-  sysZ3D1121: -0.0
+  sysZ3D1121: 0.0
   sysZ3D1122: 0.0
   sysZ3D1123: 0.0
   sysZ3D1124: 2.13500000e-02
@@ -7639,34 +7639,34 @@ bins:
   sysZ3D1130: 1.83000000e-02
   sysZ3D1131: -0.00305
   sysZ3D1132: 0.00305
-  sysZ3D1133: -0.0
+  sysZ3D1133: 0.0
   sysZ3D1134: -0.00305
   sysZ3D1135: -0.00305
   sysZ3D1136: -0.00305
-  sysZ3D1137: -0.0
+  sysZ3D1137: 0.0
   sysZ3D1138: 0.0
   sysZ3D1139: 0.00305
   sysZ3D1140: 0.00305
   sysZ3D1141: 0.0
   sysZ3D1142: 0.0
-  sysZ3D1143: -0.0
+  sysZ3D1143: 0.0
   sysZ3D1144: 0.0
   sysZ3D1145: 0.0
   sysZ3D1146: 0.0
-  sysZ3D1147: -0.0
+  sysZ3D1147: 0.0
   sysZ3D1148: 0.0
-  sysZ3D1149: -0.0
-  sysZ3D1150: -0.0
+  sysZ3D1149: 0.0
+  sysZ3D1150: 0.0
   sysZ3D1151: 0.00305
-  sysZ3D1152: -0.0
+  sysZ3D1152: 0.0
   sysZ3D1153: -0.00305
   sysZ3D1154: 0.00305
   sysZ3D1155: 0.00305
   sysZ3D1156: 0.00305
   sysZ3D1157: 0.00305
-  sysZ3D1158: -0.0
+  sysZ3D1158: 0.0
   sysZ3D1159: -0.00305
-  sysZ3D1160: -0.0
+  sysZ3D1160: 0.0
   sysZ3D1161: -0.00305
   sysZ3D1162: 0.0
   sysZ3D1163: 0.00305
@@ -7678,13 +7678,13 @@ bins:
   sysZ3D1169: 0.0
   sysZ3D1170: 0.00305
   sysZ3D1171: 9.15000000e-03
-  sysZ3D1172: -0.0
+  sysZ3D1172: 0.0
   sysZ3D1173: -0.0061
   sysZ3D1174: -9.15000000e-03
-  sysZ3D1175: -0.0
+  sysZ3D1175: 0.0
   sysZ3D1176: 0.0061
   sysZ3D1177: 9.15000000e-03
-  sysZ3D1178: -0.0
+  sysZ3D1178: 0.0
   sysZ3D1179: 0.00305
   sysZ3D1180: 0.00305
   sysZ3D1181: -0.00305
@@ -7696,7 +7696,7 @@ bins:
   sysZ3D1187: 9.15000000e-03
   sysZ3D1188: -0.0061
   sysZ3D1189: -0.0061
-  sysZ3D1190: -0.0
+  sysZ3D1190: 0.0
   sysZ3D1191: 0.00305
   sysZ3D1192: 0.00305
   sysZ3D1193: 0.0061
@@ -7714,7 +7714,7 @@ bins:
   sysZ3D1205: -9.15000000e-03
   sysZ3D1206: -9.15000000e-03
   sysZ3D1207: -0.00305
-  sysZ3D1208: -0.0
+  sysZ3D1208: 0.0
   sysZ3D1209: 0.00305
   sysZ3D1210: 9.15000000e-03
   sysZ3D1211: 0.00305
@@ -7742,12 +7742,12 @@ bins:
   sysZ3D1233: 0.0061
   sysZ3D1234: 0.0061
   sysZ3D1235: 0.0061
-  sysZ3D1236: -0.0
-  sysZ3D1237: -0.0
+  sysZ3D1236: 0.0
+  sysZ3D1237: 0.0
   sysZ3D1238: -0.00305
   sysZ3D1239: 0.0
   sysZ3D1240: 0.00305
-  sysZ3D1241: -0.0
+  sysZ3D1241: 0.0
   sysZ3D1242: 0.0
   sysZ3D1243: 0.0
   sysZ3D1244: -0.03965
@@ -7763,7 +7763,7 @@ bins:
   sysZ3D1254: 0.00305
   sysZ3D1255: -0.061
   sysZ3D1256: 1.83000000e-02
-  sysZ3D1257: -0.0
+  sysZ3D1257: 0.0
   sysZ3D1258: 0.0122
   sysZ3D1259: -0.00305
   sysZ3D1260: -0.0061
@@ -7807,79 +7807,79 @@ bins:
   sysZ3D1020: 0.0
   sysZ3D1021: 0.0
   sysZ3D1022: 0.0
-  sysZ3D1023: -0.0
+  sysZ3D1023: 0.0
   sysZ3D1024: 0.0
-  sysZ3D1025: -0.0
+  sysZ3D1025: 0.0
   sysZ3D1026: 0.0
   sysZ3D1027: 0.0
   sysZ3D1028: 0.0
   sysZ3D1029: 0.0
-  sysZ3D1030: -0.0
-  sysZ3D1031: -0.0
-  sysZ3D1032: -0.0
+  sysZ3D1030: 0.0
+  sysZ3D1031: 0.0
+  sysZ3D1032: 0.0
   sysZ3D1033: 0.0
   sysZ3D1034: 0.0
   sysZ3D1035: 0.0
   sysZ3D1036: 0.0
   sysZ3D1037: 0.0
-  sysZ3D1038: -0.0
-  sysZ3D1039: -0.0
-  sysZ3D1040: -0.0
-  sysZ3D1041: -0.0
+  sysZ3D1038: 0.0
+  sysZ3D1039: 0.0
+  sysZ3D1040: 0.0
+  sysZ3D1041: 0.0
   sysZ3D1042: 0.0
   sysZ3D1043: 0.0
-  sysZ3D1044: -0.0
+  sysZ3D1044: 0.0
   sysZ3D1045: 0.0
   sysZ3D1046: 0.0
   sysZ3D1047: 0.0
-  sysZ3D1048: -0.0
-  sysZ3D1049: -0.0
+  sysZ3D1048: 0.0
+  sysZ3D1049: 0.0
   sysZ3D1050: 0.0
   sysZ3D1051: 0.0
   sysZ3D1052: 0.0
   sysZ3D1053: 0.0
   sysZ3D1054: 0.0
-  sysZ3D1055: -0.0
-  sysZ3D1056: -0.0
+  sysZ3D1055: 0.0
+  sysZ3D1056: 0.0
   sysZ3D1057: 0.0
   sysZ3D1058: 0.0
-  sysZ3D1059: -0.0
-  sysZ3D1060: -0.0
+  sysZ3D1059: 0.0
+  sysZ3D1060: 0.0
   sysZ3D1061: 0.0
-  sysZ3D1062: -0.0
-  sysZ3D1063: -0.0
-  sysZ3D1064: -0.0
-  sysZ3D1065: -0.0
+  sysZ3D1062: 0.0
+  sysZ3D1063: 0.0
+  sysZ3D1064: 0.0
+  sysZ3D1065: 0.0
   sysZ3D1066: 0.0
   sysZ3D1067: 0.0
   sysZ3D1068: 0.0
   sysZ3D1069: 0.0
-  sysZ3D1070: -0.0
-  sysZ3D1071: -0.0
+  sysZ3D1070: 0.0
+  sysZ3D1071: 0.0
   sysZ3D1072: 0.0
   sysZ3D1073: 0.0
-  sysZ3D1074: -0.0
+  sysZ3D1074: 0.0
   sysZ3D1075: 0.0
   sysZ3D1076: 0.0
-  sysZ3D1077: -0.0
-  sysZ3D1078: -0.0
-  sysZ3D1079: -0.0
-  sysZ3D1080: -0.0
+  sysZ3D1077: 0.0
+  sysZ3D1078: 0.0
+  sysZ3D1079: 0.0
+  sysZ3D1080: 0.0
   sysZ3D1081: 0.0
   sysZ3D1082: 0.0
   sysZ3D1083: 0.0
-  sysZ3D1084: -0.0
+  sysZ3D1084: 0.0
   sysZ3D1085: 0.0
   sysZ3D1086: 0.0
   sysZ3D1087: 0.0
-  sysZ3D1088: -0.0
+  sysZ3D1088: 0.0
   sysZ3D1089: 0.0
   sysZ3D1090: 0.0
   sysZ3D1091: 0.0
   sysZ3D1092: 0.0
   sysZ3D1093: 0.0
-  sysZ3D1094: -0.0
-  sysZ3D1095: -0.0
+  sysZ3D1094: 0.0
+  sysZ3D1095: 0.0
   sysZ3D1096: 0.0
   sysZ3D1097: 0.0
   sysZ3D1098: 0.0
@@ -7887,7 +7887,7 @@ bins:
   sysZ3D1100: 0.0
   sysZ3D1101: 0.0
   sysZ3D1102: 0.0
-  sysZ3D1103: -0.0
+  sysZ3D1103: 0.0
   sysZ3D1104: -5.99640000e-01
   sysZ3D1105: -5.99640000e-01
   sysZ3D1106: -5.99640000e-01
@@ -7896,93 +7896,93 @@ bins:
   sysZ3D1109: 0.0
   sysZ3D1110: 0.0
   sysZ3D1111: 0.0
-  sysZ3D1112: -0.0
+  sysZ3D1112: 0.0
   sysZ3D1113: 1.79892000e+00
-  sysZ3D1114: -0.0
+  sysZ3D1114: 0.0
   sysZ3D1115: 0.0
   sysZ3D1116: 0.0
-  sysZ3D1117: -0.0
+  sysZ3D1117: 0.0
   sysZ3D1118: 0.0
   sysZ3D1119: 5.99640000e-01
   sysZ3D1120: 5.99640000e-01
   sysZ3D1121: 0.0
-  sysZ3D1122: -0.0
-  sysZ3D1123: -0.0
-  sysZ3D1124: -0.0
-  sysZ3D1125: -0.0
+  sysZ3D1122: 0.0
+  sysZ3D1123: 0.0
+  sysZ3D1124: 0.0
+  sysZ3D1125: 0.0
   sysZ3D1126: 1.79892000e+00
   sysZ3D1127: -1.19928000e+00
   sysZ3D1128: 0.0
   sysZ3D1129: 0.0
-  sysZ3D1130: -0.0
-  sysZ3D1131: -0.0
+  sysZ3D1130: 0.0
+  sysZ3D1131: 0.0
   sysZ3D1132: 0.0
   sysZ3D1133: 0.0
-  sysZ3D1134: -0.0
-  sysZ3D1135: -0.0
+  sysZ3D1134: 0.0
+  sysZ3D1135: 0.0
   sysZ3D1136: 0.0
-  sysZ3D1137: -0.0
-  sysZ3D1138: -0.0
-  sysZ3D1139: -0.0
+  sysZ3D1137: 0.0
+  sysZ3D1138: 0.0
+  sysZ3D1139: 0.0
   sysZ3D1140: -5.99640000e-01
-  sysZ3D1141: -0.0
+  sysZ3D1141: 0.0
   sysZ3D1142: 0.0
   sysZ3D1143: 0.0
-  sysZ3D1144: -0.0
-  sysZ3D1145: -0.0
+  sysZ3D1144: 0.0
+  sysZ3D1145: 0.0
   sysZ3D1146: 0.0
   sysZ3D1147: 0.0
-  sysZ3D1148: -0.0
+  sysZ3D1148: 0.0
   sysZ3D1149: 0.0
   sysZ3D1150: 0.0
   sysZ3D1151: 0.0
-  sysZ3D1152: -0.0
+  sysZ3D1152: 0.0
   sysZ3D1153: 0.0
   sysZ3D1154: 0.0
-  sysZ3D1155: -0.0
+  sysZ3D1155: 0.0
   sysZ3D1156: 0.0
-  sysZ3D1157: -0.0
+  sysZ3D1157: 0.0
   sysZ3D1158: 0.0
-  sysZ3D1159: -0.0
+  sysZ3D1159: 0.0
   sysZ3D1160: 0.0
-  sysZ3D1161: -0.0
+  sysZ3D1161: 0.0
   sysZ3D1162: 0.0
   sysZ3D1163: 0.0
   sysZ3D1164: 0.0
   sysZ3D1165: 0.0
   sysZ3D1166: 0.0
-  sysZ3D1167: -0.0
-  sysZ3D1168: -0.0
-  sysZ3D1169: -0.0
+  sysZ3D1167: 0.0
+  sysZ3D1168: 0.0
+  sysZ3D1169: 0.0
   sysZ3D1170: 0.0
   sysZ3D1171: -5.99640000e-01
-  sysZ3D1172: -0.0
+  sysZ3D1172: 0.0
   sysZ3D1173: 0.0
-  sysZ3D1174: -0.0
+  sysZ3D1174: 0.0
   sysZ3D1175: 0.0
   sysZ3D1176: -5.99640000e-01
   sysZ3D1177: 0.0
   sysZ3D1178: 0.0
-  sysZ3D1179: -0.0
+  sysZ3D1179: 0.0
   sysZ3D1180: 0.0
-  sysZ3D1181: -0.0
-  sysZ3D1182: -0.0
+  sysZ3D1181: 0.0
+  sysZ3D1182: 0.0
   sysZ3D1183: 0.0
   sysZ3D1184: 0.0
   sysZ3D1185: 0.0
   sysZ3D1186: 0.0
   sysZ3D1187: 0.0
   sysZ3D1188: 0.0
-  sysZ3D1189: -0.0
-  sysZ3D1190: -0.0
-  sysZ3D1191: -0.0
+  sysZ3D1189: 0.0
+  sysZ3D1190: 0.0
+  sysZ3D1191: 0.0
   sysZ3D1192: 0.0
   sysZ3D1193: 5.99640000e-01
   sysZ3D1194: 7.19568000e+00
   sysZ3D1195: -1.79892000e+00
   sysZ3D1196: -1.19928000e+00
   sysZ3D1197: -5.99640000e-01
-  sysZ3D1198: -0.0
+  sysZ3D1198: 0.0
   sysZ3D1199: 1.19928000e+00
   sysZ3D1200: 1.79892000e+00
   sysZ3D1201: 1.19928000e+00
@@ -7991,7 +7991,7 @@ bins:
   sysZ3D1204: -1.19928000e+00
   sysZ3D1205: -5.99640000e-01
   sysZ3D1206: -5.99640000e-01
-  sysZ3D1207: -0.0
+  sysZ3D1207: 0.0
   sysZ3D1208: 0.0
   sysZ3D1209: 5.99640000e-01
   sysZ3D1210: 5.99640000e-01
@@ -8013,15 +8013,15 @@ bins:
   sysZ3D1226: -5.99640000e-01
   sysZ3D1227: -5.99640000e-01
   sysZ3D1228: -5.99640000e-01
-  sysZ3D1229: -0.0
+  sysZ3D1229: 0.0
   sysZ3D1230: -5.99640000e-01
   sysZ3D1231: -5.99640000e-01
   sysZ3D1232: 5.99640000e-01
   sysZ3D1233: 5.99640000e-01
   sysZ3D1234: 0.0
   sysZ3D1235: 5.99640000e-01
-  sysZ3D1236: -0.0
-  sysZ3D1237: -0.0
+  sysZ3D1236: 0.0
+  sysZ3D1237: 0.0
   sysZ3D1238: -5.99640000e-01
   sysZ3D1239: 0.0
   sysZ3D1240: 0.0
@@ -8034,7 +8034,7 @@ bins:
   sysZ3D1247: 5.99640000e-01
   sysZ3D1248: 1.79892000e+00
   sysZ3D1249: 5.99640000e-01
-  sysZ3D1250: -0.0
+  sysZ3D1250: 0.0
   sysZ3D1251: 1.79892000e+00
   sysZ3D1252: 1.19928000e+00
   sysZ3D1253: 0.0
@@ -8057,15 +8057,15 @@ bins:
   sysZ3D1270: 5.99640000e-01
   sysZ3D1271: 0.0
   sysZ3D1272: 0.0
-  sysZ3D1273: -0.0
-  sysZ3D1274: -0.0
+  sysZ3D1273: 0.0
+  sysZ3D1274: 0.0
   sysZ3D1275: 1.79892000e+00
   sys,uncor: 2.9982
   ATLAS_LUMI: 107.9352
 - stat: 6.59450000e+00
   sysZ3D1001: -1.7985
   sysZ3D1002: -0.5995
-  sysZ3D1003: -0.0
+  sysZ3D1003: 0.0
   sysZ3D1004: 0.0
   sysZ3D1005: 0.0
   sysZ3D1006: 0.0
@@ -8086,38 +8086,38 @@ bins:
   sysZ3D1021: 0.0
   sysZ3D1022: 0.0
   sysZ3D1023: 0.0
-  sysZ3D1024: -0.0
+  sysZ3D1024: 0.0
   sysZ3D1025: 0.0
-  sysZ3D1026: -0.0
+  sysZ3D1026: 0.0
   sysZ3D1027: 0.0
   sysZ3D1028: 0.0
   sysZ3D1029: 0.0
-  sysZ3D1030: -0.0
-  sysZ3D1031: -0.0
+  sysZ3D1030: 0.0
+  sysZ3D1031: 0.0
   sysZ3D1032: 0.0
-  sysZ3D1033: -0.0
+  sysZ3D1033: 0.0
   sysZ3D1034: 0.0
-  sysZ3D1035: -0.0
-  sysZ3D1036: -0.0
-  sysZ3D1037: -0.0
+  sysZ3D1035: 0.0
+  sysZ3D1036: 0.0
+  sysZ3D1037: 0.0
   sysZ3D1038: 0.0
   sysZ3D1039: 0.0
-  sysZ3D1040: -0.0
+  sysZ3D1040: 0.0
   sysZ3D1041: 0.0
-  sysZ3D1042: -0.0
-  sysZ3D1043: -0.0
+  sysZ3D1042: 0.0
+  sysZ3D1043: 0.0
   sysZ3D1044: 0.0
   sysZ3D1045: 0.0
   sysZ3D1046: 0.0
-  sysZ3D1047: -0.0
+  sysZ3D1047: 0.0
   sysZ3D1048: 0.0
-  sysZ3D1049: -0.0
-  sysZ3D1050: -0.0
+  sysZ3D1049: 0.0
+  sysZ3D1050: 0.0
   sysZ3D1051: 0.0
-  sysZ3D1052: -0.0
-  sysZ3D1053: -0.0
-  sysZ3D1054: -0.0
-  sysZ3D1055: -0.0
+  sysZ3D1052: 0.0
+  sysZ3D1053: 0.0
+  sysZ3D1054: 0.0
+  sysZ3D1055: 0.0
   sysZ3D1056: 0.0
   sysZ3D1057: 0.0
   sysZ3D1058: 0.0
@@ -8128,8 +8128,8 @@ bins:
   sysZ3D1063: 0.0
   sysZ3D1064: 0.0
   sysZ3D1065: 0.0
-  sysZ3D1066: -0.0
-  sysZ3D1067: -0.0
+  sysZ3D1066: 0.0
+  sysZ3D1067: 0.0
   sysZ3D1068: 0.0
   sysZ3D1069: 0.0
   sysZ3D1070: 0.0
@@ -8142,28 +8142,28 @@ bins:
   sysZ3D1077: 0.0
   sysZ3D1078: 0.0
   sysZ3D1079: 0.0
-  sysZ3D1080: -0.0
+  sysZ3D1080: 0.0
   sysZ3D1081: 0.0
-  sysZ3D1082: -0.0
+  sysZ3D1082: 0.0
   sysZ3D1083: 0.0
   sysZ3D1084: 0.0
   sysZ3D1085: 0.0
-  sysZ3D1086: -0.0
+  sysZ3D1086: 0.0
   sysZ3D1087: 0.0
   sysZ3D1088: 0.0
-  sysZ3D1089: -0.0
+  sysZ3D1089: 0.0
   sysZ3D1090: 0.0
   sysZ3D1091: 0.0
-  sysZ3D1092: -0.0
+  sysZ3D1092: 0.0
   sysZ3D1093: 0.0
   sysZ3D1094: 0.0
   sysZ3D1095: 0.0
   sysZ3D1096: 0.0
-  sysZ3D1097: -0.0
+  sysZ3D1097: 0.0
   sysZ3D1098: 0.0
   sysZ3D1099: 0.0
   sysZ3D1100: 0.0
-  sysZ3D1101: -0.0
+  sysZ3D1101: 0.0
   sysZ3D1102: 0.0
   sysZ3D1103: 0.0
   sysZ3D1104: -0.5995
@@ -8174,87 +8174,87 @@ bins:
   sysZ3D1109: 0.0
   sysZ3D1110: 0.0
   sysZ3D1111: 0.0
-  sysZ3D1112: -0.0
+  sysZ3D1112: 0.0
   sysZ3D1113: 1.7985
-  sysZ3D1114: -0.0
+  sysZ3D1114: 0.0
   sysZ3D1115: 0.0
-  sysZ3D1116: -0.0
+  sysZ3D1116: 0.0
   sysZ3D1117: 0.0
   sysZ3D1118: 0.0
   sysZ3D1119: 0.0
   sysZ3D1120: 0.5995
   sysZ3D1121: 0.5995
-  sysZ3D1122: -0.0
-  sysZ3D1123: -0.0
-  sysZ3D1124: -0.0
-  sysZ3D1125: -0.0
+  sysZ3D1122: 0.0
+  sysZ3D1123: 0.0
+  sysZ3D1124: 0.0
+  sysZ3D1125: 0.0
   sysZ3D1126: 1.7985
   sysZ3D1127: -0.5995
-  sysZ3D1128: -0.0
-  sysZ3D1129: -0.0
-  sysZ3D1130: -0.0
-  sysZ3D1131: -0.0
+  sysZ3D1128: 0.0
+  sysZ3D1129: 0.0
+  sysZ3D1130: 0.0
+  sysZ3D1131: 0.0
   sysZ3D1132: 0.0
   sysZ3D1133: 0.0
-  sysZ3D1134: -0.0
-  sysZ3D1135: -0.0
+  sysZ3D1134: 0.0
+  sysZ3D1135: 0.0
   sysZ3D1136: 0.0
-  sysZ3D1137: -0.0
+  sysZ3D1137: 0.0
   sysZ3D1138: 0.0
   sysZ3D1139: 0.0
   sysZ3D1140: 0.5995
-  sysZ3D1141: -0.0
-  sysZ3D1142: -0.0
-  sysZ3D1143: -0.0
-  sysZ3D1144: -0.0
+  sysZ3D1141: 0.0
+  sysZ3D1142: 0.0
+  sysZ3D1143: 0.0
+  sysZ3D1144: 0.0
   sysZ3D1145: 0.0
-  sysZ3D1146: -0.0
+  sysZ3D1146: 0.0
   sysZ3D1147: 0.0
   sysZ3D1148: 0.0
   sysZ3D1149: 0.0
-  sysZ3D1150: -0.0
-  sysZ3D1151: -0.0
-  sysZ3D1152: -0.0
-  sysZ3D1153: -0.0
-  sysZ3D1154: -0.0
-  sysZ3D1155: -0.0
+  sysZ3D1150: 0.0
+  sysZ3D1151: 0.0
+  sysZ3D1152: 0.0
+  sysZ3D1153: 0.0
+  sysZ3D1154: 0.0
+  sysZ3D1155: 0.0
   sysZ3D1156: 0.0
   sysZ3D1157: 0.0
-  sysZ3D1158: -0.0
+  sysZ3D1158: 0.0
   sysZ3D1159: 0.0
   sysZ3D1160: 0.0
   sysZ3D1161: 0.0
   sysZ3D1162: 0.0
   sysZ3D1163: 0.0
-  sysZ3D1164: -0.0
+  sysZ3D1164: 0.0
   sysZ3D1165: 0.0
   sysZ3D1166: 0.0
-  sysZ3D1167: -0.0
-  sysZ3D1168: -0.0
-  sysZ3D1169: -0.0
+  sysZ3D1167: 0.0
+  sysZ3D1168: 0.0
+  sysZ3D1169: 0.0
   sysZ3D1170: 0.5995
   sysZ3D1171: -0.5995
-  sysZ3D1172: -0.0
+  sysZ3D1172: 0.0
   sysZ3D1173: 0.0
-  sysZ3D1174: -0.0
+  sysZ3D1174: 0.0
   sysZ3D1175: 0.0
   sysZ3D1176: -0.5995
-  sysZ3D1177: -0.0
+  sysZ3D1177: 0.0
   sysZ3D1178: 0.0
-  sysZ3D1179: -0.0
+  sysZ3D1179: 0.0
   sysZ3D1180: 0.0
   sysZ3D1181: 0.0
-  sysZ3D1182: -0.0
+  sysZ3D1182: 0.0
   sysZ3D1183: 0.0
   sysZ3D1184: 0.0
   sysZ3D1185: 0.0
-  sysZ3D1186: -0.0
+  sysZ3D1186: 0.0
   sysZ3D1187: 0.0
-  sysZ3D1188: -0.0
+  sysZ3D1188: 0.0
   sysZ3D1189: 0.0
-  sysZ3D1190: -0.0
-  sysZ3D1191: -0.0
-  sysZ3D1192: -0.0
+  sysZ3D1190: 0.0
+  sysZ3D1191: 0.0
+  sysZ3D1192: 0.0
   sysZ3D1193: 0.5995
   sysZ3D1194: 6.59450000e+00
   sysZ3D1195: -1.199
@@ -8269,7 +8269,7 @@ bins:
   sysZ3D1204: -1.199
   sysZ3D1205: -0.5995
   sysZ3D1206: -0.5995
-  sysZ3D1207: -0.0
+  sysZ3D1207: 0.0
   sysZ3D1208: 0.0
   sysZ3D1209: 0.5995
   sysZ3D1210: 0.5995
@@ -8278,7 +8278,7 @@ bins:
   sysZ3D1213: 0.0
   sysZ3D1214: 0.5995
   sysZ3D1215: 1.199
-  sysZ3D1216: -0.0
+  sysZ3D1216: 0.0
   sysZ3D1217: -1.7985
   sysZ3D1218: -1.199
   sysZ3D1219: -0.5995
@@ -8286,21 +8286,21 @@ bins:
   sysZ3D1221: 0.5995
   sysZ3D1222: 0.5995
   sysZ3D1223: 0.5995
-  sysZ3D1224: -0.0
+  sysZ3D1224: 0.0
   sysZ3D1225: -0.5995
   sysZ3D1226: -0.5995
   sysZ3D1227: -1.199
   sysZ3D1228: -0.5995
-  sysZ3D1229: -0.0
-  sysZ3D1230: -0.0
+  sysZ3D1229: 0.0
+  sysZ3D1230: 0.0
   sysZ3D1231: -0.5995
   sysZ3D1232: 0.5995
   sysZ3D1233: 0.5995
   sysZ3D1234: 0.0
   sysZ3D1235: 0.5995
-  sysZ3D1236: -0.0
-  sysZ3D1237: -0.0
-  sysZ3D1238: -0.0
+  sysZ3D1236: 0.0
+  sysZ3D1237: 0.0
+  sysZ3D1238: 0.0
   sysZ3D1239: 0.0
   sysZ3D1240: 0.0
   sysZ3D1241: 0.0
@@ -8312,7 +8312,7 @@ bins:
   sysZ3D1247: 0.5995
   sysZ3D1248: 1.7985
   sysZ3D1249: 0.5995
-  sysZ3D1250: -0.0
+  sysZ3D1250: 0.0
   sysZ3D1251: 1.199
   sysZ3D1252: 0.5995
   sysZ3D1253: 0.0
@@ -8322,7 +8322,7 @@ bins:
   sysZ3D1257: -1.199
   sysZ3D1258: 0.5995
   sysZ3D1259: -2.398
-  sysZ3D1260: -0.0
+  sysZ3D1260: 0.0
   sysZ3D1261: 0.5995
   sysZ3D1262: 2.398
   sysZ3D1263: 1.7985
@@ -8331,11 +8331,11 @@ bins:
   sysZ3D1266: -4.796
   sysZ3D1267: -0.5995
   sysZ3D1268: 0.5995
-  sysZ3D1269: -0.0
+  sysZ3D1269: 0.0
   sysZ3D1270: 0.5995
   sysZ3D1271: 0.5995
-  sysZ3D1272: -0.0
-  sysZ3D1273: -0.0
+  sysZ3D1272: 0.0
+  sysZ3D1273: 0.0
   sysZ3D1274: -0.5995
   sysZ3D1275: 2.398
   sys,uncor: 2.9975
@@ -8343,7 +8343,7 @@ bins:
 - stat: 6.567
   sysZ3D1001: -1.791
   sysZ3D1002: -0.597
-  sysZ3D1003: -0.0
+  sysZ3D1003: 0.0
   sysZ3D1004: 0.0
   sysZ3D1005: 0.0
   sysZ3D1006: 0.0
@@ -8361,84 +8361,84 @@ bins:
   sysZ3D1018: 0.0
   sysZ3D1019: 0.0
   sysZ3D1020: 0.0
-  sysZ3D1021: -0.0
+  sysZ3D1021: 0.0
   sysZ3D1022: 0.0
-  sysZ3D1023: -0.0
+  sysZ3D1023: 0.0
   sysZ3D1024: 0.0
-  sysZ3D1025: -0.0
+  sysZ3D1025: 0.0
   sysZ3D1026: 0.0
-  sysZ3D1027: -0.0
-  sysZ3D1028: -0.0
+  sysZ3D1027: 0.0
+  sysZ3D1028: 0.0
   sysZ3D1029: 0.0
-  sysZ3D1030: -0.0
-  sysZ3D1031: -0.0
+  sysZ3D1030: 0.0
+  sysZ3D1031: 0.0
   sysZ3D1032: 0.0
-  sysZ3D1033: -0.0
-  sysZ3D1034: -0.0
+  sysZ3D1033: 0.0
+  sysZ3D1034: 0.0
   sysZ3D1035: 0.0
   sysZ3D1036: 0.0
   sysZ3D1037: 0.0
-  sysZ3D1038: -0.0
+  sysZ3D1038: 0.0
   sysZ3D1039: 0.0
   sysZ3D1040: 0.0
-  sysZ3D1041: -0.0
+  sysZ3D1041: 0.0
   sysZ3D1042: 0.0
-  sysZ3D1043: -0.0
-  sysZ3D1044: -0.0
+  sysZ3D1043: 0.0
+  sysZ3D1044: 0.0
   sysZ3D1045: 0.0
   sysZ3D1046: 0.0
   sysZ3D1047: 0.0
   sysZ3D1048: 0.0
-  sysZ3D1049: -0.0
-  sysZ3D1050: -0.0
+  sysZ3D1049: 0.0
+  sysZ3D1050: 0.0
   sysZ3D1051: 0.0
-  sysZ3D1052: -0.0
-  sysZ3D1053: -0.0
-  sysZ3D1054: -0.0
+  sysZ3D1052: 0.0
+  sysZ3D1053: 0.0
+  sysZ3D1054: 0.0
   sysZ3D1055: 0.0
-  sysZ3D1056: -0.0
+  sysZ3D1056: 0.0
   sysZ3D1057: 0.0
   sysZ3D1058: 0.0
-  sysZ3D1059: -0.0
-  sysZ3D1060: -0.0
+  sysZ3D1059: 0.0
+  sysZ3D1060: 0.0
   sysZ3D1061: 0.0
-  sysZ3D1062: -0.0
+  sysZ3D1062: 0.0
   sysZ3D1063: 0.0
-  sysZ3D1064: -0.0
-  sysZ3D1065: -0.0
-  sysZ3D1066: -0.0
-  sysZ3D1067: -0.0
+  sysZ3D1064: 0.0
+  sysZ3D1065: 0.0
+  sysZ3D1066: 0.0
+  sysZ3D1067: 0.0
   sysZ3D1068: 0.0
   sysZ3D1069: 0.0
-  sysZ3D1070: -0.0
-  sysZ3D1071: -0.0
-  sysZ3D1072: -0.0
+  sysZ3D1070: 0.0
+  sysZ3D1071: 0.0
+  sysZ3D1072: 0.0
   sysZ3D1073: 0.0
   sysZ3D1074: 0.0
-  sysZ3D1075: -0.0
+  sysZ3D1075: 0.0
   sysZ3D1076: 0.0
-  sysZ3D1077: -0.0
+  sysZ3D1077: 0.0
   sysZ3D1078: 0.0
   sysZ3D1079: 0.0
   sysZ3D1080: 0.0
-  sysZ3D1081: -0.0
+  sysZ3D1081: 0.0
   sysZ3D1082: 0.0
-  sysZ3D1083: -0.0
-  sysZ3D1084: -0.0
-  sysZ3D1085: -0.0
+  sysZ3D1083: 0.0
+  sysZ3D1084: 0.0
+  sysZ3D1085: 0.0
   sysZ3D1086: 0.0
-  sysZ3D1087: -0.0
-  sysZ3D1088: -0.0
+  sysZ3D1087: 0.0
+  sysZ3D1088: 0.0
   sysZ3D1089: 0.0
   sysZ3D1090: 0.0
   sysZ3D1091: 0.0
-  sysZ3D1092: -0.0
+  sysZ3D1092: 0.0
   sysZ3D1093: 0.0
-  sysZ3D1094: -0.0
+  sysZ3D1094: 0.0
   sysZ3D1095: 0.0
-  sysZ3D1096: -0.0
+  sysZ3D1096: 0.0
   sysZ3D1097: 0.0
-  sysZ3D1098: -0.0
+  sysZ3D1098: 0.0
   sysZ3D1099: 0.0
   sysZ3D1100: 0.0
   sysZ3D1101: 0.0
@@ -8452,9 +8452,9 @@ bins:
   sysZ3D1109: 0.0
   sysZ3D1110: 0.0
   sysZ3D1111: 0.0
-  sysZ3D1112: -0.0
+  sysZ3D1112: 0.0
   sysZ3D1113: 1.791
-  sysZ3D1114: -0.0
+  sysZ3D1114: 0.0
   sysZ3D1115: 0.0
   sysZ3D1116: 0.597
   sysZ3D1117: 0.0
@@ -8463,16 +8463,16 @@ bins:
   sysZ3D1120: 0.597
   sysZ3D1121: 0.0
   sysZ3D1122: 0.0
-  sysZ3D1123: -0.0
+  sysZ3D1123: 0.0
   sysZ3D1124: 0.0
-  sysZ3D1125: -0.0
+  sysZ3D1125: 0.0
   sysZ3D1126: 1.791
   sysZ3D1127: -0.597
-  sysZ3D1128: -0.0
-  sysZ3D1129: -0.0
-  sysZ3D1130: -0.0
-  sysZ3D1131: -0.0
-  sysZ3D1132: -0.0
+  sysZ3D1128: 0.0
+  sysZ3D1129: 0.0
+  sysZ3D1130: 0.0
+  sysZ3D1131: 0.0
+  sysZ3D1132: 0.0
   sysZ3D1133: 0.0
   sysZ3D1134: 0.0
   sysZ3D1135: 0.0
@@ -8481,57 +8481,57 @@ bins:
   sysZ3D1138: 0.0
   sysZ3D1139: 0.0
   sysZ3D1140: 0.0
-  sysZ3D1141: -0.0
-  sysZ3D1142: -0.0
+  sysZ3D1141: 0.0
+  sysZ3D1142: 0.0
   sysZ3D1143: 0.0
-  sysZ3D1144: -0.0
-  sysZ3D1145: -0.0
+  sysZ3D1144: 0.0
+  sysZ3D1145: 0.0
   sysZ3D1146: 0.0
   sysZ3D1147: 0.0
   sysZ3D1148: 0.0
   sysZ3D1149: 0.0
   sysZ3D1150: 0.0
-  sysZ3D1151: -0.0
+  sysZ3D1151: 0.0
   sysZ3D1152: 0.0
-  sysZ3D1153: -0.0
+  sysZ3D1153: 0.0
   sysZ3D1154: 0.0
-  sysZ3D1155: -0.0
+  sysZ3D1155: 0.0
   sysZ3D1156: 0.0
   sysZ3D1157: 0.0
   sysZ3D1158: 0.0
-  sysZ3D1159: -0.0
-  sysZ3D1160: -0.0
+  sysZ3D1159: 0.0
+  sysZ3D1160: 0.0
   sysZ3D1161: 0.0
-  sysZ3D1162: -0.0
+  sysZ3D1162: 0.0
   sysZ3D1163: 0.0
   sysZ3D1164: 0.0
   sysZ3D1165: 0.0
   sysZ3D1166: 0.0
-  sysZ3D1167: -0.0
-  sysZ3D1168: -0.0
-  sysZ3D1169: -0.0
+  sysZ3D1167: 0.0
+  sysZ3D1168: 0.0
+  sysZ3D1169: 0.0
   sysZ3D1170: 0.0
   sysZ3D1171: -0.597
   sysZ3D1172: 0.0
-  sysZ3D1173: -0.0
-  sysZ3D1174: -0.0
+  sysZ3D1173: 0.0
+  sysZ3D1174: 0.0
   sysZ3D1175: 0.0
   sysZ3D1176: 0.0
   sysZ3D1177: 0.597
   sysZ3D1178: 0.0
-  sysZ3D1179: -0.0
-  sysZ3D1180: -0.0
-  sysZ3D1181: -0.0
-  sysZ3D1182: -0.0
+  sysZ3D1179: 0.0
+  sysZ3D1180: 0.0
+  sysZ3D1181: 0.0
+  sysZ3D1182: 0.0
   sysZ3D1183: 0.0
-  sysZ3D1184: -0.0
+  sysZ3D1184: 0.0
   sysZ3D1185: 0.0
-  sysZ3D1186: -0.0
+  sysZ3D1186: 0.0
   sysZ3D1187: 0.0
-  sysZ3D1188: -0.0
-  sysZ3D1189: -0.0
+  sysZ3D1188: 0.0
+  sysZ3D1189: 0.0
   sysZ3D1190: 0.0
-  sysZ3D1191: -0.0
+  sysZ3D1191: 0.0
   sysZ3D1192: 0.0
   sysZ3D1193: 0.0
   sysZ3D1194: 7.164
@@ -8548,7 +8548,7 @@ bins:
   sysZ3D1205: -0.597
   sysZ3D1206: -0.597
   sysZ3D1207: -0.597
-  sysZ3D1208: -0.0
+  sysZ3D1208: 0.0
   sysZ3D1209: 0.0
   sysZ3D1210: 0.597
   sysZ3D1211: 0.0
@@ -8565,20 +8565,20 @@ bins:
   sysZ3D1222: 0.597
   sysZ3D1223: 0.597
   sysZ3D1224: 0.0
-  sysZ3D1225: -0.0
+  sysZ3D1225: 0.0
   sysZ3D1226: -0.597
   sysZ3D1227: -1.791
   sysZ3D1228: -1.194
-  sysZ3D1229: -0.0
-  sysZ3D1230: -0.0
+  sysZ3D1229: 0.0
+  sysZ3D1230: 0.0
   sysZ3D1231: -0.597
   sysZ3D1232: 0.597
   sysZ3D1233: 0.597
   sysZ3D1234: 0.597
   sysZ3D1235: 0.597
   sysZ3D1236: 0.0
-  sysZ3D1237: -0.0
-  sysZ3D1238: -0.0
+  sysZ3D1237: 0.0
+  sysZ3D1238: 0.0
   sysZ3D1239: 0.0
   sysZ3D1240: 0.0
   sysZ3D1241: 0.0
@@ -8586,11 +8586,11 @@ bins:
   sysZ3D1243: 0.0
   sysZ3D1244: -2.388
   sysZ3D1245: 1.194
-  sysZ3D1246: -0.0
+  sysZ3D1246: 0.0
   sysZ3D1247: 0.597
   sysZ3D1248: 1.194
   sysZ3D1249: 1.194
-  sysZ3D1250: -0.0
+  sysZ3D1250: 0.0
   sysZ3D1251: 1.194
   sysZ3D1252: 0.597
   sysZ3D1253: 0.0
@@ -8612,294 +8612,16 @@ bins:
   sysZ3D1269: -0.597
   sysZ3D1270: 0.597
   sysZ3D1271: 0.597
-  sysZ3D1272: -0.0
-  sysZ3D1273: -0.0
+  sysZ3D1272: 0.0
+  sysZ3D1273: 0.0
   sysZ3D1274: -0.597
   sysZ3D1275: 2.388
   sys,uncor: 2.985
   ATLAS_LUMI: 107.46
 - stat: 6.51816
   sysZ3D1001: -1.77768000e+00
-  sysZ3D1002: -0.0
-  sysZ3D1003: -0.0
-  sysZ3D1004: 0.0
-  sysZ3D1005: 0.0
-  sysZ3D1006: 0.0
-  sysZ3D1007: 0.0
-  sysZ3D1008: 0.0
-  sysZ3D1009: 0.0
-  sysZ3D1010: 0.0
-  sysZ3D1011: 0.0
-  sysZ3D1012: 0.0
-  sysZ3D1013: 0.0
-  sysZ3D1014: 0.0
-  sysZ3D1015: 0.0
-  sysZ3D1016: 0.0
-  sysZ3D1017: 0.0
-  sysZ3D1018: 0.0
-  sysZ3D1019: 0.0
-  sysZ3D1020: -0.0
-  sysZ3D1021: 0.0
-  sysZ3D1022: -0.0
-  sysZ3D1023: 0.0
-  sysZ3D1024: -0.0
-  sysZ3D1025: 0.0
-  sysZ3D1026: 0.0
-  sysZ3D1027: -0.0
-  sysZ3D1028: 0.0
-  sysZ3D1029: -0.0
-  sysZ3D1030: -0.0
-  sysZ3D1031: 0.0
-  sysZ3D1032: -0.0
-  sysZ3D1033: 0.0
-  sysZ3D1034: 0.0
-  sysZ3D1035: -0.59256
-  sysZ3D1036: 0.0
-  sysZ3D1037: -0.0
-  sysZ3D1038: 0.0
-  sysZ3D1039: 0.0
-  sysZ3D1040: -0.0
-  sysZ3D1041: -0.0
-  sysZ3D1042: 0.0
-  sysZ3D1043: -0.0
-  sysZ3D1044: 0.0
-  sysZ3D1045: -0.0
-  sysZ3D1046: 0.0
-  sysZ3D1047: 0.0
-  sysZ3D1048: 0.0
-  sysZ3D1049: 0.0
-  sysZ3D1050: -0.0
-  sysZ3D1051: 0.0
-  sysZ3D1052: 0.0
-  sysZ3D1053: 0.0
-  sysZ3D1054: 0.0
-  sysZ3D1055: 0.0
-  sysZ3D1056: 0.0
-  sysZ3D1057: -0.0
-  sysZ3D1058: 0.0
-  sysZ3D1059: 0.0
-  sysZ3D1060: 0.0
-  sysZ3D1061: -0.0
-  sysZ3D1062: 0.0
-  sysZ3D1063: 0.0
-  sysZ3D1064: -0.0
-  sysZ3D1065: -0.0
-  sysZ3D1066: 0.0
-  sysZ3D1067: 0.0
-  sysZ3D1068: 0.0
-  sysZ3D1069: -0.0
-  sysZ3D1070: 0.0
-  sysZ3D1071: -0.0
-  sysZ3D1072: -0.0
-  sysZ3D1073: -0.0
-  sysZ3D1074: -0.0
-  sysZ3D1075: 0.0
-  sysZ3D1076: 0.0
-  sysZ3D1077: 0.0
-  sysZ3D1078: -0.0
-  sysZ3D1079: -0.0
-  sysZ3D1080: -0.0
-  sysZ3D1081: -0.0
-  sysZ3D1082: 0.0
-  sysZ3D1083: -0.0
-  sysZ3D1084: -0.0
-  sysZ3D1085: -0.0
-  sysZ3D1086: -0.0
-  sysZ3D1087: 0.0
-  sysZ3D1088: 0.0
-  sysZ3D1089: 0.0
-  sysZ3D1090: 0.0
-  sysZ3D1091: -0.0
-  sysZ3D1092: 0.0
-  sysZ3D1093: 0.0
-  sysZ3D1094: 0.0
-  sysZ3D1095: -0.0
-  sysZ3D1096: 0.0
-  sysZ3D1097: 0.0
-  sysZ3D1098: -0.0
-  sysZ3D1099: 0.0
-  sysZ3D1100: 0.0
-  sysZ3D1101: 0.0
-  sysZ3D1102: 0.0
-  sysZ3D1103: 0.0
-  sysZ3D1104: -0.0
-  sysZ3D1105: -0.59256
-  sysZ3D1106: -0.59256
-  sysZ3D1107: 0.0
-  sysZ3D1108: 0.0
-  sysZ3D1109: 0.0
-  sysZ3D1110: 0.0
-  sysZ3D1111: 0.0
-  sysZ3D1112: -0.0
-  sysZ3D1113: 1.77768000e+00
-  sysZ3D1114: -0.59256
-  sysZ3D1115: 0.0
-  sysZ3D1116: -0.0
-  sysZ3D1117: 0.59256
-  sysZ3D1118: 0.59256
-  sysZ3D1119: 0.59256
-  sysZ3D1120: 0.0
-  sysZ3D1121: 0.59256
-  sysZ3D1122: 0.59256
-  sysZ3D1123: -0.0
-  sysZ3D1124: -0.0
-  sysZ3D1125: 0.0
-  sysZ3D1126: 1.77768000e+00
-  sysZ3D1127: 0.0
-  sysZ3D1128: 0.0
-  sysZ3D1129: -0.0
-  sysZ3D1130: -0.0
-  sysZ3D1131: 0.0
-  sysZ3D1132: 0.0
-  sysZ3D1133: 0.0
-  sysZ3D1134: 0.0
-  sysZ3D1135: -0.0
-  sysZ3D1136: -0.0
-  sysZ3D1137: -0.0
-  sysZ3D1138: 0.0
-  sysZ3D1139: 0.0
-  sysZ3D1140: -0.0
-  sysZ3D1141: 0.0
-  sysZ3D1142: -0.0
-  sysZ3D1143: 0.0
-  sysZ3D1144: 0.0
-  sysZ3D1145: -0.0
-  sysZ3D1146: 0.0
-  sysZ3D1147: -0.0
-  sysZ3D1148: -0.0
-  sysZ3D1149: 0.0
-  sysZ3D1150: -0.0
-  sysZ3D1151: -0.0
-  sysZ3D1152: -0.0
-  sysZ3D1153: -0.0
-  sysZ3D1154: 0.0
-  sysZ3D1155: 0.0
-  sysZ3D1156: 0.0
-  sysZ3D1157: 0.0
-  sysZ3D1158: 0.0
-  sysZ3D1159: 0.59256
-  sysZ3D1160: -0.0
-  sysZ3D1161: -0.0
-  sysZ3D1162: 0.0
-  sysZ3D1163: 0.0
-  sysZ3D1164: 0.0
-  sysZ3D1165: -0.0
-  sysZ3D1166: 0.0
-  sysZ3D1167: -0.0
-  sysZ3D1168: -0.0
-  sysZ3D1169: -0.0
-  sysZ3D1170: 0.59256
-  sysZ3D1171: -0.59256
-  sysZ3D1172: -0.0
-  sysZ3D1173: -0.0
-  sysZ3D1174: -0.0
-  sysZ3D1175: 0.0
-  sysZ3D1176: 0.0
-  sysZ3D1177: 0.59256
-  sysZ3D1178: 0.59256
-  sysZ3D1179: -0.0
-  sysZ3D1180: 0.0
-  sysZ3D1181: -0.0
-  sysZ3D1182: -0.0
-  sysZ3D1183: 0.0
-  sysZ3D1184: -0.0
-  sysZ3D1185: 0.0
-  sysZ3D1186: 0.0
-  sysZ3D1187: 0.0
-  sysZ3D1188: -0.0
-  sysZ3D1189: -0.0
-  sysZ3D1190: 0.0
-  sysZ3D1191: -0.0
-  sysZ3D1192: 0.0
-  sysZ3D1193: 0.0
-  sysZ3D1194: 7.11072000e+00
-  sysZ3D1195: -0.59256
-  sysZ3D1196: -0.59256
-  sysZ3D1197: -0.59256
-  sysZ3D1198: -1.77768000e+00
-  sysZ3D1199: -0.0
-  sysZ3D1200: 0.59256
-  sysZ3D1201: 1.18512
-  sysZ3D1202: 0.0
-  sysZ3D1203: 2.37024
-  sysZ3D1204: -0.59256
-  sysZ3D1205: -0.59256
-  sysZ3D1206: -0.59256
-  sysZ3D1207: -0.59256
-  sysZ3D1208: -0.0
-  sysZ3D1209: 0.0
-  sysZ3D1210: 0.59256
-  sysZ3D1211: 0.0
-  sysZ3D1212: 0.0
-  sysZ3D1213: 0.59256
-  sysZ3D1214: 0.59256
-  sysZ3D1215: 0.59256
-  sysZ3D1216: 0.59256
-  sysZ3D1217: -1.77768000e+00
-  sysZ3D1218: -1.18512
-  sysZ3D1219: -0.59256
-  sysZ3D1220: 0.0
-  sysZ3D1221: 0.59256
-  sysZ3D1222: 0.0
-  sysZ3D1223: 0.59256
-  sysZ3D1224: 0.0
-  sysZ3D1225: -0.0
-  sysZ3D1226: -0.59256
-  sysZ3D1227: -1.18512
-  sysZ3D1228: -1.18512
-  sysZ3D1229: -0.0
-  sysZ3D1230: -0.0
-  sysZ3D1231: -0.59256
-  sysZ3D1232: 0.0
-  sysZ3D1233: 0.59256
-  sysZ3D1234: 0.0
-  sysZ3D1235: 0.59256
-  sysZ3D1236: 0.0
-  sysZ3D1237: -0.0
-  sysZ3D1238: -0.0
-  sysZ3D1239: 0.0
-  sysZ3D1240: 0.0
-  sysZ3D1241: 0.0
-  sysZ3D1242: 0.0
-  sysZ3D1243: 0.0
-  sysZ3D1244: -1.77768000e+00
-  sysZ3D1245: 1.18512
-  sysZ3D1246: -0.0
-  sysZ3D1247: 0.0
-  sysZ3D1248: 1.18512
-  sysZ3D1249: 1.18512
-  sysZ3D1250: -0.0
-  sysZ3D1251: 1.18512
-  sysZ3D1252: 1.18512
-  sysZ3D1253: 0.0
-  sysZ3D1254: 0.0
-  sysZ3D1255: 2.37024
-  sysZ3D1256: 1.18512
-  sysZ3D1257: -0.59256
-  sysZ3D1258: 0.59256
-  sysZ3D1259: -1.18512
-  sysZ3D1260: -0.0
-  sysZ3D1261: 0.59256
-  sysZ3D1262: 2.37024
-  sysZ3D1263: 2.37024
-  sysZ3D1264: 4.74048
-  sysZ3D1265: 1.18512
-  sysZ3D1266: -5.33304
-  sysZ3D1267: -0.0
-  sysZ3D1268: 0.0
-  sysZ3D1269: -0.0
-  sysZ3D1270: 0.59256
-  sysZ3D1271: 0.59256
-  sysZ3D1272: 0.0
-  sysZ3D1273: -0.0
-  sysZ3D1274: -0.59256
-  sysZ3D1275: 2.37024
-  sys,uncor: 2.9628
-  ATLAS_LUMI: 106.6608
-- stat: 6.45546
-  sysZ3D1001: -1.76058000e+00
   sysZ3D1002: 0.0
-  sysZ3D1003: -0.0
+  sysZ3D1003: 0.0
   sysZ3D1004: 0.0
   sysZ3D1005: 0.0
   sysZ3D1006: 0.0
@@ -8917,59 +8639,59 @@ bins:
   sysZ3D1018: 0.0
   sysZ3D1019: 0.0
   sysZ3D1020: 0.0
-  sysZ3D1021: -0.0
+  sysZ3D1021: 0.0
   sysZ3D1022: 0.0
   sysZ3D1023: 0.0
-  sysZ3D1024: -0.0
+  sysZ3D1024: 0.0
   sysZ3D1025: 0.0
-  sysZ3D1026: -0.0
-  sysZ3D1027: -0.0
+  sysZ3D1026: 0.0
+  sysZ3D1027: 0.0
   sysZ3D1028: 0.0
-  sysZ3D1029: -0.0
-  sysZ3D1030: -0.0
-  sysZ3D1031: -0.0
-  sysZ3D1032: -0.0
-  sysZ3D1033: -0.0
-  sysZ3D1034: -0.0
-  sysZ3D1035: -0.0
-  sysZ3D1036: -0.0
+  sysZ3D1029: 0.0
+  sysZ3D1030: 0.0
+  sysZ3D1031: 0.0
+  sysZ3D1032: 0.0
+  sysZ3D1033: 0.0
+  sysZ3D1034: 0.0
+  sysZ3D1035: -0.59256
+  sysZ3D1036: 0.0
   sysZ3D1037: 0.0
-  sysZ3D1038: -0.0
-  sysZ3D1039: -0.0
+  sysZ3D1038: 0.0
+  sysZ3D1039: 0.0
   sysZ3D1040: 0.0
   sysZ3D1041: 0.0
   sysZ3D1042: 0.0
-  sysZ3D1043: -0.0
+  sysZ3D1043: 0.0
   sysZ3D1044: 0.0
   sysZ3D1045: 0.0
   sysZ3D1046: 0.0
   sysZ3D1047: 0.0
-  sysZ3D1048: -0.0
-  sysZ3D1049: -0.0
+  sysZ3D1048: 0.0
+  sysZ3D1049: 0.0
   sysZ3D1050: 0.0
-  sysZ3D1051: -0.0
+  sysZ3D1051: 0.0
   sysZ3D1052: 0.0
   sysZ3D1053: 0.0
-  sysZ3D1054: -0.0
+  sysZ3D1054: 0.0
   sysZ3D1055: 0.0
   sysZ3D1056: 0.0
   sysZ3D1057: 0.0
-  sysZ3D1058: -0.0
+  sysZ3D1058: 0.0
   sysZ3D1059: 0.0
   sysZ3D1060: 0.0
   sysZ3D1061: 0.0
-  sysZ3D1062: -0.0
+  sysZ3D1062: 0.0
   sysZ3D1063: 0.0
   sysZ3D1064: 0.0
-  sysZ3D1065: -0.0
-  sysZ3D1066: -0.0
+  sysZ3D1065: 0.0
+  sysZ3D1066: 0.0
   sysZ3D1067: 0.0
   sysZ3D1068: 0.0
-  sysZ3D1069: -0.0
+  sysZ3D1069: 0.0
   sysZ3D1070: 0.0
-  sysZ3D1071: -0.0
-  sysZ3D1072: -0.0
-  sysZ3D1073: -0.0
+  sysZ3D1071: 0.0
+  sysZ3D1072: 0.0
+  sysZ3D1073: 0.0
   sysZ3D1074: 0.0
   sysZ3D1075: 0.0
   sysZ3D1076: 0.0
@@ -8977,12 +8699,12 @@ bins:
   sysZ3D1078: 0.0
   sysZ3D1079: 0.0
   sysZ3D1080: 0.0
-  sysZ3D1081: -0.0
+  sysZ3D1081: 0.0
   sysZ3D1082: 0.0
   sysZ3D1083: 0.0
   sysZ3D1084: 0.0
-  sysZ3D1085: -0.0
-  sysZ3D1086: -0.0
+  sysZ3D1085: 0.0
+  sysZ3D1086: 0.0
   sysZ3D1087: 0.0
   sysZ3D1088: 0.0
   sysZ3D1089: 0.0
@@ -8990,121 +8712,399 @@ bins:
   sysZ3D1091: 0.0
   sysZ3D1092: 0.0
   sysZ3D1093: 0.0
-  sysZ3D1094: -0.0
+  sysZ3D1094: 0.0
   sysZ3D1095: 0.0
   sysZ3D1096: 0.0
-  sysZ3D1097: -0.0
+  sysZ3D1097: 0.0
   sysZ3D1098: 0.0
   sysZ3D1099: 0.0
   sysZ3D1100: 0.0
   sysZ3D1101: 0.0
   sysZ3D1102: 0.0
   sysZ3D1103: 0.0
-  sysZ3D1104: -0.0
+  sysZ3D1104: 0.0
+  sysZ3D1105: -0.59256
+  sysZ3D1106: -0.59256
+  sysZ3D1107: 0.0
+  sysZ3D1108: 0.0
+  sysZ3D1109: 0.0
+  sysZ3D1110: 0.0
+  sysZ3D1111: 0.0
+  sysZ3D1112: 0.0
+  sysZ3D1113: 1.77768000e+00
+  sysZ3D1114: -0.59256
+  sysZ3D1115: 0.0
+  sysZ3D1116: 0.0
+  sysZ3D1117: 0.59256
+  sysZ3D1118: 0.59256
+  sysZ3D1119: 0.59256
+  sysZ3D1120: 0.0
+  sysZ3D1121: 0.59256
+  sysZ3D1122: 0.59256
+  sysZ3D1123: 0.0
+  sysZ3D1124: 0.0
+  sysZ3D1125: 0.0
+  sysZ3D1126: 1.77768000e+00
+  sysZ3D1127: 0.0
+  sysZ3D1128: 0.0
+  sysZ3D1129: 0.0
+  sysZ3D1130: 0.0
+  sysZ3D1131: 0.0
+  sysZ3D1132: 0.0
+  sysZ3D1133: 0.0
+  sysZ3D1134: 0.0
+  sysZ3D1135: 0.0
+  sysZ3D1136: 0.0
+  sysZ3D1137: 0.0
+  sysZ3D1138: 0.0
+  sysZ3D1139: 0.0
+  sysZ3D1140: 0.0
+  sysZ3D1141: 0.0
+  sysZ3D1142: 0.0
+  sysZ3D1143: 0.0
+  sysZ3D1144: 0.0
+  sysZ3D1145: 0.0
+  sysZ3D1146: 0.0
+  sysZ3D1147: 0.0
+  sysZ3D1148: 0.0
+  sysZ3D1149: 0.0
+  sysZ3D1150: 0.0
+  sysZ3D1151: 0.0
+  sysZ3D1152: 0.0
+  sysZ3D1153: 0.0
+  sysZ3D1154: 0.0
+  sysZ3D1155: 0.0
+  sysZ3D1156: 0.0
+  sysZ3D1157: 0.0
+  sysZ3D1158: 0.0
+  sysZ3D1159: 0.59256
+  sysZ3D1160: 0.0
+  sysZ3D1161: 0.0
+  sysZ3D1162: 0.0
+  sysZ3D1163: 0.0
+  sysZ3D1164: 0.0
+  sysZ3D1165: 0.0
+  sysZ3D1166: 0.0
+  sysZ3D1167: 0.0
+  sysZ3D1168: 0.0
+  sysZ3D1169: 0.0
+  sysZ3D1170: 0.59256
+  sysZ3D1171: -0.59256
+  sysZ3D1172: 0.0
+  sysZ3D1173: 0.0
+  sysZ3D1174: 0.0
+  sysZ3D1175: 0.0
+  sysZ3D1176: 0.0
+  sysZ3D1177: 0.59256
+  sysZ3D1178: 0.59256
+  sysZ3D1179: 0.0
+  sysZ3D1180: 0.0
+  sysZ3D1181: 0.0
+  sysZ3D1182: 0.0
+  sysZ3D1183: 0.0
+  sysZ3D1184: 0.0
+  sysZ3D1185: 0.0
+  sysZ3D1186: 0.0
+  sysZ3D1187: 0.0
+  sysZ3D1188: 0.0
+  sysZ3D1189: 0.0
+  sysZ3D1190: 0.0
+  sysZ3D1191: 0.0
+  sysZ3D1192: 0.0
+  sysZ3D1193: 0.0
+  sysZ3D1194: 7.11072000e+00
+  sysZ3D1195: -0.59256
+  sysZ3D1196: -0.59256
+  sysZ3D1197: -0.59256
+  sysZ3D1198: -1.77768000e+00
+  sysZ3D1199: 0.0
+  sysZ3D1200: 0.59256
+  sysZ3D1201: 1.18512
+  sysZ3D1202: 0.0
+  sysZ3D1203: 2.37024
+  sysZ3D1204: -0.59256
+  sysZ3D1205: -0.59256
+  sysZ3D1206: -0.59256
+  sysZ3D1207: -0.59256
+  sysZ3D1208: 0.0
+  sysZ3D1209: 0.0
+  sysZ3D1210: 0.59256
+  sysZ3D1211: 0.0
+  sysZ3D1212: 0.0
+  sysZ3D1213: 0.59256
+  sysZ3D1214: 0.59256
+  sysZ3D1215: 0.59256
+  sysZ3D1216: 0.59256
+  sysZ3D1217: -1.77768000e+00
+  sysZ3D1218: -1.18512
+  sysZ3D1219: -0.59256
+  sysZ3D1220: 0.0
+  sysZ3D1221: 0.59256
+  sysZ3D1222: 0.0
+  sysZ3D1223: 0.59256
+  sysZ3D1224: 0.0
+  sysZ3D1225: 0.0
+  sysZ3D1226: -0.59256
+  sysZ3D1227: -1.18512
+  sysZ3D1228: -1.18512
+  sysZ3D1229: 0.0
+  sysZ3D1230: 0.0
+  sysZ3D1231: -0.59256
+  sysZ3D1232: 0.0
+  sysZ3D1233: 0.59256
+  sysZ3D1234: 0.0
+  sysZ3D1235: 0.59256
+  sysZ3D1236: 0.0
+  sysZ3D1237: 0.0
+  sysZ3D1238: 0.0
+  sysZ3D1239: 0.0
+  sysZ3D1240: 0.0
+  sysZ3D1241: 0.0
+  sysZ3D1242: 0.0
+  sysZ3D1243: 0.0
+  sysZ3D1244: -1.77768000e+00
+  sysZ3D1245: 1.18512
+  sysZ3D1246: 0.0
+  sysZ3D1247: 0.0
+  sysZ3D1248: 1.18512
+  sysZ3D1249: 1.18512
+  sysZ3D1250: 0.0
+  sysZ3D1251: 1.18512
+  sysZ3D1252: 1.18512
+  sysZ3D1253: 0.0
+  sysZ3D1254: 0.0
+  sysZ3D1255: 2.37024
+  sysZ3D1256: 1.18512
+  sysZ3D1257: -0.59256
+  sysZ3D1258: 0.59256
+  sysZ3D1259: -1.18512
+  sysZ3D1260: 0.0
+  sysZ3D1261: 0.59256
+  sysZ3D1262: 2.37024
+  sysZ3D1263: 2.37024
+  sysZ3D1264: 4.74048
+  sysZ3D1265: 1.18512
+  sysZ3D1266: -5.33304
+  sysZ3D1267: 0.0
+  sysZ3D1268: 0.0
+  sysZ3D1269: 0.0
+  sysZ3D1270: 0.59256
+  sysZ3D1271: 0.59256
+  sysZ3D1272: 0.0
+  sysZ3D1273: 0.0
+  sysZ3D1274: -0.59256
+  sysZ3D1275: 2.37024
+  sys,uncor: 2.9628
+  ATLAS_LUMI: 106.6608
+- stat: 6.45546
+  sysZ3D1001: -1.76058000e+00
+  sysZ3D1002: 0.0
+  sysZ3D1003: 0.0
+  sysZ3D1004: 0.0
+  sysZ3D1005: 0.0
+  sysZ3D1006: 0.0
+  sysZ3D1007: 0.0
+  sysZ3D1008: 0.0
+  sysZ3D1009: 0.0
+  sysZ3D1010: 0.0
+  sysZ3D1011: 0.0
+  sysZ3D1012: 0.0
+  sysZ3D1013: 0.0
+  sysZ3D1014: 0.0
+  sysZ3D1015: 0.0
+  sysZ3D1016: 0.0
+  sysZ3D1017: 0.0
+  sysZ3D1018: 0.0
+  sysZ3D1019: 0.0
+  sysZ3D1020: 0.0
+  sysZ3D1021: 0.0
+  sysZ3D1022: 0.0
+  sysZ3D1023: 0.0
+  sysZ3D1024: 0.0
+  sysZ3D1025: 0.0
+  sysZ3D1026: 0.0
+  sysZ3D1027: 0.0
+  sysZ3D1028: 0.0
+  sysZ3D1029: 0.0
+  sysZ3D1030: 0.0
+  sysZ3D1031: 0.0
+  sysZ3D1032: 0.0
+  sysZ3D1033: 0.0
+  sysZ3D1034: 0.0
+  sysZ3D1035: 0.0
+  sysZ3D1036: 0.0
+  sysZ3D1037: 0.0
+  sysZ3D1038: 0.0
+  sysZ3D1039: 0.0
+  sysZ3D1040: 0.0
+  sysZ3D1041: 0.0
+  sysZ3D1042: 0.0
+  sysZ3D1043: 0.0
+  sysZ3D1044: 0.0
+  sysZ3D1045: 0.0
+  sysZ3D1046: 0.0
+  sysZ3D1047: 0.0
+  sysZ3D1048: 0.0
+  sysZ3D1049: 0.0
+  sysZ3D1050: 0.0
+  sysZ3D1051: 0.0
+  sysZ3D1052: 0.0
+  sysZ3D1053: 0.0
+  sysZ3D1054: 0.0
+  sysZ3D1055: 0.0
+  sysZ3D1056: 0.0
+  sysZ3D1057: 0.0
+  sysZ3D1058: 0.0
+  sysZ3D1059: 0.0
+  sysZ3D1060: 0.0
+  sysZ3D1061: 0.0
+  sysZ3D1062: 0.0
+  sysZ3D1063: 0.0
+  sysZ3D1064: 0.0
+  sysZ3D1065: 0.0
+  sysZ3D1066: 0.0
+  sysZ3D1067: 0.0
+  sysZ3D1068: 0.0
+  sysZ3D1069: 0.0
+  sysZ3D1070: 0.0
+  sysZ3D1071: 0.0
+  sysZ3D1072: 0.0
+  sysZ3D1073: 0.0
+  sysZ3D1074: 0.0
+  sysZ3D1075: 0.0
+  sysZ3D1076: 0.0
+  sysZ3D1077: 0.0
+  sysZ3D1078: 0.0
+  sysZ3D1079: 0.0
+  sysZ3D1080: 0.0
+  sysZ3D1081: 0.0
+  sysZ3D1082: 0.0
+  sysZ3D1083: 0.0
+  sysZ3D1084: 0.0
+  sysZ3D1085: 0.0
+  sysZ3D1086: 0.0
+  sysZ3D1087: 0.0
+  sysZ3D1088: 0.0
+  sysZ3D1089: 0.0
+  sysZ3D1090: 0.0
+  sysZ3D1091: 0.0
+  sysZ3D1092: 0.0
+  sysZ3D1093: 0.0
+  sysZ3D1094: 0.0
+  sysZ3D1095: 0.0
+  sysZ3D1096: 0.0
+  sysZ3D1097: 0.0
+  sysZ3D1098: 0.0
+  sysZ3D1099: 0.0
+  sysZ3D1100: 0.0
+  sysZ3D1101: 0.0
+  sysZ3D1102: 0.0
+  sysZ3D1103: 0.0
+  sysZ3D1104: 0.0
   sysZ3D1105: -0.58686
   sysZ3D1106: -0.58686
   sysZ3D1107: 0.0
   sysZ3D1108: 0.0
   sysZ3D1109: 0.0
   sysZ3D1110: 0.0
-  sysZ3D1111: -0.0
-  sysZ3D1112: -0.0
+  sysZ3D1111: 0.0
+  sysZ3D1112: 0.0
   sysZ3D1113: 1.76058000e+00
   sysZ3D1114: 0.0
-  sysZ3D1115: -0.0
-  sysZ3D1116: -0.0
+  sysZ3D1115: 0.0
+  sysZ3D1116: 0.0
   sysZ3D1117: 0.58686
   sysZ3D1118: 0.58686
-  sysZ3D1119: -0.0
-  sysZ3D1120: -0.0
+  sysZ3D1119: 0.0
+  sysZ3D1120: 0.0
   sysZ3D1121: 0.0
   sysZ3D1122: 0.0
-  sysZ3D1123: -0.0
-  sysZ3D1124: -0.0
+  sysZ3D1123: 0.0
+  sysZ3D1124: 0.0
   sysZ3D1125: -0.58686
   sysZ3D1126: 1.76058000e+00
   sysZ3D1127: 0.58686
-  sysZ3D1128: -0.0
-  sysZ3D1129: -0.0
+  sysZ3D1128: 0.0
+  sysZ3D1129: 0.0
   sysZ3D1130: 0.0
-  sysZ3D1131: -0.0
-  sysZ3D1132: -0.0
-  sysZ3D1133: -0.0
-  sysZ3D1134: -0.0
-  sysZ3D1135: -0.0
+  sysZ3D1131: 0.0
+  sysZ3D1132: 0.0
+  sysZ3D1133: 0.0
+  sysZ3D1134: 0.0
+  sysZ3D1135: 0.0
   sysZ3D1136: 0.0
   sysZ3D1137: 0.0
-  sysZ3D1138: -0.0
+  sysZ3D1138: 0.0
   sysZ3D1139: 0.0
-  sysZ3D1140: -0.0
+  sysZ3D1140: 0.0
   sysZ3D1141: 0.0
   sysZ3D1142: 0.0
-  sysZ3D1143: -0.0
+  sysZ3D1143: 0.0
   sysZ3D1144: 0.0
   sysZ3D1145: 0.0
   sysZ3D1146: 0.0
-  sysZ3D1147: -0.0
-  sysZ3D1148: -0.0
-  sysZ3D1149: -0.0
+  sysZ3D1147: 0.0
+  sysZ3D1148: 0.0
+  sysZ3D1149: 0.0
   sysZ3D1150: 0.0
   sysZ3D1151: 0.0
-  sysZ3D1152: -0.0
+  sysZ3D1152: 0.0
   sysZ3D1153: 0.0
-  sysZ3D1154: -0.0
+  sysZ3D1154: 0.0
   sysZ3D1155: 0.0
-  sysZ3D1156: -0.0
-  sysZ3D1157: -0.0
-  sysZ3D1158: -0.0
+  sysZ3D1156: 0.0
+  sysZ3D1157: 0.0
+  sysZ3D1158: 0.0
   sysZ3D1159: -0.58686
   sysZ3D1160: 0.58686
   sysZ3D1161: 0.0
-  sysZ3D1162: -0.0
-  sysZ3D1163: -0.0
-  sysZ3D1164: -0.0
+  sysZ3D1162: 0.0
+  sysZ3D1163: 0.0
+  sysZ3D1164: 0.0
   sysZ3D1165: 0.0
   sysZ3D1166: 0.0
-  sysZ3D1167: -0.0
-  sysZ3D1168: -0.0
-  sysZ3D1169: -0.0
+  sysZ3D1167: 0.0
+  sysZ3D1168: 0.0
+  sysZ3D1169: 0.0
   sysZ3D1170: 0.58686
   sysZ3D1171: -0.58686
   sysZ3D1172: 0.0
-  sysZ3D1173: -0.0
-  sysZ3D1174: -0.0
+  sysZ3D1173: 0.0
+  sysZ3D1174: 0.0
   sysZ3D1175: 0.0
   sysZ3D1176: 0.0
   sysZ3D1177: 0.58686
   sysZ3D1178: 0.58686
   sysZ3D1179: 0.0
   sysZ3D1180: 0.0
-  sysZ3D1181: -0.0
-  sysZ3D1182: -0.0
+  sysZ3D1181: 0.0
+  sysZ3D1182: 0.0
   sysZ3D1183: 0.0
-  sysZ3D1184: -0.0
-  sysZ3D1185: -0.0
+  sysZ3D1184: 0.0
+  sysZ3D1185: 0.0
   sysZ3D1186: 0.0
   sysZ3D1187: 0.0
-  sysZ3D1188: -0.0
-  sysZ3D1189: -0.0
+  sysZ3D1188: 0.0
+  sysZ3D1189: 0.0
   sysZ3D1190: 0.0
   sysZ3D1191: 0.0
   sysZ3D1192: 0.0
   sysZ3D1193: 0.0
   sysZ3D1194: 7.04232000e+00
-  sysZ3D1195: -0.0
-  sysZ3D1196: -0.0
+  sysZ3D1195: 0.0
+  sysZ3D1196: 0.0
   sysZ3D1197: -0.58686
   sysZ3D1198: -1.17372
-  sysZ3D1199: -0.0
+  sysZ3D1199: 0.0
   sysZ3D1200: 0.58686
   sysZ3D1201: 1.17372
   sysZ3D1202: 0.0
   sysZ3D1203: 1.76058000e+00
-  sysZ3D1204: -0.0
-  sysZ3D1205: -0.0
+  sysZ3D1204: 0.0
+  sysZ3D1205: 0.0
   sysZ3D1206: -0.58686
   sysZ3D1207: -0.58686
-  sysZ3D1208: -0.0
+  sysZ3D1208: 0.0
   sysZ3D1209: 0.0
   sysZ3D1210: 0.58686
   sysZ3D1211: 0.0
@@ -9116,16 +9116,16 @@ bins:
   sysZ3D1217: -1.17372
   sysZ3D1218: -1.17372
   sysZ3D1219: -0.58686
-  sysZ3D1220: -0.0
+  sysZ3D1220: 0.0
   sysZ3D1221: 0.0
   sysZ3D1222: 0.58686
   sysZ3D1223: 0.58686
   sysZ3D1224: 0.0
-  sysZ3D1225: -0.0
-  sysZ3D1226: -0.0
+  sysZ3D1225: 0.0
+  sysZ3D1226: 0.0
   sysZ3D1227: -1.17372
   sysZ3D1228: -0.58686
-  sysZ3D1229: -0.0
+  sysZ3D1229: 0.0
   sysZ3D1230: -0.58686
   sysZ3D1231: -0.58686
   sysZ3D1232: 0.0
@@ -9133,8 +9133,8 @@ bins:
   sysZ3D1234: 0.0
   sysZ3D1235: 0.58686
   sysZ3D1236: 0.0
-  sysZ3D1237: -0.0
-  sysZ3D1238: -0.0
+  sysZ3D1237: 0.0
+  sysZ3D1238: 0.0
   sysZ3D1239: 0.0
   sysZ3D1240: 0.0
   sysZ3D1241: 0.0
@@ -9142,11 +9142,11 @@ bins:
   sysZ3D1243: 0.0
   sysZ3D1244: -1.76058000e+00
   sysZ3D1245: 1.17372
-  sysZ3D1246: -0.0
+  sysZ3D1246: 0.0
   sysZ3D1247: 0.58686
   sysZ3D1248: 0.58686
   sysZ3D1249: 0.58686
-  sysZ3D1250: -0.0
+  sysZ3D1250: 0.0
   sysZ3D1251: 1.76058000e+00
   sysZ3D1252: 1.76058000e+00
   sysZ3D1253: 0.0
@@ -9169,7 +9169,7 @@ bins:
   sysZ3D1270: 0.58686
   sysZ3D1271: 0.58686
   sysZ3D1272: 0.0
-  sysZ3D1273: -0.0
+  sysZ3D1273: 0.0
   sysZ3D1274: -1.17372
   sysZ3D1275: 2.9343
   sys,uncor: 2.9343
@@ -9177,7 +9177,7 @@ bins:
 - stat: 6.22094000e+00
   sysZ3D1001: -1.69662000e+00
   sysZ3D1002: 1.13108
-  sysZ3D1003: -0.0
+  sysZ3D1003: 0.0
   sysZ3D1004: 0.0
   sysZ3D1005: 0.0
   sysZ3D1006: 0.0
@@ -9196,158 +9196,158 @@ bins:
   sysZ3D1019: 0.0
   sysZ3D1020: 0.0
   sysZ3D1021: 0.0
-  sysZ3D1022: -0.0
+  sysZ3D1022: 0.0
   sysZ3D1023: 0.0
-  sysZ3D1024: -0.0
+  sysZ3D1024: 0.0
   sysZ3D1025: 0.0
-  sysZ3D1026: -0.0
-  sysZ3D1027: -0.0
-  sysZ3D1028: -0.0
+  sysZ3D1026: 0.0
+  sysZ3D1027: 0.0
+  sysZ3D1028: 0.0
   sysZ3D1029: 0.0
-  sysZ3D1030: -0.0
-  sysZ3D1031: -0.0
+  sysZ3D1030: 0.0
+  sysZ3D1031: 0.0
   sysZ3D1032: 0.0
-  sysZ3D1033: -0.0
-  sysZ3D1034: -0.0
-  sysZ3D1035: -0.0
-  sysZ3D1036: -0.0
-  sysZ3D1037: -0.0
-  sysZ3D1038: -0.0
-  sysZ3D1039: -0.0
+  sysZ3D1033: 0.0
+  sysZ3D1034: 0.0
+  sysZ3D1035: 0.0
+  sysZ3D1036: 0.0
+  sysZ3D1037: 0.0
+  sysZ3D1038: 0.0
+  sysZ3D1039: 0.0
   sysZ3D1040: 0.0
-  sysZ3D1041: -0.0
+  sysZ3D1041: 0.0
   sysZ3D1042: 0.0
   sysZ3D1043: 0.0
   sysZ3D1044: 0.0
   sysZ3D1045: 0.0
-  sysZ3D1046: -0.0
-  sysZ3D1047: -0.0
+  sysZ3D1046: 0.0
+  sysZ3D1047: 0.0
   sysZ3D1048: 0.0
   sysZ3D1049: 0.0
   sysZ3D1050: 0.0
-  sysZ3D1051: -0.0
-  sysZ3D1052: -0.0
-  sysZ3D1053: -0.0
+  sysZ3D1051: 0.0
+  sysZ3D1052: 0.0
+  sysZ3D1053: 0.0
   sysZ3D1054: 0.0
-  sysZ3D1055: -0.0
+  sysZ3D1055: 0.0
   sysZ3D1056: 0.0
-  sysZ3D1057: -0.0
-  sysZ3D1058: -0.0
-  sysZ3D1059: -0.0
+  sysZ3D1057: 0.0
+  sysZ3D1058: 0.0
+  sysZ3D1059: 0.0
   sysZ3D1060: 0.0
-  sysZ3D1061: -0.0
+  sysZ3D1061: 0.0
   sysZ3D1062: 0.0
-  sysZ3D1063: -0.0
-  sysZ3D1064: -0.0
-  sysZ3D1065: -0.0
+  sysZ3D1063: 0.0
+  sysZ3D1064: 0.0
+  sysZ3D1065: 0.0
   sysZ3D1066: 0.0
   sysZ3D1067: 0.0
   sysZ3D1068: 0.0
   sysZ3D1069: 0.0
-  sysZ3D1070: -0.0
+  sysZ3D1070: 0.0
   sysZ3D1071: 0.0
-  sysZ3D1072: -0.0
-  sysZ3D1073: -0.0
+  sysZ3D1072: 0.0
+  sysZ3D1073: 0.0
   sysZ3D1074: 0.0
   sysZ3D1075: 0.0
-  sysZ3D1076: -0.0
-  sysZ3D1077: -0.0
-  sysZ3D1078: -0.0
+  sysZ3D1076: 0.0
+  sysZ3D1077: 0.0
+  sysZ3D1078: 0.0
   sysZ3D1079: 0.0
-  sysZ3D1080: -0.0
+  sysZ3D1080: 0.0
   sysZ3D1081: 0.0
   sysZ3D1082: 0.0
   sysZ3D1083: 0.0
-  sysZ3D1084: -0.0
-  sysZ3D1085: -0.0
-  sysZ3D1086: -0.0
+  sysZ3D1084: 0.0
+  sysZ3D1085: 0.0
+  sysZ3D1086: 0.0
   sysZ3D1087: 0.0
   sysZ3D1088: 0.0
   sysZ3D1089: 0.0
   sysZ3D1090: 0.0
   sysZ3D1091: 0.0
-  sysZ3D1092: -0.0
+  sysZ3D1092: 0.0
   sysZ3D1093: 0.0
-  sysZ3D1094: -0.0
+  sysZ3D1094: 0.0
   sysZ3D1095: 0.0
   sysZ3D1096: 0.0
   sysZ3D1097: 0.0
   sysZ3D1098: 0.0
   sysZ3D1099: 0.0
   sysZ3D1100: 0.0
-  sysZ3D1101: -0.0
+  sysZ3D1101: 0.0
   sysZ3D1102: 0.0
   sysZ3D1103: 0.0
-  sysZ3D1104: -0.0
+  sysZ3D1104: 0.0
   sysZ3D1105: -0.56554
   sysZ3D1106: -0.56554
   sysZ3D1107: 0.0
   sysZ3D1108: 0.0
   sysZ3D1109: 0.0
   sysZ3D1110: 0.0
-  sysZ3D1111: -0.0
-  sysZ3D1112: -0.0
+  sysZ3D1111: 0.0
+  sysZ3D1112: 0.0
   sysZ3D1113: 1.69662000e+00
   sysZ3D1114: 0.0
   sysZ3D1115: 0.56554
   sysZ3D1116: 0.56554
   sysZ3D1117: 0.56554
   sysZ3D1118: 0.0
-  sysZ3D1119: -0.0
-  sysZ3D1120: -0.0
-  sysZ3D1121: -0.0
+  sysZ3D1119: 0.0
+  sysZ3D1120: 0.0
+  sysZ3D1121: 0.0
   sysZ3D1122: 0.56554
   sysZ3D1123: 0.0
-  sysZ3D1124: -0.0
+  sysZ3D1124: 0.0
   sysZ3D1125: 0.0
   sysZ3D1126: 1.69662000e+00
   sysZ3D1127: 1.13108
   sysZ3D1128: 0.0
   sysZ3D1129: 0.0
   sysZ3D1130: 0.0
-  sysZ3D1131: -0.0
+  sysZ3D1131: 0.0
   sysZ3D1132: 0.0
-  sysZ3D1133: -0.0
+  sysZ3D1133: 0.0
   sysZ3D1134: 0.56554
   sysZ3D1135: 0.0
-  sysZ3D1136: -0.0
+  sysZ3D1136: 0.0
   sysZ3D1137: 0.0
   sysZ3D1138: 0.0
-  sysZ3D1139: -0.0
+  sysZ3D1139: 0.0
   sysZ3D1140: 0.0
   sysZ3D1141: 0.0
-  sysZ3D1142: -0.0
-  sysZ3D1143: -0.0
-  sysZ3D1144: -0.0
+  sysZ3D1142: 0.0
+  sysZ3D1143: 0.0
+  sysZ3D1144: 0.0
   sysZ3D1145: 0.0
   sysZ3D1146: 0.0
-  sysZ3D1147: -0.0
-  sysZ3D1148: -0.0
+  sysZ3D1147: 0.0
+  sysZ3D1148: 0.0
   sysZ3D1149: 0.0
-  sysZ3D1150: -0.0
+  sysZ3D1150: 0.0
   sysZ3D1151: 0.0
-  sysZ3D1152: -0.0
+  sysZ3D1152: 0.0
   sysZ3D1153: 0.0
-  sysZ3D1154: -0.0
-  sysZ3D1155: -0.0
+  sysZ3D1154: 0.0
+  sysZ3D1155: 0.0
   sysZ3D1156: 0.0
-  sysZ3D1157: -0.0
-  sysZ3D1158: -0.0
+  sysZ3D1157: 0.0
+  sysZ3D1158: 0.0
   sysZ3D1159: 0.0
   sysZ3D1160: 0.0
   sysZ3D1161: 0.0
-  sysZ3D1162: -0.0
-  sysZ3D1163: -0.0
-  sysZ3D1164: -0.0
-  sysZ3D1165: -0.0
-  sysZ3D1166: -0.0
-  sysZ3D1167: -0.0
-  sysZ3D1168: -0.0
-  sysZ3D1169: -0.0
+  sysZ3D1162: 0.0
+  sysZ3D1163: 0.0
+  sysZ3D1164: 0.0
+  sysZ3D1165: 0.0
+  sysZ3D1166: 0.0
+  sysZ3D1167: 0.0
+  sysZ3D1168: 0.0
+  sysZ3D1169: 0.0
   sysZ3D1170: 0.56554
-  sysZ3D1171: -0.0
+  sysZ3D1171: 0.0
   sysZ3D1172: 0.0
-  sysZ3D1173: -0.0
+  sysZ3D1173: 0.0
   sysZ3D1174: -0.56554
   sysZ3D1175: 0.0
   sysZ3D1176: 0.0
@@ -9355,22 +9355,22 @@ bins:
   sysZ3D1178: 0.56554
   sysZ3D1179: 0.0
   sysZ3D1180: 0.0
-  sysZ3D1181: -0.0
-  sysZ3D1182: -0.0
+  sysZ3D1181: 0.0
+  sysZ3D1182: 0.0
   sysZ3D1183: 0.0
-  sysZ3D1184: -0.0
-  sysZ3D1185: -0.0
+  sysZ3D1184: 0.0
+  sysZ3D1185: 0.0
   sysZ3D1186: 0.0
   sysZ3D1187: 0.0
-  sysZ3D1188: -0.0
-  sysZ3D1189: -0.0
+  sysZ3D1188: 0.0
+  sysZ3D1189: 0.0
   sysZ3D1190: 0.0
   sysZ3D1191: 0.0
   sysZ3D1192: 0.0
-  sysZ3D1193: -0.0
+  sysZ3D1193: 0.0
   sysZ3D1194: 7.35202000e+00
   sysZ3D1195: 0.0
-  sysZ3D1196: -0.0
+  sysZ3D1196: 0.0
   sysZ3D1197: -0.56554
   sysZ3D1198: -0.56554
   sysZ3D1199: 0.0
@@ -9378,11 +9378,11 @@ bins:
   sysZ3D1201: 0.56554
   sysZ3D1202: 0.0
   sysZ3D1203: 1.13108
-  sysZ3D1204: -0.0
-  sysZ3D1205: -0.0
+  sysZ3D1204: 0.0
+  sysZ3D1205: 0.0
   sysZ3D1206: -0.56554
-  sysZ3D1207: -0.0
-  sysZ3D1208: -0.0
+  sysZ3D1207: 0.0
+  sysZ3D1208: 0.0
   sysZ3D1209: 0.0
   sysZ3D1210: 0.56554
   sysZ3D1211: 0.0
@@ -9394,25 +9394,25 @@ bins:
   sysZ3D1217: -1.13108
   sysZ3D1218: -0.56554
   sysZ3D1219: -0.56554
-  sysZ3D1220: -0.0
+  sysZ3D1220: 0.0
   sysZ3D1221: 0.0
   sysZ3D1222: 0.56554
   sysZ3D1223: 0.0
-  sysZ3D1224: -0.0
-  sysZ3D1225: -0.0
-  sysZ3D1226: -0.0
+  sysZ3D1224: 0.0
+  sysZ3D1225: 0.0
+  sysZ3D1226: 0.0
   sysZ3D1227: -0.56554
   sysZ3D1228: -0.56554
-  sysZ3D1229: -0.0
+  sysZ3D1229: 0.0
   sysZ3D1230: -0.56554
   sysZ3D1231: -0.56554
   sysZ3D1232: 0.0
   sysZ3D1233: 0.0
   sysZ3D1234: 0.0
   sysZ3D1235: 0.56554
-  sysZ3D1236: -0.0
-  sysZ3D1237: -0.0
-  sysZ3D1238: -0.0
+  sysZ3D1236: 0.0
+  sysZ3D1237: 0.0
+  sysZ3D1238: 0.0
   sysZ3D1239: 0.0
   sysZ3D1240: 0.0
   sysZ3D1241: 0.0
@@ -9420,11 +9420,11 @@ bins:
   sysZ3D1243: 0.0
   sysZ3D1244: -1.13108
   sysZ3D1245: 1.69662000e+00
-  sysZ3D1246: -0.0
+  sysZ3D1246: 0.0
   sysZ3D1247: 0.0
   sysZ3D1248: 0.56554
   sysZ3D1249: 0.56554
-  sysZ3D1250: -0.0
+  sysZ3D1250: 0.0
   sysZ3D1251: 1.69662000e+00
   sysZ3D1252: 1.69662000e+00
   sysZ3D1253: 0.0
@@ -9434,7 +9434,7 @@ bins:
   sysZ3D1257: -1.13108
   sysZ3D1258: 0.0
   sysZ3D1259: -1.13108
-  sysZ3D1260: -0.0
+  sysZ3D1260: 0.0
   sysZ3D1261: 0.0
   sysZ3D1262: 2.26216
   sysZ3D1263: 2.26216
@@ -9446,8 +9446,8 @@ bins:
   sysZ3D1269: 0.0
   sysZ3D1270: 1.13108
   sysZ3D1271: 0.56554
-  sysZ3D1272: -0.0
-  sysZ3D1273: -0.0
+  sysZ3D1272: 0.0
+  sysZ3D1273: 0.0
   sysZ3D1274: -1.13108
   sysZ3D1275: 2.8277
   sys,uncor: 3.39324000e+00
@@ -9455,7 +9455,7 @@ bins:
 - stat: 5.70394
   sysZ3D1001: -1.55562000e+00
   sysZ3D1002: 1.03708
-  sysZ3D1003: -0.0
+  sysZ3D1003: 0.0
   sysZ3D1004: 0.0
   sysZ3D1005: 0.0
   sysZ3D1006: 0.0
@@ -9474,105 +9474,105 @@ bins:
   sysZ3D1019: 0.0
   sysZ3D1020: 0.0
   sysZ3D1021: 0.0
-  sysZ3D1022: -0.0
+  sysZ3D1022: 0.0
   sysZ3D1023: 0.0
   sysZ3D1024: 0.0
   sysZ3D1025: 0.0
   sysZ3D1026: 0.0
   sysZ3D1027: 0.0
-  sysZ3D1028: -0.0
-  sysZ3D1029: -0.0
-  sysZ3D1030: -0.0
-  sysZ3D1031: -0.0
-  sysZ3D1032: -0.0
-  sysZ3D1033: -0.0
+  sysZ3D1028: 0.0
+  sysZ3D1029: 0.0
+  sysZ3D1030: 0.0
+  sysZ3D1031: 0.0
+  sysZ3D1032: 0.0
+  sysZ3D1033: 0.0
   sysZ3D1034: 0.0
-  sysZ3D1035: -0.0
+  sysZ3D1035: 0.0
   sysZ3D1036: 0.0
-  sysZ3D1037: -0.0
-  sysZ3D1038: -0.0
-  sysZ3D1039: -0.0
-  sysZ3D1040: -0.0
-  sysZ3D1041: -0.0
+  sysZ3D1037: 0.0
+  sysZ3D1038: 0.0
+  sysZ3D1039: 0.0
+  sysZ3D1040: 0.0
+  sysZ3D1041: 0.0
   sysZ3D1042: -0.51854
-  sysZ3D1043: -0.0
-  sysZ3D1044: -0.0
-  sysZ3D1045: -0.0
+  sysZ3D1043: 0.0
+  sysZ3D1044: 0.0
+  sysZ3D1045: 0.0
   sysZ3D1046: 0.0
   sysZ3D1047: 0.0
-  sysZ3D1048: -0.0
+  sysZ3D1048: 0.0
   sysZ3D1049: 0.0
-  sysZ3D1050: -0.0
+  sysZ3D1050: 0.0
   sysZ3D1051: 0.0
-  sysZ3D1052: -0.0
+  sysZ3D1052: 0.0
   sysZ3D1053: 0.0
   sysZ3D1054: 0.0
-  sysZ3D1055: -0.0
+  sysZ3D1055: 0.0
   sysZ3D1056: 0.0
   sysZ3D1057: 0.0
-  sysZ3D1058: -0.0
-  sysZ3D1059: -0.0
-  sysZ3D1060: -0.0
+  sysZ3D1058: 0.0
+  sysZ3D1059: 0.0
+  sysZ3D1060: 0.0
   sysZ3D1061: 0.0
   sysZ3D1062: 0.0
   sysZ3D1063: 0.0
   sysZ3D1064: 0.0
-  sysZ3D1065: -0.0
+  sysZ3D1065: 0.0
   sysZ3D1066: 0.0
   sysZ3D1067: 0.0
   sysZ3D1068: 0.0
-  sysZ3D1069: -0.0
+  sysZ3D1069: 0.0
   sysZ3D1070: 0.0
-  sysZ3D1071: -0.0
-  sysZ3D1072: -0.0
+  sysZ3D1071: 0.0
+  sysZ3D1072: 0.0
   sysZ3D1073: 0.0
-  sysZ3D1074: -0.0
-  sysZ3D1075: -0.0
+  sysZ3D1074: 0.0
+  sysZ3D1075: 0.0
   sysZ3D1076: 0.0
   sysZ3D1077: 0.0
-  sysZ3D1078: -0.0
-  sysZ3D1079: -0.0
-  sysZ3D1080: -0.0
+  sysZ3D1078: 0.0
+  sysZ3D1079: 0.0
+  sysZ3D1080: 0.0
   sysZ3D1081: 0.0
   sysZ3D1082: 0.0
-  sysZ3D1083: -0.0
+  sysZ3D1083: 0.0
   sysZ3D1084: 0.0
   sysZ3D1085: 0.0
-  sysZ3D1086: -0.0
-  sysZ3D1087: -0.0
+  sysZ3D1086: 0.0
+  sysZ3D1087: 0.0
   sysZ3D1088: 0.0
   sysZ3D1089: 0.0
   sysZ3D1090: 0.0
   sysZ3D1091: 0.0
   sysZ3D1092: 0.0
-  sysZ3D1093: -0.0
-  sysZ3D1094: -0.0
-  sysZ3D1095: -0.0
-  sysZ3D1096: -0.0
+  sysZ3D1093: 0.0
+  sysZ3D1094: 0.0
+  sysZ3D1095: 0.0
+  sysZ3D1096: 0.0
   sysZ3D1097: 0.0
   sysZ3D1098: 0.0
   sysZ3D1099: 0.0
-  sysZ3D1100: -0.0
-  sysZ3D1101: -0.0
+  sysZ3D1100: 0.0
+  sysZ3D1101: 0.0
   sysZ3D1102: 0.0
   sysZ3D1103: 0.0
-  sysZ3D1104: -0.0
+  sysZ3D1104: 0.0
   sysZ3D1105: -0.51854
   sysZ3D1106: -0.51854
   sysZ3D1107: 0.0
   sysZ3D1108: 0.0
   sysZ3D1109: 0.0
   sysZ3D1110: 0.0
-  sysZ3D1111: -0.0
-  sysZ3D1112: -0.0
+  sysZ3D1111: 0.0
+  sysZ3D1112: 0.0
   sysZ3D1113: 1.55562000e+00
   sysZ3D1114: 0.0
   sysZ3D1115: 0.51854
   sysZ3D1116: 1.03708
   sysZ3D1117: 0.51854
   sysZ3D1118: 0.0
-  sysZ3D1119: -0.0
-  sysZ3D1120: -0.0
+  sysZ3D1119: 0.0
+  sysZ3D1120: 0.0
   sysZ3D1121: 0.51854
   sysZ3D1122: 0.0
   sysZ3D1123: 0.51854
@@ -9580,75 +9580,75 @@ bins:
   sysZ3D1125: 0.0
   sysZ3D1126: 1.55562000e+00
   sysZ3D1127: 1.55562000e+00
-  sysZ3D1128: -0.0
+  sysZ3D1128: 0.0
   sysZ3D1129: 0.0
-  sysZ3D1130: -0.0
+  sysZ3D1130: 0.0
   sysZ3D1131: 0.0
-  sysZ3D1132: -0.0
-  sysZ3D1133: -0.0
+  sysZ3D1132: 0.0
+  sysZ3D1133: 0.0
   sysZ3D1134: -0.51854
-  sysZ3D1135: -0.0
+  sysZ3D1135: 0.0
   sysZ3D1136: 0.0
   sysZ3D1137: 0.0
-  sysZ3D1138: -0.0
-  sysZ3D1139: -0.0
+  sysZ3D1138: 0.0
+  sysZ3D1139: 0.0
   sysZ3D1140: 0.0
   sysZ3D1141: 0.0
   sysZ3D1142: 0.0
   sysZ3D1143: 0.0
-  sysZ3D1144: -0.0
-  sysZ3D1145: -0.0
+  sysZ3D1144: 0.0
+  sysZ3D1145: 0.0
   sysZ3D1146: 0.0
   sysZ3D1147: 0.0
-  sysZ3D1148: -0.0
-  sysZ3D1149: -0.0
+  sysZ3D1148: 0.0
+  sysZ3D1149: 0.0
   sysZ3D1150: 0.0
   sysZ3D1151: 0.0
   sysZ3D1152: 0.0
   sysZ3D1153: 0.0
   sysZ3D1154: 0.0
   sysZ3D1155: 0.0
-  sysZ3D1156: -0.0
+  sysZ3D1156: 0.0
   sysZ3D1157: 0.0
-  sysZ3D1158: -0.0
-  sysZ3D1159: -0.0
-  sysZ3D1160: -0.0
+  sysZ3D1158: 0.0
+  sysZ3D1159: 0.0
+  sysZ3D1160: 0.0
   sysZ3D1161: 0.0
   sysZ3D1162: 0.0
   sysZ3D1163: 0.0
   sysZ3D1164: 0.0
-  sysZ3D1165: -0.0
+  sysZ3D1165: 0.0
   sysZ3D1166: 0.0
   sysZ3D1167: 0.0
-  sysZ3D1168: -0.0
-  sysZ3D1169: -0.0
+  sysZ3D1168: 0.0
+  sysZ3D1169: 0.0
   sysZ3D1170: 0.51854
-  sysZ3D1171: -0.0
+  sysZ3D1171: 0.0
   sysZ3D1172: 0.0
-  sysZ3D1173: -0.0
-  sysZ3D1174: -0.0
+  sysZ3D1173: 0.0
+  sysZ3D1174: 0.0
   sysZ3D1175: 0.0
   sysZ3D1176: 0.0
   sysZ3D1177: 0.51854
   sysZ3D1178: 0.0
   sysZ3D1179: 0.0
-  sysZ3D1180: -0.0
-  sysZ3D1181: -0.0
-  sysZ3D1182: -0.0
-  sysZ3D1183: -0.0
+  sysZ3D1180: 0.0
+  sysZ3D1181: 0.0
+  sysZ3D1182: 0.0
+  sysZ3D1183: 0.0
   sysZ3D1184: -0.51854
-  sysZ3D1185: -0.0
+  sysZ3D1185: 0.0
   sysZ3D1186: 0.0
   sysZ3D1187: 0.0
   sysZ3D1188: -0.51854
-  sysZ3D1189: -0.0
+  sysZ3D1189: 0.0
   sysZ3D1190: 0.0
   sysZ3D1191: 0.0
   sysZ3D1192: 0.0
   sysZ3D1193: 0.0
   sysZ3D1194: 6.74102
-  sysZ3D1195: -0.0
-  sysZ3D1196: -0.0
+  sysZ3D1195: 0.0
+  sysZ3D1196: 0.0
   sysZ3D1197: -0.51854
   sysZ3D1198: -0.51854
   sysZ3D1199: 0.0
@@ -9656,11 +9656,11 @@ bins:
   sysZ3D1201: 0.51854
   sysZ3D1202: 0.0
   sysZ3D1203: 0.51854
-  sysZ3D1204: -0.0
-  sysZ3D1205: -0.0
+  sysZ3D1204: 0.0
+  sysZ3D1205: 0.0
   sysZ3D1206: -0.51854
-  sysZ3D1207: -0.0
-  sysZ3D1208: -0.0
+  sysZ3D1207: 0.0
+  sysZ3D1208: 0.0
   sysZ3D1209: 0.0
   sysZ3D1210: 0.51854
   sysZ3D1211: 0.0
@@ -9670,18 +9670,18 @@ bins:
   sysZ3D1215: 1.03708
   sysZ3D1216: 0.51854
   sysZ3D1217: -1.03708
-  sysZ3D1218: -0.0
+  sysZ3D1218: 0.0
   sysZ3D1219: -0.51854
   sysZ3D1220: 0.0
   sysZ3D1221: 0.0
   sysZ3D1222: 0.0
   sysZ3D1223: 0.0
-  sysZ3D1224: -0.0
-  sysZ3D1225: -0.0
+  sysZ3D1224: 0.0
+  sysZ3D1225: 0.0
   sysZ3D1226: -0.51854
   sysZ3D1227: -0.51854
-  sysZ3D1228: -0.0
-  sysZ3D1229: -0.0
+  sysZ3D1228: 0.0
+  sysZ3D1229: 0.0
   sysZ3D1230: -0.51854
   sysZ3D1231: -0.51854
   sysZ3D1232: 0.0
@@ -9689,8 +9689,8 @@ bins:
   sysZ3D1234: 0.0
   sysZ3D1235: 0.0
   sysZ3D1236: 0.0
-  sysZ3D1237: -0.0
-  sysZ3D1238: -0.0
+  sysZ3D1237: 0.0
+  sysZ3D1238: 0.0
   sysZ3D1239: 0.0
   sysZ3D1240: 0.0
   sysZ3D1241: 0.0
@@ -9705,7 +9705,7 @@ bins:
   sysZ3D1250: -0.51854
   sysZ3D1251: 1.03708
   sysZ3D1252: 0.51854
-  sysZ3D1253: -0.0
+  sysZ3D1253: 0.0
   sysZ3D1254: 0.51854
   sysZ3D1255: 2.5927
   sysZ3D1256: 0.51854
@@ -9721,11 +9721,11 @@ bins:
   sysZ3D1266: -5.1854
   sysZ3D1267: -1.03708
   sysZ3D1268: 0.51854
-  sysZ3D1269: -0.0
+  sysZ3D1269: 0.0
   sysZ3D1270: 0.51854
   sysZ3D1271: 0.51854
-  sysZ3D1272: -0.0
-  sysZ3D1273: -0.0
+  sysZ3D1272: 0.0
+  sysZ3D1273: 0.0
   sysZ3D1274: -1.03708
   sysZ3D1275: 3.11124000e+00
   sys,uncor: 3.11124000e+00
@@ -9733,7 +9733,7 @@ bins:
 - stat: 5.41152000e+00
   sysZ3D1001: -1.80384000e+00
   sysZ3D1002: 4.50960000e-01
-  sysZ3D1003: -0.0
+  sysZ3D1003: 0.0
   sysZ3D1004: 0.0
   sysZ3D1005: 0.0
   sysZ3D1006: 0.0
@@ -9751,106 +9751,106 @@ bins:
   sysZ3D1018: 0.0
   sysZ3D1019: 0.0
   sysZ3D1020: 0.0
-  sysZ3D1021: -0.0
-  sysZ3D1022: -0.0
-  sysZ3D1023: -0.0
+  sysZ3D1021: 0.0
+  sysZ3D1022: 0.0
+  sysZ3D1023: 0.0
   sysZ3D1024: 0.0
-  sysZ3D1025: -0.0
-  sysZ3D1026: -0.0
-  sysZ3D1027: -0.0
-  sysZ3D1028: -0.0
+  sysZ3D1025: 0.0
+  sysZ3D1026: 0.0
+  sysZ3D1027: 0.0
+  sysZ3D1028: 0.0
   sysZ3D1029: 0.0
   sysZ3D1030: 0.0
-  sysZ3D1031: -0.0
-  sysZ3D1032: -0.0
+  sysZ3D1031: 0.0
+  sysZ3D1032: 0.0
   sysZ3D1033: 0.0
-  sysZ3D1034: -0.0
+  sysZ3D1034: 0.0
   sysZ3D1035: 0.0
   sysZ3D1036: 0.0
-  sysZ3D1037: -0.0
+  sysZ3D1037: 0.0
   sysZ3D1038: 0.0
-  sysZ3D1039: -0.0
-  sysZ3D1040: -0.0
-  sysZ3D1041: -0.0
+  sysZ3D1039: 0.0
+  sysZ3D1040: 0.0
+  sysZ3D1041: 0.0
   sysZ3D1042: 0.0
-  sysZ3D1043: -0.0
-  sysZ3D1044: -0.0
-  sysZ3D1045: -0.0
+  sysZ3D1043: 0.0
+  sysZ3D1044: 0.0
+  sysZ3D1045: 0.0
   sysZ3D1046: 0.0
   sysZ3D1047: 0.0
-  sysZ3D1048: -0.0
-  sysZ3D1049: -0.0
-  sysZ3D1050: -0.0
-  sysZ3D1051: -0.0
-  sysZ3D1052: -0.0
+  sysZ3D1048: 0.0
+  sysZ3D1049: 0.0
+  sysZ3D1050: 0.0
+  sysZ3D1051: 0.0
+  sysZ3D1052: 0.0
   sysZ3D1053: 0.0
-  sysZ3D1054: -0.0
-  sysZ3D1055: -0.0
+  sysZ3D1054: 0.0
+  sysZ3D1055: 0.0
   sysZ3D1056: 0.0
   sysZ3D1057: 0.0
-  sysZ3D1058: -0.0
+  sysZ3D1058: 0.0
   sysZ3D1059: 0.0
-  sysZ3D1060: -0.0
+  sysZ3D1060: 0.0
   sysZ3D1061: -4.50960000e-01
-  sysZ3D1062: -0.0
-  sysZ3D1063: -0.0
+  sysZ3D1062: 0.0
+  sysZ3D1063: 0.0
   sysZ3D1064: 0.0
-  sysZ3D1065: -0.0
+  sysZ3D1065: 0.0
   sysZ3D1066: 0.0
-  sysZ3D1067: -0.0
+  sysZ3D1067: 0.0
   sysZ3D1068: 0.0
   sysZ3D1069: 0.0
-  sysZ3D1070: -0.0
+  sysZ3D1070: 0.0
   sysZ3D1071: 0.0
   sysZ3D1072: 0.0
   sysZ3D1073: 0.0
-  sysZ3D1074: -0.0
-  sysZ3D1075: -0.0
-  sysZ3D1076: -0.0
+  sysZ3D1074: 0.0
+  sysZ3D1075: 0.0
+  sysZ3D1076: 0.0
   sysZ3D1077: 0.0
   sysZ3D1078: 0.0
   sysZ3D1079: 0.0
   sysZ3D1080: 0.0
-  sysZ3D1081: -0.0
+  sysZ3D1081: 0.0
   sysZ3D1082: 0.0
   sysZ3D1083: 0.0
-  sysZ3D1084: -0.0
-  sysZ3D1085: -0.0
+  sysZ3D1084: 0.0
+  sysZ3D1085: 0.0
   sysZ3D1086: 0.0
   sysZ3D1087: 0.0
   sysZ3D1088: 0.0
   sysZ3D1089: 0.0
   sysZ3D1090: 0.0
-  sysZ3D1091: -0.0
+  sysZ3D1091: 0.0
   sysZ3D1092: 0.0
-  sysZ3D1093: -0.0
+  sysZ3D1093: 0.0
   sysZ3D1094: 0.0
   sysZ3D1095: 0.0
-  sysZ3D1096: -0.0
-  sysZ3D1097: -0.0
+  sysZ3D1096: 0.0
+  sysZ3D1097: 0.0
   sysZ3D1098: 0.0
   sysZ3D1099: 0.0
   sysZ3D1100: 0.0
   sysZ3D1101: 0.0
-  sysZ3D1102: -0.0
-  sysZ3D1103: -0.0
-  sysZ3D1104: -0.0
+  sysZ3D1102: 0.0
+  sysZ3D1103: 0.0
+  sysZ3D1104: 0.0
   sysZ3D1105: -4.50960000e-01
   sysZ3D1106: -4.50960000e-01
   sysZ3D1107: 0.0
   sysZ3D1108: 0.0
   sysZ3D1109: 0.0
   sysZ3D1110: 0.0
-  sysZ3D1111: -0.0
-  sysZ3D1112: -0.0
+  sysZ3D1111: 0.0
+  sysZ3D1112: 0.0
   sysZ3D1113: 1.35288000e+00
   sysZ3D1114: 4.50960000e-01
   sysZ3D1115: 4.50960000e-01
   sysZ3D1116: 4.50960000e-01
-  sysZ3D1117: -0.0
+  sysZ3D1117: 0.0
   sysZ3D1118: 0.0
-  sysZ3D1119: -0.0
-  sysZ3D1120: -0.0
+  sysZ3D1119: 0.0
+  sysZ3D1120: 0.0
   sysZ3D1121: -4.50960000e-01
   sysZ3D1122: 0.0
   sysZ3D1123: 4.50960000e-01
@@ -9859,91 +9859,91 @@ bins:
   sysZ3D1126: 1.35288000e+00
   sysZ3D1127: 4.50960000e-01
   sysZ3D1128: 0.0
-  sysZ3D1129: -0.0
-  sysZ3D1130: -0.0
-  sysZ3D1131: -0.0
+  sysZ3D1129: 0.0
+  sysZ3D1130: 0.0
+  sysZ3D1131: 0.0
   sysZ3D1132: 0.0
   sysZ3D1133: 0.0
   sysZ3D1134: 0.0
   sysZ3D1135: 0.0
   sysZ3D1136: 0.0
-  sysZ3D1137: -0.0
+  sysZ3D1137: 0.0
   sysZ3D1138: 0.0
-  sysZ3D1139: -0.0
-  sysZ3D1140: -0.0
-  sysZ3D1141: -0.0
+  sysZ3D1139: 0.0
+  sysZ3D1140: 0.0
+  sysZ3D1141: 0.0
   sysZ3D1142: 0.0
-  sysZ3D1143: -0.0
-  sysZ3D1144: -0.0
+  sysZ3D1143: 0.0
+  sysZ3D1144: 0.0
   sysZ3D1145: 0.0
   sysZ3D1146: 0.0
   sysZ3D1147: 0.0
   sysZ3D1148: 0.0
-  sysZ3D1149: -0.0
+  sysZ3D1149: 0.0
   sysZ3D1150: 0.0
-  sysZ3D1151: -0.0
+  sysZ3D1151: 0.0
   sysZ3D1152: 0.0
-  sysZ3D1153: -0.0
+  sysZ3D1153: 0.0
   sysZ3D1154: 0.0
-  sysZ3D1155: -0.0
-  sysZ3D1156: -0.0
+  sysZ3D1155: 0.0
+  sysZ3D1156: 0.0
   sysZ3D1157: 0.0
-  sysZ3D1158: -0.0
+  sysZ3D1158: 0.0
   sysZ3D1159: 0.0
   sysZ3D1160: -4.50960000e-01
-  sysZ3D1161: -0.0
-  sysZ3D1162: -0.0
-  sysZ3D1163: -0.0
+  sysZ3D1161: 0.0
+  sysZ3D1162: 0.0
+  sysZ3D1163: 0.0
   sysZ3D1164: 0.0
   sysZ3D1165: 0.0
   sysZ3D1166: 0.0
-  sysZ3D1167: -0.0
-  sysZ3D1168: -0.0
-  sysZ3D1169: -0.0
+  sysZ3D1167: 0.0
+  sysZ3D1168: 0.0
+  sysZ3D1169: 0.0
   sysZ3D1170: 4.50960000e-01
-  sysZ3D1171: -0.0
-  sysZ3D1172: -0.0
-  sysZ3D1173: -0.0
-  sysZ3D1174: -0.0
+  sysZ3D1171: 0.0
+  sysZ3D1172: 0.0
+  sysZ3D1173: 0.0
+  sysZ3D1174: 0.0
   sysZ3D1175: 0.0
   sysZ3D1176: -4.50960000e-01
-  sysZ3D1177: -0.0
-  sysZ3D1178: -0.0
+  sysZ3D1177: 0.0
+  sysZ3D1178: 0.0
   sysZ3D1179: 4.50960000e-01
-  sysZ3D1180: -0.0
-  sysZ3D1181: -0.0
-  sysZ3D1182: -0.0
-  sysZ3D1183: -0.0
+  sysZ3D1180: 0.0
+  sysZ3D1181: 0.0
+  sysZ3D1182: 0.0
+  sysZ3D1183: 0.0
   sysZ3D1184: -4.50960000e-01
   sysZ3D1185: -4.50960000e-01
-  sysZ3D1186: -0.0
+  sysZ3D1186: 0.0
   sysZ3D1187: 0.0
-  sysZ3D1188: -0.0
-  sysZ3D1189: -0.0
-  sysZ3D1190: -0.0
+  sysZ3D1188: 0.0
+  sysZ3D1189: 0.0
+  sysZ3D1190: 0.0
   sysZ3D1191: 0.0
-  sysZ3D1192: -0.0
-  sysZ3D1193: -0.0
+  sysZ3D1192: 0.0
+  sysZ3D1193: 0.0
   sysZ3D1194: 5.86248
   sysZ3D1195: -4.50960000e-01
-  sysZ3D1196: -0.0
+  sysZ3D1196: 0.0
   sysZ3D1197: -4.50960000e-01
-  sysZ3D1198: -0.0
+  sysZ3D1198: 0.0
   sysZ3D1199: 4.50960000e-01
   sysZ3D1200: 4.50960000e-01
   sysZ3D1201: 4.50960000e-01
   sysZ3D1202: 0.0
   sysZ3D1203: 4.50960000e-01
   sysZ3D1204: -4.50960000e-01
-  sysZ3D1205: -0.0
+  sysZ3D1205: 0.0
   sysZ3D1206: -4.50960000e-01
-  sysZ3D1207: -0.0
-  sysZ3D1208: -0.0
+  sysZ3D1207: 0.0
+  sysZ3D1208: 0.0
   sysZ3D1209: 0.0
   sysZ3D1210: 0.0
   sysZ3D1211: 0.0
   sysZ3D1212: 0.0
-  sysZ3D1213: -0.0
+  sysZ3D1213: 0.0
   sysZ3D1214: 4.50960000e-01
   sysZ3D1215: 9.01920000e-01
   sysZ3D1216: 0.0
@@ -9953,22 +9953,22 @@ bins:
   sysZ3D1220: 0.0
   sysZ3D1221: 0.0
   sysZ3D1222: 0.0
-  sysZ3D1223: -0.0
-  sysZ3D1224: -0.0
-  sysZ3D1225: -0.0
-  sysZ3D1226: -0.0
+  sysZ3D1223: 0.0
+  sysZ3D1224: 0.0
+  sysZ3D1225: 0.0
+  sysZ3D1226: 0.0
   sysZ3D1227: -4.50960000e-01
   sysZ3D1228: 0.0
-  sysZ3D1229: -0.0
-  sysZ3D1230: -0.0
+  sysZ3D1229: 0.0
+  sysZ3D1230: 0.0
   sysZ3D1231: -4.50960000e-01
   sysZ3D1232: 0.0
   sysZ3D1233: 0.0
   sysZ3D1234: 0.0
   sysZ3D1235: 0.0
-  sysZ3D1236: -0.0
-  sysZ3D1237: -0.0
-  sysZ3D1238: -0.0
+  sysZ3D1236: 0.0
+  sysZ3D1237: 0.0
+  sysZ3D1238: 0.0
   sysZ3D1239: 0.0
   sysZ3D1240: 0.0
   sysZ3D1241: 0.0
@@ -9976,21 +9976,21 @@ bins:
   sysZ3D1243: 0.0
   sysZ3D1244: -9.01920000e-01
   sysZ3D1245: 4.50960000e-01
-  sysZ3D1246: -0.0
+  sysZ3D1246: 0.0
   sysZ3D1247: 0.0
   sysZ3D1248: 9.01920000e-01
   sysZ3D1249: 0.0
-  sysZ3D1250: -0.0
+  sysZ3D1250: 0.0
   sysZ3D1251: 9.01920000e-01
   sysZ3D1252: 4.50960000e-01
-  sysZ3D1253: -0.0
+  sysZ3D1253: 0.0
   sysZ3D1254: 4.50960000e-01
   sysZ3D1255: 2.70576000e+00
   sysZ3D1256: 4.50960000e-01
   sysZ3D1257: -4.50960000e-01
   sysZ3D1258: 4.50960000e-01
   sysZ3D1259: -9.01920000e-01
-  sysZ3D1260: -0.0
+  sysZ3D1260: 0.0
   sysZ3D1261: 0.0
   sysZ3D1262: 1.35288000e+00
   sysZ3D1263: 1.35288000e+00
@@ -9999,11 +9999,11 @@ bins:
   sysZ3D1266: -4.96056
   sysZ3D1267: -4.50960000e-01
   sysZ3D1268: 4.50960000e-01
-  sysZ3D1269: -0.0
+  sysZ3D1269: 0.0
   sysZ3D1270: 4.50960000e-01
   sysZ3D1271: 4.50960000e-01
-  sysZ3D1272: -0.0
-  sysZ3D1273: -0.0
+  sysZ3D1272: 0.0
+  sysZ3D1273: 0.0
   sysZ3D1274: -9.01920000e-01
   sysZ3D1275: 2.70576000e+00
   sys,uncor: 2.70576000e+00
@@ -10011,7 +10011,7 @@ bins:
 - stat: 4.75592
   sysZ3D1001: -1.46336
   sysZ3D1002: 0.36584
-  sysZ3D1003: -0.0
+  sysZ3D1003: 0.0
   sysZ3D1004: 0.0
   sysZ3D1005: 0.0
   sysZ3D1006: 0.0
@@ -10028,185 +10028,185 @@ bins:
   sysZ3D1017: 0.0
   sysZ3D1018: 0.0
   sysZ3D1019: 0.0
-  sysZ3D1020: -0.0
-  sysZ3D1021: -0.0
-  sysZ3D1022: -0.0
+  sysZ3D1020: 0.0
+  sysZ3D1021: 0.0
+  sysZ3D1022: 0.0
   sysZ3D1023: 0.0
-  sysZ3D1024: -0.0
+  sysZ3D1024: 0.0
   sysZ3D1025: 0.36584
-  sysZ3D1026: -0.0
-  sysZ3D1027: -0.0
-  sysZ3D1028: -0.0
+  sysZ3D1026: 0.0
+  sysZ3D1027: 0.0
+  sysZ3D1028: 0.0
   sysZ3D1029: 0.0
-  sysZ3D1030: -0.0
-  sysZ3D1031: -0.0
+  sysZ3D1030: 0.0
+  sysZ3D1031: 0.0
   sysZ3D1032: 0.0
   sysZ3D1033: 0.0
   sysZ3D1034: 0.0
   sysZ3D1035: 0.0
   sysZ3D1036: 0.0
-  sysZ3D1037: -0.0
-  sysZ3D1038: -0.0
+  sysZ3D1037: 0.0
+  sysZ3D1038: 0.0
   sysZ3D1039: 0.0
-  sysZ3D1040: -0.0
-  sysZ3D1041: -0.0
-  sysZ3D1042: -0.0
+  sysZ3D1040: 0.0
+  sysZ3D1041: 0.0
+  sysZ3D1042: 0.0
   sysZ3D1043: 0.0
   sysZ3D1044: 0.0
   sysZ3D1045: 0.0
-  sysZ3D1046: -0.0
+  sysZ3D1046: 0.0
   sysZ3D1047: 0.0
-  sysZ3D1048: -0.0
+  sysZ3D1048: 0.0
   sysZ3D1049: 0.0
   sysZ3D1050: 0.36584
   sysZ3D1051: 0.0
-  sysZ3D1052: -0.0
-  sysZ3D1053: -0.0
-  sysZ3D1054: -0.0
+  sysZ3D1052: 0.0
+  sysZ3D1053: 0.0
+  sysZ3D1054: 0.0
   sysZ3D1055: 0.0
   sysZ3D1056: 0.0
-  sysZ3D1057: -0.0
+  sysZ3D1057: 0.0
   sysZ3D1058: 0.0
   sysZ3D1059: 0.0
   sysZ3D1060: 0.0
   sysZ3D1061: 0.0
   sysZ3D1062: 0.0
-  sysZ3D1063: -0.0
-  sysZ3D1064: -0.0
+  sysZ3D1063: 0.0
+  sysZ3D1064: 0.0
   sysZ3D1065: 0.0
-  sysZ3D1066: -0.0
-  sysZ3D1067: -0.0
+  sysZ3D1066: 0.0
+  sysZ3D1067: 0.0
   sysZ3D1068: 0.0
-  sysZ3D1069: -0.0
+  sysZ3D1069: 0.0
   sysZ3D1070: 0.0
-  sysZ3D1071: -0.0
-  sysZ3D1072: -0.0
+  sysZ3D1071: 0.0
+  sysZ3D1072: 0.0
   sysZ3D1073: 0.0
-  sysZ3D1074: -0.0
-  sysZ3D1075: -0.0
-  sysZ3D1076: -0.0
-  sysZ3D1077: -0.0
-  sysZ3D1078: -0.0
-  sysZ3D1079: -0.0
-  sysZ3D1080: -0.0
+  sysZ3D1074: 0.0
+  sysZ3D1075: 0.0
+  sysZ3D1076: 0.0
+  sysZ3D1077: 0.0
+  sysZ3D1078: 0.0
+  sysZ3D1079: 0.0
+  sysZ3D1080: 0.0
   sysZ3D1081: 0.0
-  sysZ3D1082: -0.0
+  sysZ3D1082: 0.0
   sysZ3D1083: 0.0
-  sysZ3D1084: -0.0
-  sysZ3D1085: -0.0
-  sysZ3D1086: -0.0
+  sysZ3D1084: 0.0
+  sysZ3D1085: 0.0
+  sysZ3D1086: 0.0
   sysZ3D1087: 0.0
   sysZ3D1088: 0.0
-  sysZ3D1089: -0.0
-  sysZ3D1090: -0.0
-  sysZ3D1091: -0.0
-  sysZ3D1092: -0.0
+  sysZ3D1089: 0.0
+  sysZ3D1090: 0.0
+  sysZ3D1091: 0.0
+  sysZ3D1092: 0.0
   sysZ3D1093: 0.0
-  sysZ3D1094: -0.0
+  sysZ3D1094: 0.0
   sysZ3D1095: 0.0
   sysZ3D1096: 0.0
   sysZ3D1097: 0.0
   sysZ3D1098: 0.0
   sysZ3D1099: 0.0
-  sysZ3D1100: -0.0
-  sysZ3D1101: -0.0
+  sysZ3D1100: 0.0
+  sysZ3D1101: 0.0
   sysZ3D1102: 0.0
-  sysZ3D1103: -0.0
-  sysZ3D1104: -0.0
+  sysZ3D1103: 0.0
+  sysZ3D1104: 0.0
   sysZ3D1105: -0.36584
   sysZ3D1106: -0.36584
-  sysZ3D1107: -0.0
+  sysZ3D1107: 0.0
   sysZ3D1108: 0.0
   sysZ3D1109: 0.0
   sysZ3D1110: 0.0
-  sysZ3D1111: -0.0
-  sysZ3D1112: -0.0
+  sysZ3D1111: 0.0
+  sysZ3D1112: 0.0
   sysZ3D1113: 1.09752000e+00
   sysZ3D1114: 0.36584
   sysZ3D1115: 0.73168
   sysZ3D1116: 0.36584
   sysZ3D1117: -0.36584
-  sysZ3D1118: -0.0
-  sysZ3D1119: -0.0
-  sysZ3D1120: -0.0
-  sysZ3D1121: -0.0
-  sysZ3D1122: -0.0
+  sysZ3D1118: 0.0
+  sysZ3D1119: 0.0
+  sysZ3D1120: 0.0
+  sysZ3D1121: 0.0
+  sysZ3D1122: 0.0
   sysZ3D1123: 0.36584
   sysZ3D1124: 0.73168
   sysZ3D1125: 0.0
   sysZ3D1126: 1.09752000e+00
   sysZ3D1127: 1.09752000e+00
-  sysZ3D1128: -0.0
+  sysZ3D1128: 0.0
   sysZ3D1129: 0.0
-  sysZ3D1130: -0.0
+  sysZ3D1130: 0.0
   sysZ3D1131: 0.0
-  sysZ3D1132: -0.0
+  sysZ3D1132: 0.0
   sysZ3D1133: 0.36584
   sysZ3D1134: 0.0
-  sysZ3D1135: -0.0
+  sysZ3D1135: 0.0
   sysZ3D1136: 0.0
-  sysZ3D1137: -0.0
-  sysZ3D1138: -0.0
+  sysZ3D1137: 0.0
+  sysZ3D1138: 0.0
   sysZ3D1139: 0.0
-  sysZ3D1140: -0.0
+  sysZ3D1140: 0.0
   sysZ3D1141: 0.0
   sysZ3D1142: 0.0
-  sysZ3D1143: -0.0
+  sysZ3D1143: 0.0
   sysZ3D1144: 0.0
   sysZ3D1145: 0.0
   sysZ3D1146: 0.0
   sysZ3D1147: 0.0
   sysZ3D1148: 0.0
-  sysZ3D1149: -0.0
+  sysZ3D1149: 0.0
   sysZ3D1150: 0.0
   sysZ3D1151: 0.0
   sysZ3D1152: 0.0
-  sysZ3D1153: -0.0
+  sysZ3D1153: 0.0
   sysZ3D1154: 0.0
   sysZ3D1155: 0.0
   sysZ3D1156: 0.0
   sysZ3D1157: 0.0
   sysZ3D1158: 0.0
   sysZ3D1159: -0.36584
-  sysZ3D1160: -0.0
+  sysZ3D1160: 0.0
   sysZ3D1161: 0.36584
   sysZ3D1162: 0.0
   sysZ3D1163: 0.0
-  sysZ3D1164: -0.0
+  sysZ3D1164: 0.0
   sysZ3D1165: 0.0
   sysZ3D1166: 0.0
   sysZ3D1167: 0.0
   sysZ3D1168: -0.36584
-  sysZ3D1169: -0.0
+  sysZ3D1169: 0.0
   sysZ3D1170: 0.0
-  sysZ3D1171: -0.0
-  sysZ3D1172: -0.0
-  sysZ3D1173: -0.0
+  sysZ3D1171: 0.0
+  sysZ3D1172: 0.0
+  sysZ3D1173: 0.0
   sysZ3D1174: -0.36584
   sysZ3D1175: 0.0
   sysZ3D1176: 0.36584
   sysZ3D1177: 0.36584
-  sysZ3D1178: -0.0
+  sysZ3D1178: 0.0
   sysZ3D1179: 0.36584
   sysZ3D1180: 0.0
-  sysZ3D1181: -0.0
-  sysZ3D1182: -0.0
-  sysZ3D1183: -0.0
+  sysZ3D1181: 0.0
+  sysZ3D1182: 0.0
+  sysZ3D1183: 0.0
   sysZ3D1184: -0.36584
-  sysZ3D1185: -0.0
+  sysZ3D1185: 0.0
   sysZ3D1186: 0.0
   sysZ3D1187: 0.0
   sysZ3D1188: -0.36584
-  sysZ3D1189: -0.0
+  sysZ3D1189: 0.0
   sysZ3D1190: 0.0
   sysZ3D1191: 0.0
   sysZ3D1192: 0.0
-  sysZ3D1193: -0.0
+  sysZ3D1193: 0.0
   sysZ3D1194: 5.12176
   sysZ3D1195: -0.36584
   sysZ3D1196: -0.36584
   sysZ3D1197: -0.36584
-  sysZ3D1198: -0.0
+  sysZ3D1198: 0.0
   sysZ3D1199: 0.36584
   sysZ3D1200: 0.73168
   sysZ3D1201: 0.36584
@@ -10215,38 +10215,38 @@ bins:
   sysZ3D1204: -0.36584
   sysZ3D1205: -0.36584
   sysZ3D1206: -0.36584
-  sysZ3D1207: -0.0
+  sysZ3D1207: 0.0
   sysZ3D1208: 0.0
   sysZ3D1209: 0.0
   sysZ3D1210: 0.36584
   sysZ3D1211: 0.0
   sysZ3D1212: 0.0
-  sysZ3D1213: -0.0
+  sysZ3D1213: 0.0
   sysZ3D1214: 0.0
   sysZ3D1215: 0.73168
-  sysZ3D1216: -0.0
+  sysZ3D1216: 0.0
   sysZ3D1217: -0.73168
   sysZ3D1218: 0.36584
   sysZ3D1219: -0.36584
   sysZ3D1220: 0.0
   sysZ3D1221: 0.0
   sysZ3D1222: 0.0
-  sysZ3D1223: -0.0
+  sysZ3D1223: 0.0
   sysZ3D1224: -0.36584
   sysZ3D1225: -0.36584
-  sysZ3D1226: -0.0
+  sysZ3D1226: 0.0
   sysZ3D1227: -0.36584
   sysZ3D1228: 0.0
-  sysZ3D1229: -0.0
-  sysZ3D1230: -0.0
+  sysZ3D1229: 0.0
+  sysZ3D1230: 0.0
   sysZ3D1231: -0.36584
   sysZ3D1232: 0.0
   sysZ3D1233: 0.0
   sysZ3D1234: 0.0
   sysZ3D1235: 0.0
-  sysZ3D1236: -0.0
-  sysZ3D1237: -0.0
-  sysZ3D1238: -0.0
+  sysZ3D1236: 0.0
+  sysZ3D1237: 0.0
+  sysZ3D1238: 0.0
   sysZ3D1239: 0.0
   sysZ3D1240: 0.0
   sysZ3D1241: 0.0
@@ -10258,17 +10258,17 @@ bins:
   sysZ3D1247: 0.0
   sysZ3D1248: 0.73168
   sysZ3D1249: 0.0
-  sysZ3D1250: -0.0
+  sysZ3D1250: 0.0
   sysZ3D1251: 0.73168
   sysZ3D1252: 0.0
-  sysZ3D1253: -0.0
+  sysZ3D1253: 0.0
   sysZ3D1254: 0.36584
   sysZ3D1255: 2.56088
   sysZ3D1256: 0.36584
   sysZ3D1257: -0.36584
   sysZ3D1258: 0.0
   sysZ3D1259: -0.73168
-  sysZ3D1260: -0.0
+  sysZ3D1260: 0.0
   sysZ3D1261: 0.0
   sysZ3D1262: 1.09752000e+00
   sysZ3D1263: 1.46336
@@ -10289,7 +10289,7 @@ bins:
 - stat: 3.74360000e+00
   sysZ3D1001: -1.33700000e+00
   sysZ3D1002: 2.67400000e-01
-  sysZ3D1003: -0.0
+  sysZ3D1003: 0.0
   sysZ3D1004: 0.0
   sysZ3D1005: 0.0
   sysZ3D1006: 0.0
@@ -10312,170 +10312,170 @@ bins:
   sysZ3D1023: 2.67400000e-01
   sysZ3D1024: -2.67400000e-01
   sysZ3D1025: 2.67400000e-01
-  sysZ3D1026: -0.0
+  sysZ3D1026: 0.0
   sysZ3D1027: 0.0
-  sysZ3D1028: -0.0
-  sysZ3D1029: -0.0
-  sysZ3D1030: -0.0
-  sysZ3D1031: -0.0
-  sysZ3D1032: -0.0
-  sysZ3D1033: -0.0
+  sysZ3D1028: 0.0
+  sysZ3D1029: 0.0
+  sysZ3D1030: 0.0
+  sysZ3D1031: 0.0
+  sysZ3D1032: 0.0
+  sysZ3D1033: 0.0
   sysZ3D1034: 0.0
-  sysZ3D1035: -0.0
+  sysZ3D1035: 0.0
   sysZ3D1036: 0.0
-  sysZ3D1037: -0.0
+  sysZ3D1037: 0.0
   sysZ3D1038: 0.0
-  sysZ3D1039: -0.0
+  sysZ3D1039: 0.0
   sysZ3D1040: 0.0
-  sysZ3D1041: -0.0
-  sysZ3D1042: -0.0
+  sysZ3D1041: 0.0
+  sysZ3D1042: 0.0
   sysZ3D1043: -2.67400000e-01
-  sysZ3D1044: -0.0
-  sysZ3D1045: -0.0
-  sysZ3D1046: -0.0
+  sysZ3D1044: 0.0
+  sysZ3D1045: 0.0
+  sysZ3D1046: 0.0
   sysZ3D1047: 0.0
   sysZ3D1048: 0.0
-  sysZ3D1049: -0.0
+  sysZ3D1049: 0.0
   sysZ3D1050: 0.0
-  sysZ3D1051: -0.0
+  sysZ3D1051: 0.0
   sysZ3D1052: 0.0
   sysZ3D1053: 0.0
-  sysZ3D1054: -0.0
-  sysZ3D1055: -0.0
+  sysZ3D1054: 0.0
+  sysZ3D1055: 0.0
   sysZ3D1056: -2.67400000e-01
   sysZ3D1057: 0.0
   sysZ3D1058: 0.0
-  sysZ3D1059: -0.0
-  sysZ3D1060: -0.0
-  sysZ3D1061: -0.0
+  sysZ3D1059: 0.0
+  sysZ3D1060: 0.0
+  sysZ3D1061: 0.0
   sysZ3D1062: 0.0
-  sysZ3D1063: -0.0
-  sysZ3D1064: -0.0
+  sysZ3D1063: 0.0
+  sysZ3D1064: 0.0
   sysZ3D1065: -2.67400000e-01
   sysZ3D1066: 0.0
-  sysZ3D1067: -0.0
-  sysZ3D1068: -0.0
-  sysZ3D1069: -0.0
+  sysZ3D1067: 0.0
+  sysZ3D1068: 0.0
+  sysZ3D1069: 0.0
   sysZ3D1070: 0.0
   sysZ3D1071: 0.0
   sysZ3D1072: 2.67400000e-01
   sysZ3D1073: 0.0
-  sysZ3D1074: -0.0
-  sysZ3D1075: -0.0
+  sysZ3D1074: 0.0
+  sysZ3D1075: 0.0
   sysZ3D1076: 0.0
   sysZ3D1077: 0.0
   sysZ3D1078: 0.0
-  sysZ3D1079: -0.0
-  sysZ3D1080: -0.0
+  sysZ3D1079: 0.0
+  sysZ3D1080: 0.0
   sysZ3D1081: 0.0
-  sysZ3D1082: -0.0
+  sysZ3D1082: 0.0
   sysZ3D1083: 0.0
-  sysZ3D1084: -0.0
+  sysZ3D1084: 0.0
   sysZ3D1085: 0.0
   sysZ3D1086: 0.0
-  sysZ3D1087: -0.0
-  sysZ3D1088: -0.0
-  sysZ3D1089: -0.0
+  sysZ3D1087: 0.0
+  sysZ3D1088: 0.0
+  sysZ3D1089: 0.0
   sysZ3D1090: 0.0
   sysZ3D1091: 0.0
-  sysZ3D1092: -0.0
-  sysZ3D1093: -0.0
+  sysZ3D1092: 0.0
+  sysZ3D1093: 0.0
   sysZ3D1094: 0.0
   sysZ3D1095: 0.0
-  sysZ3D1096: -0.0
-  sysZ3D1097: -0.0
-  sysZ3D1098: -0.0
-  sysZ3D1099: -0.0
+  sysZ3D1096: 0.0
+  sysZ3D1097: 0.0
+  sysZ3D1098: 0.0
+  sysZ3D1099: 0.0
   sysZ3D1100: 0.0
   sysZ3D1101: 0.0
   sysZ3D1102: 0.0
   sysZ3D1103: 0.0
-  sysZ3D1104: -0.0
+  sysZ3D1104: 0.0
   sysZ3D1105: -2.67400000e-01
   sysZ3D1106: -2.67400000e-01
-  sysZ3D1107: -0.0
+  sysZ3D1107: 0.0
   sysZ3D1108: 0.0
   sysZ3D1109: 0.0
   sysZ3D1110: 0.0
-  sysZ3D1111: -0.0
-  sysZ3D1112: -0.0
+  sysZ3D1111: 0.0
+  sysZ3D1112: 0.0
   sysZ3D1113: 8.02200000e-01
   sysZ3D1114: 8.02200000e-01
   sysZ3D1115: 5.34800000e-01
-  sysZ3D1116: -0.0
-  sysZ3D1117: -0.0
+  sysZ3D1116: 0.0
+  sysZ3D1117: 0.0
   sysZ3D1118: 0.0
-  sysZ3D1119: -0.0
-  sysZ3D1120: -0.0
-  sysZ3D1121: -0.0
-  sysZ3D1122: -0.0
-  sysZ3D1123: -0.0
+  sysZ3D1119: 0.0
+  sysZ3D1120: 0.0
+  sysZ3D1121: 0.0
+  sysZ3D1122: 0.0
+  sysZ3D1123: 0.0
   sysZ3D1124: 5.34800000e-01
   sysZ3D1125: 2.67400000e-01
   sysZ3D1126: 8.02200000e-01
   sysZ3D1127: 2.67400000e-01
   sysZ3D1128: 0.0
-  sysZ3D1129: -0.0
+  sysZ3D1129: 0.0
   sysZ3D1130: 0.0
-  sysZ3D1131: -0.0
-  sysZ3D1132: -0.0
+  sysZ3D1131: 0.0
+  sysZ3D1132: 0.0
   sysZ3D1133: 0.0
-  sysZ3D1134: -0.0
+  sysZ3D1134: 0.0
   sysZ3D1135: 0.0
-  sysZ3D1136: -0.0
-  sysZ3D1137: -0.0
-  sysZ3D1138: -0.0
+  sysZ3D1136: 0.0
+  sysZ3D1137: 0.0
+  sysZ3D1138: 0.0
   sysZ3D1139: 0.0
   sysZ3D1140: 0.0
   sysZ3D1141: 0.0
   sysZ3D1142: 0.0
-  sysZ3D1143: -0.0
+  sysZ3D1143: 0.0
   sysZ3D1144: 0.0
   sysZ3D1145: 0.0
   sysZ3D1146: 0.0
   sysZ3D1147: 0.0
   sysZ3D1148: 0.0
-  sysZ3D1149: -0.0
+  sysZ3D1149: 0.0
   sysZ3D1150: 0.0
   sysZ3D1151: 0.0
-  sysZ3D1152: -0.0
-  sysZ3D1153: -0.0
+  sysZ3D1152: 0.0
+  sysZ3D1153: 0.0
   sysZ3D1154: 0.0
   sysZ3D1155: 0.0
   sysZ3D1156: 0.0
   sysZ3D1157: 0.0
-  sysZ3D1158: -0.0
-  sysZ3D1159: -0.0
-  sysZ3D1160: -0.0
+  sysZ3D1158: 0.0
+  sysZ3D1159: 0.0
+  sysZ3D1160: 0.0
   sysZ3D1161: 0.0
   sysZ3D1162: 0.0
   sysZ3D1163: -2.67400000e-01
   sysZ3D1164: -2.67400000e-01
-  sysZ3D1165: -0.0
+  sysZ3D1165: 0.0
   sysZ3D1166: 0.0
-  sysZ3D1167: -0.0
+  sysZ3D1167: 0.0
   sysZ3D1168: -2.67400000e-01
-  sysZ3D1169: -0.0
+  sysZ3D1169: 0.0
   sysZ3D1170: 2.67400000e-01
   sysZ3D1171: 0.0
   sysZ3D1172: -2.67400000e-01
   sysZ3D1173: -2.67400000e-01
   sysZ3D1174: -2.67400000e-01
-  sysZ3D1175: -0.0
+  sysZ3D1175: 0.0
   sysZ3D1176: 2.67400000e-01
   sysZ3D1177: 2.67400000e-01
-  sysZ3D1178: -0.0
+  sysZ3D1178: 0.0
   sysZ3D1179: 2.67400000e-01
   sysZ3D1180: 0.0
   sysZ3D1181: -2.67400000e-01
   sysZ3D1182: 0.0
-  sysZ3D1183: -0.0
+  sysZ3D1183: 0.0
   sysZ3D1184: -2.67400000e-01
-  sysZ3D1185: -0.0
+  sysZ3D1185: 0.0
   sysZ3D1186: 0.0
   sysZ3D1187: 2.67400000e-01
-  sysZ3D1188: -0.0
-  sysZ3D1189: -0.0
+  sysZ3D1188: 0.0
+  sysZ3D1189: 0.0
   sysZ3D1190: 2.67400000e-01
   sysZ3D1191: 0.0
   sysZ3D1192: 0.0
@@ -10490,10 +10490,10 @@ bins:
   sysZ3D1201: 5.34800000e-01
   sysZ3D1202: 0.0
   sysZ3D1203: 0.0
-  sysZ3D1204: -0.0
-  sysZ3D1205: -0.0
+  sysZ3D1204: 0.0
+  sysZ3D1205: 0.0
   sysZ3D1206: -2.67400000e-01
-  sysZ3D1207: -0.0
+  sysZ3D1207: 0.0
   sysZ3D1208: 0.0
   sysZ3D1209: 0.0
   sysZ3D1210: 2.67400000e-01
@@ -10505,25 +10505,25 @@ bins:
   sysZ3D1216: 0.0
   sysZ3D1217: -8.02200000e-01
   sysZ3D1218: 2.67400000e-01
-  sysZ3D1219: -0.0
-  sysZ3D1220: -0.0
+  sysZ3D1219: 0.0
+  sysZ3D1220: 0.0
   sysZ3D1221: 0.0
   sysZ3D1222: 0.0
   sysZ3D1223: 0.0
-  sysZ3D1224: -0.0
+  sysZ3D1224: 0.0
   sysZ3D1225: -2.67400000e-01
   sysZ3D1226: -2.67400000e-01
   sysZ3D1227: -5.34800000e-01
   sysZ3D1228: 2.67400000e-01
   sysZ3D1229: 0.0
-  sysZ3D1230: -0.0
+  sysZ3D1230: 0.0
   sysZ3D1231: -2.67400000e-01
   sysZ3D1232: 0.0
   sysZ3D1233: 0.0
   sysZ3D1234: 0.0
   sysZ3D1235: 0.0
-  sysZ3D1236: -0.0
-  sysZ3D1237: -0.0
+  sysZ3D1236: 0.0
+  sysZ3D1237: 0.0
   sysZ3D1238: -2.67400000e-01
   sysZ3D1239: 0.0
   sysZ3D1240: 0.0
@@ -10531,19 +10531,19 @@ bins:
   sysZ3D1242: 0.0
   sysZ3D1243: 0.0
   sysZ3D1244: -2.67400000e-01
-  sysZ3D1245: -0.0
+  sysZ3D1245: 0.0
   sysZ3D1246: -2.67400000e-01
   sysZ3D1247: 0.0
   sysZ3D1248: 5.34800000e-01
   sysZ3D1249: 0.0
-  sysZ3D1250: -0.0
+  sysZ3D1250: 0.0
   sysZ3D1251: 8.02200000e-01
   sysZ3D1252: 2.67400000e-01
   sysZ3D1253: 0.0
   sysZ3D1254: 0.0
   sysZ3D1255: 1.87180000e+00
   sysZ3D1256: 2.67400000e-01
-  sysZ3D1257: -0.0
+  sysZ3D1257: 0.0
   sysZ3D1258: 0.0
   sysZ3D1259: -5.34800000e-01
   sysZ3D1260: 0.0
@@ -10555,7 +10555,7 @@ bins:
   sysZ3D1266: -3.47620000e+00
   sysZ3D1267: -5.34800000e-01
   sysZ3D1268: 2.67400000e-01
-  sysZ3D1269: -0.0
+  sysZ3D1269: 0.0
   sysZ3D1270: 2.67400000e-01
   sysZ3D1271: 2.67400000e-01
   sysZ3D1272: 0.0
@@ -10584,183 +10584,183 @@ bins:
   sysZ3D1017: 0.0
   sysZ3D1018: 0.0
   sysZ3D1019: 0.0
-  sysZ3D1020: -0.0
+  sysZ3D1020: 0.0
   sysZ3D1021: 0.0
-  sysZ3D1022: -0.0
+  sysZ3D1022: 0.0
   sysZ3D1023: 0.319324
   sysZ3D1024: -1.59662000e-01
   sysZ3D1025: 4.78986000e-01
   sysZ3D1026: -1.59662000e-01
   sysZ3D1027: 0.159662
-  sysZ3D1028: -0.0
+  sysZ3D1028: 0.0
   sysZ3D1029: 0.159662
   sysZ3D1030: 0.0
-  sysZ3D1031: -0.0
-  sysZ3D1032: -0.0
+  sysZ3D1031: 0.0
+  sysZ3D1032: 0.0
   sysZ3D1033: 0.0
-  sysZ3D1034: -0.0
+  sysZ3D1034: 0.0
   sysZ3D1035: 0.0
   sysZ3D1036: 0.0
   sysZ3D1037: 0.0
   sysZ3D1038: 0.0
-  sysZ3D1039: -0.0
+  sysZ3D1039: 0.0
   sysZ3D1040: 0.0
   sysZ3D1041: 0.0
-  sysZ3D1042: -0.0
+  sysZ3D1042: 0.0
   sysZ3D1043: 0.0
-  sysZ3D1044: -0.0
+  sysZ3D1044: 0.0
   sysZ3D1045: 0.0
   sysZ3D1046: 0.0
   sysZ3D1047: 0.0
-  sysZ3D1048: -0.0
+  sysZ3D1048: 0.0
   sysZ3D1049: 0.0
-  sysZ3D1050: -0.0
+  sysZ3D1050: 0.0
   sysZ3D1051: 0.0
   sysZ3D1052: 0.0
-  sysZ3D1053: -0.0
+  sysZ3D1053: 0.0
   sysZ3D1054: 0.0
   sysZ3D1055: 0.0
-  sysZ3D1056: -0.0
-  sysZ3D1057: -0.0
+  sysZ3D1056: 0.0
+  sysZ3D1057: 0.0
   sysZ3D1058: 0.0
-  sysZ3D1059: -0.0
+  sysZ3D1059: 0.0
   sysZ3D1060: 0.0
   sysZ3D1061: 0.0
   sysZ3D1062: 0.0
   sysZ3D1063: 0.0
-  sysZ3D1064: -0.0
+  sysZ3D1064: 0.0
   sysZ3D1065: -1.59662000e-01
-  sysZ3D1066: -0.0
-  sysZ3D1067: -0.0
+  sysZ3D1066: 0.0
+  sysZ3D1067: 0.0
   sysZ3D1068: 0.0
-  sysZ3D1069: -0.0
+  sysZ3D1069: 0.0
   sysZ3D1070: -1.59662000e-01
   sysZ3D1071: 0.0
   sysZ3D1072: 0.0
   sysZ3D1073: -1.59662000e-01
-  sysZ3D1074: -0.0
-  sysZ3D1075: -0.0
+  sysZ3D1074: 0.0
+  sysZ3D1075: 0.0
   sysZ3D1076: 0.0
-  sysZ3D1077: -0.0
-  sysZ3D1078: -0.0
-  sysZ3D1079: -0.0
+  sysZ3D1077: 0.0
+  sysZ3D1078: 0.0
+  sysZ3D1079: 0.0
   sysZ3D1080: 0.0
-  sysZ3D1081: -0.0
+  sysZ3D1081: 0.0
   sysZ3D1082: 0.0
   sysZ3D1083: -1.59662000e-01
-  sysZ3D1084: -0.0
+  sysZ3D1084: 0.0
   sysZ3D1085: 0.0
   sysZ3D1086: -1.59662000e-01
   sysZ3D1087: -1.59662000e-01
   sysZ3D1088: 0.0
   sysZ3D1089: 0.159662
-  sysZ3D1090: -0.0
+  sysZ3D1090: 0.0
   sysZ3D1091: 0.0
-  sysZ3D1092: -0.0
+  sysZ3D1092: 0.0
   sysZ3D1093: 0.0
-  sysZ3D1094: -0.0
-  sysZ3D1095: -0.0
+  sysZ3D1094: 0.0
+  sysZ3D1095: 0.0
   sysZ3D1096: 0.0
   sysZ3D1097: 0.0
-  sysZ3D1098: -0.0
-  sysZ3D1099: -0.0
-  sysZ3D1100: -0.0
+  sysZ3D1098: 0.0
+  sysZ3D1099: 0.0
+  sysZ3D1100: 0.0
   sysZ3D1101: 0.0
-  sysZ3D1102: -0.0
-  sysZ3D1103: -0.0
-  sysZ3D1104: -0.0
+  sysZ3D1102: 0.0
+  sysZ3D1103: 0.0
+  sysZ3D1104: 0.0
   sysZ3D1105: -1.59662000e-01
   sysZ3D1106: -1.59662000e-01
-  sysZ3D1107: -0.0
+  sysZ3D1107: 0.0
   sysZ3D1108: 0.0
   sysZ3D1109: 0.0
   sysZ3D1110: 0.0
   sysZ3D1111: 0.0
-  sysZ3D1112: -0.0
+  sysZ3D1112: 0.0
   sysZ3D1113: 0.638648
   sysZ3D1114: 9.57972000e-01
   sysZ3D1115: 0.0
   sysZ3D1116: -1.59662000e-01
-  sysZ3D1117: -0.0
-  sysZ3D1118: -0.0
-  sysZ3D1119: -0.0
-  sysZ3D1120: -0.0
-  sysZ3D1121: -0.0
-  sysZ3D1122: -0.0
-  sysZ3D1123: -0.0
-  sysZ3D1124: -0.0
+  sysZ3D1117: 0.0
+  sysZ3D1118: 0.0
+  sysZ3D1119: 0.0
+  sysZ3D1120: 0.0
+  sysZ3D1121: 0.0
+  sysZ3D1122: 0.0
+  sysZ3D1123: 0.0
+  sysZ3D1124: 0.0
   sysZ3D1125: 0.159662
   sysZ3D1126: 4.78986000e-01
   sysZ3D1127: 0.159662
-  sysZ3D1128: -0.0
+  sysZ3D1128: 0.0
   sysZ3D1129: 0.159662
-  sysZ3D1130: -0.0
-  sysZ3D1131: -0.0
+  sysZ3D1130: 0.0
+  sysZ3D1131: 0.0
   sysZ3D1132: 0.159662
-  sysZ3D1133: -0.0
-  sysZ3D1134: -0.0
+  sysZ3D1133: 0.0
+  sysZ3D1134: 0.0
   sysZ3D1135: 0.0
-  sysZ3D1136: -0.0
-  sysZ3D1137: -0.0
+  sysZ3D1136: 0.0
+  sysZ3D1137: 0.0
   sysZ3D1138: 0.0
   sysZ3D1139: 0.0
   sysZ3D1140: 0.0
   sysZ3D1141: 0.0
   sysZ3D1142: 0.0
-  sysZ3D1143: -0.0
+  sysZ3D1143: 0.0
   sysZ3D1144: 0.0
   sysZ3D1145: 0.0
   sysZ3D1146: 0.0
-  sysZ3D1147: -0.0
+  sysZ3D1147: 0.0
   sysZ3D1148: 0.0
-  sysZ3D1149: -0.0
-  sysZ3D1150: -0.0
+  sysZ3D1149: 0.0
+  sysZ3D1150: 0.0
   sysZ3D1151: 0.0
-  sysZ3D1152: -0.0
+  sysZ3D1152: 0.0
   sysZ3D1153: 0.0
   sysZ3D1154: 0.0
   sysZ3D1155: 0.0
   sysZ3D1156: 0.0
-  sysZ3D1157: -0.0
+  sysZ3D1157: 0.0
   sysZ3D1158: 0.0
   sysZ3D1159: 0.0
   sysZ3D1160: 0.0
-  sysZ3D1161: -0.0
-  sysZ3D1162: -0.0
+  sysZ3D1161: 0.0
+  sysZ3D1162: 0.0
   sysZ3D1163: 0.0
-  sysZ3D1164: -0.0
+  sysZ3D1164: 0.0
   sysZ3D1165: 0.0
   sysZ3D1166: 0.0
   sysZ3D1167: 0.0
   sysZ3D1168: -1.59662000e-01
-  sysZ3D1169: -0.0
+  sysZ3D1169: 0.0
   sysZ3D1170: 0.0
   sysZ3D1171: 0.0
   sysZ3D1172: -1.59662000e-01
   sysZ3D1173: -1.59662000e-01
   sysZ3D1174: -1.59662000e-01
-  sysZ3D1175: -0.0
+  sysZ3D1175: 0.0
   sysZ3D1176: 0.159662
   sysZ3D1177: 0.0
   sysZ3D1178: -1.59662000e-01
   sysZ3D1179: 0.159662
   sysZ3D1180: 0.0
   sysZ3D1181: -1.59662000e-01
-  sysZ3D1182: -0.0
-  sysZ3D1183: -0.0
+  sysZ3D1182: 0.0
+  sysZ3D1183: 0.0
   sysZ3D1184: -1.59662000e-01
-  sysZ3D1185: -0.0
-  sysZ3D1186: -0.0
+  sysZ3D1185: 0.0
+  sysZ3D1186: 0.0
   sysZ3D1187: 0.159662
-  sysZ3D1188: -0.0
-  sysZ3D1189: -0.0
+  sysZ3D1188: 0.0
+  sysZ3D1189: 0.0
   sysZ3D1190: 0.0
-  sysZ3D1191: -0.0
+  sysZ3D1191: 0.0
   sysZ3D1192: 0.0
-  sysZ3D1193: -0.0
+  sysZ3D1193: 0.0
   sysZ3D1194: 1.91594400e+00
   sysZ3D1195: -1.59662000e-01
-  sysZ3D1196: -0.0
+  sysZ3D1196: 0.0
   sysZ3D1197: -1.59662000e-01
   sysZ3D1198: -1.59662000e-01
   sysZ3D1199: 0.159662
@@ -10768,10 +10768,10 @@ bins:
   sysZ3D1201: 0.319324
   sysZ3D1202: 0.0
   sysZ3D1203: 0.319324
-  sysZ3D1204: -0.0
-  sysZ3D1205: -0.0
+  sysZ3D1204: 0.0
+  sysZ3D1205: 0.0
   sysZ3D1206: -1.59662000e-01
-  sysZ3D1207: -0.0
+  sysZ3D1207: 0.0
   sysZ3D1208: 0.0
   sysZ3D1209: 0.0
   sysZ3D1210: 0.159662
@@ -10784,24 +10784,24 @@ bins:
   sysZ3D1217: -3.19324000e-01
   sysZ3D1218: 0.0
   sysZ3D1219: 0.159662
-  sysZ3D1220: -0.0
+  sysZ3D1220: 0.0
   sysZ3D1221: 0.0
   sysZ3D1222: 0.0
   sysZ3D1223: 0.0
-  sysZ3D1224: -0.0
+  sysZ3D1224: 0.0
   sysZ3D1225: -1.59662000e-01
   sysZ3D1226: -1.59662000e-01
   sysZ3D1227: -3.19324000e-01
   sysZ3D1228: -1.59662000e-01
   sysZ3D1229: 0.159662
   sysZ3D1230: 0.0
-  sysZ3D1231: -0.0
-  sysZ3D1232: -0.0
+  sysZ3D1231: 0.0
+  sysZ3D1232: 0.0
   sysZ3D1233: 0.0
   sysZ3D1234: 0.0
   sysZ3D1235: 0.0
   sysZ3D1236: 0.0
-  sysZ3D1237: -0.0
+  sysZ3D1237: 0.0
   sysZ3D1238: -1.59662000e-01
   sysZ3D1239: 0.0
   sysZ3D1240: 0.0
@@ -10836,7 +10836,7 @@ bins:
   sysZ3D1269: -1.59662000e-01
   sysZ3D1270: 0.159662
   sysZ3D1271: 0.159662
-  sysZ3D1272: -0.0
+  sysZ3D1272: 0.0
   sysZ3D1273: -1.59662000e-01
   sysZ3D1274: -1.59662000e-01
   sysZ3D1275: 1.277296
@@ -10862,40 +10862,40 @@ bins:
   sysZ3D1017: 0.0
   sysZ3D1018: 0.0
   sysZ3D1019: 0.0
-  sysZ3D1020: -0.0
+  sysZ3D1020: 0.0
   sysZ3D1021: 0.0
-  sysZ3D1022: -0.0
+  sysZ3D1022: 0.0
   sysZ3D1023: 0.104032
   sysZ3D1024: -1.04032000e-01
   sysZ3D1025: 0.208064
   sysZ3D1026: -5.20160000e-02
   sysZ3D1027: 0.052016
-  sysZ3D1028: -0.0
+  sysZ3D1028: 0.0
   sysZ3D1029: 0.0
   sysZ3D1030: 0.0
-  sysZ3D1031: -0.0
+  sysZ3D1031: 0.0
   sysZ3D1032: 0.0
-  sysZ3D1033: -0.0
-  sysZ3D1034: -0.0
+  sysZ3D1033: 0.0
+  sysZ3D1034: 0.0
   sysZ3D1035: 0.0
-  sysZ3D1036: -0.0
+  sysZ3D1036: 0.0
   sysZ3D1037: -5.20160000e-02
   sysZ3D1038: 0.0
   sysZ3D1039: 0.0
-  sysZ3D1040: -0.0
+  sysZ3D1040: 0.0
   sysZ3D1041: 0.0
-  sysZ3D1042: -0.0
+  sysZ3D1042: 0.0
   sysZ3D1043: 0.0
   sysZ3D1044: 0.0
-  sysZ3D1045: -0.0
-  sysZ3D1046: -0.0
-  sysZ3D1047: -0.0
-  sysZ3D1048: -0.0
+  sysZ3D1045: 0.0
+  sysZ3D1046: 0.0
+  sysZ3D1047: 0.0
+  sysZ3D1048: 0.0
   sysZ3D1049: 0.0
   sysZ3D1050: 0.0
   sysZ3D1051: 0.0
   sysZ3D1052: 0.0
-  sysZ3D1053: -0.0
+  sysZ3D1053: 0.0
   sysZ3D1054: 0.0
   sysZ3D1055: 0.0
   sysZ3D1056: 0.0
@@ -10903,50 +10903,50 @@ bins:
   sysZ3D1058: 0.0
   sysZ3D1059: 0.0
   sysZ3D1060: 0.0
-  sysZ3D1061: -0.0
+  sysZ3D1061: 0.0
   sysZ3D1062: 0.0
   sysZ3D1063: 0.0
   sysZ3D1064: 0.0
   sysZ3D1065: 0.0
-  sysZ3D1066: -0.0
-  sysZ3D1067: -0.0
+  sysZ3D1066: 0.0
+  sysZ3D1067: 0.0
   sysZ3D1068: 0.0
   sysZ3D1069: 0.0
   sysZ3D1070: 0.0
   sysZ3D1071: 0.0
   sysZ3D1072: 0.0
-  sysZ3D1073: -0.0
+  sysZ3D1073: 0.0
   sysZ3D1074: 0.0
-  sysZ3D1075: -0.0
+  sysZ3D1075: 0.0
   sysZ3D1076: 0.0
-  sysZ3D1077: -0.0
-  sysZ3D1078: -0.0
+  sysZ3D1077: 0.0
+  sysZ3D1078: 0.0
   sysZ3D1079: 0.0
   sysZ3D1080: 0.0
   sysZ3D1081: 0.052016
-  sysZ3D1082: -0.0
-  sysZ3D1083: -0.0
-  sysZ3D1084: -0.0
+  sysZ3D1082: 0.0
+  sysZ3D1083: 0.0
+  sysZ3D1084: 0.0
   sysZ3D1085: 0.0
   sysZ3D1086: 0.0
   sysZ3D1087: 0.0
-  sysZ3D1088: -0.0
-  sysZ3D1089: -0.0
-  sysZ3D1090: -0.0
-  sysZ3D1091: -0.0
+  sysZ3D1088: 0.0
+  sysZ3D1089: 0.0
+  sysZ3D1090: 0.0
+  sysZ3D1091: 0.0
   sysZ3D1092: 0.0
-  sysZ3D1093: -0.0
-  sysZ3D1094: -0.0
-  sysZ3D1095: -0.0
-  sysZ3D1096: -0.0
-  sysZ3D1097: -0.0
+  sysZ3D1093: 0.0
+  sysZ3D1094: 0.0
+  sysZ3D1095: 0.0
+  sysZ3D1096: 0.0
+  sysZ3D1097: 0.0
   sysZ3D1098: 0.0
   sysZ3D1099: 0.0
   sysZ3D1100: 0.0
   sysZ3D1101: 0.052016
-  sysZ3D1102: -0.0
+  sysZ3D1102: 0.0
   sysZ3D1103: 0.0
-  sysZ3D1104: -0.0
+  sysZ3D1104: 0.0
   sysZ3D1105: -5.20160000e-02
   sysZ3D1106: -5.20160000e-02
   sysZ3D1107: 0.0
@@ -10954,57 +10954,57 @@ bins:
   sysZ3D1109: 0.0
   sysZ3D1110: 0.0
   sysZ3D1111: 0.0
-  sysZ3D1112: -0.0
+  sysZ3D1112: 0.0
   sysZ3D1113: 0.26008
   sysZ3D1114: 3.12096000e-01
   sysZ3D1115: -1.04032000e-01
   sysZ3D1116: -5.20160000e-02
-  sysZ3D1117: -0.0
-  sysZ3D1118: -0.0
+  sysZ3D1117: 0.0
+  sysZ3D1118: 0.0
   sysZ3D1119: 0.0
-  sysZ3D1120: -0.0
-  sysZ3D1121: -0.0
-  sysZ3D1122: -0.0
-  sysZ3D1123: -0.0
+  sysZ3D1120: 0.0
+  sysZ3D1121: 0.0
+  sysZ3D1122: 0.0
+  sysZ3D1123: 0.0
   sysZ3D1124: -1.04032000e-01
   sysZ3D1125: 0.26008
   sysZ3D1126: 0.208064
   sysZ3D1127: -5.20160000e-02
-  sysZ3D1128: -0.0
+  sysZ3D1128: 0.0
   sysZ3D1129: 0.0
   sysZ3D1130: 0.0
   sysZ3D1131: -5.20160000e-02
-  sysZ3D1132: -0.0
+  sysZ3D1132: 0.0
   sysZ3D1133: 0.052016
   sysZ3D1134: 0.0
-  sysZ3D1135: -0.0
+  sysZ3D1135: 0.0
   sysZ3D1136: 0.0
-  sysZ3D1137: -0.0
+  sysZ3D1137: 0.0
   sysZ3D1138: 0.0
   sysZ3D1139: 0.0
   sysZ3D1140: 0.0
-  sysZ3D1141: -0.0
+  sysZ3D1141: 0.0
   sysZ3D1142: 0.0
-  sysZ3D1143: -0.0
-  sysZ3D1144: -0.0
+  sysZ3D1143: 0.0
+  sysZ3D1144: 0.0
   sysZ3D1145: 0.0
   sysZ3D1146: 0.0
   sysZ3D1147: 0.0
   sysZ3D1148: 0.0
-  sysZ3D1149: -0.0
+  sysZ3D1149: 0.0
   sysZ3D1150: 0.0
   sysZ3D1151: 0.0
   sysZ3D1152: 0.0
-  sysZ3D1153: -0.0
+  sysZ3D1153: 0.0
   sysZ3D1154: 0.0
   sysZ3D1155: 0.0
   sysZ3D1156: 0.0
-  sysZ3D1157: -0.0
+  sysZ3D1157: 0.0
   sysZ3D1158: 0.0
   sysZ3D1159: 0.0
-  sysZ3D1160: -0.0
+  sysZ3D1160: 0.0
   sysZ3D1161: 0.0
-  sysZ3D1162: -0.0
+  sysZ3D1162: 0.0
   sysZ3D1163: 0.0
   sysZ3D1164: 0.052016
   sysZ3D1165: 0.052016
@@ -11024,7 +11024,7 @@ bins:
   sysZ3D1179: 0.104032
   sysZ3D1180: 0.0
   sysZ3D1181: -5.20160000e-02
-  sysZ3D1182: -0.0
+  sysZ3D1182: 0.0
   sysZ3D1183: 0.0
   sysZ3D1184: -5.20160000e-02
   sysZ3D1185: 0.052016
@@ -11038,7 +11038,7 @@ bins:
   sysZ3D1193: 0.052016
   sysZ3D1194: 6.76208000e-01
   sysZ3D1195: -5.20160000e-02
-  sysZ3D1196: -0.0
+  sysZ3D1196: 0.0
   sysZ3D1197: -5.20160000e-02
   sysZ3D1198: -5.20160000e-02
   sysZ3D1199: 0.052016
@@ -11046,16 +11046,16 @@ bins:
   sysZ3D1201: 0.104032
   sysZ3D1202: 0.0
   sysZ3D1203: 1.56048000e-01
-  sysZ3D1204: -0.0
-  sysZ3D1205: -0.0
+  sysZ3D1204: 0.0
+  sysZ3D1205: 0.0
   sysZ3D1206: -5.20160000e-02
-  sysZ3D1207: -0.0
+  sysZ3D1207: 0.0
   sysZ3D1208: 0.0
   sysZ3D1209: 0.0
   sysZ3D1210: 0.052016
   sysZ3D1211: 0.0
   sysZ3D1212: 0.0
-  sysZ3D1213: -0.0
+  sysZ3D1213: 0.0
   sysZ3D1214: -1.04032000e-01
   sysZ3D1215: -0.26008
   sysZ3D1216: 0.052016
@@ -11063,24 +11063,24 @@ bins:
   sysZ3D1218: -5.20160000e-02
   sysZ3D1219: 0.104032
   sysZ3D1220: -5.20160000e-02
-  sysZ3D1221: -0.0
+  sysZ3D1221: 0.0
   sysZ3D1222: 0.0
   sysZ3D1223: 0.052016
-  sysZ3D1224: -0.0
+  sysZ3D1224: 0.0
   sysZ3D1225: -5.20160000e-02
   sysZ3D1226: -5.20160000e-02
   sysZ3D1227: -1.04032000e-01
   sysZ3D1228: -5.20160000e-02
-  sysZ3D1229: -0.0
+  sysZ3D1229: 0.0
   sysZ3D1230: 0.0
   sysZ3D1231: 0.052016
-  sysZ3D1232: -0.0
+  sysZ3D1232: 0.0
   sysZ3D1233: 0.0
   sysZ3D1234: 0.0
   sysZ3D1235: 0.0
-  sysZ3D1236: -0.0
-  sysZ3D1237: -0.0
-  sysZ3D1238: -0.0
+  sysZ3D1236: 0.0
+  sysZ3D1237: 0.0
+  sysZ3D1238: 0.0
   sysZ3D1239: 0.0
   sysZ3D1240: 0.0
   sysZ3D1241: 0.0
@@ -11111,10 +11111,10 @@ bins:
   sysZ3D1266: -8.84272000e-01
   sysZ3D1267: -2.08064000e-01
   sysZ3D1268: 0.104032
-  sysZ3D1269: -0.0
+  sysZ3D1269: 0.0
   sysZ3D1270: 0.052016
   sysZ3D1271: 0.052016
-  sysZ3D1272: -0.0
+  sysZ3D1272: 0.0
   sysZ3D1273: -5.20160000e-02
   sysZ3D1274: -5.20160000e-02
   sysZ3D1275: 0.572176
@@ -11140,83 +11140,83 @@ bins:
   sysZ3D1017: 0.0
   sysZ3D1018: 0.0
   sysZ3D1019: 0.0
-  sysZ3D1020: -0.0
-  sysZ3D1021: -0.0
+  sysZ3D1020: 0.0
+  sysZ3D1021: 0.0
   sysZ3D1022: 0.0
-  sysZ3D1023: -0.0
-  sysZ3D1024: -0.0
+  sysZ3D1023: 0.0
+  sysZ3D1024: 0.0
   sysZ3D1025: 0.0
   sysZ3D1026: 0.0
-  sysZ3D1027: -0.0
-  sysZ3D1028: -0.0
-  sysZ3D1029: -0.0
+  sysZ3D1027: 0.0
+  sysZ3D1028: 0.0
+  sysZ3D1029: 0.0
   sysZ3D1030: 0.0
   sysZ3D1031: 0.0
   sysZ3D1032: 0.0
-  sysZ3D1033: -0.0
-  sysZ3D1034: -0.0
+  sysZ3D1033: 0.0
+  sysZ3D1034: 0.0
   sysZ3D1035: 0.0
   sysZ3D1036: 0.0
-  sysZ3D1037: -0.0
+  sysZ3D1037: 0.0
   sysZ3D1038: 0.0
-  sysZ3D1039: -0.0
+  sysZ3D1039: 0.0
   sysZ3D1040: 0.0
   sysZ3D1041: 0.0
   sysZ3D1042: 0.0
-  sysZ3D1043: -0.0
+  sysZ3D1043: 0.0
   sysZ3D1044: 0.0
-  sysZ3D1045: -0.0
-  sysZ3D1046: -0.0
-  sysZ3D1047: -0.0
+  sysZ3D1045: 0.0
+  sysZ3D1046: 0.0
+  sysZ3D1047: 0.0
   sysZ3D1048: 0.0
   sysZ3D1049: 0.0
-  sysZ3D1050: -0.0
-  sysZ3D1051: -0.0
-  sysZ3D1052: -0.0
-  sysZ3D1053: -0.0
-  sysZ3D1054: -0.0
+  sysZ3D1050: 0.0
+  sysZ3D1051: 0.0
+  sysZ3D1052: 0.0
+  sysZ3D1053: 0.0
+  sysZ3D1054: 0.0
   sysZ3D1055: 0.0
   sysZ3D1056: 0.0
-  sysZ3D1057: -0.0
-  sysZ3D1058: -0.0
+  sysZ3D1057: 0.0
+  sysZ3D1058: 0.0
   sysZ3D1059: 0.0
   sysZ3D1060: 0.0
-  sysZ3D1061: -0.0
+  sysZ3D1061: 0.0
   sysZ3D1062: 0.0
   sysZ3D1063: 0.0
   sysZ3D1064: 0.0
   sysZ3D1065: 0.0
   sysZ3D1066: 0.0
-  sysZ3D1067: -0.0
-  sysZ3D1068: -0.0
+  sysZ3D1067: 0.0
+  sysZ3D1068: 0.0
   sysZ3D1069: 0.0
   sysZ3D1070: 0.0
   sysZ3D1071: 0.0
-  sysZ3D1072: -0.0
-  sysZ3D1073: -0.0
+  sysZ3D1072: 0.0
+  sysZ3D1073: 0.0
   sysZ3D1074: 0.0
   sysZ3D1075: 0.0
-  sysZ3D1076: -0.0
+  sysZ3D1076: 0.0
   sysZ3D1077: 0.0
   sysZ3D1078: 0.0
   sysZ3D1079: 0.0
   sysZ3D1080: 0.0
   sysZ3D1081: 0.0
-  sysZ3D1082: -0.0
-  sysZ3D1083: -0.0
+  sysZ3D1082: 0.0
+  sysZ3D1083: 0.0
   sysZ3D1084: 0.0
-  sysZ3D1085: -0.0
-  sysZ3D1086: -0.0
+  sysZ3D1085: 0.0
+  sysZ3D1086: 0.0
   sysZ3D1087: 0.0
   sysZ3D1088: 0.0
   sysZ3D1089: 0.0
   sysZ3D1090: 0.0
   sysZ3D1091: 0.0
   sysZ3D1092: 0.0
-  sysZ3D1093: -0.0
+  sysZ3D1093: 0.0
   sysZ3D1094: 0.0
   sysZ3D1095: 0.0
-  sysZ3D1096: -0.0
+  sysZ3D1096: 0.0
   sysZ3D1097: 0.0
   sysZ3D1098: 0.0
   sysZ3D1099: 0.0
@@ -11232,25 +11232,25 @@ bins:
   sysZ3D1109: 0.0
   sysZ3D1110: 0.0
   sysZ3D1111: 0.0
-  sysZ3D1112: -0.0
+  sysZ3D1112: 0.0
   sysZ3D1113: 1.41688
-  sysZ3D1114: -0.0
-  sysZ3D1115: -0.0
-  sysZ3D1116: -0.0
+  sysZ3D1114: 0.0
+  sysZ3D1115: 0.0
+  sysZ3D1116: 0.0
   sysZ3D1117: 0.70844
-  sysZ3D1118: -0.0
+  sysZ3D1118: 0.0
   sysZ3D1119: -0.70844
   sysZ3D1120: -0.70844
   sysZ3D1121: 0.0
   sysZ3D1122: 0.0
   sysZ3D1123: 0.0
-  sysZ3D1124: -0.0
-  sysZ3D1125: -0.0
+  sysZ3D1124: 0.0
+  sysZ3D1125: 0.0
   sysZ3D1126: -2.83376
   sysZ3D1127: -1.41688
-  sysZ3D1128: -0.0
+  sysZ3D1128: 0.0
   sysZ3D1129: 0.0
-  sysZ3D1130: -0.0
+  sysZ3D1130: 0.0
   sysZ3D1131: 0.0
   sysZ3D1132: 0.0
   sysZ3D1133: 0.0
@@ -11263,37 +11263,37 @@ bins:
   sysZ3D1140: 0.70844
   sysZ3D1141: 0.0
   sysZ3D1142: 0.0
-  sysZ3D1143: -0.0
-  sysZ3D1144: -0.0
+  sysZ3D1143: 0.0
+  sysZ3D1144: 0.0
   sysZ3D1145: 0.0
-  sysZ3D1146: -0.0
-  sysZ3D1147: -0.0
+  sysZ3D1146: 0.0
+  sysZ3D1147: 0.0
   sysZ3D1148: 0.0
-  sysZ3D1149: -0.0
+  sysZ3D1149: 0.0
   sysZ3D1150: 0.0
-  sysZ3D1151: -0.0
+  sysZ3D1151: 0.0
   sysZ3D1152: 0.0
-  sysZ3D1153: -0.0
+  sysZ3D1153: 0.0
   sysZ3D1154: 0.0
   sysZ3D1155: 0.0
-  sysZ3D1156: -0.0
+  sysZ3D1156: 0.0
   sysZ3D1157: 0.0
-  sysZ3D1158: -0.0
+  sysZ3D1158: 0.0
   sysZ3D1159: 0.0
-  sysZ3D1160: -0.0
+  sysZ3D1160: 0.0
   sysZ3D1161: 0.0
   sysZ3D1162: 0.0
-  sysZ3D1163: -0.0
+  sysZ3D1163: 0.0
   sysZ3D1164: 0.0
   sysZ3D1165: 0.0
   sysZ3D1166: 0.0
   sysZ3D1167: 0.0
-  sysZ3D1168: -0.0
+  sysZ3D1168: 0.0
   sysZ3D1169: 0.0
-  sysZ3D1170: -0.0
-  sysZ3D1171: -0.0
-  sysZ3D1172: -0.0
-  sysZ3D1173: -0.0
+  sysZ3D1170: 0.0
+  sysZ3D1171: 0.0
+  sysZ3D1172: 0.0
+  sysZ3D1173: 0.0
   sysZ3D1174: 0.70844
   sysZ3D1175: 0.0
   sysZ3D1176: 0.0
@@ -11303,17 +11303,17 @@ bins:
   sysZ3D1180: 0.0
   sysZ3D1181: 0.0
   sysZ3D1182: 0.0
-  sysZ3D1183: -0.0
-  sysZ3D1184: -0.0
+  sysZ3D1183: 0.0
+  sysZ3D1184: 0.0
   sysZ3D1185: -0.70844
   sysZ3D1186: 0.0
   sysZ3D1187: 0.0
   sysZ3D1188: 0.0
-  sysZ3D1189: -0.0
-  sysZ3D1190: -0.0
-  sysZ3D1191: -0.0
-  sysZ3D1192: -0.0
-  sysZ3D1193: -0.0
+  sysZ3D1189: 0.0
+  sysZ3D1190: 0.0
+  sysZ3D1191: 0.0
+  sysZ3D1192: 0.0
+  sysZ3D1193: 0.0
   sysZ3D1194: -7.79284
   sysZ3D1195: 1.41688
   sysZ3D1196: 0.70844
@@ -11328,21 +11328,21 @@ bins:
   sysZ3D1205: 0.70844
   sysZ3D1206: 0.70844
   sysZ3D1207: 0.0
-  sysZ3D1208: -0.0
+  sysZ3D1208: 0.0
   sysZ3D1209: -0.70844
   sysZ3D1210: -0.70844
-  sysZ3D1211: -0.0
-  sysZ3D1212: -0.0
-  sysZ3D1213: -0.0
+  sysZ3D1211: 0.0
+  sysZ3D1212: 0.0
+  sysZ3D1213: 0.0
   sysZ3D1214: -0.70844
   sysZ3D1215: -1.41688
   sysZ3D1216: 0.70844
   sysZ3D1217: 2.83376
   sysZ3D1218: 0.70844
   sysZ3D1219: 0.70844
-  sysZ3D1220: -0.0
+  sysZ3D1220: 0.0
   sysZ3D1221: -0.70844
-  sysZ3D1222: -0.0
+  sysZ3D1222: 0.0
   sysZ3D1223: 0.0
   sysZ3D1224: 0.70844
   sysZ3D1225: 0.70844
@@ -11354,13 +11354,13 @@ bins:
   sysZ3D1231: 0.70844
   sysZ3D1232: -0.70844
   sysZ3D1233: -0.70844
-  sysZ3D1234: -0.0
-  sysZ3D1235: -0.0
+  sysZ3D1234: 0.0
+  sysZ3D1235: 0.0
   sysZ3D1236: 0.0
   sysZ3D1237: 0.0
   sysZ3D1238: 0.0
-  sysZ3D1239: -0.0
-  sysZ3D1240: -0.0
+  sysZ3D1239: 0.0
+  sysZ3D1240: 0.0
   sysZ3D1241: 0.0
   sysZ3D1242: 0.0
   sysZ3D1243: 0.0
@@ -11378,7 +11378,7 @@ bins:
   sysZ3D1255: -2.12532000e+00
   sysZ3D1256: -0.70844
   sysZ3D1257: 0.70844
-  sysZ3D1258: -0.0
+  sysZ3D1258: 0.0
   sysZ3D1259: 1.41688
   sysZ3D1260: 0.70844
   sysZ3D1261: 0.0
@@ -11389,11 +11389,11 @@ bins:
   sysZ3D1266: -4.95908
   sysZ3D1267: -0.70844
   sysZ3D1268: 0.0
-  sysZ3D1269: -0.0
+  sysZ3D1269: 0.0
   sysZ3D1270: 0.70844
   sysZ3D1271: 0.70844
   sysZ3D1272: 0.0
-  sysZ3D1273: -0.0
+  sysZ3D1273: 0.0
   sysZ3D1274: -0.70844
   sysZ3D1275: 2.12532000e+00
   sys,uncor: 3.5422
@@ -11401,7 +11401,7 @@ bins:
 - stat: 7.74818000e+00
   sysZ3D1001: -2.11314
   sysZ3D1002: -0.70438
-  sysZ3D1003: -0.0
+  sysZ3D1003: 0.0
   sysZ3D1004: 0.0
   sysZ3D1005: 0.0
   sysZ3D1006: 0.0
@@ -11419,78 +11419,78 @@ bins:
   sysZ3D1018: 0.0
   sysZ3D1019: 0.0
   sysZ3D1020: 0.0
-  sysZ3D1021: -0.0
-  sysZ3D1022: -0.0
-  sysZ3D1023: -0.0
+  sysZ3D1021: 0.0
+  sysZ3D1022: 0.0
+  sysZ3D1023: 0.0
   sysZ3D1024: 0.0
   sysZ3D1025: -0.70438
   sysZ3D1026: 0.0
-  sysZ3D1027: -0.0
+  sysZ3D1027: 0.0
   sysZ3D1028: 0.0
   sysZ3D1029: 0.0
   sysZ3D1030: 0.0
   sysZ3D1031: 0.0
-  sysZ3D1032: -0.0
+  sysZ3D1032: 0.0
   sysZ3D1033: 0.0
-  sysZ3D1034: -0.0
+  sysZ3D1034: 0.0
   sysZ3D1035: 0.0
   sysZ3D1036: 0.0
   sysZ3D1037: 0.0
-  sysZ3D1038: -0.0
-  sysZ3D1039: -0.0
+  sysZ3D1038: 0.0
+  sysZ3D1039: 0.0
   sysZ3D1040: 0.0
-  sysZ3D1041: -0.0
-  sysZ3D1042: -0.0
-  sysZ3D1043: -0.0
+  sysZ3D1041: 0.0
+  sysZ3D1042: 0.0
+  sysZ3D1043: 0.0
   sysZ3D1044: 0.0
-  sysZ3D1045: -0.0
-  sysZ3D1046: -0.0
-  sysZ3D1047: -0.0
-  sysZ3D1048: -0.0
-  sysZ3D1049: -0.0
+  sysZ3D1045: 0.0
+  sysZ3D1046: 0.0
+  sysZ3D1047: 0.0
+  sysZ3D1048: 0.0
+  sysZ3D1049: 0.0
   sysZ3D1050: 0.0
-  sysZ3D1051: -0.0
+  sysZ3D1051: 0.0
   sysZ3D1052: 0.0
   sysZ3D1053: 0.0
   sysZ3D1054: 0.0
   sysZ3D1055: 0.0
-  sysZ3D1056: -0.0
-  sysZ3D1057: -0.0
-  sysZ3D1058: -0.0
+  sysZ3D1056: 0.0
+  sysZ3D1057: 0.0
+  sysZ3D1058: 0.0
   sysZ3D1059: 0.0
-  sysZ3D1060: -0.0
-  sysZ3D1061: -0.0
-  sysZ3D1062: -0.0
+  sysZ3D1060: 0.0
+  sysZ3D1061: 0.0
+  sysZ3D1062: 0.0
   sysZ3D1063: 0.0
-  sysZ3D1064: -0.0
-  sysZ3D1065: -0.0
+  sysZ3D1064: 0.0
+  sysZ3D1065: 0.0
   sysZ3D1066: 0.0
   sysZ3D1067: 0.0
-  sysZ3D1068: -0.0
-  sysZ3D1069: -0.0
+  sysZ3D1068: 0.0
+  sysZ3D1069: 0.0
   sysZ3D1070: 0.0
-  sysZ3D1071: -0.0
+  sysZ3D1071: 0.0
   sysZ3D1072: 0.0
-  sysZ3D1073: -0.0
+  sysZ3D1073: 0.0
   sysZ3D1074: 0.0
-  sysZ3D1075: -0.0
+  sysZ3D1075: 0.0
   sysZ3D1076: 0.0
   sysZ3D1077: 0.0
-  sysZ3D1078: -0.0
-  sysZ3D1079: -0.0
+  sysZ3D1078: 0.0
+  sysZ3D1079: 0.0
   sysZ3D1080: 0.0
   sysZ3D1081: 0.0
   sysZ3D1082: 0.0
   sysZ3D1083: 0.0
   sysZ3D1084: 0.0
   sysZ3D1085: 0.0
-  sysZ3D1086: -0.0
+  sysZ3D1086: 0.0
   sysZ3D1087: 0.0
-  sysZ3D1088: -0.0
-  sysZ3D1089: -0.0
+  sysZ3D1088: 0.0
+  sysZ3D1089: 0.0
   sysZ3D1090: 0.0
   sysZ3D1091: 0.0
-  sysZ3D1092: -0.0
+  sysZ3D1092: 0.0
   sysZ3D1093: 0.0
   sysZ3D1094: 0.0
   sysZ3D1095: 0.0
@@ -11510,88 +11510,88 @@ bins:
   sysZ3D1109: 0.0
   sysZ3D1110: 0.0
   sysZ3D1111: 0.0
-  sysZ3D1112: -0.0
+  sysZ3D1112: 0.0
   sysZ3D1113: 2.11314
   sysZ3D1114: 0.0
-  sysZ3D1115: -0.0
-  sysZ3D1116: -0.0
-  sysZ3D1117: -0.0
-  sysZ3D1118: -0.0
+  sysZ3D1115: 0.0
+  sysZ3D1116: 0.0
+  sysZ3D1117: 0.0
+  sysZ3D1118: 0.0
   sysZ3D1119: 0.0
   sysZ3D1120: -0.70438
   sysZ3D1121: -0.70438
   sysZ3D1122: 0.0
-  sysZ3D1123: -0.0
+  sysZ3D1123: 0.0
   sysZ3D1124: 0.0
   sysZ3D1125: 0.0
   sysZ3D1126: -2.11314
   sysZ3D1127: -0.70438
-  sysZ3D1128: -0.0
+  sysZ3D1128: 0.0
   sysZ3D1129: 0.0
-  sysZ3D1130: -0.0
-  sysZ3D1131: -0.0
-  sysZ3D1132: -0.0
+  sysZ3D1130: 0.0
+  sysZ3D1131: 0.0
+  sysZ3D1132: 0.0
   sysZ3D1133: 0.0
   sysZ3D1134: 0.0
-  sysZ3D1135: -0.0
+  sysZ3D1135: 0.0
   sysZ3D1136: 0.0
   sysZ3D1137: 0.0
   sysZ3D1138: 0.0
-  sysZ3D1139: -0.0
+  sysZ3D1139: 0.0
   sysZ3D1140: -0.70438
   sysZ3D1141: 0.0
   sysZ3D1142: 0.0
   sysZ3D1143: 0.0
-  sysZ3D1144: -0.0
-  sysZ3D1145: -0.0
+  sysZ3D1144: 0.0
+  sysZ3D1145: 0.0
   sysZ3D1146: 0.0
-  sysZ3D1147: -0.0
-  sysZ3D1148: -0.0
+  sysZ3D1147: 0.0
+  sysZ3D1148: 0.0
   sysZ3D1149: 0.0
-  sysZ3D1150: -0.0
+  sysZ3D1150: 0.0
   sysZ3D1151: 0.0
   sysZ3D1152: 0.0
   sysZ3D1153: 0.0
   sysZ3D1154: 0.70438
   sysZ3D1155: 0.0
   sysZ3D1156: 0.0
-  sysZ3D1157: -0.0
+  sysZ3D1157: 0.0
   sysZ3D1158: 0.0
-  sysZ3D1159: -0.0
+  sysZ3D1159: 0.0
   sysZ3D1160: 0.0
   sysZ3D1161: 0.0
   sysZ3D1162: 0.0
-  sysZ3D1163: -0.0
-  sysZ3D1164: -0.0
+  sysZ3D1163: 0.0
+  sysZ3D1164: 0.0
   sysZ3D1165: 0.0
   sysZ3D1166: 0.0
   sysZ3D1167: 0.0
-  sysZ3D1168: -0.0
+  sysZ3D1168: 0.0
   sysZ3D1169: 0.0
   sysZ3D1170: -0.70438
-  sysZ3D1171: -0.0
-  sysZ3D1172: -0.0
-  sysZ3D1173: -0.0
+  sysZ3D1171: 0.0
+  sysZ3D1172: 0.0
+  sysZ3D1173: 0.0
   sysZ3D1174: 0.70438
   sysZ3D1175: 0.0
   sysZ3D1176: 0.0
-  sysZ3D1177: -0.0
+  sysZ3D1177: 0.0
   sysZ3D1178: -0.70438
   sysZ3D1179: 0.0
   sysZ3D1180: 0.0
   sysZ3D1181: 0.0
   sysZ3D1182: 0.0
-  sysZ3D1183: -0.0
+  sysZ3D1183: 0.0
   sysZ3D1184: 0.0
-  sysZ3D1185: -0.0
+  sysZ3D1185: 0.0
   sysZ3D1186: 0.0
   sysZ3D1187: 0.0
   sysZ3D1188: 0.0
   sysZ3D1189: 0.0
-  sysZ3D1190: -0.0
-  sysZ3D1191: -0.0
-  sysZ3D1192: -0.0
-  sysZ3D1193: -0.0
+  sysZ3D1190: 0.0
+  sysZ3D1191: 0.0
+  sysZ3D1192: 0.0
+  sysZ3D1193: 0.0
   sysZ3D1194: -7.74818000e+00
   sysZ3D1195: 1.40876
   sysZ3D1196: 0.70438
@@ -11606,21 +11606,21 @@ bins:
   sysZ3D1205: 0.70438
   sysZ3D1206: 0.70438
   sysZ3D1207: 0.0
-  sysZ3D1208: -0.0
-  sysZ3D1209: -0.0
+  sysZ3D1208: 0.0
+  sysZ3D1209: 0.0
   sysZ3D1210: -0.70438
-  sysZ3D1211: -0.0
-  sysZ3D1212: -0.0
-  sysZ3D1213: -0.0
+  sysZ3D1211: 0.0
+  sysZ3D1212: 0.0
+  sysZ3D1213: 0.0
   sysZ3D1214: -0.70438
   sysZ3D1215: -1.40876
   sysZ3D1216: 0.0
   sysZ3D1217: 2.81752
   sysZ3D1218: 1.40876
   sysZ3D1219: 0.70438
-  sysZ3D1220: -0.0
+  sysZ3D1220: 0.0
   sysZ3D1221: -0.70438
-  sysZ3D1222: -0.0
+  sysZ3D1222: 0.0
   sysZ3D1223: -0.70438
   sysZ3D1224: 0.70438
   sysZ3D1225: 0.70438
@@ -11630,22 +11630,22 @@ bins:
   sysZ3D1229: 0.0
   sysZ3D1230: 0.0
   sysZ3D1231: 0.70438
-  sysZ3D1232: -0.0
+  sysZ3D1232: 0.0
   sysZ3D1233: -0.70438
-  sysZ3D1234: -0.0
+  sysZ3D1234: 0.0
   sysZ3D1235: -0.70438
   sysZ3D1236: 0.0
   sysZ3D1237: 0.0
   sysZ3D1238: 0.0
-  sysZ3D1239: -0.0
-  sysZ3D1240: -0.0
+  sysZ3D1239: 0.0
+  sysZ3D1240: 0.0
   sysZ3D1241: 0.0
   sysZ3D1242: 0.0
   sysZ3D1243: 0.0
   sysZ3D1244: 2.11314
   sysZ3D1245: -1.40876
   sysZ3D1246: 0.70438
-  sysZ3D1247: -0.0
+  sysZ3D1247: 0.0
   sysZ3D1248: -2.11314
   sysZ3D1249: -0.70438
   sysZ3D1250: 0.0
@@ -11659,7 +11659,7 @@ bins:
   sysZ3D1258: -0.70438
   sysZ3D1259: 0.70438
   sysZ3D1260: 0.70438
-  sysZ3D1261: -0.0
+  sysZ3D1261: 0.0
   sysZ3D1262: 1.40876
   sysZ3D1263: 2.11314
   sysZ3D1264: 1.40876
@@ -11671,7 +11671,7 @@ bins:
   sysZ3D1270: 0.70438
   sysZ3D1271: 0.70438
   sysZ3D1272: 0.0
-  sysZ3D1273: -0.0
+  sysZ3D1273: 0.0
   sysZ3D1274: -0.70438
   sysZ3D1275: 2.11314
   sys,uncor: 3.5219
@@ -11679,1397 +11679,7 @@ bins:
 - stat: 7.70946000e+00
   sysZ3D1001: -2.10258000e+00
   sysZ3D1002: -0.70086
-  sysZ3D1003: -0.0
-  sysZ3D1004: 0.0
-  sysZ3D1005: 0.0
-  sysZ3D1006: 0.0
-  sysZ3D1007: 0.0
-  sysZ3D1008: 0.0
-  sysZ3D1009: 0.0
-  sysZ3D1010: 0.0
-  sysZ3D1011: 0.0
-  sysZ3D1012: 0.0
-  sysZ3D1013: 0.0
-  sysZ3D1014: 0.0
-  sysZ3D1015: 0.0
-  sysZ3D1016: 0.0
-  sysZ3D1017: 0.0
-  sysZ3D1018: 0.0
-  sysZ3D1019: 0.0
-  sysZ3D1020: -0.0
-  sysZ3D1021: -0.0
-  sysZ3D1022: 0.0
-  sysZ3D1023: 0.0
-  sysZ3D1024: 0.0
-  sysZ3D1025: 0.0
-  sysZ3D1026: 0.0
-  sysZ3D1027: 0.0
-  sysZ3D1028: 0.0
-  sysZ3D1029: -0.0
-  sysZ3D1030: 0.0
-  sysZ3D1031: 0.0
-  sysZ3D1032: -0.0
-  sysZ3D1033: 0.0
-  sysZ3D1034: 0.0
-  sysZ3D1035: 0.0
-  sysZ3D1036: -0.0
-  sysZ3D1037: -0.0
-  sysZ3D1038: 0.0
-  sysZ3D1039: -0.0
-  sysZ3D1040: -0.0
-  sysZ3D1041: 0.0
-  sysZ3D1042: -0.0
-  sysZ3D1043: 0.0
-  sysZ3D1044: -0.0
-  sysZ3D1045: 0.0
-  sysZ3D1046: -0.0
-  sysZ3D1047: 0.0
-  sysZ3D1048: -0.0
-  sysZ3D1049: 0.0
-  sysZ3D1050: 0.0
-  sysZ3D1051: 0.0
-  sysZ3D1052: 0.0
-  sysZ3D1053: 0.0
-  sysZ3D1054: -0.0
-  sysZ3D1055: -0.0
-  sysZ3D1056: 0.0
-  sysZ3D1057: 0.0
-  sysZ3D1058: -0.0
-  sysZ3D1059: 0.0
-  sysZ3D1060: -0.0
-  sysZ3D1061: -0.0
-  sysZ3D1062: 0.0
-  sysZ3D1063: -0.0
-  sysZ3D1064: 0.0
-  sysZ3D1065: 0.0
-  sysZ3D1066: -0.0
-  sysZ3D1067: 0.0
-  sysZ3D1068: -0.0
-  sysZ3D1069: 0.0
-  sysZ3D1070: -0.0
-  sysZ3D1071: 0.0
-  sysZ3D1072: 0.0
-  sysZ3D1073: -0.0
-  sysZ3D1074: 0.0
-  sysZ3D1075: 0.0
-  sysZ3D1076: -0.0
-  sysZ3D1077: 0.0
-  sysZ3D1078: 0.0
-  sysZ3D1079: 0.0
-  sysZ3D1080: 0.0
-  sysZ3D1081: 0.0
-  sysZ3D1082: 0.0
-  sysZ3D1083: 0.0
-  sysZ3D1084: -0.0
-  sysZ3D1085: -0.0
-  sysZ3D1086: 0.0
-  sysZ3D1087: 0.0
-  sysZ3D1088: 0.0
-  sysZ3D1089: 0.0
-  sysZ3D1090: 0.0
-  sysZ3D1091: 0.0
-  sysZ3D1092: 0.0
-  sysZ3D1093: 0.0
-  sysZ3D1094: 0.0
-  sysZ3D1095: 0.0
-  sysZ3D1096: 0.0
-  sysZ3D1097: 0.0
-  sysZ3D1098: -0.0
-  sysZ3D1099: 0.0
-  sysZ3D1100: 0.0
-  sysZ3D1101: 0.0
-  sysZ3D1102: 0.0
-  sysZ3D1103: 0.0
-  sysZ3D1104: -0.0
-  sysZ3D1105: -0.70086
-  sysZ3D1106: -0.70086
-  sysZ3D1107: 0.0
-  sysZ3D1108: 0.0
-  sysZ3D1109: 0.0
-  sysZ3D1110: 0.0
-  sysZ3D1111: 0.0
-  sysZ3D1112: -0.0
-  sysZ3D1113: 1.40172
-  sysZ3D1114: -0.0
-  sysZ3D1115: -0.0
-  sysZ3D1116: -0.70086
-  sysZ3D1117: -0.0
-  sysZ3D1118: -0.70086
-  sysZ3D1119: -0.70086
-  sysZ3D1120: -0.70086
-  sysZ3D1121: -0.70086
-  sysZ3D1122: -0.0
-  sysZ3D1123: 0.0
-  sysZ3D1124: -0.0
-  sysZ3D1125: -0.0
-  sysZ3D1126: -2.10258000e+00
-  sysZ3D1127: -0.70086
-  sysZ3D1128: -0.0
-  sysZ3D1129: 0.0
-  sysZ3D1130: -0.0
-  sysZ3D1131: -0.0
-  sysZ3D1132: -0.0
-  sysZ3D1133: -0.0
-  sysZ3D1134: -0.0
-  sysZ3D1135: -0.0
-  sysZ3D1136: 0.0
-  sysZ3D1137: 0.0
-  sysZ3D1138: -0.0
-  sysZ3D1139: -0.0
-  sysZ3D1140: -0.0
-  sysZ3D1141: 0.0
-  sysZ3D1142: -0.0
-  sysZ3D1143: -0.0
-  sysZ3D1144: 0.0
-  sysZ3D1145: 0.0
-  sysZ3D1146: 0.0
-  sysZ3D1147: 0.0
-  sysZ3D1148: -0.0
-  sysZ3D1149: -0.0
-  sysZ3D1150: -0.0
-  sysZ3D1151: -0.0
-  sysZ3D1152: -0.0
-  sysZ3D1153: 0.70086
-  sysZ3D1154: -0.0
-  sysZ3D1155: -0.0
-  sysZ3D1156: 0.0
-  sysZ3D1157: -0.0
-  sysZ3D1158: -0.0
-  sysZ3D1159: 0.0
-  sysZ3D1160: -0.0
-  sysZ3D1161: -0.0
-  sysZ3D1162: -0.0
-  sysZ3D1163: -0.0
-  sysZ3D1164: 0.0
-  sysZ3D1165: 0.0
-  sysZ3D1166: 0.0
-  sysZ3D1167: 0.0
-  sysZ3D1168: -0.0
-  sysZ3D1169: 0.0
-  sysZ3D1170: -0.70086
-  sysZ3D1171: -0.0
-  sysZ3D1172: -0.0
-  sysZ3D1173: -0.0
-  sysZ3D1174: 0.70086
-  sysZ3D1175: 0.0
-  sysZ3D1176: 0.0
-  sysZ3D1177: -0.70086
-  sysZ3D1178: -0.70086
-  sysZ3D1179: 0.0
-  sysZ3D1180: 0.0
-  sysZ3D1181: 0.0
-  sysZ3D1182: 0.0
-  sysZ3D1183: -0.0
-  sysZ3D1184: 0.0
-  sysZ3D1185: -0.0
-  sysZ3D1186: 0.0
-  sysZ3D1187: 0.0
-  sysZ3D1188: 0.0
-  sysZ3D1189: -0.0
-  sysZ3D1190: -0.0
-  sysZ3D1191: -0.0
-  sysZ3D1192: -0.0
-  sysZ3D1193: -0.0
-  sysZ3D1194: -8.41032000e+00
-  sysZ3D1195: 0.70086
-  sysZ3D1196: 0.70086
-  sysZ3D1197: 0.70086
-  sysZ3D1198: 0.70086
-  sysZ3D1199: -0.70086
-  sysZ3D1200: -1.40172
-  sysZ3D1201: -2.10258000e+00
-  sysZ3D1202: 0.0
-  sysZ3D1203: -2.80344
-  sysZ3D1204: 0.70086
-  sysZ3D1205: 0.70086
-  sysZ3D1206: 0.70086
-  sysZ3D1207: 0.0
-  sysZ3D1208: -0.0
-  sysZ3D1209: -0.0
-  sysZ3D1210: -0.70086
-  sysZ3D1211: -0.0
-  sysZ3D1212: -0.0
-  sysZ3D1213: -0.70086
-  sysZ3D1214: -0.70086
-  sysZ3D1215: -1.40172
-  sysZ3D1216: -0.70086
-  sysZ3D1217: 2.80344
-  sysZ3D1218: 1.40172
-  sysZ3D1219: 0.70086
-  sysZ3D1220: -0.0
-  sysZ3D1221: -0.70086
-  sysZ3D1222: -0.0
-  sysZ3D1223: -0.70086
-  sysZ3D1224: 0.0
-  sysZ3D1225: 0.70086
-  sysZ3D1226: 0.70086
-  sysZ3D1227: 1.40172
-  sysZ3D1228: 0.70086
-  sysZ3D1229: 0.0
-  sysZ3D1230: 0.0
-  sysZ3D1231: 0.70086
-  sysZ3D1232: -0.0
-  sysZ3D1233: -0.70086
-  sysZ3D1234: -0.70086
-  sysZ3D1235: -0.70086
-  sysZ3D1236: 0.0
-  sysZ3D1237: 0.0
-  sysZ3D1238: 0.0
-  sysZ3D1239: -0.0
-  sysZ3D1240: -0.0
-  sysZ3D1241: 0.0
-  sysZ3D1242: 0.0
-  sysZ3D1243: 0.0
-  sysZ3D1244: 2.10258000e+00
-  sysZ3D1245: -1.40172
-  sysZ3D1246: 0.70086
-  sysZ3D1247: -0.0
-  sysZ3D1248: -2.10258000e+00
-  sysZ3D1249: -1.40172
-  sysZ3D1250: 0.0
-  sysZ3D1251: -1.40172
-  sysZ3D1252: -0.0
-  sysZ3D1253: 0.0
-  sysZ3D1254: -0.70086
-  sysZ3D1255: -2.80344
-  sysZ3D1256: -0.70086
-  sysZ3D1257: 0.70086
-  sysZ3D1258: -0.0
-  sysZ3D1259: 1.40172
-  sysZ3D1260: 0.70086
-  sysZ3D1261: -0.0
-  sysZ3D1262: 1.40172
-  sysZ3D1263: 2.80344
-  sysZ3D1264: 2.80344
-  sysZ3D1265: 0.70086
-  sysZ3D1266: -5.60688
-  sysZ3D1267: -2.10258000e+00
-  sysZ3D1268: 0.0
-  sysZ3D1269: -0.70086
-  sysZ3D1270: 0.70086
-  sysZ3D1271: 1.40172
-  sysZ3D1272: 0.0
-  sysZ3D1273: -0.0
-  sysZ3D1274: -0.70086
-  sysZ3D1275: 2.10258000e+00
-  sys,uncor: 3.5043
-  ATLAS_LUMI: 126.1548
-- stat: 7.67646000e+00
-  sysZ3D1001: -2.09358000e+00
-  sysZ3D1002: -0.0
-  sysZ3D1003: -0.0
-  sysZ3D1004: 0.0
-  sysZ3D1005: 0.0
-  sysZ3D1006: 0.0
-  sysZ3D1007: 0.0
-  sysZ3D1008: 0.0
-  sysZ3D1009: 0.0
-  sysZ3D1010: 0.0
-  sysZ3D1011: 0.0
-  sysZ3D1012: 0.0
-  sysZ3D1013: 0.0
-  sysZ3D1014: 0.0
-  sysZ3D1015: 0.0
-  sysZ3D1016: 0.0
-  sysZ3D1017: 0.0
-  sysZ3D1018: 0.0
-  sysZ3D1019: 0.0
-  sysZ3D1020: -0.0
-  sysZ3D1021: 0.0
-  sysZ3D1022: 0.0
-  sysZ3D1023: -0.0
-  sysZ3D1024: 0.0
-  sysZ3D1025: -0.0
-  sysZ3D1026: 0.0
-  sysZ3D1027: 0.0
-  sysZ3D1028: -0.0
-  sysZ3D1029: 0.0
-  sysZ3D1030: 0.0
-  sysZ3D1031: -0.0
-  sysZ3D1032: 0.0
-  sysZ3D1033: -0.0
-  sysZ3D1034: 0.0
-  sysZ3D1035: 0.69786
-  sysZ3D1036: -0.0
-  sysZ3D1037: 0.0
-  sysZ3D1038: -0.0
-  sysZ3D1039: -0.0
-  sysZ3D1040: 0.0
-  sysZ3D1041: 0.0
-  sysZ3D1042: 0.0
-  sysZ3D1043: -0.0
-  sysZ3D1044: 0.0
-  sysZ3D1045: 0.0
-  sysZ3D1046: 0.0
-  sysZ3D1047: -0.0
-  sysZ3D1048: 0.0
-  sysZ3D1049: -0.0
-  sysZ3D1050: -0.0
-  sysZ3D1051: 0.0
-  sysZ3D1052: -0.0
-  sysZ3D1053: -0.0
-  sysZ3D1054: 0.0
-  sysZ3D1055: -0.0
-  sysZ3D1056: -0.0
-  sysZ3D1057: -0.0
-  sysZ3D1058: 0.0
-  sysZ3D1059: -0.0
-  sysZ3D1060: -0.0
-  sysZ3D1061: 0.0
-  sysZ3D1062: -0.0
-  sysZ3D1063: -0.0
-  sysZ3D1064: 0.0
-  sysZ3D1065: 0.0
-  sysZ3D1066: 0.0
-  sysZ3D1067: 0.0
-  sysZ3D1068: -0.0
-  sysZ3D1069: -0.0
-  sysZ3D1070: -0.0
-  sysZ3D1071: 0.0
-  sysZ3D1072: 0.0
-  sysZ3D1073: 0.0
-  sysZ3D1074: -0.0
-  sysZ3D1075: -0.0
-  sysZ3D1076: -0.0
-  sysZ3D1077: -0.0
-  sysZ3D1078: -0.0
-  sysZ3D1079: 0.0
-  sysZ3D1080: -0.0
-  sysZ3D1081: -0.0
-  sysZ3D1082: 0.0
-  sysZ3D1083: -0.0
-  sysZ3D1084: 0.0
-  sysZ3D1085: 0.0
-  sysZ3D1086: 0.0
-  sysZ3D1087: -0.0
-  sysZ3D1088: 0.0
-  sysZ3D1089: 0.0
-  sysZ3D1090: 0.0
-  sysZ3D1091: 0.0
-  sysZ3D1092: 0.0
-  sysZ3D1093: 0.0
-  sysZ3D1094: 0.0
-  sysZ3D1095: 0.0
-  sysZ3D1096: -0.0
-  sysZ3D1097: 0.0
-  sysZ3D1098: -0.0
-  sysZ3D1099: 0.0
-  sysZ3D1100: 0.0
-  sysZ3D1101: -0.0
-  sysZ3D1102: 0.0
-  sysZ3D1103: 0.0
-  sysZ3D1104: -0.0
-  sysZ3D1105: -0.69786
-  sysZ3D1106: -0.69786
-  sysZ3D1107: 0.0
-  sysZ3D1108: 0.0
-  sysZ3D1109: 0.0
-  sysZ3D1110: 0.0
-  sysZ3D1111: 0.0
-  sysZ3D1112: -0.0
-  sysZ3D1113: 1.39572
-  sysZ3D1114: -0.0
-  sysZ3D1115: 0.0
-  sysZ3D1116: -0.0
-  sysZ3D1117: -0.69786
-  sysZ3D1118: -0.0
-  sysZ3D1119: -0.69786
-  sysZ3D1120: 0.0
-  sysZ3D1121: -0.69786
-  sysZ3D1122: -0.69786
-  sysZ3D1123: 0.0
-  sysZ3D1124: -0.0
-  sysZ3D1125: -0.0
-  sysZ3D1126: -2.09358000e+00
-  sysZ3D1127: -0.0
-  sysZ3D1128: -0.0
-  sysZ3D1129: 0.0
-  sysZ3D1130: -0.0
-  sysZ3D1131: 0.0
-  sysZ3D1132: -0.0
-  sysZ3D1133: -0.0
-  sysZ3D1134: -0.0
-  sysZ3D1135: 0.0
-  sysZ3D1136: 0.0
-  sysZ3D1137: 0.0
-  sysZ3D1138: -0.0
-  sysZ3D1139: 0.0
-  sysZ3D1140: 0.0
-  sysZ3D1141: -0.0
-  sysZ3D1142: 0.0
-  sysZ3D1143: -0.0
-  sysZ3D1144: -0.0
-  sysZ3D1145: -0.0
-  sysZ3D1146: -0.0
-  sysZ3D1147: 0.0
-  sysZ3D1148: 0.0
-  sysZ3D1149: 0.0
-  sysZ3D1150: 0.0
-  sysZ3D1151: 0.0
-  sysZ3D1152: 0.0
-  sysZ3D1153: -0.0
-  sysZ3D1154: -0.0
-  sysZ3D1155: 0.0
-  sysZ3D1156: -0.0
-  sysZ3D1157: -0.0
-  sysZ3D1158: -0.0
-  sysZ3D1159: -0.0
-  sysZ3D1160: -0.0
-  sysZ3D1161: 0.0
-  sysZ3D1162: 0.0
-  sysZ3D1163: 0.0
-  sysZ3D1164: 0.0
-  sysZ3D1165: 0.0
-  sysZ3D1166: 0.0
-  sysZ3D1167: 0.0
-  sysZ3D1168: -0.0
-  sysZ3D1169: 0.0
-  sysZ3D1170: -0.0
-  sysZ3D1171: -0.0
-  sysZ3D1172: -0.0
-  sysZ3D1173: -0.0
-  sysZ3D1174: 0.0
-  sysZ3D1175: 0.0
-  sysZ3D1176: 0.0
-  sysZ3D1177: -0.69786
-  sysZ3D1178: -0.69786
-  sysZ3D1179: -0.0
-  sysZ3D1180: 0.0
-  sysZ3D1181: 0.0
-  sysZ3D1182: 0.0
-  sysZ3D1183: -0.0
-  sysZ3D1184: 0.0
-  sysZ3D1185: -0.0
-  sysZ3D1186: 0.0
-  sysZ3D1187: 0.0
-  sysZ3D1188: 0.69786
-  sysZ3D1189: 0.0
-  sysZ3D1190: -0.0
-  sysZ3D1191: -0.0
-  sysZ3D1192: -0.0
-  sysZ3D1193: -0.0
-  sysZ3D1194: -8.37432000e+00
-  sysZ3D1195: -0.0
-  sysZ3D1196: 0.0
-  sysZ3D1197: 0.69786
-  sysZ3D1198: 0.69786
-  sysZ3D1199: 0.0
-  sysZ3D1200: -0.69786
-  sysZ3D1201: -1.39572
-  sysZ3D1202: 0.0
-  sysZ3D1203: -2.79144
-  sysZ3D1204: 0.0
-  sysZ3D1205: 0.69786
-  sysZ3D1206: 0.69786
-  sysZ3D1207: 0.69786
-  sysZ3D1208: 0.0
-  sysZ3D1209: -0.0
-  sysZ3D1210: -0.69786
-  sysZ3D1211: -0.0
-  sysZ3D1212: -0.0
-  sysZ3D1213: -0.69786
-  sysZ3D1214: -0.69786
-  sysZ3D1215: -1.39572
-  sysZ3D1216: -0.69786
-  sysZ3D1217: 2.79144
-  sysZ3D1218: 2.09358000e+00
-  sysZ3D1219: 0.69786
-  sysZ3D1220: 0.0
-  sysZ3D1221: -0.0
-  sysZ3D1222: -0.0
-  sysZ3D1223: -0.69786
-  sysZ3D1224: -0.0
-  sysZ3D1225: 0.0
-  sysZ3D1226: 0.69786
-  sysZ3D1227: 1.39572
-  sysZ3D1228: 0.69786
-  sysZ3D1229: 0.0
-  sysZ3D1230: 0.0
-  sysZ3D1231: 0.69786
-  sysZ3D1232: -0.0
-  sysZ3D1233: -0.0
-  sysZ3D1234: -0.0
-  sysZ3D1235: -0.69786
-  sysZ3D1236: -0.0
-  sysZ3D1237: 0.0
-  sysZ3D1238: 0.69786
-  sysZ3D1239: -0.0
-  sysZ3D1240: -0.0
-  sysZ3D1241: 0.0
-  sysZ3D1242: 0.0
-  sysZ3D1243: 0.0
-  sysZ3D1244: 2.09358000e+00
-  sysZ3D1245: -1.39572
-  sysZ3D1246: 0.0
-  sysZ3D1247: -0.0
-  sysZ3D1248: -1.39572
-  sysZ3D1249: -1.39572
-  sysZ3D1250: 0.0
-  sysZ3D1251: -2.09358000e+00
-  sysZ3D1252: -0.69786
-  sysZ3D1253: -0.0
-  sysZ3D1254: -0.69786
-  sysZ3D1255: -2.09358000e+00
-  sysZ3D1256: -0.69786
-  sysZ3D1257: 0.69786
-  sysZ3D1258: -0.69786
-  sysZ3D1259: 0.69786
-  sysZ3D1260: 0.69786
-  sysZ3D1261: 0.0
-  sysZ3D1262: 1.39572
-  sysZ3D1263: 2.79144
-  sysZ3D1264: 3.48930000e+00
-  sysZ3D1265: 0.69786
-  sysZ3D1266: -5.58288
-  sysZ3D1267: -1.39572
-  sysZ3D1268: -0.0
-  sysZ3D1269: -0.0
-  sysZ3D1270: 0.69786
-  sysZ3D1271: 1.39572
-  sysZ3D1272: 0.0
-  sysZ3D1273: -0.0
-  sysZ3D1274: -1.39572
-  sysZ3D1275: 2.79144
-  sys,uncor: 3.48930000e+00
-  ATLAS_LUMI: 125.6148
-- stat: 7.58758000e+00
-  sysZ3D1001: -2.06934
-  sysZ3D1002: 0.0
-  sysZ3D1003: -0.0
-  sysZ3D1004: 0.0
-  sysZ3D1005: 0.0
-  sysZ3D1006: 0.0
-  sysZ3D1007: 0.0
-  sysZ3D1008: 0.0
-  sysZ3D1009: 0.0
-  sysZ3D1010: 0.0
-  sysZ3D1011: 0.0
-  sysZ3D1012: 0.0
-  sysZ3D1013: 0.0
-  sysZ3D1014: 0.0
-  sysZ3D1015: 0.0
-  sysZ3D1016: 0.0
-  sysZ3D1017: 0.0
-  sysZ3D1018: 0.0
-  sysZ3D1019: 0.0
-  sysZ3D1020: -0.0
-  sysZ3D1021: -0.0
-  sysZ3D1022: -0.0
-  sysZ3D1023: -0.0
-  sysZ3D1024: 0.0
-  sysZ3D1025: -0.0
-  sysZ3D1026: 0.0
-  sysZ3D1027: 0.0
-  sysZ3D1028: -0.0
-  sysZ3D1029: 0.0
-  sysZ3D1030: 0.0
-  sysZ3D1031: 0.0
-  sysZ3D1032: -0.0
-  sysZ3D1033: 0.0
-  sysZ3D1034: 0.0
-  sysZ3D1035: 0.0
-  sysZ3D1036: -0.0
-  sysZ3D1037: -0.0
-  sysZ3D1038: 0.0
-  sysZ3D1039: 0.0
-  sysZ3D1040: -0.0
-  sysZ3D1041: -0.0
-  sysZ3D1042: -0.0
-  sysZ3D1043: -0.0
-  sysZ3D1044: 0.0
-  sysZ3D1045: -6.89780000e-01
-  sysZ3D1046: -0.0
-  sysZ3D1047: -0.0
-  sysZ3D1048: -0.0
-  sysZ3D1049: 0.0
-  sysZ3D1050: -0.0
-  sysZ3D1051: 0.0
-  sysZ3D1052: 0.0
-  sysZ3D1053: 0.0
-  sysZ3D1054: 0.0
-  sysZ3D1055: -0.0
-  sysZ3D1056: 0.0
-  sysZ3D1057: -0.0
-  sysZ3D1058: 0.0
-  sysZ3D1059: 0.0
-  sysZ3D1060: -0.0
-  sysZ3D1061: -0.0
-  sysZ3D1062: 0.0
-  sysZ3D1063: -0.0
-  sysZ3D1064: -0.0
-  sysZ3D1065: 0.0
-  sysZ3D1066: 0.0
-  sysZ3D1067: -0.0
-  sysZ3D1068: 0.0
-  sysZ3D1069: -0.0
-  sysZ3D1070: 0.0
-  sysZ3D1071: 0.0
-  sysZ3D1072: 0.0
-  sysZ3D1073: 0.0
-  sysZ3D1074: -0.0
-  sysZ3D1075: -0.0
-  sysZ3D1076: 0.0
-  sysZ3D1077: -0.0
-  sysZ3D1078: -0.0
-  sysZ3D1079: 0.0
-  sysZ3D1080: 0.0
-  sysZ3D1081: 0.0
-  sysZ3D1082: 0.0
-  sysZ3D1083: 0.0
-  sysZ3D1084: -0.0
-  sysZ3D1085: 0.0
-  sysZ3D1086: -0.0
-  sysZ3D1087: 0.0
-  sysZ3D1088: 0.0
-  sysZ3D1089: 0.0
-  sysZ3D1090: -0.0
-  sysZ3D1091: 0.0
-  sysZ3D1092: 0.0
-  sysZ3D1093: 0.0
-  sysZ3D1094: 0.0
-  sysZ3D1095: 0.0
-  sysZ3D1096: 0.0
-  sysZ3D1097: 0.0
-  sysZ3D1098: 0.0
-  sysZ3D1099: 0.0
-  sysZ3D1100: 0.0
-  sysZ3D1101: 0.0
-  sysZ3D1102: 0.0
-  sysZ3D1103: 0.0
-  sysZ3D1104: -0.0
-  sysZ3D1105: -6.89780000e-01
-  sysZ3D1106: -6.89780000e-01
-  sysZ3D1107: 0.0
-  sysZ3D1108: 0.0
-  sysZ3D1109: 0.0
-  sysZ3D1110: 0.0
-  sysZ3D1111: -0.0
-  sysZ3D1112: -0.0
-  sysZ3D1113: 1.37956000e+00
-  sysZ3D1114: -0.0
-  sysZ3D1115: 0.0
-  sysZ3D1116: 6.89780000e-01
-  sysZ3D1117: -0.0
-  sysZ3D1118: -0.0
-  sysZ3D1119: 0.0
-  sysZ3D1120: -6.89780000e-01
-  sysZ3D1121: -0.0
-  sysZ3D1122: -0.0
-  sysZ3D1123: 0.0
-  sysZ3D1124: 6.89780000e-01
-  sysZ3D1125: -0.0
-  sysZ3D1126: -2.75912000e+00
-  sysZ3D1127: 6.89780000e-01
-  sysZ3D1128: -0.0
-  sysZ3D1129: 0.0
-  sysZ3D1130: -0.0
-  sysZ3D1131: -0.0
-  sysZ3D1132: -0.0
-  sysZ3D1133: 0.0
-  sysZ3D1134: 6.89780000e-01
-  sysZ3D1135: 0.0
-  sysZ3D1136: -0.0
-  sysZ3D1137: -0.0
-  sysZ3D1138: 0.0
-  sysZ3D1139: -0.0
-  sysZ3D1140: 0.0
-  sysZ3D1141: -0.0
-  sysZ3D1142: -0.0
-  sysZ3D1143: 0.0
-  sysZ3D1144: -0.0
-  sysZ3D1145: -0.0
-  sysZ3D1146: 0.0
-  sysZ3D1147: -0.0
-  sysZ3D1148: 0.0
-  sysZ3D1149: 0.0
-  sysZ3D1150: -0.0
-  sysZ3D1151: 0.0
-  sysZ3D1152: 0.0
-  sysZ3D1153: -0.0
-  sysZ3D1154: 0.0
-  sysZ3D1155: 0.0
-  sysZ3D1156: 0.0
-  sysZ3D1157: -0.0
-  sysZ3D1158: 0.0
-  sysZ3D1159: 6.89780000e-01
-  sysZ3D1160: -0.0
-  sysZ3D1161: -0.0
-  sysZ3D1162: 0.0
-  sysZ3D1163: 0.0
-  sysZ3D1164: -0.0
-  sysZ3D1165: 0.0
-  sysZ3D1166: 0.0
-  sysZ3D1167: -0.0
-  sysZ3D1168: -0.0
-  sysZ3D1169: -0.0
-  sysZ3D1170: -6.89780000e-01
-  sysZ3D1171: -0.0
-  sysZ3D1172: -0.0
-  sysZ3D1173: -0.0
-  sysZ3D1174: 0.0
-  sysZ3D1175: 0.0
-  sysZ3D1176: 0.0
-  sysZ3D1177: -6.89780000e-01
-  sysZ3D1178: -0.0
-  sysZ3D1179: -0.0
-  sysZ3D1180: 0.0
-  sysZ3D1181: 0.0
-  sysZ3D1182: 0.0
-  sysZ3D1183: -0.0
-  sysZ3D1184: 0.0
-  sysZ3D1185: 0.0
-  sysZ3D1186: -0.0
-  sysZ3D1187: 0.0
-  sysZ3D1188: 6.89780000e-01
-  sysZ3D1189: 0.0
-  sysZ3D1190: -0.0
-  sysZ3D1191: -0.0
-  sysZ3D1192: -0.0
-  sysZ3D1193: -0.0
-  sysZ3D1194: -8.27736
-  sysZ3D1195: -0.0
-  sysZ3D1196: 0.0
-  sysZ3D1197: 6.89780000e-01
-  sysZ3D1198: 6.89780000e-01
-  sysZ3D1199: 0.0
-  sysZ3D1200: -6.89780000e-01
-  sysZ3D1201: -1.37956000e+00
-  sysZ3D1202: 0.0
-  sysZ3D1203: -2.75912000e+00
-  sysZ3D1204: 0.0
-  sysZ3D1205: 0.0
-  sysZ3D1206: 6.89780000e-01
-  sysZ3D1207: 0.0
-  sysZ3D1208: 0.0
-  sysZ3D1209: -0.0
-  sysZ3D1210: -6.89780000e-01
-  sysZ3D1211: -0.0
-  sysZ3D1212: -0.0
-  sysZ3D1213: -6.89780000e-01
-  sysZ3D1214: -6.89780000e-01
-  sysZ3D1215: -1.37956000e+00
-  sysZ3D1216: -6.89780000e-01
-  sysZ3D1217: 2.06934
-  sysZ3D1218: 1.37956000e+00
-  sysZ3D1219: 6.89780000e-01
-  sysZ3D1220: 0.0
-  sysZ3D1221: -0.0
-  sysZ3D1222: -0.0
-  sysZ3D1223: -6.89780000e-01
-  sysZ3D1224: -0.0
-  sysZ3D1225: 0.0
-  sysZ3D1226: 6.89780000e-01
-  sysZ3D1227: 1.37956000e+00
-  sysZ3D1228: 1.37956000e+00
-  sysZ3D1229: 0.0
-  sysZ3D1230: 0.0
-  sysZ3D1231: 6.89780000e-01
-  sysZ3D1232: 0.0
-  sysZ3D1233: -0.0
-  sysZ3D1234: -0.0
-  sysZ3D1235: -6.89780000e-01
-  sysZ3D1236: -0.0
-  sysZ3D1237: 0.0
-  sysZ3D1238: 0.0
-  sysZ3D1239: -0.0
-  sysZ3D1240: -0.0
-  sysZ3D1241: 0.0
-  sysZ3D1242: 0.0
-  sysZ3D1243: 0.0
-  sysZ3D1244: 1.37956000e+00
-  sysZ3D1245: -1.37956000e+00
-  sysZ3D1246: 0.0
-  sysZ3D1247: -0.0
-  sysZ3D1248: -1.37956000e+00
-  sysZ3D1249: -1.37956000e+00
-  sysZ3D1250: 0.0
-  sysZ3D1251: -2.06934
-  sysZ3D1252: -2.06934
-  sysZ3D1253: -0.0
-  sysZ3D1254: -6.89780000e-01
-  sysZ3D1255: -2.06934
-  sysZ3D1256: -6.89780000e-01
-  sysZ3D1257: 6.89780000e-01
-  sysZ3D1258: -6.89780000e-01
-  sysZ3D1259: 6.89780000e-01
-  sysZ3D1260: 6.89780000e-01
-  sysZ3D1261: -0.0
-  sysZ3D1262: 2.06934
-  sysZ3D1263: 2.75912000e+00
-  sysZ3D1264: 4.82846000e+00
-  sysZ3D1265: 6.89780000e-01
-  sysZ3D1266: -5.51824000e+00
-  sysZ3D1267: -2.06934
-  sysZ3D1268: 0.0
-  sysZ3D1269: -0.0
-  sysZ3D1270: 6.89780000e-01
-  sysZ3D1271: 1.37956000e+00
-  sysZ3D1272: 0.0
-  sysZ3D1273: -0.0
-  sysZ3D1274: -1.37956000e+00
-  sysZ3D1275: 2.75912000e+00
-  sys,uncor: 3.4489
-  ATLAS_LUMI: 124.1604
-- stat: 7.25714000e+00
-  sysZ3D1001: -1.97922000e+00
-  sysZ3D1002: 1.31948
-  sysZ3D1003: -0.0
-  sysZ3D1004: 0.0
-  sysZ3D1005: 0.0
-  sysZ3D1006: 0.0
-  sysZ3D1007: 0.0
-  sysZ3D1008: 0.0
-  sysZ3D1009: 0.0
-  sysZ3D1010: 0.0
-  sysZ3D1011: 0.0
-  sysZ3D1012: 0.0
-  sysZ3D1013: 0.0
-  sysZ3D1014: 0.0
-  sysZ3D1015: 0.0
-  sysZ3D1016: 0.0
-  sysZ3D1017: 0.0
-  sysZ3D1018: 0.0
-  sysZ3D1019: 0.0
-  sysZ3D1020: -0.0
-  sysZ3D1021: -0.0
-  sysZ3D1022: 0.0
-  sysZ3D1023: 0.0
-  sysZ3D1024: -0.0
-  sysZ3D1025: 0.0
-  sysZ3D1026: -0.0
-  sysZ3D1027: 0.0
-  sysZ3D1028: -0.0
-  sysZ3D1029: -0.0
-  sysZ3D1030: -0.0
-  sysZ3D1031: 0.0
-  sysZ3D1032: 0.0
-  sysZ3D1033: 0.0
-  sysZ3D1034: 0.0
-  sysZ3D1035: 0.0
-  sysZ3D1036: 0.0
-  sysZ3D1037: -0.0
-  sysZ3D1038: 0.0
-  sysZ3D1039: 0.0
-  sysZ3D1040: -0.0
-  sysZ3D1041: -0.0
-  sysZ3D1042: 0.0
-  sysZ3D1043: 0.0
-  sysZ3D1044: 0.0
-  sysZ3D1045: -0.0
-  sysZ3D1046: 0.65974
-  sysZ3D1047: 0.0
-  sysZ3D1048: -0.0
-  sysZ3D1049: -0.0
-  sysZ3D1050: -0.0
-  sysZ3D1051: 0.0
-  sysZ3D1052: 0.0
-  sysZ3D1053: 0.0
-  sysZ3D1054: -0.0
-  sysZ3D1055: 0.0
-  sysZ3D1056: -0.0
-  sysZ3D1057: -0.0
-  sysZ3D1058: 0.0
-  sysZ3D1059: 0.0
-  sysZ3D1060: -0.0
-  sysZ3D1061: 0.0
-  sysZ3D1062: -0.0
-  sysZ3D1063: 0.0
-  sysZ3D1064: 0.0
-  sysZ3D1065: -0.0
-  sysZ3D1066: 0.0
-  sysZ3D1067: -0.0
-  sysZ3D1068: -0.0
-  sysZ3D1069: 0.0
-  sysZ3D1070: -0.0
-  sysZ3D1071: -0.0
-  sysZ3D1072: -0.0
-  sysZ3D1073: 0.0
-  sysZ3D1074: 0.0
-  sysZ3D1075: 0.0
-  sysZ3D1076: -0.0
-  sysZ3D1077: 0.0
-  sysZ3D1078: -0.0
-  sysZ3D1079: 0.0
-  sysZ3D1080: 0.0
-  sysZ3D1081: 0.0
-  sysZ3D1082: -0.0
-  sysZ3D1083: 0.0
-  sysZ3D1084: 0.0
-  sysZ3D1085: -0.0
-  sysZ3D1086: 0.0
-  sysZ3D1087: 0.0
-  sysZ3D1088: -0.0
-  sysZ3D1089: 0.0
-  sysZ3D1090: 0.0
-  sysZ3D1091: 0.0
-  sysZ3D1092: -0.0
-  sysZ3D1093: 0.0
-  sysZ3D1094: 0.0
-  sysZ3D1095: 0.0
-  sysZ3D1096: 0.0
-  sysZ3D1097: -0.0
-  sysZ3D1098: 0.0
-  sysZ3D1099: -0.0
-  sysZ3D1100: 0.0
-  sysZ3D1101: 0.0
-  sysZ3D1102: 0.0
-  sysZ3D1103: 0.0
-  sysZ3D1104: -0.0
-  sysZ3D1105: -0.65974
-  sysZ3D1106: -0.65974
-  sysZ3D1107: 0.0
-  sysZ3D1108: 0.0
-  sysZ3D1109: 0.0
-  sysZ3D1110: 0.0
-  sysZ3D1111: -0.0
-  sysZ3D1112: -0.0
-  sysZ3D1113: 1.31948
-  sysZ3D1114: -0.0
-  sysZ3D1115: 0.0
-  sysZ3D1116: -0.65974
-  sysZ3D1117: -0.65974
-  sysZ3D1118: -0.65974
-  sysZ3D1119: 0.0
-  sysZ3D1120: 0.0
-  sysZ3D1121: -0.0
-  sysZ3D1122: -0.0
-  sysZ3D1123: -0.0
-  sysZ3D1124: -0.0
-  sysZ3D1125: -0.65974
-  sysZ3D1126: -1.97922000e+00
-  sysZ3D1127: 0.65974
-  sysZ3D1128: -0.0
-  sysZ3D1129: 0.0
-  sysZ3D1130: -0.0
-  sysZ3D1131: 0.0
-  sysZ3D1132: -0.0
-  sysZ3D1133: -0.0
-  sysZ3D1134: -0.0
-  sysZ3D1135: -0.0
-  sysZ3D1136: 0.0
-  sysZ3D1137: -0.0
-  sysZ3D1138: -0.0
-  sysZ3D1139: 0.0
-  sysZ3D1140: -0.0
-  sysZ3D1141: -0.0
-  sysZ3D1142: -0.0
-  sysZ3D1143: -0.0
-  sysZ3D1144: -0.0
-  sysZ3D1145: -0.0
-  sysZ3D1146: 0.0
-  sysZ3D1147: 0.0
-  sysZ3D1148: 0.0
-  sysZ3D1149: -0.0
-  sysZ3D1150: 0.0
-  sysZ3D1151: 0.0
-  sysZ3D1152: -0.0
-  sysZ3D1153: -0.0
-  sysZ3D1154: 0.0
-  sysZ3D1155: 0.0
-  sysZ3D1156: 0.0
-  sysZ3D1157: 0.0
-  sysZ3D1158: 0.0
-  sysZ3D1159: 0.0
-  sysZ3D1160: -0.0
-  sysZ3D1161: 0.0
-  sysZ3D1162: -0.0
-  sysZ3D1163: -0.0
-  sysZ3D1164: 0.0
-  sysZ3D1165: 0.0
-  sysZ3D1166: 0.0
-  sysZ3D1167: 0.0
-  sysZ3D1168: -0.0
-  sysZ3D1169: 0.0
-  sysZ3D1170: -0.65974
-  sysZ3D1171: 0.0
-  sysZ3D1172: -0.0
-  sysZ3D1173: -0.0
-  sysZ3D1174: 0.0
-  sysZ3D1175: 0.0
-  sysZ3D1176: 0.0
-  sysZ3D1177: -0.0
-  sysZ3D1178: -0.0
-  sysZ3D1179: -0.0
-  sysZ3D1180: 0.0
-  sysZ3D1181: 0.0
-  sysZ3D1182: 0.0
-  sysZ3D1183: -0.0
-  sysZ3D1184: 0.0
-  sysZ3D1185: 0.0
-  sysZ3D1186: -0.0
-  sysZ3D1187: 0.0
-  sysZ3D1188: 0.0
-  sysZ3D1189: 0.0
-  sysZ3D1190: 0.0
-  sysZ3D1191: -0.0
-  sysZ3D1192: -0.0
-  sysZ3D1193: -0.0
-  sysZ3D1194: -8.57662
-  sysZ3D1195: -0.0
-  sysZ3D1196: 0.0
-  sysZ3D1197: 0.65974
-  sysZ3D1198: 0.65974
-  sysZ3D1199: -0.0
-  sysZ3D1200: -0.65974
-  sysZ3D1201: -0.65974
-  sysZ3D1202: 0.0
-  sysZ3D1203: -1.97922000e+00
-  sysZ3D1204: -0.0
-  sysZ3D1205: 0.0
-  sysZ3D1206: 0.65974
-  sysZ3D1207: 0.0
-  sysZ3D1208: -0.0
-  sysZ3D1209: -0.0
-  sysZ3D1210: -0.65974
-  sysZ3D1211: -0.0
-  sysZ3D1212: -0.0
-  sysZ3D1213: -0.65974
-  sysZ3D1214: -0.65974
-  sysZ3D1215: -1.31948
-  sysZ3D1216: -0.65974
-  sysZ3D1217: 1.31948
-  sysZ3D1218: 1.31948
-  sysZ3D1219: 0.65974
-  sysZ3D1220: 0.0
-  sysZ3D1221: -0.0
-  sysZ3D1222: -0.0
-  sysZ3D1223: -0.65974
-  sysZ3D1224: 0.0
-  sysZ3D1225: 0.0
-  sysZ3D1226: 0.65974
-  sysZ3D1227: 0.65974
-  sysZ3D1228: 0.65974
-  sysZ3D1229: 0.0
-  sysZ3D1230: 0.65974
-  sysZ3D1231: 0.65974
-  sysZ3D1232: 0.0
-  sysZ3D1233: -0.0
-  sysZ3D1234: -0.0
-  sysZ3D1235: -0.65974
-  sysZ3D1236: 0.0
-  sysZ3D1237: 0.0
-  sysZ3D1238: 0.0
-  sysZ3D1239: -0.0
-  sysZ3D1240: -0.0
-  sysZ3D1241: 0.0
-  sysZ3D1242: 0.0
-  sysZ3D1243: 0.0
-  sysZ3D1244: 1.31948
-  sysZ3D1245: -1.31948
-  sysZ3D1246: 0.0
-  sysZ3D1247: -0.65974
-  sysZ3D1248: -0.65974
-  sysZ3D1249: -0.65974
-  sysZ3D1250: 0.65974
-  sysZ3D1251: -1.97922000e+00
-  sysZ3D1252: -1.97922000e+00
-  sysZ3D1253: -0.0
-  sysZ3D1254: -0.65974
-  sysZ3D1255: -1.97922000e+00
-  sysZ3D1256: -0.0
-  sysZ3D1257: 1.31948
-  sysZ3D1258: -0.0
-  sysZ3D1259: 0.65974
-  sysZ3D1260: 0.65974
-  sysZ3D1261: 0.0
-  sysZ3D1262: 1.31948
-  sysZ3D1263: 2.63896
-  sysZ3D1264: 5.93766
-  sysZ3D1265: 0.65974
-  sysZ3D1266: -5.27792
-  sysZ3D1267: -1.97922000e+00
-  sysZ3D1268: 0.0
-  sysZ3D1269: -0.0
-  sysZ3D1270: 0.65974
-  sysZ3D1271: 1.31948
-  sysZ3D1272: 0.0
-  sysZ3D1273: -0.0
-  sysZ3D1274: -1.31948
-  sysZ3D1275: 2.63896
-  sys,uncor: 3.2987
-  ATLAS_LUMI: 118.7532
-- stat: 6.61870000e+00
-  sysZ3D1001: -1.8051
-  sysZ3D1002: 1.2034
-  sysZ3D1003: -0.0
-  sysZ3D1004: 0.0
-  sysZ3D1005: 0.0
-  sysZ3D1006: 0.0
-  sysZ3D1007: 0.0
-  sysZ3D1008: 0.0
-  sysZ3D1009: 0.0
-  sysZ3D1010: 0.0
-  sysZ3D1011: 0.0
-  sysZ3D1012: 0.0
-  sysZ3D1013: 0.0
-  sysZ3D1014: 0.0
-  sysZ3D1015: 0.0
-  sysZ3D1016: 0.0
-  sysZ3D1017: 0.0
-  sysZ3D1018: 0.0
-  sysZ3D1019: 0.0
-  sysZ3D1020: -0.0
-  sysZ3D1021: -0.0
-  sysZ3D1022: 0.0
-  sysZ3D1023: 0.0
-  sysZ3D1024: -0.0
-  sysZ3D1025: 0.0
-  sysZ3D1026: -0.0
-  sysZ3D1027: 0.0
-  sysZ3D1028: 0.0
-  sysZ3D1029: 0.0
-  sysZ3D1030: 0.0
-  sysZ3D1031: 0.0
-  sysZ3D1032: 0.0
-  sysZ3D1033: 0.0
-  sysZ3D1034: -0.0
-  sysZ3D1035: -0.0
-  sysZ3D1036: -0.0
-  sysZ3D1037: 0.0
-  sysZ3D1038: -0.0
-  sysZ3D1039: -0.0
-  sysZ3D1040: -0.0
-  sysZ3D1041: 0.0
-  sysZ3D1042: 0.6017
-  sysZ3D1043: -0.0
-  sysZ3D1044: 0.0
-  sysZ3D1045: 0.0
-  sysZ3D1046: -0.0
-  sysZ3D1047: -0.0
-  sysZ3D1048: 0.0
-  sysZ3D1049: -0.0
-  sysZ3D1050: 0.0
-  sysZ3D1051: -0.0
-  sysZ3D1052: 0.0
-  sysZ3D1053: 0.0
-  sysZ3D1054: -0.0
-  sysZ3D1055: -0.0
-  sysZ3D1056: -0.0
-  sysZ3D1057: 0.0
-  sysZ3D1058: 0.0
-  sysZ3D1059: 0.0
-  sysZ3D1060: 0.0
-  sysZ3D1061: 0.0
-  sysZ3D1062: 0.0
-  sysZ3D1063: 0.0
-  sysZ3D1064: -0.0
-  sysZ3D1065: 0.0
-  sysZ3D1066: -0.0
-  sysZ3D1067: -0.0
-  sysZ3D1068: 0.0
-  sysZ3D1069: 0.0
-  sysZ3D1070: 0.0
-  sysZ3D1071: 0.0
-  sysZ3D1072: 0.0
-  sysZ3D1073: 0.0
-  sysZ3D1074: 0.0
-  sysZ3D1075: 0.0
-  sysZ3D1076: -0.0
-  sysZ3D1077: -0.0
-  sysZ3D1078: 0.0
-  sysZ3D1079: -0.0
-  sysZ3D1080: 0.0
-  sysZ3D1081: 0.0
-  sysZ3D1082: 0.0
-  sysZ3D1083: -0.0
-  sysZ3D1084: 0.0
-  sysZ3D1085: 0.0
-  sysZ3D1086: 0.0
-  sysZ3D1087: 0.0
-  sysZ3D1088: 0.0
-  sysZ3D1089: 0.0
-  sysZ3D1090: -0.0
-  sysZ3D1091: 0.0
-  sysZ3D1092: 0.0
-  sysZ3D1093: -0.0
-  sysZ3D1094: 0.0
-  sysZ3D1095: -0.0
-  sysZ3D1096: 0.0
-  sysZ3D1097: 0.0
-  sysZ3D1098: 0.0
-  sysZ3D1099: 0.0
-  sysZ3D1100: 0.0
-  sysZ3D1101: -0.0
-  sysZ3D1102: 0.0
-  sysZ3D1103: 0.0
-  sysZ3D1104: -0.0
-  sysZ3D1105: -0.6017
-  sysZ3D1106: -0.6017
-  sysZ3D1107: 0.0
-  sysZ3D1108: 0.0
-  sysZ3D1109: 0.0
-  sysZ3D1110: 0.0
-  sysZ3D1111: -0.0
-  sysZ3D1112: -0.0
-  sysZ3D1113: 0.6017
-  sysZ3D1114: -0.0
-  sysZ3D1115: -0.6017
-  sysZ3D1116: -0.6017
-  sysZ3D1117: -0.6017
-  sysZ3D1118: 0.0
-  sysZ3D1119: 0.0
-  sysZ3D1120: 0.0
-  sysZ3D1121: 0.0
-  sysZ3D1122: 0.0
-  sysZ3D1123: -0.6017
-  sysZ3D1124: 0.0
-  sysZ3D1125: -0.0
-  sysZ3D1126: -2.4068
-  sysZ3D1127: 2.4068
-  sysZ3D1128: -0.0
-  sysZ3D1129: 0.0
-  sysZ3D1130: 0.0
-  sysZ3D1131: -0.0
-  sysZ3D1132: 0.0
-  sysZ3D1133: 0.0
-  sysZ3D1134: 0.6017
-  sysZ3D1135: 0.0
-  sysZ3D1136: -0.0
-  sysZ3D1137: -0.0
-  sysZ3D1138: -0.0
-  sysZ3D1139: 0.0
-  sysZ3D1140: 0.0
-  sysZ3D1141: -0.0
-  sysZ3D1142: -0.0
-  sysZ3D1143: -0.0
-  sysZ3D1144: 0.0
-  sysZ3D1145: -0.0
-  sysZ3D1146: 0.0
-  sysZ3D1147: 0.0
-  sysZ3D1148: -0.0
-  sysZ3D1149: 0.0
-  sysZ3D1150: -0.0
-  sysZ3D1151: -0.0
-  sysZ3D1152: -0.0
-  sysZ3D1153: -0.0
-  sysZ3D1154: -0.0
-  sysZ3D1155: 0.0
-  sysZ3D1156: 0.0
-  sysZ3D1157: 0.0
-  sysZ3D1158: 0.0
-  sysZ3D1159: -0.6017
-  sysZ3D1160: -0.0
-  sysZ3D1161: -0.0
-  sysZ3D1162: -0.0
-  sysZ3D1163: 0.0
-  sysZ3D1164: -0.0
-  sysZ3D1165: 0.0
-  sysZ3D1166: -0.0
-  sysZ3D1167: -0.0
-  sysZ3D1168: 0.0
-  sysZ3D1169: 0.0
-  sysZ3D1170: -0.6017
-  sysZ3D1171: 0.0
-  sysZ3D1172: -0.0
-  sysZ3D1173: 0.0
-  sysZ3D1174: 0.0
-  sysZ3D1175: 0.0
-  sysZ3D1176: -0.0
-  sysZ3D1177: -0.6017
-  sysZ3D1178: -0.0
-  sysZ3D1179: -0.0
-  sysZ3D1180: 0.0
-  sysZ3D1181: 0.0
-  sysZ3D1182: 0.0
-  sysZ3D1183: -0.0
-  sysZ3D1184: 0.0
-  sysZ3D1185: 0.0
-  sysZ3D1186: 0.0
-  sysZ3D1187: 0.0
-  sysZ3D1188: 0.0
-  sysZ3D1189: 0.0
-  sysZ3D1190: -0.0
-  sysZ3D1191: 0.0
-  sysZ3D1192: -0.0
-  sysZ3D1193: -0.0
-  sysZ3D1194: -7.8221
-  sysZ3D1195: 0.0
-  sysZ3D1196: 0.0
-  sysZ3D1197: 0.0
-  sysZ3D1198: 0.0
-  sysZ3D1199: -0.0
-  sysZ3D1200: -0.6017
-  sysZ3D1201: -0.6017
-  sysZ3D1202: 0.0
-  sysZ3D1203: -1.2034
-  sysZ3D1204: 0.0
-  sysZ3D1205: 0.0
-  sysZ3D1206: 0.6017
-  sysZ3D1207: 0.0
-  sysZ3D1208: -0.0
-  sysZ3D1209: -0.0
-  sysZ3D1210: -0.6017
-  sysZ3D1211: -0.0
-  sysZ3D1212: -0.0
-  sysZ3D1213: -0.6017
-  sysZ3D1214: -0.6017
-  sysZ3D1215: -1.8051
-  sysZ3D1216: -0.0
-  sysZ3D1217: 1.2034
-  sysZ3D1218: 0.6017
-  sysZ3D1219: 0.6017
-  sysZ3D1220: -0.0
-  sysZ3D1221: -0.0
-  sysZ3D1222: -0.0
-  sysZ3D1223: -0.0
-  sysZ3D1224: 0.0
-  sysZ3D1225: 0.0
-  sysZ3D1226: 0.6017
-  sysZ3D1227: 0.6017
-  sysZ3D1228: 0.6017
-  sysZ3D1229: 0.0
-  sysZ3D1230: 0.6017
-  sysZ3D1231: 0.6017
-  sysZ3D1232: -0.0
-  sysZ3D1233: -0.0
-  sysZ3D1234: -0.0
-  sysZ3D1235: -0.0
-  sysZ3D1236: 0.0
-  sysZ3D1237: -0.0
-  sysZ3D1238: 0.0
-  sysZ3D1239: -0.0
-  sysZ3D1240: -0.0
-  sysZ3D1241: 0.0
-  sysZ3D1242: 0.0
-  sysZ3D1243: 0.0
-  sysZ3D1244: 1.2034
-  sysZ3D1245: -1.2034
-  sysZ3D1246: 0.6017
-  sysZ3D1247: -0.6017
-  sysZ3D1248: -0.6017
-  sysZ3D1249: -0.6017
-  sysZ3D1250: 0.6017
-  sysZ3D1251: -1.8051
-  sysZ3D1252: -1.2034
-  sysZ3D1253: 0.0
-  sysZ3D1254: -0.6017
-  sysZ3D1255: -1.8051
-  sysZ3D1256: -0.6017
-  sysZ3D1257: 0.6017
-  sysZ3D1258: -0.0
-  sysZ3D1259: 0.6017
-  sysZ3D1260: 0.6017
-  sysZ3D1261: 0.0
-  sysZ3D1262: 0.6017
-  sysZ3D1263: 2.4068
-  sysZ3D1264: 6.017
-  sysZ3D1265: 0.6017
-  sysZ3D1266: -5.4153
-  sysZ3D1267: -1.8051
-  sysZ3D1268: 0.0
-  sysZ3D1269: -0.0
-  sysZ3D1270: 0.6017
-  sysZ3D1271: 1.2034
-  sysZ3D1272: 0.0
-  sysZ3D1273: -0.0
-  sysZ3D1274: -1.2034
-  sysZ3D1275: 3.0085
-  sys,uncor: 3.0085
-  ATLAS_LUMI: 108.306
-- stat: 5.7299
-  sysZ3D1001: -2.0836
-  sysZ3D1002: 0.5209
-  sysZ3D1003: -0.0
+  sysZ3D1003: 0.0
   sysZ3D1004: 0.0
   sysZ3D1005: 0.0
   sysZ3D1006: 0.0
@@ -13087,267 +11697,267 @@ bins:
   sysZ3D1018: 0.0
   sysZ3D1019: 0.0
   sysZ3D1020: 0.0
-  sysZ3D1021: -0.0
+  sysZ3D1021: 0.0
   sysZ3D1022: 0.0
   sysZ3D1023: 0.0
   sysZ3D1024: 0.0
   sysZ3D1025: 0.0
   sysZ3D1026: 0.0
   sysZ3D1027: 0.0
-  sysZ3D1028: -0.0
-  sysZ3D1029: -0.0
-  sysZ3D1030: -0.0
-  sysZ3D1031: -0.0
-  sysZ3D1032: -0.0
-  sysZ3D1033: -0.0
+  sysZ3D1028: 0.0
+  sysZ3D1029: 0.0
+  sysZ3D1030: 0.0
+  sysZ3D1031: 0.0
+  sysZ3D1032: 0.0
+  sysZ3D1033: 0.0
   sysZ3D1034: 0.0
-  sysZ3D1035: -0.0
-  sysZ3D1036: -0.0
+  sysZ3D1035: 0.0
+  sysZ3D1036: 0.0
   sysZ3D1037: 0.0
   sysZ3D1038: 0.0
   sysZ3D1039: 0.0
-  sysZ3D1040: 0.5209
+  sysZ3D1040: 0.0
   sysZ3D1041: 0.0
-  sysZ3D1042: -0.0
+  sysZ3D1042: 0.0
   sysZ3D1043: 0.0
   sysZ3D1044: 0.0
   sysZ3D1045: 0.0
   sysZ3D1046: 0.0
-  sysZ3D1047: -0.0
+  sysZ3D1047: 0.0
   sysZ3D1048: 0.0
   sysZ3D1049: 0.0
-  sysZ3D1050: 0.5209
+  sysZ3D1050: 0.0
   sysZ3D1051: 0.0
   sysZ3D1052: 0.0
-  sysZ3D1053: -0.0
+  sysZ3D1053: 0.0
   sysZ3D1054: 0.0
-  sysZ3D1055: -0.0
-  sysZ3D1056: -0.0
+  sysZ3D1055: 0.0
+  sysZ3D1056: 0.0
   sysZ3D1057: 0.0
   sysZ3D1058: 0.0
-  sysZ3D1059: -0.0
-  sysZ3D1060: -0.0
-  sysZ3D1061: 0.5209
-  sysZ3D1062: -0.0
+  sysZ3D1059: 0.0
+  sysZ3D1060: 0.0
+  sysZ3D1061: 0.0
+  sysZ3D1062: 0.0
   sysZ3D1063: 0.0
-  sysZ3D1064: -0.0
+  sysZ3D1064: 0.0
   sysZ3D1065: 0.0
-  sysZ3D1066: -0.0
+  sysZ3D1066: 0.0
   sysZ3D1067: 0.0
-  sysZ3D1068: -0.0
+  sysZ3D1068: 0.0
   sysZ3D1069: 0.0
   sysZ3D1070: 0.0
   sysZ3D1071: 0.0
-  sysZ3D1072: -0.0
-  sysZ3D1073: -0.0
+  sysZ3D1072: 0.0
+  sysZ3D1073: 0.0
   sysZ3D1074: 0.0
-  sysZ3D1075: -0.0
+  sysZ3D1075: 0.0
   sysZ3D1076: 0.0
-  sysZ3D1077: -0.0
-  sysZ3D1078: -0.0
+  sysZ3D1077: 0.0
+  sysZ3D1078: 0.0
   sysZ3D1079: 0.0
-  sysZ3D1080: -0.0
-  sysZ3D1081: -0.0
+  sysZ3D1080: 0.0
+  sysZ3D1081: 0.0
   sysZ3D1082: 0.0
-  sysZ3D1083: -0.0
+  sysZ3D1083: 0.0
   sysZ3D1084: 0.0
   sysZ3D1085: 0.0
-  sysZ3D1086: -0.0
-  sysZ3D1087: -0.0
+  sysZ3D1086: 0.0
+  sysZ3D1087: 0.0
   sysZ3D1088: 0.0
   sysZ3D1089: 0.0
   sysZ3D1090: 0.0
-  sysZ3D1091: -0.0
+  sysZ3D1091: 0.0
   sysZ3D1092: 0.0
   sysZ3D1093: 0.0
   sysZ3D1094: 0.0
   sysZ3D1095: 0.0
   sysZ3D1096: 0.0
   sysZ3D1097: 0.0
-  sysZ3D1098: -0.0
+  sysZ3D1098: 0.0
   sysZ3D1099: 0.0
-  sysZ3D1100: -0.0
+  sysZ3D1100: 0.0
   sysZ3D1101: 0.0
   sysZ3D1102: 0.0
   sysZ3D1103: 0.0
-  sysZ3D1104: -0.0
-  sysZ3D1105: -0.5209
-  sysZ3D1106: -0.5209
+  sysZ3D1104: 0.0
+  sysZ3D1105: -0.70086
+  sysZ3D1106: -0.70086
   sysZ3D1107: 0.0
   sysZ3D1108: 0.0
   sysZ3D1109: 0.0
   sysZ3D1110: 0.0
-  sysZ3D1111: -0.0
-  sysZ3D1112: -0.0
-  sysZ3D1113: 1.0418
+  sysZ3D1111: 0.0
+  sysZ3D1112: 0.0
+  sysZ3D1113: 1.40172
   sysZ3D1114: 0.0
-  sysZ3D1115: -0.0
-  sysZ3D1116: -0.5209
+  sysZ3D1115: 0.0
+  sysZ3D1116: -0.70086
   sysZ3D1117: 0.0
-  sysZ3D1118: 0.0
-  sysZ3D1119: 0.0
-  sysZ3D1120: -0.0
-  sysZ3D1121: 0.0
+  sysZ3D1118: -0.70086
+  sysZ3D1119: -0.70086
+  sysZ3D1120: -0.70086
+  sysZ3D1121: -0.70086
   sysZ3D1122: 0.0
-  sysZ3D1123: -0.5209
-  sysZ3D1124: 0.5209
-  sysZ3D1125: -0.5209
-  sysZ3D1126: -2.0836
-  sysZ3D1127: 1.0418
-  sysZ3D1128: -0.0
+  sysZ3D1123: 0.0
+  sysZ3D1124: 0.0
+  sysZ3D1125: 0.0
+  sysZ3D1126: -2.10258000e+00
+  sysZ3D1127: -0.70086
+  sysZ3D1128: 0.0
   sysZ3D1129: 0.0
-  sysZ3D1130: -0.0
-  sysZ3D1131: -0.0
-  sysZ3D1132: -0.0
-  sysZ3D1133: -0.0
-  sysZ3D1134: -0.0
-  sysZ3D1135: -0.0
-  sysZ3D1136: -0.0
-  sysZ3D1137: -0.0
+  sysZ3D1130: 0.0
+  sysZ3D1131: 0.0
+  sysZ3D1132: 0.0
+  sysZ3D1133: 0.0
+  sysZ3D1134: 0.0
+  sysZ3D1135: 0.0
+  sysZ3D1136: 0.0
+  sysZ3D1137: 0.0
   sysZ3D1138: 0.0
   sysZ3D1139: 0.0
-  sysZ3D1140: -0.0
+  sysZ3D1140: 0.0
   sysZ3D1141: 0.0
-  sysZ3D1142: -0.0
+  sysZ3D1142: 0.0
   sysZ3D1143: 0.0
-  sysZ3D1144: -0.0
-  sysZ3D1145: -0.0
+  sysZ3D1144: 0.0
+  sysZ3D1145: 0.0
   sysZ3D1146: 0.0
-  sysZ3D1147: -0.0
-  sysZ3D1148: -0.0
-  sysZ3D1149: -0.0
-  sysZ3D1150: -0.0
-  sysZ3D1151: -0.0
-  sysZ3D1152: -0.0
-  sysZ3D1153: -0.0
+  sysZ3D1147: 0.0
+  sysZ3D1148: 0.0
+  sysZ3D1149: 0.0
+  sysZ3D1150: 0.0
+  sysZ3D1151: 0.0
+  sysZ3D1152: 0.0
+  sysZ3D1153: 0.70086
   sysZ3D1154: 0.0
-  sysZ3D1155: -0.0
-  sysZ3D1156: -0.0
-  sysZ3D1157: -0.0
+  sysZ3D1155: 0.0
+  sysZ3D1156: 0.0
+  sysZ3D1157: 0.0
   sysZ3D1158: 0.0
   sysZ3D1159: 0.0
-  sysZ3D1160: 0.5209
+  sysZ3D1160: 0.0
   sysZ3D1161: 0.0
-  sysZ3D1162: -0.0
-  sysZ3D1163: 0.5209
+  sysZ3D1162: 0.0
+  sysZ3D1163: 0.0
   sysZ3D1164: 0.0
-  sysZ3D1165: 0.5209
+  sysZ3D1165: 0.0
   sysZ3D1166: 0.0
-  sysZ3D1167: -0.0
+  sysZ3D1167: 0.0
   sysZ3D1168: 0.0
   sysZ3D1169: 0.0
-  sysZ3D1170: -0.0
+  sysZ3D1170: -0.70086
   sysZ3D1171: 0.0
-  sysZ3D1172: -0.0
+  sysZ3D1172: 0.0
   sysZ3D1173: 0.0
-  sysZ3D1174: 0.0
+  sysZ3D1174: 0.70086
   sysZ3D1175: 0.0
   sysZ3D1176: 0.0
-  sysZ3D1177: -0.0
-  sysZ3D1178: 0.0
-  sysZ3D1179: -0.5209
+  sysZ3D1177: -0.70086
+  sysZ3D1178: -0.70086
+  sysZ3D1179: 0.0
   sysZ3D1180: 0.0
   sysZ3D1181: 0.0
   sysZ3D1182: 0.0
-  sysZ3D1183: -0.0
+  sysZ3D1183: 0.0
   sysZ3D1184: 0.0
   sysZ3D1185: 0.0
-  sysZ3D1186: -0.0
-  sysZ3D1187: -0.0
+  sysZ3D1186: 0.0
+  sysZ3D1187: 0.0
   sysZ3D1188: 0.0
   sysZ3D1189: 0.0
-  sysZ3D1190: -0.0
+  sysZ3D1190: 0.0
   sysZ3D1191: 0.0
-  sysZ3D1192: -0.0
+  sysZ3D1192: 0.0
   sysZ3D1193: 0.0
-  sysZ3D1194: -6.77170000e+00
-  sysZ3D1195: 0.5209
-  sysZ3D1196: 0.0
-  sysZ3D1197: 0.5209
-  sysZ3D1198: -0.0
-  sysZ3D1199: -0.5209
-  sysZ3D1200: -0.5209
-  sysZ3D1201: -0.5209
+  sysZ3D1194: -8.41032000e+00
+  sysZ3D1195: 0.70086
+  sysZ3D1196: 0.70086
+  sysZ3D1197: 0.70086
+  sysZ3D1198: 0.70086
+  sysZ3D1199: -0.70086
+  sysZ3D1200: -1.40172
+  sysZ3D1201: -2.10258000e+00
   sysZ3D1202: 0.0
-  sysZ3D1203: -1.0418
-  sysZ3D1204: 0.5209
-  sysZ3D1205: 0.0
-  sysZ3D1206: 0.5209
+  sysZ3D1203: -2.80344
+  sysZ3D1204: 0.70086
+  sysZ3D1205: 0.70086
+  sysZ3D1206: 0.70086
   sysZ3D1207: 0.0
-  sysZ3D1208: -0.0
-  sysZ3D1209: -0.0
-  sysZ3D1210: -0.5209
-  sysZ3D1211: -0.0
-  sysZ3D1212: -0.0
-  sysZ3D1213: -0.0
-  sysZ3D1214: -0.5209
-  sysZ3D1215: -1.56270000e+00
-  sysZ3D1216: 0.0
-  sysZ3D1217: 1.0418
-  sysZ3D1218: 0.5209
-  sysZ3D1219: 0.5209
-  sysZ3D1220: -0.0
-  sysZ3D1221: -0.0
-  sysZ3D1222: -0.0
-  sysZ3D1223: 0.0
-  sysZ3D1224: 0.5209
-  sysZ3D1225: 0.5209
-  sysZ3D1226: 0.0
-  sysZ3D1227: 0.5209
-  sysZ3D1228: 0.0
+  sysZ3D1208: 0.0
+  sysZ3D1209: 0.0
+  sysZ3D1210: -0.70086
+  sysZ3D1211: 0.0
+  sysZ3D1212: 0.0
+  sysZ3D1213: -0.70086
+  sysZ3D1214: -0.70086
+  sysZ3D1215: -1.40172
+  sysZ3D1216: -0.70086
+  sysZ3D1217: 2.80344
+  sysZ3D1218: 1.40172
+  sysZ3D1219: 0.70086
+  sysZ3D1220: 0.0
+  sysZ3D1221: -0.70086
+  sysZ3D1222: 0.0
+  sysZ3D1223: -0.70086
+  sysZ3D1224: 0.0
+  sysZ3D1225: 0.70086
+  sysZ3D1226: 0.70086
+  sysZ3D1227: 1.40172
+  sysZ3D1228: 0.70086
   sysZ3D1229: 0.0
   sysZ3D1230: 0.0
-  sysZ3D1231: 0.5209
-  sysZ3D1232: -0.0
-  sysZ3D1233: -0.0
-  sysZ3D1234: -0.0
-  sysZ3D1235: -0.0
+  sysZ3D1231: 0.70086
+  sysZ3D1232: 0.0
+  sysZ3D1233: -0.70086
+  sysZ3D1234: -0.70086
+  sysZ3D1235: -0.70086
   sysZ3D1236: 0.0
   sysZ3D1237: 0.0
   sysZ3D1238: 0.0
-  sysZ3D1239: -0.0
-  sysZ3D1240: -0.0
+  sysZ3D1239: 0.0
+  sysZ3D1240: 0.0
   sysZ3D1241: 0.0
   sysZ3D1242: 0.0
   sysZ3D1243: 0.0
-  sysZ3D1244: 1.0418
-  sysZ3D1245: -1.0418
-  sysZ3D1246: 0.5209
-  sysZ3D1247: -0.5209
-  sysZ3D1248: -1.0418
-  sysZ3D1249: -0.5209
+  sysZ3D1244: 2.10258000e+00
+  sysZ3D1245: -1.40172
+  sysZ3D1246: 0.70086
+  sysZ3D1247: 0.0
+  sysZ3D1248: -2.10258000e+00
+  sysZ3D1249: -1.40172
   sysZ3D1250: 0.0
-  sysZ3D1251: -1.0418
-  sysZ3D1252: -0.5209
-  sysZ3D1253: -0.0
-  sysZ3D1254: -0.5209
-  sysZ3D1255: -2.0836
-  sysZ3D1256: -0.5209
-  sysZ3D1257: 1.0418
-  sysZ3D1258: -0.5209
-  sysZ3D1259: 0.5209
-  sysZ3D1260: 0.5209
-  sysZ3D1261: -0.0
-  sysZ3D1262: 1.0418
-  sysZ3D1263: 2.0836
-  sysZ3D1264: 4.68810000e+00
-  sysZ3D1265: 0.5209
-  sysZ3D1266: -5.20900000e+00
-  sysZ3D1267: -1.56270000e+00
-  sysZ3D1268: 0.5209
-  sysZ3D1269: -0.5209
-  sysZ3D1270: 0.5209
-  sysZ3D1271: 1.0418
+  sysZ3D1251: -1.40172
+  sysZ3D1252: 0.0
+  sysZ3D1253: 0.0
+  sysZ3D1254: -0.70086
+  sysZ3D1255: -2.80344
+  sysZ3D1256: -0.70086
+  sysZ3D1257: 0.70086
+  sysZ3D1258: 0.0
+  sysZ3D1259: 1.40172
+  sysZ3D1260: 0.70086
+  sysZ3D1261: 0.0
+  sysZ3D1262: 1.40172
+  sysZ3D1263: 2.80344
+  sysZ3D1264: 2.80344
+  sysZ3D1265: 0.70086
+  sysZ3D1266: -5.60688
+  sysZ3D1267: -2.10258000e+00
+  sysZ3D1268: 0.0
+  sysZ3D1269: -0.70086
+  sysZ3D1270: 0.70086
+  sysZ3D1271: 1.40172
   sysZ3D1272: 0.0
-  sysZ3D1273: -0.0
-  sysZ3D1274: -1.0418
-  sysZ3D1275: 2.60450000e+00
-  sys,uncor: 3.12540000e+00
-  ATLAS_LUMI: 9.37620000e+01
-- stat: 5.49588
-  sysZ3D1001: -1.69104
-  sysZ3D1002: 0.42276
-  sysZ3D1003: -0.0
+  sysZ3D1273: 0.0
+  sysZ3D1274: -0.70086
+  sysZ3D1275: 2.10258000e+00
+  sys,uncor: 3.5043
+  ATLAS_LUMI: 126.1548
+- stat: 7.67646000e+00
+  sysZ3D1001: -2.09358000e+00
+  sysZ3D1002: 0.0
+  sysZ3D1003: 0.0
   sysZ3D1004: 0.0
   sysZ3D1005: 0.0
   sysZ3D1006: 0.0
@@ -13364,179 +11974,1569 @@ bins:
   sysZ3D1017: 0.0
   sysZ3D1018: 0.0
   sysZ3D1019: 0.0
-  sysZ3D1020: -0.0
+  sysZ3D1020: 0.0
   sysZ3D1021: 0.0
   sysZ3D1022: 0.0
-  sysZ3D1023: 0.42276
-  sysZ3D1024: -0.0
-  sysZ3D1025: 0.42276
-  sysZ3D1026: -0.0
+  sysZ3D1023: 0.0
+  sysZ3D1024: 0.0
+  sysZ3D1025: 0.0
+  sysZ3D1026: 0.0
   sysZ3D1027: 0.0
   sysZ3D1028: 0.0
   sysZ3D1029: 0.0
   sysZ3D1030: 0.0
   sysZ3D1031: 0.0
-  sysZ3D1032: -0.0
-  sysZ3D1033: -0.0
-  sysZ3D1034: -0.0
-  sysZ3D1035: -0.0
-  sysZ3D1036: -0.0
+  sysZ3D1032: 0.0
+  sysZ3D1033: 0.0
+  sysZ3D1034: 0.0
+  sysZ3D1035: 0.69786
+  sysZ3D1036: 0.0
   sysZ3D1037: 0.0
   sysZ3D1038: 0.0
-  sysZ3D1039: -0.0
+  sysZ3D1039: 0.0
   sysZ3D1040: 0.0
   sysZ3D1041: 0.0
   sysZ3D1042: 0.0
-  sysZ3D1043: -0.0
-  sysZ3D1044: -0.0
+  sysZ3D1043: 0.0
+  sysZ3D1044: 0.0
   sysZ3D1045: 0.0
   sysZ3D1046: 0.0
-  sysZ3D1047: -0.0
-  sysZ3D1048: -0.0
+  sysZ3D1047: 0.0
+  sysZ3D1048: 0.0
+  sysZ3D1049: 0.0
+  sysZ3D1050: 0.0
+  sysZ3D1051: 0.0
+  sysZ3D1052: 0.0
+  sysZ3D1053: 0.0
+  sysZ3D1054: 0.0
+  sysZ3D1055: 0.0
+  sysZ3D1056: 0.0
+  sysZ3D1057: 0.0
+  sysZ3D1058: 0.0
+  sysZ3D1059: 0.0
+  sysZ3D1060: 0.0
+  sysZ3D1061: 0.0
+  sysZ3D1062: 0.0
+  sysZ3D1063: 0.0
+  sysZ3D1064: 0.0
+  sysZ3D1065: 0.0
+  sysZ3D1066: 0.0
+  sysZ3D1067: 0.0
+  sysZ3D1068: 0.0
+  sysZ3D1069: 0.0
+  sysZ3D1070: 0.0
+  sysZ3D1071: 0.0
+  sysZ3D1072: 0.0
+  sysZ3D1073: 0.0
+  sysZ3D1074: 0.0
+  sysZ3D1075: 0.0
+  sysZ3D1076: 0.0
+  sysZ3D1077: 0.0
+  sysZ3D1078: 0.0
+  sysZ3D1079: 0.0
+  sysZ3D1080: 0.0
+  sysZ3D1081: 0.0
+  sysZ3D1082: 0.0
+  sysZ3D1083: 0.0
+  sysZ3D1084: 0.0
+  sysZ3D1085: 0.0
+  sysZ3D1086: 0.0
+  sysZ3D1087: 0.0
+  sysZ3D1088: 0.0
+  sysZ3D1089: 0.0
+  sysZ3D1090: 0.0
+  sysZ3D1091: 0.0
+  sysZ3D1092: 0.0
+  sysZ3D1093: 0.0
+  sysZ3D1094: 0.0
+  sysZ3D1095: 0.0
+  sysZ3D1096: 0.0
+  sysZ3D1097: 0.0
+  sysZ3D1098: 0.0
+  sysZ3D1099: 0.0
+  sysZ3D1100: 0.0
+  sysZ3D1101: 0.0
+  sysZ3D1102: 0.0
+  sysZ3D1103: 0.0
+  sysZ3D1104: 0.0
+  sysZ3D1105: -0.69786
+  sysZ3D1106: -0.69786
+  sysZ3D1107: 0.0
+  sysZ3D1108: 0.0
+  sysZ3D1109: 0.0
+  sysZ3D1110: 0.0
+  sysZ3D1111: 0.0
+  sysZ3D1112: 0.0
+  sysZ3D1113: 1.39572
+  sysZ3D1114: 0.0
+  sysZ3D1115: 0.0
+  sysZ3D1116: 0.0
+  sysZ3D1117: -0.69786
+  sysZ3D1118: 0.0
+  sysZ3D1119: -0.69786
+  sysZ3D1120: 0.0
+  sysZ3D1121: -0.69786
+  sysZ3D1122: -0.69786
+  sysZ3D1123: 0.0
+  sysZ3D1124: 0.0
+  sysZ3D1125: 0.0
+  sysZ3D1126: -2.09358000e+00
+  sysZ3D1127: 0.0
+  sysZ3D1128: 0.0
+  sysZ3D1129: 0.0
+  sysZ3D1130: 0.0
+  sysZ3D1131: 0.0
+  sysZ3D1132: 0.0
+  sysZ3D1133: 0.0
+  sysZ3D1134: 0.0
+  sysZ3D1135: 0.0
+  sysZ3D1136: 0.0
+  sysZ3D1137: 0.0
+  sysZ3D1138: 0.0
+  sysZ3D1139: 0.0
+  sysZ3D1140: 0.0
+  sysZ3D1141: 0.0
+  sysZ3D1142: 0.0
+  sysZ3D1143: 0.0
+  sysZ3D1144: 0.0
+  sysZ3D1145: 0.0
+  sysZ3D1146: 0.0
+  sysZ3D1147: 0.0
+  sysZ3D1148: 0.0
+  sysZ3D1149: 0.0
+  sysZ3D1150: 0.0
+  sysZ3D1151: 0.0
+  sysZ3D1152: 0.0
+  sysZ3D1153: 0.0
+  sysZ3D1154: 0.0
+  sysZ3D1155: 0.0
+  sysZ3D1156: 0.0
+  sysZ3D1157: 0.0
+  sysZ3D1158: 0.0
+  sysZ3D1159: 0.0
+  sysZ3D1160: 0.0
+  sysZ3D1161: 0.0
+  sysZ3D1162: 0.0
+  sysZ3D1163: 0.0
+  sysZ3D1164: 0.0
+  sysZ3D1165: 0.0
+  sysZ3D1166: 0.0
+  sysZ3D1167: 0.0
+  sysZ3D1168: 0.0
+  sysZ3D1169: 0.0
+  sysZ3D1170: 0.0
+  sysZ3D1171: 0.0
+  sysZ3D1172: 0.0
+  sysZ3D1173: 0.0
+  sysZ3D1174: 0.0
+  sysZ3D1175: 0.0
+  sysZ3D1176: 0.0
+  sysZ3D1177: -0.69786
+  sysZ3D1178: -0.69786
+  sysZ3D1179: 0.0
+  sysZ3D1180: 0.0
+  sysZ3D1181: 0.0
+  sysZ3D1182: 0.0
+  sysZ3D1183: 0.0
+  sysZ3D1184: 0.0
+  sysZ3D1185: 0.0
+  sysZ3D1186: 0.0
+  sysZ3D1187: 0.0
+  sysZ3D1188: 0.69786
+  sysZ3D1189: 0.0
+  sysZ3D1190: 0.0
+  sysZ3D1191: 0.0
+  sysZ3D1192: 0.0
+  sysZ3D1193: 0.0
+  sysZ3D1194: -8.37432000e+00
+  sysZ3D1195: 0.0
+  sysZ3D1196: 0.0
+  sysZ3D1197: 0.69786
+  sysZ3D1198: 0.69786
+  sysZ3D1199: 0.0
+  sysZ3D1200: -0.69786
+  sysZ3D1201: -1.39572
+  sysZ3D1202: 0.0
+  sysZ3D1203: -2.79144
+  sysZ3D1204: 0.0
+  sysZ3D1205: 0.69786
+  sysZ3D1206: 0.69786
+  sysZ3D1207: 0.69786
+  sysZ3D1208: 0.0
+  sysZ3D1209: 0.0
+  sysZ3D1210: -0.69786
+  sysZ3D1211: 0.0
+  sysZ3D1212: 0.0
+  sysZ3D1213: -0.69786
+  sysZ3D1214: -0.69786
+  sysZ3D1215: -1.39572
+  sysZ3D1216: -0.69786
+  sysZ3D1217: 2.79144
+  sysZ3D1218: 2.09358000e+00
+  sysZ3D1219: 0.69786
+  sysZ3D1220: 0.0
+  sysZ3D1221: 0.0
+  sysZ3D1222: 0.0
+  sysZ3D1223: -0.69786
+  sysZ3D1224: 0.0
+  sysZ3D1225: 0.0
+  sysZ3D1226: 0.69786
+  sysZ3D1227: 1.39572
+  sysZ3D1228: 0.69786
+  sysZ3D1229: 0.0
+  sysZ3D1230: 0.0
+  sysZ3D1231: 0.69786
+  sysZ3D1232: 0.0
+  sysZ3D1233: 0.0
+  sysZ3D1234: 0.0
+  sysZ3D1235: -0.69786
+  sysZ3D1236: 0.0
+  sysZ3D1237: 0.0
+  sysZ3D1238: 0.69786
+  sysZ3D1239: 0.0
+  sysZ3D1240: 0.0
+  sysZ3D1241: 0.0
+  sysZ3D1242: 0.0
+  sysZ3D1243: 0.0
+  sysZ3D1244: 2.09358000e+00
+  sysZ3D1245: -1.39572
+  sysZ3D1246: 0.0
+  sysZ3D1247: 0.0
+  sysZ3D1248: -1.39572
+  sysZ3D1249: -1.39572
+  sysZ3D1250: 0.0
+  sysZ3D1251: -2.09358000e+00
+  sysZ3D1252: -0.69786
+  sysZ3D1253: 0.0
+  sysZ3D1254: -0.69786
+  sysZ3D1255: -2.09358000e+00
+  sysZ3D1256: -0.69786
+  sysZ3D1257: 0.69786
+  sysZ3D1258: -0.69786
+  sysZ3D1259: 0.69786
+  sysZ3D1260: 0.69786
+  sysZ3D1261: 0.0
+  sysZ3D1262: 1.39572
+  sysZ3D1263: 2.79144
+  sysZ3D1264: 3.48930000e+00
+  sysZ3D1265: 0.69786
+  sysZ3D1266: -5.58288
+  sysZ3D1267: -1.39572
+  sysZ3D1268: 0.0
+  sysZ3D1269: 0.0
+  sysZ3D1270: 0.69786
+  sysZ3D1271: 1.39572
+  sysZ3D1272: 0.0
+  sysZ3D1273: 0.0
+  sysZ3D1274: -1.39572
+  sysZ3D1275: 2.79144
+  sys,uncor: 3.48930000e+00
+  ATLAS_LUMI: 125.6148
+- stat: 7.58758000e+00
+  sysZ3D1001: -2.06934
+  sysZ3D1002: 0.0
+  sysZ3D1003: 0.0
+  sysZ3D1004: 0.0
+  sysZ3D1005: 0.0
+  sysZ3D1006: 0.0
+  sysZ3D1007: 0.0
+  sysZ3D1008: 0.0
+  sysZ3D1009: 0.0
+  sysZ3D1010: 0.0
+  sysZ3D1011: 0.0
+  sysZ3D1012: 0.0
+  sysZ3D1013: 0.0
+  sysZ3D1014: 0.0
+  sysZ3D1015: 0.0
+  sysZ3D1016: 0.0
+  sysZ3D1017: 0.0
+  sysZ3D1018: 0.0
+  sysZ3D1019: 0.0
+  sysZ3D1020: 0.0
+  sysZ3D1021: 0.0
+  sysZ3D1022: 0.0
+  sysZ3D1023: 0.0
+  sysZ3D1024: 0.0
+  sysZ3D1025: 0.0
+  sysZ3D1026: 0.0
+  sysZ3D1027: 0.0
+  sysZ3D1028: 0.0
+  sysZ3D1029: 0.0
+  sysZ3D1030: 0.0
+  sysZ3D1031: 0.0
+  sysZ3D1032: 0.0
+  sysZ3D1033: 0.0
+  sysZ3D1034: 0.0
+  sysZ3D1035: 0.0
+  sysZ3D1036: 0.0
+  sysZ3D1037: 0.0
+  sysZ3D1038: 0.0
+  sysZ3D1039: 0.0
+  sysZ3D1040: 0.0
+  sysZ3D1041: 0.0
+  sysZ3D1042: 0.0
+  sysZ3D1043: 0.0
+  sysZ3D1044: 0.0
+  sysZ3D1045: -6.89780000e-01
+  sysZ3D1046: 0.0
+  sysZ3D1047: 0.0
+  sysZ3D1048: 0.0
+  sysZ3D1049: 0.0
+  sysZ3D1050: 0.0
+  sysZ3D1051: 0.0
+  sysZ3D1052: 0.0
+  sysZ3D1053: 0.0
+  sysZ3D1054: 0.0
+  sysZ3D1055: 0.0
+  sysZ3D1056: 0.0
+  sysZ3D1057: 0.0
+  sysZ3D1058: 0.0
+  sysZ3D1059: 0.0
+  sysZ3D1060: 0.0
+  sysZ3D1061: 0.0
+  sysZ3D1062: 0.0
+  sysZ3D1063: 0.0
+  sysZ3D1064: 0.0
+  sysZ3D1065: 0.0
+  sysZ3D1066: 0.0
+  sysZ3D1067: 0.0
+  sysZ3D1068: 0.0
+  sysZ3D1069: 0.0
+  sysZ3D1070: 0.0
+  sysZ3D1071: 0.0
+  sysZ3D1072: 0.0
+  sysZ3D1073: 0.0
+  sysZ3D1074: 0.0
+  sysZ3D1075: 0.0
+  sysZ3D1076: 0.0
+  sysZ3D1077: 0.0
+  sysZ3D1078: 0.0
+  sysZ3D1079: 0.0
+  sysZ3D1080: 0.0
+  sysZ3D1081: 0.0
+  sysZ3D1082: 0.0
+  sysZ3D1083: 0.0
+  sysZ3D1084: 0.0
+  sysZ3D1085: 0.0
+  sysZ3D1086: 0.0
+  sysZ3D1087: 0.0
+  sysZ3D1088: 0.0
+  sysZ3D1089: 0.0
+  sysZ3D1090: 0.0
+  sysZ3D1091: 0.0
+  sysZ3D1092: 0.0
+  sysZ3D1093: 0.0
+  sysZ3D1094: 0.0
+  sysZ3D1095: 0.0
+  sysZ3D1096: 0.0
+  sysZ3D1097: 0.0
+  sysZ3D1098: 0.0
+  sysZ3D1099: 0.0
+  sysZ3D1100: 0.0
+  sysZ3D1101: 0.0
+  sysZ3D1102: 0.0
+  sysZ3D1103: 0.0
+  sysZ3D1104: 0.0
+  sysZ3D1105: -6.89780000e-01
+  sysZ3D1106: -6.89780000e-01
+  sysZ3D1107: 0.0
+  sysZ3D1108: 0.0
+  sysZ3D1109: 0.0
+  sysZ3D1110: 0.0
+  sysZ3D1111: 0.0
+  sysZ3D1112: 0.0
+  sysZ3D1113: 1.37956000e+00
+  sysZ3D1114: 0.0
+  sysZ3D1115: 0.0
+  sysZ3D1116: 6.89780000e-01
+  sysZ3D1117: 0.0
+  sysZ3D1118: 0.0
+  sysZ3D1119: 0.0
+  sysZ3D1120: -6.89780000e-01
+  sysZ3D1121: 0.0
+  sysZ3D1122: 0.0
+  sysZ3D1123: 0.0
+  sysZ3D1124: 6.89780000e-01
+  sysZ3D1125: 0.0
+  sysZ3D1126: -2.75912000e+00
+  sysZ3D1127: 6.89780000e-01
+  sysZ3D1128: 0.0
+  sysZ3D1129: 0.0
+  sysZ3D1130: 0.0
+  sysZ3D1131: 0.0
+  sysZ3D1132: 0.0
+  sysZ3D1133: 0.0
+  sysZ3D1134: 6.89780000e-01
+  sysZ3D1135: 0.0
+  sysZ3D1136: 0.0
+  sysZ3D1137: 0.0
+  sysZ3D1138: 0.0
+  sysZ3D1139: 0.0
+  sysZ3D1140: 0.0
+  sysZ3D1141: 0.0
+  sysZ3D1142: 0.0
+  sysZ3D1143: 0.0
+  sysZ3D1144: 0.0
+  sysZ3D1145: 0.0
+  sysZ3D1146: 0.0
+  sysZ3D1147: 0.0
+  sysZ3D1148: 0.0
+  sysZ3D1149: 0.0
+  sysZ3D1150: 0.0
+  sysZ3D1151: 0.0
+  sysZ3D1152: 0.0
+  sysZ3D1153: 0.0
+  sysZ3D1154: 0.0
+  sysZ3D1155: 0.0
+  sysZ3D1156: 0.0
+  sysZ3D1157: 0.0
+  sysZ3D1158: 0.0
+  sysZ3D1159: 6.89780000e-01
+  sysZ3D1160: 0.0
+  sysZ3D1161: 0.0
+  sysZ3D1162: 0.0
+  sysZ3D1163: 0.0
+  sysZ3D1164: 0.0
+  sysZ3D1165: 0.0
+  sysZ3D1166: 0.0
+  sysZ3D1167: 0.0
+  sysZ3D1168: 0.0
+  sysZ3D1169: 0.0
+  sysZ3D1170: -6.89780000e-01
+  sysZ3D1171: 0.0
+  sysZ3D1172: 0.0
+  sysZ3D1173: 0.0
+  sysZ3D1174: 0.0
+  sysZ3D1175: 0.0
+  sysZ3D1176: 0.0
+  sysZ3D1177: -6.89780000e-01
+  sysZ3D1178: 0.0
+  sysZ3D1179: 0.0
+  sysZ3D1180: 0.0
+  sysZ3D1181: 0.0
+  sysZ3D1182: 0.0
+  sysZ3D1183: 0.0
+  sysZ3D1184: 0.0
+  sysZ3D1185: 0.0
+  sysZ3D1186: 0.0
+  sysZ3D1187: 0.0
+  sysZ3D1188: 6.89780000e-01
+  sysZ3D1189: 0.0
+  sysZ3D1190: 0.0
+  sysZ3D1191: 0.0
+  sysZ3D1192: 0.0
+  sysZ3D1193: 0.0
+  sysZ3D1194: -8.27736
+  sysZ3D1195: 0.0
+  sysZ3D1196: 0.0
+  sysZ3D1197: 6.89780000e-01
+  sysZ3D1198: 6.89780000e-01
+  sysZ3D1199: 0.0
+  sysZ3D1200: -6.89780000e-01
+  sysZ3D1201: -1.37956000e+00
+  sysZ3D1202: 0.0
+  sysZ3D1203: -2.75912000e+00
+  sysZ3D1204: 0.0
+  sysZ3D1205: 0.0
+  sysZ3D1206: 6.89780000e-01
+  sysZ3D1207: 0.0
+  sysZ3D1208: 0.0
+  sysZ3D1209: 0.0
+  sysZ3D1210: -6.89780000e-01
+  sysZ3D1211: 0.0
+  sysZ3D1212: 0.0
+  sysZ3D1213: -6.89780000e-01
+  sysZ3D1214: -6.89780000e-01
+  sysZ3D1215: -1.37956000e+00
+  sysZ3D1216: -6.89780000e-01
+  sysZ3D1217: 2.06934
+  sysZ3D1218: 1.37956000e+00
+  sysZ3D1219: 6.89780000e-01
+  sysZ3D1220: 0.0
+  sysZ3D1221: 0.0
+  sysZ3D1222: 0.0
+  sysZ3D1223: -6.89780000e-01
+  sysZ3D1224: 0.0
+  sysZ3D1225: 0.0
+  sysZ3D1226: 6.89780000e-01
+  sysZ3D1227: 1.37956000e+00
+  sysZ3D1228: 1.37956000e+00
+  sysZ3D1229: 0.0
+  sysZ3D1230: 0.0
+  sysZ3D1231: 6.89780000e-01
+  sysZ3D1232: 0.0
+  sysZ3D1233: 0.0
+  sysZ3D1234: 0.0
+  sysZ3D1235: -6.89780000e-01
+  sysZ3D1236: 0.0
+  sysZ3D1237: 0.0
+  sysZ3D1238: 0.0
+  sysZ3D1239: 0.0
+  sysZ3D1240: 0.0
+  sysZ3D1241: 0.0
+  sysZ3D1242: 0.0
+  sysZ3D1243: 0.0
+  sysZ3D1244: 1.37956000e+00
+  sysZ3D1245: -1.37956000e+00
+  sysZ3D1246: 0.0
+  sysZ3D1247: 0.0
+  sysZ3D1248: -1.37956000e+00
+  sysZ3D1249: -1.37956000e+00
+  sysZ3D1250: 0.0
+  sysZ3D1251: -2.06934
+  sysZ3D1252: -2.06934
+  sysZ3D1253: 0.0
+  sysZ3D1254: -6.89780000e-01
+  sysZ3D1255: -2.06934
+  sysZ3D1256: -6.89780000e-01
+  sysZ3D1257: 6.89780000e-01
+  sysZ3D1258: -6.89780000e-01
+  sysZ3D1259: 6.89780000e-01
+  sysZ3D1260: 6.89780000e-01
+  sysZ3D1261: 0.0
+  sysZ3D1262: 2.06934
+  sysZ3D1263: 2.75912000e+00
+  sysZ3D1264: 4.82846000e+00
+  sysZ3D1265: 6.89780000e-01
+  sysZ3D1266: -5.51824000e+00
+  sysZ3D1267: -2.06934
+  sysZ3D1268: 0.0
+  sysZ3D1269: 0.0
+  sysZ3D1270: 6.89780000e-01
+  sysZ3D1271: 1.37956000e+00
+  sysZ3D1272: 0.0
+  sysZ3D1273: 0.0
+  sysZ3D1274: -1.37956000e+00
+  sysZ3D1275: 2.75912000e+00
+  sys,uncor: 3.4489
+  ATLAS_LUMI: 124.1604
+- stat: 7.25714000e+00
+  sysZ3D1001: -1.97922000e+00
+  sysZ3D1002: 1.31948
+  sysZ3D1003: 0.0
+  sysZ3D1004: 0.0
+  sysZ3D1005: 0.0
+  sysZ3D1006: 0.0
+  sysZ3D1007: 0.0
+  sysZ3D1008: 0.0
+  sysZ3D1009: 0.0
+  sysZ3D1010: 0.0
+  sysZ3D1011: 0.0
+  sysZ3D1012: 0.0
+  sysZ3D1013: 0.0
+  sysZ3D1014: 0.0
+  sysZ3D1015: 0.0
+  sysZ3D1016: 0.0
+  sysZ3D1017: 0.0
+  sysZ3D1018: 0.0
+  sysZ3D1019: 0.0
+  sysZ3D1020: 0.0
+  sysZ3D1021: 0.0
+  sysZ3D1022: 0.0
+  sysZ3D1023: 0.0
+  sysZ3D1024: 0.0
+  sysZ3D1025: 0.0
+  sysZ3D1026: 0.0
+  sysZ3D1027: 0.0
+  sysZ3D1028: 0.0
+  sysZ3D1029: 0.0
+  sysZ3D1030: 0.0
+  sysZ3D1031: 0.0
+  sysZ3D1032: 0.0
+  sysZ3D1033: 0.0
+  sysZ3D1034: 0.0
+  sysZ3D1035: 0.0
+  sysZ3D1036: 0.0
+  sysZ3D1037: 0.0
+  sysZ3D1038: 0.0
+  sysZ3D1039: 0.0
+  sysZ3D1040: 0.0
+  sysZ3D1041: 0.0
+  sysZ3D1042: 0.0
+  sysZ3D1043: 0.0
+  sysZ3D1044: 0.0
+  sysZ3D1045: 0.0
+  sysZ3D1046: 0.65974
+  sysZ3D1047: 0.0
+  sysZ3D1048: 0.0
+  sysZ3D1049: 0.0
+  sysZ3D1050: 0.0
+  sysZ3D1051: 0.0
+  sysZ3D1052: 0.0
+  sysZ3D1053: 0.0
+  sysZ3D1054: 0.0
+  sysZ3D1055: 0.0
+  sysZ3D1056: 0.0
+  sysZ3D1057: 0.0
+  sysZ3D1058: 0.0
+  sysZ3D1059: 0.0
+  sysZ3D1060: 0.0
+  sysZ3D1061: 0.0
+  sysZ3D1062: 0.0
+  sysZ3D1063: 0.0
+  sysZ3D1064: 0.0
+  sysZ3D1065: 0.0
+  sysZ3D1066: 0.0
+  sysZ3D1067: 0.0
+  sysZ3D1068: 0.0
+  sysZ3D1069: 0.0
+  sysZ3D1070: 0.0
+  sysZ3D1071: 0.0
+  sysZ3D1072: 0.0
+  sysZ3D1073: 0.0
+  sysZ3D1074: 0.0
+  sysZ3D1075: 0.0
+  sysZ3D1076: 0.0
+  sysZ3D1077: 0.0
+  sysZ3D1078: 0.0
+  sysZ3D1079: 0.0
+  sysZ3D1080: 0.0
+  sysZ3D1081: 0.0
+  sysZ3D1082: 0.0
+  sysZ3D1083: 0.0
+  sysZ3D1084: 0.0
+  sysZ3D1085: 0.0
+  sysZ3D1086: 0.0
+  sysZ3D1087: 0.0
+  sysZ3D1088: 0.0
+  sysZ3D1089: 0.0
+  sysZ3D1090: 0.0
+  sysZ3D1091: 0.0
+  sysZ3D1092: 0.0
+  sysZ3D1093: 0.0
+  sysZ3D1094: 0.0
+  sysZ3D1095: 0.0
+  sysZ3D1096: 0.0
+  sysZ3D1097: 0.0
+  sysZ3D1098: 0.0
+  sysZ3D1099: 0.0
+  sysZ3D1100: 0.0
+  sysZ3D1101: 0.0
+  sysZ3D1102: 0.0
+  sysZ3D1103: 0.0
+  sysZ3D1104: 0.0
+  sysZ3D1105: -0.65974
+  sysZ3D1106: -0.65974
+  sysZ3D1107: 0.0
+  sysZ3D1108: 0.0
+  sysZ3D1109: 0.0
+  sysZ3D1110: 0.0
+  sysZ3D1111: 0.0
+  sysZ3D1112: 0.0
+  sysZ3D1113: 1.31948
+  sysZ3D1114: 0.0
+  sysZ3D1115: 0.0
+  sysZ3D1116: -0.65974
+  sysZ3D1117: -0.65974
+  sysZ3D1118: -0.65974
+  sysZ3D1119: 0.0
+  sysZ3D1120: 0.0
+  sysZ3D1121: 0.0
+  sysZ3D1122: 0.0
+  sysZ3D1123: 0.0
+  sysZ3D1124: 0.0
+  sysZ3D1125: -0.65974
+  sysZ3D1126: -1.97922000e+00
+  sysZ3D1127: 0.65974
+  sysZ3D1128: 0.0
+  sysZ3D1129: 0.0
+  sysZ3D1130: 0.0
+  sysZ3D1131: 0.0
+  sysZ3D1132: 0.0
+  sysZ3D1133: 0.0
+  sysZ3D1134: 0.0
+  sysZ3D1135: 0.0
+  sysZ3D1136: 0.0
+  sysZ3D1137: 0.0
+  sysZ3D1138: 0.0
+  sysZ3D1139: 0.0
+  sysZ3D1140: 0.0
+  sysZ3D1141: 0.0
+  sysZ3D1142: 0.0
+  sysZ3D1143: 0.0
+  sysZ3D1144: 0.0
+  sysZ3D1145: 0.0
+  sysZ3D1146: 0.0
+  sysZ3D1147: 0.0
+  sysZ3D1148: 0.0
+  sysZ3D1149: 0.0
+  sysZ3D1150: 0.0
+  sysZ3D1151: 0.0
+  sysZ3D1152: 0.0
+  sysZ3D1153: 0.0
+  sysZ3D1154: 0.0
+  sysZ3D1155: 0.0
+  sysZ3D1156: 0.0
+  sysZ3D1157: 0.0
+  sysZ3D1158: 0.0
+  sysZ3D1159: 0.0
+  sysZ3D1160: 0.0
+  sysZ3D1161: 0.0
+  sysZ3D1162: 0.0
+  sysZ3D1163: 0.0
+  sysZ3D1164: 0.0
+  sysZ3D1165: 0.0
+  sysZ3D1166: 0.0
+  sysZ3D1167: 0.0
+  sysZ3D1168: 0.0
+  sysZ3D1169: 0.0
+  sysZ3D1170: -0.65974
+  sysZ3D1171: 0.0
+  sysZ3D1172: 0.0
+  sysZ3D1173: 0.0
+  sysZ3D1174: 0.0
+  sysZ3D1175: 0.0
+  sysZ3D1176: 0.0
+  sysZ3D1177: 0.0
+  sysZ3D1178: 0.0
+  sysZ3D1179: 0.0
+  sysZ3D1180: 0.0
+  sysZ3D1181: 0.0
+  sysZ3D1182: 0.0
+  sysZ3D1183: 0.0
+  sysZ3D1184: 0.0
+  sysZ3D1185: 0.0
+  sysZ3D1186: 0.0
+  sysZ3D1187: 0.0
+  sysZ3D1188: 0.0
+  sysZ3D1189: 0.0
+  sysZ3D1190: 0.0
+  sysZ3D1191: 0.0
+  sysZ3D1192: 0.0
+  sysZ3D1193: 0.0
+  sysZ3D1194: -8.57662
+  sysZ3D1195: 0.0
+  sysZ3D1196: 0.0
+  sysZ3D1197: 0.65974
+  sysZ3D1198: 0.65974
+  sysZ3D1199: 0.0
+  sysZ3D1200: -0.65974
+  sysZ3D1201: -0.65974
+  sysZ3D1202: 0.0
+  sysZ3D1203: -1.97922000e+00
+  sysZ3D1204: 0.0
+  sysZ3D1205: 0.0
+  sysZ3D1206: 0.65974
+  sysZ3D1207: 0.0
+  sysZ3D1208: 0.0
+  sysZ3D1209: 0.0
+  sysZ3D1210: -0.65974
+  sysZ3D1211: 0.0
+  sysZ3D1212: 0.0
+  sysZ3D1213: -0.65974
+  sysZ3D1214: -0.65974
+  sysZ3D1215: -1.31948
+  sysZ3D1216: -0.65974
+  sysZ3D1217: 1.31948
+  sysZ3D1218: 1.31948
+  sysZ3D1219: 0.65974
+  sysZ3D1220: 0.0
+  sysZ3D1221: 0.0
+  sysZ3D1222: 0.0
+  sysZ3D1223: -0.65974
+  sysZ3D1224: 0.0
+  sysZ3D1225: 0.0
+  sysZ3D1226: 0.65974
+  sysZ3D1227: 0.65974
+  sysZ3D1228: 0.65974
+  sysZ3D1229: 0.0
+  sysZ3D1230: 0.65974
+  sysZ3D1231: 0.65974
+  sysZ3D1232: 0.0
+  sysZ3D1233: 0.0
+  sysZ3D1234: 0.0
+  sysZ3D1235: -0.65974
+  sysZ3D1236: 0.0
+  sysZ3D1237: 0.0
+  sysZ3D1238: 0.0
+  sysZ3D1239: 0.0
+  sysZ3D1240: 0.0
+  sysZ3D1241: 0.0
+  sysZ3D1242: 0.0
+  sysZ3D1243: 0.0
+  sysZ3D1244: 1.31948
+  sysZ3D1245: -1.31948
+  sysZ3D1246: 0.0
+  sysZ3D1247: -0.65974
+  sysZ3D1248: -0.65974
+  sysZ3D1249: -0.65974
+  sysZ3D1250: 0.65974
+  sysZ3D1251: -1.97922000e+00
+  sysZ3D1252: -1.97922000e+00
+  sysZ3D1253: 0.0
+  sysZ3D1254: -0.65974
+  sysZ3D1255: -1.97922000e+00
+  sysZ3D1256: 0.0
+  sysZ3D1257: 1.31948
+  sysZ3D1258: 0.0
+  sysZ3D1259: 0.65974
+  sysZ3D1260: 0.65974
+  sysZ3D1261: 0.0
+  sysZ3D1262: 1.31948
+  sysZ3D1263: 2.63896
+  sysZ3D1264: 5.93766
+  sysZ3D1265: 0.65974
+  sysZ3D1266: -5.27792
+  sysZ3D1267: -1.97922000e+00
+  sysZ3D1268: 0.0
+  sysZ3D1269: 0.0
+  sysZ3D1270: 0.65974
+  sysZ3D1271: 1.31948
+  sysZ3D1272: 0.0
+  sysZ3D1273: 0.0
+  sysZ3D1274: -1.31948
+  sysZ3D1275: 2.63896
+  sys,uncor: 3.2987
+  ATLAS_LUMI: 118.7532
+- stat: 6.61870000e+00
+  sysZ3D1001: -1.8051
+  sysZ3D1002: 1.2034
+  sysZ3D1003: 0.0
+  sysZ3D1004: 0.0
+  sysZ3D1005: 0.0
+  sysZ3D1006: 0.0
+  sysZ3D1007: 0.0
+  sysZ3D1008: 0.0
+  sysZ3D1009: 0.0
+  sysZ3D1010: 0.0
+  sysZ3D1011: 0.0
+  sysZ3D1012: 0.0
+  sysZ3D1013: 0.0
+  sysZ3D1014: 0.0
+  sysZ3D1015: 0.0
+  sysZ3D1016: 0.0
+  sysZ3D1017: 0.0
+  sysZ3D1018: 0.0
+  sysZ3D1019: 0.0
+  sysZ3D1020: 0.0
+  sysZ3D1021: 0.0
+  sysZ3D1022: 0.0
+  sysZ3D1023: 0.0
+  sysZ3D1024: 0.0
+  sysZ3D1025: 0.0
+  sysZ3D1026: 0.0
+  sysZ3D1027: 0.0
+  sysZ3D1028: 0.0
+  sysZ3D1029: 0.0
+  sysZ3D1030: 0.0
+  sysZ3D1031: 0.0
+  sysZ3D1032: 0.0
+  sysZ3D1033: 0.0
+  sysZ3D1034: 0.0
+  sysZ3D1035: 0.0
+  sysZ3D1036: 0.0
+  sysZ3D1037: 0.0
+  sysZ3D1038: 0.0
+  sysZ3D1039: 0.0
+  sysZ3D1040: 0.0
+  sysZ3D1041: 0.0
+  sysZ3D1042: 0.6017
+  sysZ3D1043: 0.0
+  sysZ3D1044: 0.0
+  sysZ3D1045: 0.0
+  sysZ3D1046: 0.0
+  sysZ3D1047: 0.0
+  sysZ3D1048: 0.0
+  sysZ3D1049: 0.0
+  sysZ3D1050: 0.0
+  sysZ3D1051: 0.0
+  sysZ3D1052: 0.0
+  sysZ3D1053: 0.0
+  sysZ3D1054: 0.0
+  sysZ3D1055: 0.0
+  sysZ3D1056: 0.0
+  sysZ3D1057: 0.0
+  sysZ3D1058: 0.0
+  sysZ3D1059: 0.0
+  sysZ3D1060: 0.0
+  sysZ3D1061: 0.0
+  sysZ3D1062: 0.0
+  sysZ3D1063: 0.0
+  sysZ3D1064: 0.0
+  sysZ3D1065: 0.0
+  sysZ3D1066: 0.0
+  sysZ3D1067: 0.0
+  sysZ3D1068: 0.0
+  sysZ3D1069: 0.0
+  sysZ3D1070: 0.0
+  sysZ3D1071: 0.0
+  sysZ3D1072: 0.0
+  sysZ3D1073: 0.0
+  sysZ3D1074: 0.0
+  sysZ3D1075: 0.0
+  sysZ3D1076: 0.0
+  sysZ3D1077: 0.0
+  sysZ3D1078: 0.0
+  sysZ3D1079: 0.0
+  sysZ3D1080: 0.0
+  sysZ3D1081: 0.0
+  sysZ3D1082: 0.0
+  sysZ3D1083: 0.0
+  sysZ3D1084: 0.0
+  sysZ3D1085: 0.0
+  sysZ3D1086: 0.0
+  sysZ3D1087: 0.0
+  sysZ3D1088: 0.0
+  sysZ3D1089: 0.0
+  sysZ3D1090: 0.0
+  sysZ3D1091: 0.0
+  sysZ3D1092: 0.0
+  sysZ3D1093: 0.0
+  sysZ3D1094: 0.0
+  sysZ3D1095: 0.0
+  sysZ3D1096: 0.0
+  sysZ3D1097: 0.0
+  sysZ3D1098: 0.0
+  sysZ3D1099: 0.0
+  sysZ3D1100: 0.0
+  sysZ3D1101: 0.0
+  sysZ3D1102: 0.0
+  sysZ3D1103: 0.0
+  sysZ3D1104: 0.0
+  sysZ3D1105: -0.6017
+  sysZ3D1106: -0.6017
+  sysZ3D1107: 0.0
+  sysZ3D1108: 0.0
+  sysZ3D1109: 0.0
+  sysZ3D1110: 0.0
+  sysZ3D1111: 0.0
+  sysZ3D1112: 0.0
+  sysZ3D1113: 0.6017
+  sysZ3D1114: 0.0
+  sysZ3D1115: -0.6017
+  sysZ3D1116: -0.6017
+  sysZ3D1117: -0.6017
+  sysZ3D1118: 0.0
+  sysZ3D1119: 0.0
+  sysZ3D1120: 0.0
+  sysZ3D1121: 0.0
+  sysZ3D1122: 0.0
+  sysZ3D1123: -0.6017
+  sysZ3D1124: 0.0
+  sysZ3D1125: 0.0
+  sysZ3D1126: -2.4068
+  sysZ3D1127: 2.4068
+  sysZ3D1128: 0.0
+  sysZ3D1129: 0.0
+  sysZ3D1130: 0.0
+  sysZ3D1131: 0.0
+  sysZ3D1132: 0.0
+  sysZ3D1133: 0.0
+  sysZ3D1134: 0.6017
+  sysZ3D1135: 0.0
+  sysZ3D1136: 0.0
+  sysZ3D1137: 0.0
+  sysZ3D1138: 0.0
+  sysZ3D1139: 0.0
+  sysZ3D1140: 0.0
+  sysZ3D1141: 0.0
+  sysZ3D1142: 0.0
+  sysZ3D1143: 0.0
+  sysZ3D1144: 0.0
+  sysZ3D1145: 0.0
+  sysZ3D1146: 0.0
+  sysZ3D1147: 0.0
+  sysZ3D1148: 0.0
+  sysZ3D1149: 0.0
+  sysZ3D1150: 0.0
+  sysZ3D1151: 0.0
+  sysZ3D1152: 0.0
+  sysZ3D1153: 0.0
+  sysZ3D1154: 0.0
+  sysZ3D1155: 0.0
+  sysZ3D1156: 0.0
+  sysZ3D1157: 0.0
+  sysZ3D1158: 0.0
+  sysZ3D1159: -0.6017
+  sysZ3D1160: 0.0
+  sysZ3D1161: 0.0
+  sysZ3D1162: 0.0
+  sysZ3D1163: 0.0
+  sysZ3D1164: 0.0
+  sysZ3D1165: 0.0
+  sysZ3D1166: 0.0
+  sysZ3D1167: 0.0
+  sysZ3D1168: 0.0
+  sysZ3D1169: 0.0
+  sysZ3D1170: -0.6017
+  sysZ3D1171: 0.0
+  sysZ3D1172: 0.0
+  sysZ3D1173: 0.0
+  sysZ3D1174: 0.0
+  sysZ3D1175: 0.0
+  sysZ3D1176: 0.0
+  sysZ3D1177: -0.6017
+  sysZ3D1178: 0.0
+  sysZ3D1179: 0.0
+  sysZ3D1180: 0.0
+  sysZ3D1181: 0.0
+  sysZ3D1182: 0.0
+  sysZ3D1183: 0.0
+  sysZ3D1184: 0.0
+  sysZ3D1185: 0.0
+  sysZ3D1186: 0.0
+  sysZ3D1187: 0.0
+  sysZ3D1188: 0.0
+  sysZ3D1189: 0.0
+  sysZ3D1190: 0.0
+  sysZ3D1191: 0.0
+  sysZ3D1192: 0.0
+  sysZ3D1193: 0.0
+  sysZ3D1194: -7.8221
+  sysZ3D1195: 0.0
+  sysZ3D1196: 0.0
+  sysZ3D1197: 0.0
+  sysZ3D1198: 0.0
+  sysZ3D1199: 0.0
+  sysZ3D1200: -0.6017
+  sysZ3D1201: -0.6017
+  sysZ3D1202: 0.0
+  sysZ3D1203: -1.2034
+  sysZ3D1204: 0.0
+  sysZ3D1205: 0.0
+  sysZ3D1206: 0.6017
+  sysZ3D1207: 0.0
+  sysZ3D1208: 0.0
+  sysZ3D1209: 0.0
+  sysZ3D1210: -0.6017
+  sysZ3D1211: 0.0
+  sysZ3D1212: 0.0
+  sysZ3D1213: -0.6017
+  sysZ3D1214: -0.6017
+  sysZ3D1215: -1.8051
+  sysZ3D1216: 0.0
+  sysZ3D1217: 1.2034
+  sysZ3D1218: 0.6017
+  sysZ3D1219: 0.6017
+  sysZ3D1220: 0.0
+  sysZ3D1221: 0.0
+  sysZ3D1222: 0.0
+  sysZ3D1223: 0.0
+  sysZ3D1224: 0.0
+  sysZ3D1225: 0.0
+  sysZ3D1226: 0.6017
+  sysZ3D1227: 0.6017
+  sysZ3D1228: 0.6017
+  sysZ3D1229: 0.0
+  sysZ3D1230: 0.6017
+  sysZ3D1231: 0.6017
+  sysZ3D1232: 0.0
+  sysZ3D1233: 0.0
+  sysZ3D1234: 0.0
+  sysZ3D1235: 0.0
+  sysZ3D1236: 0.0
+  sysZ3D1237: 0.0
+  sysZ3D1238: 0.0
+  sysZ3D1239: 0.0
+  sysZ3D1240: 0.0
+  sysZ3D1241: 0.0
+  sysZ3D1242: 0.0
+  sysZ3D1243: 0.0
+  sysZ3D1244: 1.2034
+  sysZ3D1245: -1.2034
+  sysZ3D1246: 0.6017
+  sysZ3D1247: -0.6017
+  sysZ3D1248: -0.6017
+  sysZ3D1249: -0.6017
+  sysZ3D1250: 0.6017
+  sysZ3D1251: -1.8051
+  sysZ3D1252: -1.2034
+  sysZ3D1253: 0.0
+  sysZ3D1254: -0.6017
+  sysZ3D1255: -1.8051
+  sysZ3D1256: -0.6017
+  sysZ3D1257: 0.6017
+  sysZ3D1258: 0.0
+  sysZ3D1259: 0.6017
+  sysZ3D1260: 0.6017
+  sysZ3D1261: 0.0
+  sysZ3D1262: 0.6017
+  sysZ3D1263: 2.4068
+  sysZ3D1264: 6.017
+  sysZ3D1265: 0.6017
+  sysZ3D1266: -5.4153
+  sysZ3D1267: -1.8051
+  sysZ3D1268: 0.0
+  sysZ3D1269: 0.0
+  sysZ3D1270: 0.6017
+  sysZ3D1271: 1.2034
+  sysZ3D1272: 0.0
+  sysZ3D1273: 0.0
+  sysZ3D1274: -1.2034
+  sysZ3D1275: 3.0085
+  sys,uncor: 3.0085
+  ATLAS_LUMI: 108.306
+- stat: 5.7299
+  sysZ3D1001: -2.0836
+  sysZ3D1002: 0.5209
+  sysZ3D1003: 0.0
+  sysZ3D1004: 0.0
+  sysZ3D1005: 0.0
+  sysZ3D1006: 0.0
+  sysZ3D1007: 0.0
+  sysZ3D1008: 0.0
+  sysZ3D1009: 0.0
+  sysZ3D1010: 0.0
+  sysZ3D1011: 0.0
+  sysZ3D1012: 0.0
+  sysZ3D1013: 0.0
+  sysZ3D1014: 0.0
+  sysZ3D1015: 0.0
+  sysZ3D1016: 0.0
+  sysZ3D1017: 0.0
+  sysZ3D1018: 0.0
+  sysZ3D1019: 0.0
+  sysZ3D1020: 0.0
+  sysZ3D1021: 0.0
+  sysZ3D1022: 0.0
+  sysZ3D1023: 0.0
+  sysZ3D1024: 0.0
+  sysZ3D1025: 0.0
+  sysZ3D1026: 0.0
+  sysZ3D1027: 0.0
+  sysZ3D1028: 0.0
+  sysZ3D1029: 0.0
+  sysZ3D1030: 0.0
+  sysZ3D1031: 0.0
+  sysZ3D1032: 0.0
+  sysZ3D1033: 0.0
+  sysZ3D1034: 0.0
+  sysZ3D1035: 0.0
+  sysZ3D1036: 0.0
+  sysZ3D1037: 0.0
+  sysZ3D1038: 0.0
+  sysZ3D1039: 0.0
+  sysZ3D1040: 0.5209
+  sysZ3D1041: 0.0
+  sysZ3D1042: 0.0
+  sysZ3D1043: 0.0
+  sysZ3D1044: 0.0
+  sysZ3D1045: 0.0
+  sysZ3D1046: 0.0
+  sysZ3D1047: 0.0
+  sysZ3D1048: 0.0
+  sysZ3D1049: 0.0
+  sysZ3D1050: 0.5209
+  sysZ3D1051: 0.0
+  sysZ3D1052: 0.0
+  sysZ3D1053: 0.0
+  sysZ3D1054: 0.0
+  sysZ3D1055: 0.0
+  sysZ3D1056: 0.0
+  sysZ3D1057: 0.0
+  sysZ3D1058: 0.0
+  sysZ3D1059: 0.0
+  sysZ3D1060: 0.0
+  sysZ3D1061: 0.5209
+  sysZ3D1062: 0.0
+  sysZ3D1063: 0.0
+  sysZ3D1064: 0.0
+  sysZ3D1065: 0.0
+  sysZ3D1066: 0.0
+  sysZ3D1067: 0.0
+  sysZ3D1068: 0.0
+  sysZ3D1069: 0.0
+  sysZ3D1070: 0.0
+  sysZ3D1071: 0.0
+  sysZ3D1072: 0.0
+  sysZ3D1073: 0.0
+  sysZ3D1074: 0.0
+  sysZ3D1075: 0.0
+  sysZ3D1076: 0.0
+  sysZ3D1077: 0.0
+  sysZ3D1078: 0.0
+  sysZ3D1079: 0.0
+  sysZ3D1080: 0.0
+  sysZ3D1081: 0.0
+  sysZ3D1082: 0.0
+  sysZ3D1083: 0.0
+  sysZ3D1084: 0.0
+  sysZ3D1085: 0.0
+  sysZ3D1086: 0.0
+  sysZ3D1087: 0.0
+  sysZ3D1088: 0.0
+  sysZ3D1089: 0.0
+  sysZ3D1090: 0.0
+  sysZ3D1091: 0.0
+  sysZ3D1092: 0.0
+  sysZ3D1093: 0.0
+  sysZ3D1094: 0.0
+  sysZ3D1095: 0.0
+  sysZ3D1096: 0.0
+  sysZ3D1097: 0.0
+  sysZ3D1098: 0.0
+  sysZ3D1099: 0.0
+  sysZ3D1100: 0.0
+  sysZ3D1101: 0.0
+  sysZ3D1102: 0.0
+  sysZ3D1103: 0.0
+  sysZ3D1104: 0.0
+  sysZ3D1105: -0.5209
+  sysZ3D1106: -0.5209
+  sysZ3D1107: 0.0
+  sysZ3D1108: 0.0
+  sysZ3D1109: 0.0
+  sysZ3D1110: 0.0
+  sysZ3D1111: 0.0
+  sysZ3D1112: 0.0
+  sysZ3D1113: 1.0418
+  sysZ3D1114: 0.0
+  sysZ3D1115: 0.0
+  sysZ3D1116: -0.5209
+  sysZ3D1117: 0.0
+  sysZ3D1118: 0.0
+  sysZ3D1119: 0.0
+  sysZ3D1120: 0.0
+  sysZ3D1121: 0.0
+  sysZ3D1122: 0.0
+  sysZ3D1123: -0.5209
+  sysZ3D1124: 0.5209
+  sysZ3D1125: -0.5209
+  sysZ3D1126: -2.0836
+  sysZ3D1127: 1.0418
+  sysZ3D1128: 0.0
+  sysZ3D1129: 0.0
+  sysZ3D1130: 0.0
+  sysZ3D1131: 0.0
+  sysZ3D1132: 0.0
+  sysZ3D1133: 0.0
+  sysZ3D1134: 0.0
+  sysZ3D1135: 0.0
+  sysZ3D1136: 0.0
+  sysZ3D1137: 0.0
+  sysZ3D1138: 0.0
+  sysZ3D1139: 0.0
+  sysZ3D1140: 0.0
+  sysZ3D1141: 0.0
+  sysZ3D1142: 0.0
+  sysZ3D1143: 0.0
+  sysZ3D1144: 0.0
+  sysZ3D1145: 0.0
+  sysZ3D1146: 0.0
+  sysZ3D1147: 0.0
+  sysZ3D1148: 0.0
+  sysZ3D1149: 0.0
+  sysZ3D1150: 0.0
+  sysZ3D1151: 0.0
+  sysZ3D1152: 0.0
+  sysZ3D1153: 0.0
+  sysZ3D1154: 0.0
+  sysZ3D1155: 0.0
+  sysZ3D1156: 0.0
+  sysZ3D1157: 0.0
+  sysZ3D1158: 0.0
+  sysZ3D1159: 0.0
+  sysZ3D1160: 0.5209
+  sysZ3D1161: 0.0
+  sysZ3D1162: 0.0
+  sysZ3D1163: 0.5209
+  sysZ3D1164: 0.0
+  sysZ3D1165: 0.5209
+  sysZ3D1166: 0.0
+  sysZ3D1167: 0.0
+  sysZ3D1168: 0.0
+  sysZ3D1169: 0.0
+  sysZ3D1170: 0.0
+  sysZ3D1171: 0.0
+  sysZ3D1172: 0.0
+  sysZ3D1173: 0.0
+  sysZ3D1174: 0.0
+  sysZ3D1175: 0.0
+  sysZ3D1176: 0.0
+  sysZ3D1177: 0.0
+  sysZ3D1178: 0.0
+  sysZ3D1179: -0.5209
+  sysZ3D1180: 0.0
+  sysZ3D1181: 0.0
+  sysZ3D1182: 0.0
+  sysZ3D1183: 0.0
+  sysZ3D1184: 0.0
+  sysZ3D1185: 0.0
+  sysZ3D1186: 0.0
+  sysZ3D1187: 0.0
+  sysZ3D1188: 0.0
+  sysZ3D1189: 0.0
+  sysZ3D1190: 0.0
+  sysZ3D1191: 0.0
+  sysZ3D1192: 0.0
+  sysZ3D1193: 0.0
+  sysZ3D1194: -6.77170000e+00
+  sysZ3D1195: 0.5209
+  sysZ3D1196: 0.0
+  sysZ3D1197: 0.5209
+  sysZ3D1198: 0.0
+  sysZ3D1199: -0.5209
+  sysZ3D1200: -0.5209
+  sysZ3D1201: -0.5209
+  sysZ3D1202: 0.0
+  sysZ3D1203: -1.0418
+  sysZ3D1204: 0.5209
+  sysZ3D1205: 0.0
+  sysZ3D1206: 0.5209
+  sysZ3D1207: 0.0
+  sysZ3D1208: 0.0
+  sysZ3D1209: 0.0
+  sysZ3D1210: -0.5209
+  sysZ3D1211: 0.0
+  sysZ3D1212: 0.0
+  sysZ3D1213: 0.0
+  sysZ3D1214: -0.5209
+  sysZ3D1215: -1.56270000e+00
+  sysZ3D1216: 0.0
+  sysZ3D1217: 1.0418
+  sysZ3D1218: 0.5209
+  sysZ3D1219: 0.5209
+  sysZ3D1220: 0.0
+  sysZ3D1221: 0.0
+  sysZ3D1222: 0.0
+  sysZ3D1223: 0.0
+  sysZ3D1224: 0.5209
+  sysZ3D1225: 0.5209
+  sysZ3D1226: 0.0
+  sysZ3D1227: 0.5209
+  sysZ3D1228: 0.0
+  sysZ3D1229: 0.0
+  sysZ3D1230: 0.0
+  sysZ3D1231: 0.5209
+  sysZ3D1232: 0.0
+  sysZ3D1233: 0.0
+  sysZ3D1234: 0.0
+  sysZ3D1235: 0.0
+  sysZ3D1236: 0.0
+  sysZ3D1237: 0.0
+  sysZ3D1238: 0.0
+  sysZ3D1239: 0.0
+  sysZ3D1240: 0.0
+  sysZ3D1241: 0.0
+  sysZ3D1242: 0.0
+  sysZ3D1243: 0.0
+  sysZ3D1244: 1.0418
+  sysZ3D1245: -1.0418
+  sysZ3D1246: 0.5209
+  sysZ3D1247: -0.5209
+  sysZ3D1248: -1.0418
+  sysZ3D1249: -0.5209
+  sysZ3D1250: 0.0
+  sysZ3D1251: -1.0418
+  sysZ3D1252: -0.5209
+  sysZ3D1253: 0.0
+  sysZ3D1254: -0.5209
+  sysZ3D1255: -2.0836
+  sysZ3D1256: -0.5209
+  sysZ3D1257: 1.0418
+  sysZ3D1258: -0.5209
+  sysZ3D1259: 0.5209
+  sysZ3D1260: 0.5209
+  sysZ3D1261: 0.0
+  sysZ3D1262: 1.0418
+  sysZ3D1263: 2.0836
+  sysZ3D1264: 4.68810000e+00
+  sysZ3D1265: 0.5209
+  sysZ3D1266: -5.20900000e+00
+  sysZ3D1267: -1.56270000e+00
+  sysZ3D1268: 0.5209
+  sysZ3D1269: -0.5209
+  sysZ3D1270: 0.5209
+  sysZ3D1271: 1.0418
+  sysZ3D1272: 0.0
+  sysZ3D1273: 0.0
+  sysZ3D1274: -1.0418
+  sysZ3D1275: 2.60450000e+00
+  sys,uncor: 3.12540000e+00
+  ATLAS_LUMI: 9.37620000e+01
+- stat: 5.49588
+  sysZ3D1001: -1.69104
+  sysZ3D1002: 0.42276
+  sysZ3D1003: 0.0
+  sysZ3D1004: 0.0
+  sysZ3D1005: 0.0
+  sysZ3D1006: 0.0
+  sysZ3D1007: 0.0
+  sysZ3D1008: 0.0
+  sysZ3D1009: 0.0
+  sysZ3D1010: 0.0
+  sysZ3D1011: 0.0
+  sysZ3D1012: 0.0
+  sysZ3D1013: 0.0
+  sysZ3D1014: 0.0
+  sysZ3D1015: 0.0
+  sysZ3D1016: 0.0
+  sysZ3D1017: 0.0
+  sysZ3D1018: 0.0
+  sysZ3D1019: 0.0
+  sysZ3D1020: 0.0
+  sysZ3D1021: 0.0
+  sysZ3D1022: 0.0
+  sysZ3D1023: 0.42276
+  sysZ3D1024: 0.0
+  sysZ3D1025: 0.42276
+  sysZ3D1026: 0.0
+  sysZ3D1027: 0.0
+  sysZ3D1028: 0.0
+  sysZ3D1029: 0.0
+  sysZ3D1030: 0.0
+  sysZ3D1031: 0.0
+  sysZ3D1032: 0.0
+  sysZ3D1033: 0.0
+  sysZ3D1034: 0.0
+  sysZ3D1035: 0.0
+  sysZ3D1036: 0.0
+  sysZ3D1037: 0.0
+  sysZ3D1038: 0.0
+  sysZ3D1039: 0.0
+  sysZ3D1040: 0.0
+  sysZ3D1041: 0.0
+  sysZ3D1042: 0.0
+  sysZ3D1043: 0.0
+  sysZ3D1044: 0.0
+  sysZ3D1045: 0.0
+  sysZ3D1046: 0.0
+  sysZ3D1047: 0.0
+  sysZ3D1048: 0.0
   sysZ3D1049: 0.0
   sysZ3D1050: -0.42276
   sysZ3D1051: -0.42276
   sysZ3D1052: 0.0
   sysZ3D1053: 0.0
   sysZ3D1054: 0.0
-  sysZ3D1055: -0.0
+  sysZ3D1055: 0.0
   sysZ3D1056: 0.0
   sysZ3D1057: 0.0
-  sysZ3D1058: -0.0
-  sysZ3D1059: -0.0
-  sysZ3D1060: -0.0
-  sysZ3D1061: -0.0
-  sysZ3D1062: -0.0
-  sysZ3D1063: -0.0
+  sysZ3D1058: 0.0
+  sysZ3D1059: 0.0
+  sysZ3D1060: 0.0
+  sysZ3D1061: 0.0
+  sysZ3D1062: 0.0
+  sysZ3D1063: 0.0
   sysZ3D1064: 0.0
-  sysZ3D1065: -0.0
+  sysZ3D1065: 0.0
   sysZ3D1066: 0.0
   sysZ3D1067: 0.0
-  sysZ3D1068: -0.0
+  sysZ3D1068: 0.0
   sysZ3D1069: 0.0
-  sysZ3D1070: -0.0
-  sysZ3D1071: -0.0
+  sysZ3D1070: 0.0
+  sysZ3D1071: 0.0
   sysZ3D1072: 0.0
-  sysZ3D1073: -0.0
-  sysZ3D1074: -0.0
+  sysZ3D1073: 0.0
+  sysZ3D1074: 0.0
   sysZ3D1075: 0.0
   sysZ3D1076: 0.0
-  sysZ3D1077: -0.0
+  sysZ3D1077: 0.0
   sysZ3D1078: 0.0
   sysZ3D1079: 0.0
-  sysZ3D1080: -0.0
-  sysZ3D1081: -0.0
-  sysZ3D1082: -0.0
-  sysZ3D1083: -0.0
+  sysZ3D1080: 0.0
+  sysZ3D1081: 0.0
+  sysZ3D1082: 0.0
+  sysZ3D1083: 0.0
   sysZ3D1084: 0.0
   sysZ3D1085: 0.0
   sysZ3D1086: 0.0
   sysZ3D1087: 0.0
   sysZ3D1088: 0.0
-  sysZ3D1089: -0.0
-  sysZ3D1090: -0.0
-  sysZ3D1091: -0.0
-  sysZ3D1092: -0.0
-  sysZ3D1093: -0.0
-  sysZ3D1094: -0.0
+  sysZ3D1089: 0.0
+  sysZ3D1090: 0.0
+  sysZ3D1091: 0.0
+  sysZ3D1092: 0.0
+  sysZ3D1093: 0.0
+  sysZ3D1094: 0.0
   sysZ3D1095: 0.0
   sysZ3D1096: 0.0
-  sysZ3D1097: -0.0
-  sysZ3D1098: -0.0
+  sysZ3D1097: 0.0
+  sysZ3D1098: 0.0
   sysZ3D1099: 0.0
-  sysZ3D1100: -0.0
-  sysZ3D1101: -0.0
+  sysZ3D1100: 0.0
+  sysZ3D1101: 0.0
   sysZ3D1102: 0.0
-  sysZ3D1103: -0.0
-  sysZ3D1104: -0.0
+  sysZ3D1103: 0.0
+  sysZ3D1104: 0.0
   sysZ3D1105: -0.42276
   sysZ3D1106: -0.42276
-  sysZ3D1107: -0.0
+  sysZ3D1107: 0.0
   sysZ3D1108: 0.0
-  sysZ3D1109: -0.0
+  sysZ3D1109: 0.0
   sysZ3D1110: 0.0
-  sysZ3D1111: -0.0
-  sysZ3D1112: -0.0
+  sysZ3D1111: 0.0
+  sysZ3D1112: 0.0
   sysZ3D1113: 0.84552
   sysZ3D1114: -0.42276
   sysZ3D1115: -0.84552
-  sysZ3D1116: -0.0
+  sysZ3D1116: 0.0
   sysZ3D1117: 0.42276
   sysZ3D1118: 0.0
   sysZ3D1119: 0.0
-  sysZ3D1120: -0.0
-  sysZ3D1121: -0.0
+  sysZ3D1120: 0.0
+  sysZ3D1121: 0.0
   sysZ3D1122: 0.0
-  sysZ3D1123: -0.0
+  sysZ3D1123: 0.0
   sysZ3D1124: -0.42276
   sysZ3D1125: 0.0
   sysZ3D1126: -1.69104
   sysZ3D1127: 1.26828000e+00
-  sysZ3D1128: -0.0
+  sysZ3D1128: 0.0
   sysZ3D1129: 0.0
   sysZ3D1130: 0.0
-  sysZ3D1131: -0.0
+  sysZ3D1131: 0.0
   sysZ3D1132: 0.42276
-  sysZ3D1133: -0.0
+  sysZ3D1133: 0.0
   sysZ3D1134: -0.42276
   sysZ3D1135: 0.0
   sysZ3D1136: 0.0
-  sysZ3D1137: -0.0
+  sysZ3D1137: 0.0
   sysZ3D1138: 0.0
   sysZ3D1139: 0.0
-  sysZ3D1140: -0.0
-  sysZ3D1141: -0.0
-  sysZ3D1142: -0.0
+  sysZ3D1140: 0.0
+  sysZ3D1141: 0.0
+  sysZ3D1142: 0.0
   sysZ3D1143: 0.0
   sysZ3D1144: 0.0
-  sysZ3D1145: -0.0
+  sysZ3D1145: 0.0
   sysZ3D1146: 0.0
   sysZ3D1147: 0.0
-  sysZ3D1148: -0.0
+  sysZ3D1148: 0.0
   sysZ3D1149: 0.0
-  sysZ3D1150: -0.0
-  sysZ3D1151: -0.0
+  sysZ3D1150: 0.0
+  sysZ3D1151: 0.0
   sysZ3D1152: 0.0
   sysZ3D1153: 0.0
-  sysZ3D1154: -0.0
-  sysZ3D1155: -0.0
+  sysZ3D1154: 0.0
+  sysZ3D1155: 0.0
   sysZ3D1156: 0.0
-  sysZ3D1157: -0.0
+  sysZ3D1157: 0.0
   sysZ3D1158: 0.0
-  sysZ3D1159: -0.0
-  sysZ3D1160: -0.0
-  sysZ3D1161: -0.0
-  sysZ3D1162: -0.0
-  sysZ3D1163: -0.0
-  sysZ3D1164: -0.0
+  sysZ3D1159: 0.0
+  sysZ3D1160: 0.0
+  sysZ3D1161: 0.0
+  sysZ3D1162: 0.0
+  sysZ3D1163: 0.0
+  sysZ3D1164: 0.0
   sysZ3D1165: -0.42276
-  sysZ3D1166: -0.0
-  sysZ3D1167: -0.0
+  sysZ3D1166: 0.0
+  sysZ3D1167: 0.0
   sysZ3D1168: 0.0
   sysZ3D1169: 0.0
-  sysZ3D1170: -0.0
+  sysZ3D1170: 0.0
   sysZ3D1171: 0.0
-  sysZ3D1172: -0.0
-  sysZ3D1173: -0.0
-  sysZ3D1174: -0.0
+  sysZ3D1172: 0.0
+  sysZ3D1173: 0.0
+  sysZ3D1174: 0.0
   sysZ3D1175: 0.0
-  sysZ3D1176: -0.0
+  sysZ3D1176: 0.0
   sysZ3D1177: -0.42276
   sysZ3D1178: 0.0
-  sysZ3D1179: -0.0
+  sysZ3D1179: 0.0
   sysZ3D1180: 0.0
   sysZ3D1181: 0.0
   sysZ3D1182: 0.0
-  sysZ3D1183: -0.0
+  sysZ3D1183: 0.0
   sysZ3D1184: 0.0
   sysZ3D1185: 0.0
   sysZ3D1186: 0.0
-  sysZ3D1187: -0.0
+  sysZ3D1187: 0.0
   sysZ3D1188: 0.0
   sysZ3D1189: 0.0
   sysZ3D1190: 0.0
   sysZ3D1191: 0.0
-  sysZ3D1192: -0.0
+  sysZ3D1192: 0.0
   sysZ3D1193: 0.42276
   sysZ3D1194: -5.49588
   sysZ3D1195: 0.42276
@@ -13552,22 +13552,22 @@ bins:
   sysZ3D1205: 0.42276
   sysZ3D1206: 0.42276
   sysZ3D1207: 0.0
-  sysZ3D1208: -0.0
-  sysZ3D1209: -0.0
+  sysZ3D1208: 0.0
+  sysZ3D1209: 0.0
   sysZ3D1210: -0.42276
-  sysZ3D1211: -0.0
-  sysZ3D1212: -0.0
-  sysZ3D1213: -0.0
+  sysZ3D1211: 0.0
+  sysZ3D1212: 0.0
+  sysZ3D1213: 0.0
   sysZ3D1214: -0.42276
   sysZ3D1215: -0.84552
   sysZ3D1216: 0.0
   sysZ3D1217: 1.26828000e+00
   sysZ3D1218: 0.42276
   sysZ3D1219: 0.42276
-  sysZ3D1220: -0.0
+  sysZ3D1220: 0.0
   sysZ3D1221: -0.42276
-  sysZ3D1222: -0.0
-  sysZ3D1223: -0.0
+  sysZ3D1222: 0.0
+  sysZ3D1223: 0.0
   sysZ3D1224: 0.0
   sysZ3D1225: 0.42276
   sysZ3D1226: 0.42276
@@ -13576,22 +13576,22 @@ bins:
   sysZ3D1229: 0.0
   sysZ3D1230: 0.0
   sysZ3D1231: 0.42276
-  sysZ3D1232: -0.0
-  sysZ3D1233: -0.0
-  sysZ3D1234: -0.0
-  sysZ3D1235: -0.0
+  sysZ3D1232: 0.0
+  sysZ3D1233: 0.0
+  sysZ3D1234: 0.0
+  sysZ3D1235: 0.0
   sysZ3D1236: 0.0
   sysZ3D1237: 0.0
   sysZ3D1238: 0.42276
-  sysZ3D1239: -0.0
-  sysZ3D1240: -0.0
+  sysZ3D1239: 0.0
+  sysZ3D1240: 0.0
   sysZ3D1241: 0.0
   sysZ3D1242: 0.0
   sysZ3D1243: 0.0
   sysZ3D1244: 0.84552
   sysZ3D1245: -0.42276
   sysZ3D1246: 0.42276
-  sysZ3D1247: -0.0
+  sysZ3D1247: 0.0
   sysZ3D1248: -1.26828000e+00
   sysZ3D1249: -0.42276
   sysZ3D1250: 0.0
@@ -13602,7 +13602,7 @@ bins:
   sysZ3D1255: -1.69104
   sysZ3D1256: -0.42276
   sysZ3D1257: 0.42276
-  sysZ3D1258: -0.0
+  sysZ3D1258: 0.0
   sysZ3D1259: 0.42276
   sysZ3D1260: 0.0
   sysZ3D1261: 0.0
@@ -13617,7 +13617,7 @@ bins:
   sysZ3D1270: 0.0
   sysZ3D1271: 0.84552
   sysZ3D1272: 0.42276
-  sysZ3D1273: -0.0
+  sysZ3D1273: 0.0
   sysZ3D1274: -0.84552
   sysZ3D1275: 2.53656000e+00
   sys,uncor: 2.53656000e+00
@@ -13625,7 +13625,7 @@ bins:
 - stat: 4.6041
   sysZ3D1001: -1.5347
   sysZ3D1002: 0.30694
-  sysZ3D1003: -0.0
+  sysZ3D1003: 0.0
   sysZ3D1004: 0.0
   sysZ3D1005: 0.0
   sysZ3D1006: 0.0
@@ -13642,143 +13642,143 @@ bins:
   sysZ3D1017: 0.0
   sysZ3D1018: 0.0
   sysZ3D1019: 0.0
-  sysZ3D1020: -0.0
+  sysZ3D1020: 0.0
   sysZ3D1021: 0.0
   sysZ3D1022: 0.0
   sysZ3D1023: 0.0
   sysZ3D1024: 0.0
   sysZ3D1025: 0.0
-  sysZ3D1026: -0.0
+  sysZ3D1026: 0.0
   sysZ3D1027: 0.0
-  sysZ3D1028: -0.0
+  sysZ3D1028: 0.0
   sysZ3D1029: 0.0
-  sysZ3D1030: -0.0
+  sysZ3D1030: 0.0
   sysZ3D1031: 0.0
-  sysZ3D1032: -0.0
-  sysZ3D1033: -0.0
-  sysZ3D1034: -0.0
+  sysZ3D1032: 0.0
+  sysZ3D1033: 0.0
+  sysZ3D1034: 0.0
   sysZ3D1035: 0.0
-  sysZ3D1036: -0.0
+  sysZ3D1036: 0.0
   sysZ3D1037: 0.0
-  sysZ3D1038: -0.0
+  sysZ3D1038: 0.0
   sysZ3D1039: 0.0
-  sysZ3D1040: -0.0
-  sysZ3D1041: -0.0
-  sysZ3D1042: -0.0
+  sysZ3D1040: 0.0
+  sysZ3D1041: 0.0
+  sysZ3D1042: 0.0
   sysZ3D1043: 0.30694
-  sysZ3D1044: -0.0
-  sysZ3D1045: -0.0
-  sysZ3D1046: -0.0
+  sysZ3D1044: 0.0
+  sysZ3D1045: 0.0
+  sysZ3D1046: 0.0
   sysZ3D1047: 0.0
   sysZ3D1048: 0.0
   sysZ3D1049: 0.0
-  sysZ3D1050: -0.0
+  sysZ3D1050: 0.0
   sysZ3D1051: 0.0
   sysZ3D1052: 0.0
-  sysZ3D1053: -0.0
-  sysZ3D1054: -0.0
+  sysZ3D1053: 0.0
+  sysZ3D1054: 0.0
   sysZ3D1055: 0.0
   sysZ3D1056: 0.0
-  sysZ3D1057: -0.0
-  sysZ3D1058: -0.0
+  sysZ3D1057: 0.0
+  sysZ3D1058: 0.0
   sysZ3D1059: 0.0
-  sysZ3D1060: -0.0
-  sysZ3D1061: -0.0
+  sysZ3D1060: 0.0
+  sysZ3D1061: 0.0
   sysZ3D1062: -0.30694
   sysZ3D1063: 0.0
-  sysZ3D1064: -0.0
+  sysZ3D1064: 0.0
   sysZ3D1065: 0.30694
-  sysZ3D1066: -0.0
-  sysZ3D1067: -0.0
+  sysZ3D1066: 0.0
+  sysZ3D1067: 0.0
   sysZ3D1068: 0.0
-  sysZ3D1069: -0.0
-  sysZ3D1070: -0.0
+  sysZ3D1069: 0.0
+  sysZ3D1070: 0.0
   sysZ3D1071: 0.0
   sysZ3D1072: -0.30694
   sysZ3D1073: 0.0
   sysZ3D1074: 0.0
-  sysZ3D1075: -0.0
+  sysZ3D1075: 0.0
   sysZ3D1076: 0.0
   sysZ3D1077: 0.0
-  sysZ3D1078: -0.0
+  sysZ3D1078: 0.0
   sysZ3D1079: 0.0
   sysZ3D1080: 0.0
-  sysZ3D1081: -0.0
+  sysZ3D1081: 0.0
   sysZ3D1082: 0.0
   sysZ3D1083: 0.0
-  sysZ3D1084: -0.0
+  sysZ3D1084: 0.0
   sysZ3D1085: 0.0
   sysZ3D1086: 0.0
-  sysZ3D1087: -0.0
-  sysZ3D1088: -0.0
+  sysZ3D1087: 0.0
+  sysZ3D1088: 0.0
   sysZ3D1089: 0.0
   sysZ3D1090: 0.0
   sysZ3D1091: 0.0
   sysZ3D1092: 0.0
   sysZ3D1093: 0.0
-  sysZ3D1094: -0.0
-  sysZ3D1095: -0.0
-  sysZ3D1096: -0.0
+  sysZ3D1094: 0.0
+  sysZ3D1095: 0.0
+  sysZ3D1096: 0.0
   sysZ3D1097: 0.0
   sysZ3D1098: 0.0
   sysZ3D1099: 0.0
   sysZ3D1100: 0.0
-  sysZ3D1101: -0.0
+  sysZ3D1101: 0.0
   sysZ3D1102: 0.0
   sysZ3D1103: 0.0
-  sysZ3D1104: -0.0
+  sysZ3D1104: 0.0
   sysZ3D1105: -0.30694
   sysZ3D1106: -0.30694
-  sysZ3D1107: -0.0
+  sysZ3D1107: 0.0
   sysZ3D1108: 0.0
   sysZ3D1109: 0.0
   sysZ3D1110: 0.0
-  sysZ3D1111: -0.0
-  sysZ3D1112: -0.0
+  sysZ3D1111: 0.0
+  sysZ3D1112: 0.0
   sysZ3D1113: 0.30694
-  sysZ3D1114: -0.0
-  sysZ3D1115: -0.0
+  sysZ3D1114: 0.0
+  sysZ3D1115: 0.0
   sysZ3D1116: 0.30694
-  sysZ3D1117: -0.0
-  sysZ3D1118: -0.0
-  sysZ3D1119: -0.0
+  sysZ3D1117: 0.0
+  sysZ3D1118: 0.0
+  sysZ3D1119: 0.0
   sysZ3D1120: 0.0
-  sysZ3D1121: -0.0
+  sysZ3D1121: 0.0
   sysZ3D1122: 0.0
   sysZ3D1123: 0.30694
   sysZ3D1124: -0.30694
-  sysZ3D1125: -0.0
+  sysZ3D1125: 0.0
   sysZ3D1126: -1.22776
-  sysZ3D1127: -0.0
-  sysZ3D1128: -0.0
-  sysZ3D1129: -0.0
+  sysZ3D1127: 0.0
+  sysZ3D1128: 0.0
+  sysZ3D1129: 0.0
   sysZ3D1130: 0.0
-  sysZ3D1131: -0.0
+  sysZ3D1131: 0.0
   sysZ3D1132: 0.0
   sysZ3D1133: 0.0
-  sysZ3D1134: -0.0
+  sysZ3D1134: 0.0
   sysZ3D1135: 0.0
   sysZ3D1136: 0.0
   sysZ3D1137: 0.0
   sysZ3D1138: 0.0
-  sysZ3D1139: -0.0
-  sysZ3D1140: -0.0
-  sysZ3D1141: -0.0
-  sysZ3D1142: -0.0
+  sysZ3D1139: 0.0
+  sysZ3D1140: 0.0
+  sysZ3D1141: 0.0
+  sysZ3D1142: 0.0
   sysZ3D1143: 0.0
-  sysZ3D1144: -0.0
-  sysZ3D1145: -0.0
-  sysZ3D1146: -0.0
+  sysZ3D1144: 0.0
+  sysZ3D1145: 0.0
+  sysZ3D1146: 0.0
   sysZ3D1147: 0.0
-  sysZ3D1148: -0.0
+  sysZ3D1148: 0.0
   sysZ3D1149: 0.0
-  sysZ3D1150: -0.0
-  sysZ3D1151: -0.0
-  sysZ3D1152: -0.0
+  sysZ3D1150: 0.0
+  sysZ3D1151: 0.0
+  sysZ3D1152: 0.0
   sysZ3D1153: 0.0
-  sysZ3D1154: -0.0
-  sysZ3D1155: -0.0
-  sysZ3D1156: -0.0
+  sysZ3D1154: 0.0
+  sysZ3D1155: 0.0
+  sysZ3D1156: 0.0
   sysZ3D1157: 0.0
   sysZ3D1158: 0.0
   sysZ3D1159: 0.0
@@ -13794,27 +13794,27 @@ bins:
   sysZ3D1169: 0.0
   sysZ3D1170: -0.30694
   sysZ3D1171: 0.0
-  sysZ3D1172: -0.0
+  sysZ3D1172: 0.0
   sysZ3D1173: 0.0
   sysZ3D1174: -0.30694
-  sysZ3D1175: -0.0
+  sysZ3D1175: 0.0
   sysZ3D1176: 0.0
   sysZ3D1177: 0.0
   sysZ3D1178: 0.30694
   sysZ3D1179: -0.30694
   sysZ3D1180: 0.0
-  sysZ3D1181: -0.0
+  sysZ3D1181: 0.0
   sysZ3D1182: 0.0
-  sysZ3D1183: -0.0
+  sysZ3D1183: 0.0
   sysZ3D1184: 0.0
   sysZ3D1185: 0.0
   sysZ3D1186: 0.0
-  sysZ3D1187: -0.0
+  sysZ3D1187: 0.0
   sysZ3D1188: 0.0
   sysZ3D1189: 0.0
   sysZ3D1190: 0.0
   sysZ3D1191: 0.30694
-  sysZ3D1192: -0.0
+  sysZ3D1192: 0.0
   sysZ3D1193: 0.30694
   sysZ3D1194: -4.29716000e+00
   sysZ3D1195: 0.30694
@@ -13830,11 +13830,11 @@ bins:
   sysZ3D1205: 0.30694
   sysZ3D1206: 0.30694
   sysZ3D1207: 0.0
-  sysZ3D1208: -0.0
-  sysZ3D1209: -0.0
+  sysZ3D1208: 0.0
+  sysZ3D1209: 0.0
   sysZ3D1210: -0.30694
-  sysZ3D1211: -0.0
-  sysZ3D1212: -0.0
+  sysZ3D1211: 0.0
+  sysZ3D1212: 0.0
   sysZ3D1213: 0.0
   sysZ3D1214: 0.0
   sysZ3D1215: -0.61388
@@ -13842,32 +13842,32 @@ bins:
   sysZ3D1217: 1.22776
   sysZ3D1218: 0.30694
   sysZ3D1219: 0.30694
-  sysZ3D1220: -0.0
+  sysZ3D1220: 0.0
   sysZ3D1221: -0.30694
-  sysZ3D1222: -0.0
-  sysZ3D1223: -0.0
+  sysZ3D1222: 0.0
+  sysZ3D1223: 0.0
   sysZ3D1224: 0.0
   sysZ3D1225: 0.30694
   sysZ3D1226: 0.30694
   sysZ3D1227: 0.61388
   sysZ3D1228: -0.30694
-  sysZ3D1229: -0.0
+  sysZ3D1229: 0.0
   sysZ3D1230: 0.0
   sysZ3D1231: 0.30694
-  sysZ3D1232: -0.0
-  sysZ3D1233: -0.0
-  sysZ3D1234: -0.0
-  sysZ3D1235: -0.0
+  sysZ3D1232: 0.0
+  sysZ3D1233: 0.0
+  sysZ3D1234: 0.0
+  sysZ3D1235: 0.0
   sysZ3D1236: 0.0
   sysZ3D1237: 0.0
   sysZ3D1238: 0.30694
-  sysZ3D1239: -0.0
-  sysZ3D1240: -0.0
+  sysZ3D1239: 0.0
+  sysZ3D1240: 0.0
   sysZ3D1241: 0.0
   sysZ3D1242: 0.0
   sysZ3D1243: 0.0
   sysZ3D1244: 0.61388
-  sysZ3D1245: -0.0
+  sysZ3D1245: 0.0
   sysZ3D1246: 0.30694
   sysZ3D1247: -0.30694
   sysZ3D1248: -0.61388
@@ -13875,15 +13875,15 @@ bins:
   sysZ3D1250: 0.0
   sysZ3D1251: -0.92082
   sysZ3D1252: -0.61388
-  sysZ3D1253: -0.0
-  sysZ3D1254: -0.0
+  sysZ3D1253: 0.0
+  sysZ3D1254: 0.0
   sysZ3D1255: -0.92082
-  sysZ3D1256: -0.0
+  sysZ3D1256: 0.0
   sysZ3D1257: 0.0
-  sysZ3D1258: -0.0
+  sysZ3D1258: 0.0
   sysZ3D1259: 0.30694
   sysZ3D1260: 0.0
-  sysZ3D1261: -0.0
+  sysZ3D1261: 0.0
   sysZ3D1262: 0.61388
   sysZ3D1263: 1.5347
   sysZ3D1264: 3.0694
@@ -13891,18 +13891,18 @@ bins:
   sysZ3D1266: -3.68328
   sysZ3D1267: -0.92082
   sysZ3D1268: 0.30694
-  sysZ3D1269: -0.0
+  sysZ3D1269: 0.0
   sysZ3D1270: 0.0
   sysZ3D1271: 0.61388
   sysZ3D1272: 0.0
-  sysZ3D1273: -0.0
+  sysZ3D1273: 0.0
   sysZ3D1274: -0.92082
   sysZ3D1275: 1.84164
   sys,uncor: 2.14858000e+00
   ATLAS_LUMI: 5.52492000e+01
 - stat: 3.480192
   sysZ3D1001: -0.91584
-  sysZ3D1002: -0.0
+  sysZ3D1002: 0.0
   sysZ3D1003: -1.83168000e-01
   sysZ3D1004: 0.0
   sysZ3D1005: 0.0
@@ -13924,21 +13924,21 @@ bins:
   sysZ3D1021: 0.0
   sysZ3D1022: 0.0
   sysZ3D1023: 0.0
-  sysZ3D1024: -0.0
+  sysZ3D1024: 0.0
   sysZ3D1025: 0.0
-  sysZ3D1026: -0.0
+  sysZ3D1026: 0.0
   sysZ3D1027: 0.0
-  sysZ3D1028: -0.0
-  sysZ3D1029: -0.0
+  sysZ3D1028: 0.0
+  sysZ3D1029: 0.0
   sysZ3D1030: 0.0
   sysZ3D1031: 0.0
   sysZ3D1032: 0.0
   sysZ3D1033: 0.0
   sysZ3D1034: 0.0
   sysZ3D1035: 0.0
-  sysZ3D1036: -0.0
+  sysZ3D1036: 0.0
   sysZ3D1037: 0.0
-  sysZ3D1038: -0.0
+  sysZ3D1038: 0.0
   sysZ3D1039: 0.0
   sysZ3D1040: 0.0
   sysZ3D1041: 0.0
@@ -13947,39 +13947,39 @@ bins:
   sysZ3D1044: 0.0
   sysZ3D1045: 0.0
   sysZ3D1046: 0.0
-  sysZ3D1047: -0.0
+  sysZ3D1047: 0.0
   sysZ3D1048: 0.0
   sysZ3D1049: 0.0
   sysZ3D1050: 0.0
-  sysZ3D1051: -0.0
-  sysZ3D1052: -0.0
+  sysZ3D1051: 0.0
+  sysZ3D1052: 0.0
   sysZ3D1053: 0.0
   sysZ3D1054: 0.0
-  sysZ3D1055: -0.0
-  sysZ3D1056: -0.0
-  sysZ3D1057: -0.0
-  sysZ3D1058: -0.0
-  sysZ3D1059: -0.0
+  sysZ3D1055: 0.0
+  sysZ3D1056: 0.0
+  sysZ3D1057: 0.0
+  sysZ3D1058: 0.0
+  sysZ3D1059: 0.0
   sysZ3D1060: 0.0
   sysZ3D1061: 0.0
   sysZ3D1062: 0.0
-  sysZ3D1063: -0.0
-  sysZ3D1064: -0.0
+  sysZ3D1063: 0.0
+  sysZ3D1064: 0.0
   sysZ3D1065: 0.0
   sysZ3D1066: 0.0
   sysZ3D1067: 0.0
   sysZ3D1068: 0.0
-  sysZ3D1069: -0.0
+  sysZ3D1069: 0.0
   sysZ3D1070: 1.83168000e-01
-  sysZ3D1071: -0.0
-  sysZ3D1072: -0.0
+  sysZ3D1071: 0.0
+  sysZ3D1072: 0.0
   sysZ3D1073: 0.0
   sysZ3D1074: 0.0
   sysZ3D1075: 0.0
   sysZ3D1076: -1.83168000e-01
-  sysZ3D1077: -0.0
-  sysZ3D1078: -0.0
-  sysZ3D1079: -0.0
+  sysZ3D1077: 0.0
+  sysZ3D1078: 0.0
+  sysZ3D1079: 0.0
   sysZ3D1080: 0.0
   sysZ3D1081: 0.0
   sysZ3D1082: 0.0
@@ -13989,107 +13989,107 @@ bins:
   sysZ3D1086: 0.0
   sysZ3D1087: 0.0
   sysZ3D1088: 0.0
-  sysZ3D1089: -0.0
-  sysZ3D1090: -0.0
-  sysZ3D1091: -0.0
+  sysZ3D1089: 0.0
+  sysZ3D1090: 0.0
+  sysZ3D1091: 0.0
   sysZ3D1092: 0.0
-  sysZ3D1093: -0.0
+  sysZ3D1093: 0.0
   sysZ3D1094: 0.0
   sysZ3D1095: 0.0
-  sysZ3D1096: -0.0
+  sysZ3D1096: 0.0
   sysZ3D1097: 0.0
-  sysZ3D1098: -0.0
-  sysZ3D1099: -0.0
-  sysZ3D1100: -0.0
-  sysZ3D1101: -0.0
-  sysZ3D1102: -0.0
+  sysZ3D1098: 0.0
+  sysZ3D1099: 0.0
+  sysZ3D1100: 0.0
+  sysZ3D1101: 0.0
+  sysZ3D1102: 0.0
   sysZ3D1103: 0.0
-  sysZ3D1104: -0.0
+  sysZ3D1104: 0.0
   sysZ3D1105: -1.83168000e-01
   sysZ3D1106: -1.83168000e-01
-  sysZ3D1107: -0.0
+  sysZ3D1107: 0.0
   sysZ3D1108: 0.0
   sysZ3D1109: 0.0
   sysZ3D1110: 0.0
   sysZ3D1111: 0.0
-  sysZ3D1112: -0.0
+  sysZ3D1112: 0.0
   sysZ3D1113: 5.49504000e-01
-  sysZ3D1114: -0.0
+  sysZ3D1114: 0.0
   sysZ3D1115: 3.66336000e-01
-  sysZ3D1116: -0.0
-  sysZ3D1117: -0.0
-  sysZ3D1118: -0.0
-  sysZ3D1119: -0.0
-  sysZ3D1120: -0.0
-  sysZ3D1121: -0.0
-  sysZ3D1122: -0.0
-  sysZ3D1123: -0.0
+  sysZ3D1116: 0.0
+  sysZ3D1117: 0.0
+  sysZ3D1118: 0.0
+  sysZ3D1119: 0.0
+  sysZ3D1120: 0.0
+  sysZ3D1121: 0.0
+  sysZ3D1122: 0.0
+  sysZ3D1123: 0.0
   sysZ3D1124: 1.83168000e-01
-  sysZ3D1125: -0.0
+  sysZ3D1125: 0.0
   sysZ3D1126: -0.91584
   sysZ3D1127: 0.0
   sysZ3D1128: 1.83168000e-01
-  sysZ3D1129: -0.0
-  sysZ3D1130: -0.0
+  sysZ3D1129: 0.0
+  sysZ3D1130: 0.0
   sysZ3D1131: 0.0
-  sysZ3D1132: -0.0
+  sysZ3D1132: 0.0
   sysZ3D1133: 0.0
-  sysZ3D1134: -0.0
-  sysZ3D1135: -0.0
-  sysZ3D1136: -0.0
-  sysZ3D1137: -0.0
+  sysZ3D1134: 0.0
+  sysZ3D1135: 0.0
+  sysZ3D1136: 0.0
+  sysZ3D1137: 0.0
   sysZ3D1138: 0.0
   sysZ3D1139: 0.0
-  sysZ3D1140: -0.0
-  sysZ3D1141: -0.0
-  sysZ3D1142: -0.0
+  sysZ3D1140: 0.0
+  sysZ3D1141: 0.0
+  sysZ3D1142: 0.0
   sysZ3D1143: 0.0
-  sysZ3D1144: -0.0
-  sysZ3D1145: -0.0
-  sysZ3D1146: -0.0
+  sysZ3D1144: 0.0
+  sysZ3D1145: 0.0
+  sysZ3D1146: 0.0
   sysZ3D1147: 0.0
-  sysZ3D1148: -0.0
-  sysZ3D1149: -0.0
-  sysZ3D1150: -0.0
-  sysZ3D1151: -0.0
-  sysZ3D1152: -0.0
+  sysZ3D1148: 0.0
+  sysZ3D1149: 0.0
+  sysZ3D1150: 0.0
+  sysZ3D1151: 0.0
+  sysZ3D1152: 0.0
   sysZ3D1153: 0.0
-  sysZ3D1154: -0.0
-  sysZ3D1155: -0.0
-  sysZ3D1156: -0.0
-  sysZ3D1157: -0.0
+  sysZ3D1154: 0.0
+  sysZ3D1155: 0.0
+  sysZ3D1156: 0.0
+  sysZ3D1157: 0.0
   sysZ3D1158: 0.0
   sysZ3D1159: 0.0
-  sysZ3D1160: -0.0
+  sysZ3D1160: 0.0
   sysZ3D1161: -1.83168000e-01
-  sysZ3D1162: -0.0
+  sysZ3D1162: 0.0
   sysZ3D1163: 0.0
   sysZ3D1164: 1.83168000e-01
-  sysZ3D1165: -0.0
+  sysZ3D1165: 0.0
   sysZ3D1166: -1.83168000e-01
   sysZ3D1167: 0.0
   sysZ3D1168: 0.0
   sysZ3D1169: 0.0
-  sysZ3D1170: -0.0
+  sysZ3D1170: 0.0
   sysZ3D1171: 1.83168000e-01
-  sysZ3D1172: -0.0
-  sysZ3D1173: -0.0
+  sysZ3D1172: 0.0
+  sysZ3D1173: 0.0
   sysZ3D1174: -1.83168000e-01
-  sysZ3D1175: -0.0
+  sysZ3D1175: 0.0
   sysZ3D1176: 0.0
   sysZ3D1177: 0.0
   sysZ3D1178: 1.83168000e-01
-  sysZ3D1179: -0.0
+  sysZ3D1179: 0.0
   sysZ3D1180: 0.0
-  sysZ3D1181: -0.0
+  sysZ3D1181: 0.0
   sysZ3D1182: 0.0
-  sysZ3D1183: -0.0
+  sysZ3D1183: 0.0
   sysZ3D1184: 0.0
   sysZ3D1185: 0.0
   sysZ3D1186: 0.0
   sysZ3D1187: 0.0
-  sysZ3D1188: -0.0
-  sysZ3D1189: -0.0
+  sysZ3D1188: 0.0
+  sysZ3D1189: 0.0
   sysZ3D1190: 0.0
   sysZ3D1191: 1.83168000e-01
   sysZ3D1192: 0.0
@@ -14108,60 +14108,60 @@ bins:
   sysZ3D1205: 1.83168000e-01
   sysZ3D1206: 1.83168000e-01
   sysZ3D1207: 0.0
-  sysZ3D1208: -0.0
-  sysZ3D1209: -0.0
+  sysZ3D1208: 0.0
+  sysZ3D1209: 0.0
   sysZ3D1210: -1.83168000e-01
-  sysZ3D1211: -0.0
-  sysZ3D1212: -0.0
+  sysZ3D1211: 0.0
+  sysZ3D1212: 0.0
   sysZ3D1213: 0.0
   sysZ3D1214: 3.66336000e-01
-  sysZ3D1215: -0.0
-  sysZ3D1216: -0.0
+  sysZ3D1215: 0.0
+  sysZ3D1216: 0.0
   sysZ3D1217: 5.49504000e-01
   sysZ3D1218: 1.83168000e-01
-  sysZ3D1219: -0.0
+  sysZ3D1219: 0.0
   sysZ3D1220: 0.0
-  sysZ3D1221: -0.0
-  sysZ3D1222: -0.0
+  sysZ3D1221: 0.0
+  sysZ3D1222: 0.0
   sysZ3D1223: -1.83168000e-01
   sysZ3D1224: 0.0
   sysZ3D1225: 1.83168000e-01
   sysZ3D1226: 1.83168000e-01
   sysZ3D1227: 5.49504000e-01
   sysZ3D1228: 3.66336000e-01
-  sysZ3D1229: -0.0
-  sysZ3D1230: -0.0
+  sysZ3D1229: 0.0
+  sysZ3D1230: 0.0
   sysZ3D1231: 1.83168000e-01
-  sysZ3D1232: -0.0
-  sysZ3D1233: -0.0
-  sysZ3D1234: -0.0
+  sysZ3D1232: 0.0
+  sysZ3D1233: 0.0
+  sysZ3D1234: 0.0
   sysZ3D1235: -1.83168000e-01
   sysZ3D1236: 0.0
   sysZ3D1237: 0.0
   sysZ3D1238: 1.83168000e-01
-  sysZ3D1239: -0.0
-  sysZ3D1240: -0.0
+  sysZ3D1239: 0.0
+  sysZ3D1240: 0.0
   sysZ3D1241: 0.0
   sysZ3D1242: 0.0
   sysZ3D1243: 0.0
   sysZ3D1244: 3.66336000e-01
   sysZ3D1245: 1.83168000e-01
   sysZ3D1246: 1.83168000e-01
-  sysZ3D1247: -0.0
+  sysZ3D1247: 0.0
   sysZ3D1248: -3.66336000e-01
   sysZ3D1249: -3.66336000e-01
   sysZ3D1250: 0.0
   sysZ3D1251: -1.09900800e+00
   sysZ3D1252: -7.32672000e-01
-  sysZ3D1253: -0.0
-  sysZ3D1254: -0.0
+  sysZ3D1253: 0.0
+  sysZ3D1254: 0.0
   sysZ3D1255: -0.91584
   sysZ3D1256: -1.83168000e-01
   sysZ3D1257: 1.83168000e-01
-  sysZ3D1258: -0.0
+  sysZ3D1258: 0.0
   sysZ3D1259: 3.66336000e-01
   sysZ3D1260: 1.83168000e-01
-  sysZ3D1261: -0.0
+  sysZ3D1261: 0.0
   sysZ3D1262: 3.66336000e-01
   sysZ3D1263: 1.09900800e+00
   sysZ3D1264: 1.83168
@@ -14173,7 +14173,7 @@ bins:
   sysZ3D1270: 0.0
   sysZ3D1271: 3.66336000e-01
   sysZ3D1272: 0.0
-  sysZ3D1273: -0.0
+  sysZ3D1273: 0.0
   sysZ3D1274: -5.49504000e-01
   sysZ3D1275: 1.28217600e+00
   sys,uncor: 1.83168
@@ -14210,14 +14210,14 @@ bins:
   sysZ3D1029: 0.0
   sysZ3D1030: -5.95560000e-02
   sysZ3D1031: 0.0
-  sysZ3D1032: -0.0
+  sysZ3D1032: 0.0
   sysZ3D1033: 0.0
   sysZ3D1034: 0.0
-  sysZ3D1035: -0.0
-  sysZ3D1036: -0.0
+  sysZ3D1035: 0.0
+  sysZ3D1036: 0.0
   sysZ3D1037: 0.0
   sysZ3D1038: 0.0
-  sysZ3D1039: -0.0
+  sysZ3D1039: 0.0
   sysZ3D1040: 0.0
   sysZ3D1041: 0.0
   sysZ3D1042: 0.0
@@ -14225,29 +14225,29 @@ bins:
   sysZ3D1044: 0.0
   sysZ3D1045: 0.0
   sysZ3D1046: 0.0
-  sysZ3D1047: -0.0
+  sysZ3D1047: 0.0
   sysZ3D1048: 0.0
-  sysZ3D1049: -0.0
+  sysZ3D1049: 0.0
   sysZ3D1050: 0.0
   sysZ3D1051: 0.0
   sysZ3D1052: 0.0
-  sysZ3D1053: -0.0
+  sysZ3D1053: 0.0
   sysZ3D1054: 0.0
-  sysZ3D1055: -0.0
+  sysZ3D1055: 0.0
   sysZ3D1056: 0.0
-  sysZ3D1057: -0.0
+  sysZ3D1057: 0.0
   sysZ3D1058: 0.0
   sysZ3D1059: 0.0
   sysZ3D1060: 0.0
   sysZ3D1061: 0.0
   sysZ3D1062: 0.0
   sysZ3D1063: 0.0
-  sysZ3D1064: -0.0
-  sysZ3D1065: -0.0
+  sysZ3D1064: 0.0
+  sysZ3D1065: 0.0
   sysZ3D1066: 0.0
-  sysZ3D1067: -0.0
-  sysZ3D1068: -0.0
-  sysZ3D1069: -0.0
+  sysZ3D1067: 0.0
+  sysZ3D1068: 0.0
+  sysZ3D1069: 0.0
   sysZ3D1070: 0.0
   sysZ3D1071: 0.0
   sysZ3D1072: 0.0
@@ -14263,25 +14263,25 @@ bins:
   sysZ3D1082: 0.0
   sysZ3D1083: 0.0
   sysZ3D1084: 0.0
-  sysZ3D1085: -0.0
+  sysZ3D1085: 0.0
   sysZ3D1086: 0.0
-  sysZ3D1087: -0.0
-  sysZ3D1088: -0.0
+  sysZ3D1087: 0.0
+  sysZ3D1088: 0.0
   sysZ3D1089: 0.0
-  sysZ3D1090: -0.0
+  sysZ3D1090: 0.0
   sysZ3D1091: 0.0
   sysZ3D1092: 0.0
   sysZ3D1093: 0.0
   sysZ3D1094: 0.0
   sysZ3D1095: 0.0
-  sysZ3D1096: -0.0
+  sysZ3D1096: 0.0
   sysZ3D1097: 0.0
   sysZ3D1098: 0.0
   sysZ3D1099: 0.0
   sysZ3D1100: 0.0
   sysZ3D1101: 0.0
   sysZ3D1102: 0.0
-  sysZ3D1103: -0.0
+  sysZ3D1103: 0.0
   sysZ3D1104: -5.95560000e-02
   sysZ3D1105: -5.95560000e-02
   sysZ3D1106: -5.95560000e-02
@@ -14290,51 +14290,51 @@ bins:
   sysZ3D1109: 0.0
   sysZ3D1110: 0.0
   sysZ3D1111: 0.0
-  sysZ3D1112: -0.0
+  sysZ3D1112: 0.0
   sysZ3D1113: 2.38224000e-01
   sysZ3D1114: 5.95560000e-02
-  sysZ3D1115: -0.0
-  sysZ3D1116: -0.0
-  sysZ3D1117: -0.0
-  sysZ3D1118: -0.0
-  sysZ3D1119: -0.0
+  sysZ3D1115: 0.0
+  sysZ3D1116: 0.0
+  sysZ3D1117: 0.0
+  sysZ3D1118: 0.0
+  sysZ3D1119: 0.0
   sysZ3D1120: 0.0
-  sysZ3D1121: -0.0
-  sysZ3D1122: -0.0
-  sysZ3D1123: -0.0
+  sysZ3D1121: 0.0
+  sysZ3D1122: 0.0
+  sysZ3D1123: 0.0
   sysZ3D1124: -5.95560000e-02
   sysZ3D1125: -1.78668000e-01
   sysZ3D1126: -3.57336000e-01
   sysZ3D1127: 0.0
   sysZ3D1128: 0.0
   sysZ3D1129: 5.95560000e-02
-  sysZ3D1130: -0.0
+  sysZ3D1130: 0.0
   sysZ3D1131: 0.0
-  sysZ3D1132: -0.0
+  sysZ3D1132: 0.0
   sysZ3D1133: 0.0
   sysZ3D1134: 0.0
   sysZ3D1135: 0.0
   sysZ3D1136: 0.0
   sysZ3D1137: 0.0
   sysZ3D1138: 0.0
-  sysZ3D1139: -0.0
-  sysZ3D1140: -0.0
-  sysZ3D1141: -0.0
-  sysZ3D1142: -0.0
+  sysZ3D1139: 0.0
+  sysZ3D1140: 0.0
+  sysZ3D1141: 0.0
+  sysZ3D1142: 0.0
   sysZ3D1143: 0.0
   sysZ3D1144: 0.0
-  sysZ3D1145: -0.0
+  sysZ3D1145: 0.0
   sysZ3D1146: 0.0
   sysZ3D1147: 0.0
   sysZ3D1148: 0.0
   sysZ3D1149: 0.0
-  sysZ3D1150: -0.0
-  sysZ3D1151: -0.0
+  sysZ3D1150: 0.0
+  sysZ3D1151: 0.0
   sysZ3D1152: 0.0
   sysZ3D1153: 0.0
-  sysZ3D1154: -0.0
-  sysZ3D1155: -0.0
-  sysZ3D1156: -0.0
+  sysZ3D1154: 0.0
+  sysZ3D1155: 0.0
+  sysZ3D1156: 0.0
   sysZ3D1157: 0.0
   sysZ3D1158: 0.0
   sysZ3D1159: 0.0
@@ -14348,10 +14348,10 @@ bins:
   sysZ3D1167: -1.19112000e-01
   sysZ3D1168: -5.95560000e-02
   sysZ3D1169: 0.0
-  sysZ3D1170: -0.0
+  sysZ3D1170: 0.0
   sysZ3D1171: 1.19112000e-01
   sysZ3D1172: -5.95560000e-02
-  sysZ3D1173: -0.0
+  sysZ3D1173: 0.0
   sysZ3D1174: -1.78668000e-01
   sysZ3D1175: 0.0
   sysZ3D1176: 5.95560000e-02
@@ -14361,13 +14361,13 @@ bins:
   sysZ3D1180: 0.0
   sysZ3D1181: -5.95560000e-02
   sysZ3D1182: 0.0
-  sysZ3D1183: -0.0
+  sysZ3D1183: 0.0
   sysZ3D1184: 0.0
   sysZ3D1185: 5.95560000e-02
   sysZ3D1186: 0.0
   sysZ3D1187: 5.95560000e-02
   sysZ3D1188: -5.95560000e-02
-  sysZ3D1189: -0.0
+  sysZ3D1189: 0.0
   sysZ3D1190: 5.95560000e-02
   sysZ3D1191: 5.95560000e-02
   sysZ3D1192: 0.0
@@ -14386,21 +14386,21 @@ bins:
   sysZ3D1205: 5.95560000e-02
   sysZ3D1206: 5.95560000e-02
   sysZ3D1207: 0.0
-  sysZ3D1208: -0.0
+  sysZ3D1208: 0.0
   sysZ3D1209: -5.95560000e-02
   sysZ3D1210: -5.95560000e-02
-  sysZ3D1211: -0.0
-  sysZ3D1212: -0.0
+  sysZ3D1211: 0.0
+  sysZ3D1212: 0.0
   sysZ3D1213: -5.95560000e-02
   sysZ3D1214: -5.95560000e-02
   sysZ3D1215: 0.178668
-  sysZ3D1216: -0.0
+  sysZ3D1216: 0.0
   sysZ3D1217: 2.38224000e-01
   sysZ3D1218: 0.178668
-  sysZ3D1219: -0.0
+  sysZ3D1219: 0.0
   sysZ3D1220: 0.0
-  sysZ3D1221: -0.0
-  sysZ3D1222: -0.0
+  sysZ3D1221: 0.0
+  sysZ3D1222: 0.0
   sysZ3D1223: -5.95560000e-02
   sysZ3D1224: 0.0
   sysZ3D1225: 5.95560000e-02
@@ -14409,16 +14409,16 @@ bins:
   sysZ3D1228: 5.95560000e-02
   sysZ3D1229: 5.95560000e-02
   sysZ3D1230: 5.95560000e-02
-  sysZ3D1231: -0.0
+  sysZ3D1231: 0.0
   sysZ3D1232: 0.0
-  sysZ3D1233: -0.0
-  sysZ3D1234: -0.0
+  sysZ3D1233: 0.0
+  sysZ3D1234: 0.0
   sysZ3D1235: -5.95560000e-02
   sysZ3D1236: 0.0
   sysZ3D1237: 0.0
   sysZ3D1238: 5.95560000e-02
-  sysZ3D1239: -0.0
-  sysZ3D1240: -0.0
+  sysZ3D1239: 0.0
+  sysZ3D1240: 0.0
   sysZ3D1241: 0.0
   sysZ3D1242: 0.0
   sysZ3D1243: 0.0
@@ -14436,7 +14436,7 @@ bins:
   sysZ3D1255: -4.76448000e-01
   sysZ3D1256: -5.95560000e-02
   sysZ3D1257: 0.178668
-  sysZ3D1258: -0.0
+  sysZ3D1258: 0.0
   sysZ3D1259: 1.19112000e-01
   sysZ3D1260: 1.19112000e-01
   sysZ3D1261: 0.0
@@ -14451,7 +14451,7 @@ bins:
   sysZ3D1270: 0.0
   sysZ3D1271: 1.19112000e-01
   sysZ3D1272: 0.0
-  sysZ3D1273: -0.0
+  sysZ3D1273: 0.0
   sysZ3D1274: -1.78668000e-01
   sysZ3D1275: 5.36004000e-01
   sys,uncor: 9.52896000e-01
@@ -14459,7 +14459,7 @@ bins:
 - stat: 1.26299
   sysZ3D1001: -0.07149
   sysZ3D1002: -2.38300000e-02
-  sysZ3D1003: -0.0
+  sysZ3D1003: 0.0
   sysZ3D1004: 0.0
   sysZ3D1005: 0.0
   sysZ3D1006: 0.0
@@ -14477,53 +14477,53 @@ bins:
   sysZ3D1018: 0.0
   sysZ3D1019: 0.0
   sysZ3D1020: 0.0
-  sysZ3D1021: -0.0
-  sysZ3D1022: -0.0
+  sysZ3D1021: 0.0
+  sysZ3D1022: 0.0
   sysZ3D1023: 0.0
-  sysZ3D1024: -0.0
+  sysZ3D1024: 0.0
   sysZ3D1025: 2.38300000e-02
-  sysZ3D1026: -0.0
+  sysZ3D1026: 0.0
   sysZ3D1027: 0.0
-  sysZ3D1028: -0.0
-  sysZ3D1029: -0.0
-  sysZ3D1030: -0.0
-  sysZ3D1031: -0.0
-  sysZ3D1032: -0.0
+  sysZ3D1028: 0.0
+  sysZ3D1029: 0.0
+  sysZ3D1030: 0.0
+  sysZ3D1031: 0.0
+  sysZ3D1032: 0.0
   sysZ3D1033: 0.0
   sysZ3D1034: 0.0
-  sysZ3D1035: -0.0
-  sysZ3D1036: -0.0
+  sysZ3D1035: 0.0
+  sysZ3D1036: 0.0
   sysZ3D1037: 0.0
-  sysZ3D1038: -0.0
+  sysZ3D1038: 0.0
   sysZ3D1039: 0.0
   sysZ3D1040: 0.0
-  sysZ3D1041: -0.0
+  sysZ3D1041: 0.0
   sysZ3D1042: 0.0
-  sysZ3D1043: -0.0
+  sysZ3D1043: 0.0
   sysZ3D1044: 0.0
   sysZ3D1045: 0.0
   sysZ3D1046: 0.0
-  sysZ3D1047: -0.0
+  sysZ3D1047: 0.0
   sysZ3D1048: 0.0
   sysZ3D1049: 0.0
   sysZ3D1050: 0.0
   sysZ3D1051: 0.0
   sysZ3D1052: 0.0
-  sysZ3D1053: -0.0
+  sysZ3D1053: 0.0
   sysZ3D1054: 0.0
-  sysZ3D1055: -0.0
+  sysZ3D1055: 0.0
   sysZ3D1056: -2.38300000e-02
-  sysZ3D1057: -0.0
-  sysZ3D1058: -0.0
-  sysZ3D1059: -0.0
-  sysZ3D1060: -0.0
-  sysZ3D1061: -0.0
-  sysZ3D1062: -0.0
+  sysZ3D1057: 0.0
+  sysZ3D1058: 0.0
+  sysZ3D1059: 0.0
+  sysZ3D1060: 0.0
+  sysZ3D1061: 0.0
+  sysZ3D1062: 0.0
   sysZ3D1063: 0.0
   sysZ3D1064: 0.0
-  sysZ3D1065: -0.0
+  sysZ3D1065: 0.0
   sysZ3D1066: 0.0
-  sysZ3D1067: -0.0
+  sysZ3D1067: 0.0
   sysZ3D1068: 0.0
   sysZ3D1069: 0.0
   sysZ3D1070: 0.0
@@ -14532,31 +14532,31 @@ bins:
   sysZ3D1073: 0.0
   sysZ3D1074: 0.0
   sysZ3D1075: 0.0
-  sysZ3D1076: -0.0
+  sysZ3D1076: 0.0
   sysZ3D1077: 0.0
-  sysZ3D1078: -0.0
+  sysZ3D1078: 0.0
   sysZ3D1079: 0.0
-  sysZ3D1080: -0.0
+  sysZ3D1080: 0.0
   sysZ3D1081: 0.0
-  sysZ3D1082: -0.0
-  sysZ3D1083: -0.0
-  sysZ3D1084: -0.0
+  sysZ3D1082: 0.0
+  sysZ3D1083: 0.0
+  sysZ3D1084: 0.0
   sysZ3D1085: 0.0
   sysZ3D1086: 0.0
-  sysZ3D1087: -0.0
-  sysZ3D1088: -0.0
-  sysZ3D1089: -0.0
-  sysZ3D1090: -0.0
-  sysZ3D1091: -0.0
-  sysZ3D1092: -0.0
+  sysZ3D1087: 0.0
+  sysZ3D1088: 0.0
+  sysZ3D1089: 0.0
+  sysZ3D1090: 0.0
+  sysZ3D1091: 0.0
+  sysZ3D1092: 0.0
   sysZ3D1093: 0.0
   sysZ3D1094: 0.0
-  sysZ3D1095: -0.0
+  sysZ3D1095: 0.0
   sysZ3D1096: 0.0
   sysZ3D1097: 0.0
   sysZ3D1098: 2.38300000e-02
   sysZ3D1099: 0.0
-  sysZ3D1100: -0.0
+  sysZ3D1100: 0.0
   sysZ3D1101: 0.0
   sysZ3D1102: 0.0
   sysZ3D1103: 0.0
@@ -14564,8 +14564,8 @@ bins:
   sysZ3D1105: -0.4766
   sysZ3D1106: -0.07149
   sysZ3D1107: -2.38300000e-02
-  sysZ3D1108: -0.0
-  sysZ3D1109: -0.0
+  sysZ3D1108: 0.0
+  sysZ3D1109: 0.0
   sysZ3D1110: 0.0
   sysZ3D1111: 9.53200000e-02
   sysZ3D1112: 4.76600000e-02
@@ -14573,7 +14573,7 @@ bins:
   sysZ3D1114: -4.76600000e-02
   sysZ3D1115: -2.38300000e-02
   sysZ3D1116: -0.07149
-  sysZ3D1117: -0.0
+  sysZ3D1117: 0.0
   sysZ3D1118: -0.11915
   sysZ3D1119: -9.53200000e-02
   sysZ3D1120: -4.76600000e-02
@@ -14581,14 +14581,14 @@ bins:
   sysZ3D1122: -0.11915
   sysZ3D1123: 2.38300000e-02
   sysZ3D1124: -2.38300000e-02
-  sysZ3D1125: -0.0
-  sysZ3D1126: -0.0
+  sysZ3D1125: 0.0
+  sysZ3D1126: 0.0
   sysZ3D1127: -4.76600000e-02
-  sysZ3D1128: -0.0
-  sysZ3D1129: -0.0
-  sysZ3D1130: -0.0
-  sysZ3D1131: -0.0
-  sysZ3D1132: -0.0
+  sysZ3D1128: 0.0
+  sysZ3D1129: 0.0
+  sysZ3D1130: 0.0
+  sysZ3D1131: 0.0
+  sysZ3D1132: 0.0
   sysZ3D1133: -2.38300000e-02
   sysZ3D1134: -2.38300000e-02
   sysZ3D1135: 2.38300000e-02
@@ -14597,39 +14597,39 @@ bins:
   sysZ3D1138: -2.38300000e-02
   sysZ3D1139: 2.38300000e-02
   sysZ3D1140: 0.0
-  sysZ3D1141: -0.0
+  sysZ3D1141: 0.0
   sysZ3D1142: -2.38300000e-02
-  sysZ3D1143: -0.0
+  sysZ3D1143: 0.0
   sysZ3D1144: -2.38300000e-02
-  sysZ3D1145: -0.0
-  sysZ3D1146: -0.0
+  sysZ3D1145: 0.0
+  sysZ3D1146: 0.0
   sysZ3D1147: 2.38300000e-02
-  sysZ3D1148: -0.0
+  sysZ3D1148: 0.0
   sysZ3D1149: -0.07149
   sysZ3D1150: 4.76600000e-02
   sysZ3D1151: 4.76600000e-02
   sysZ3D1152: -4.76600000e-02
   sysZ3D1153: -2.38300000e-02
-  sysZ3D1154: -0.0
+  sysZ3D1154: 0.0
   sysZ3D1155: -2.38300000e-02
   sysZ3D1156: 2.38300000e-02
-  sysZ3D1157: -0.0
-  sysZ3D1158: -0.0
+  sysZ3D1157: 0.0
+  sysZ3D1158: 0.0
   sysZ3D1159: 4.76600000e-02
   sysZ3D1160: 2.38300000e-02
   sysZ3D1161: 2.38300000e-02
   sysZ3D1162: 0.0
-  sysZ3D1163: -0.0
-  sysZ3D1164: -0.0
-  sysZ3D1165: -0.0
+  sysZ3D1163: 0.0
+  sysZ3D1164: 0.0
+  sysZ3D1165: 0.0
   sysZ3D1166: 0.0
   sysZ3D1167: 0.0
-  sysZ3D1168: -0.0
+  sysZ3D1168: 0.0
   sysZ3D1169: -2.38300000e-02
   sysZ3D1170: 4.76600000e-02
   sysZ3D1171: -4.76600000e-02
   sysZ3D1172: 0.0
-  sysZ3D1173: -0.0
+  sysZ3D1173: 0.0
   sysZ3D1174: -2.38300000e-02
   sysZ3D1175: 0.0
   sysZ3D1176: 2.38300000e-02
@@ -14645,7 +14645,7 @@ bins:
   sysZ3D1186: 0.0
   sysZ3D1187: 2.38300000e-02
   sysZ3D1188: -4.76600000e-02
-  sysZ3D1189: -0.0
+  sysZ3D1189: 0.0
   sysZ3D1190: 2.38300000e-02
   sysZ3D1191: -2.38300000e-02
   sysZ3D1192: 2.38300000e-02
@@ -14664,19 +14664,19 @@ bins:
   sysZ3D1205: 2.38300000e-02
   sysZ3D1206: 2.38300000e-02
   sysZ3D1207: 2.38300000e-02
-  sysZ3D1208: -0.0
+  sysZ3D1208: 0.0
   sysZ3D1209: -2.38300000e-02
   sysZ3D1210: -2.38300000e-02
-  sysZ3D1211: -0.0
-  sysZ3D1212: -0.0
-  sysZ3D1213: -0.0
+  sysZ3D1211: 0.0
+  sysZ3D1212: 0.0
+  sysZ3D1213: 0.0
   sysZ3D1214: -2.38300000e-02
   sysZ3D1215: -4.76600000e-02
   sysZ3D1216: 2.38300000e-02
   sysZ3D1217: 9.53200000e-02
   sysZ3D1218: 4.76600000e-02
   sysZ3D1219: 2.38300000e-02
-  sysZ3D1220: -0.0
+  sysZ3D1220: 0.0
   sysZ3D1221: -4.76600000e-02
   sysZ3D1222: -2.38300000e-02
   sysZ3D1223: -2.38300000e-02
@@ -14690,13 +14690,13 @@ bins:
   sysZ3D1231: 2.38300000e-02
   sysZ3D1232: -2.38300000e-02
   sysZ3D1233: -2.38300000e-02
-  sysZ3D1234: -0.0
+  sysZ3D1234: 0.0
   sysZ3D1235: -2.38300000e-02
   sysZ3D1236: -2.38300000e-02
   sysZ3D1237: 0.0
   sysZ3D1238: 2.38300000e-02
-  sysZ3D1239: -0.0
-  sysZ3D1240: -0.0
+  sysZ3D1239: 0.0
+  sysZ3D1240: 0.0
   sysZ3D1241: 0.0
   sysZ3D1242: 0.0
   sysZ3D1243: 0.0
@@ -14709,7 +14709,7 @@ bins:
   sysZ3D1250: 0.0
   sysZ3D1251: -4.76600000e-02
   sysZ3D1252: -2.38300000e-02
-  sysZ3D1253: -0.0
+  sysZ3D1253: 0.0
   sysZ3D1254: 0.0
   sysZ3D1255: -0.14298
   sysZ3D1256: 2.38300000e-02
@@ -14717,7 +14717,7 @@ bins:
   sysZ3D1258: -9.53200000e-02
   sysZ3D1259: 2.38300000e-02
   sysZ3D1260: -2.38300000e-02
-  sysZ3D1261: -0.0
+  sysZ3D1261: 0.0
   sysZ3D1262: 2.38300000e-02
   sysZ3D1263: 0.07149
   sysZ3D1264: 0.07149
@@ -14725,7 +14725,7 @@ bins:
   sysZ3D1266: -1.90640000e-01
   sysZ3D1267: -4.76600000e-02
   sysZ3D1268: 0.0
-  sysZ3D1269: -0.0
+  sysZ3D1269: 0.0
   sysZ3D1270: 2.38300000e-02
   sysZ3D1271: 2.38300000e-02
   sysZ3D1272: 0.0
@@ -14737,7 +14737,7 @@ bins:
 - stat: 1.244256
   sysZ3D1001: -7.17840000e-02
   sysZ3D1002: -2.39280000e-02
-  sysZ3D1003: -0.0
+  sysZ3D1003: 0.0
   sysZ3D1004: 0.0
   sysZ3D1005: 0.0
   sysZ3D1006: 0.0
@@ -14754,96 +14754,96 @@ bins:
   sysZ3D1017: 0.0
   sysZ3D1018: 0.0
   sysZ3D1019: 0.0
-  sysZ3D1020: -0.0
+  sysZ3D1020: 0.0
   sysZ3D1021: 0.0
-  sysZ3D1022: -0.0
+  sysZ3D1022: 0.0
   sysZ3D1023: 0.0
-  sysZ3D1024: -0.0
+  sysZ3D1024: 0.0
   sysZ3D1025: 0.023928
-  sysZ3D1026: -0.0
+  sysZ3D1026: 0.0
   sysZ3D1027: 0.0
   sysZ3D1028: 0.0
-  sysZ3D1029: -0.0
+  sysZ3D1029: 0.0
   sysZ3D1030: 0.0
-  sysZ3D1031: -0.0
+  sysZ3D1031: 0.0
   sysZ3D1032: 0.0
-  sysZ3D1033: -0.0
+  sysZ3D1033: 0.0
   sysZ3D1034: 0.0
-  sysZ3D1035: -0.0
+  sysZ3D1035: 0.0
   sysZ3D1036: 0.0
-  sysZ3D1037: -0.0
+  sysZ3D1037: 0.0
   sysZ3D1038: 0.0
-  sysZ3D1039: -0.0
-  sysZ3D1040: -0.0
+  sysZ3D1039: 0.0
+  sysZ3D1040: 0.0
   sysZ3D1041: 0.0
-  sysZ3D1042: -0.0
+  sysZ3D1042: 0.0
   sysZ3D1043: 0.0
-  sysZ3D1044: -0.0
-  sysZ3D1045: -0.0
+  sysZ3D1044: 0.0
+  sysZ3D1045: 0.0
   sysZ3D1046: 0.0
   sysZ3D1047: 0.0
   sysZ3D1048: 0.0
   sysZ3D1049: 0.0
   sysZ3D1050: 0.0
-  sysZ3D1051: -0.0
-  sysZ3D1052: -0.0
-  sysZ3D1053: -0.0
-  sysZ3D1054: -0.0
+  sysZ3D1051: 0.0
+  sysZ3D1052: 0.0
+  sysZ3D1053: 0.0
+  sysZ3D1054: 0.0
   sysZ3D1055: 0.0
   sysZ3D1056: 0.0
-  sysZ3D1057: -0.0
-  sysZ3D1058: -0.0
-  sysZ3D1059: -0.0
-  sysZ3D1060: -0.0
-  sysZ3D1061: -0.0
+  sysZ3D1057: 0.0
+  sysZ3D1058: 0.0
+  sysZ3D1059: 0.0
+  sysZ3D1060: 0.0
+  sysZ3D1061: 0.0
   sysZ3D1062: 0.023928
-  sysZ3D1063: -0.0
+  sysZ3D1063: 0.0
   sysZ3D1064: 0.0
   sysZ3D1065: 0.0
   sysZ3D1066: -2.39280000e-02
-  sysZ3D1067: -0.0
+  sysZ3D1067: 0.0
   sysZ3D1068: 0.0
   sysZ3D1069: 0.0
-  sysZ3D1070: -0.0
-  sysZ3D1071: -0.0
+  sysZ3D1070: 0.0
+  sysZ3D1071: 0.0
   sysZ3D1072: 0.0
-  sysZ3D1073: -0.0
-  sysZ3D1074: -0.0
-  sysZ3D1075: -0.0
-  sysZ3D1076: -0.0
+  sysZ3D1073: 0.0
+  sysZ3D1074: 0.0
+  sysZ3D1075: 0.0
+  sysZ3D1076: 0.0
   sysZ3D1077: 0.0
   sysZ3D1078: 0.0
   sysZ3D1079: 0.0
-  sysZ3D1080: -0.0
+  sysZ3D1080: 0.0
   sysZ3D1081: 0.0
   sysZ3D1082: 0.0
   sysZ3D1083: 0.0
-  sysZ3D1084: -0.0
-  sysZ3D1085: -0.0
+  sysZ3D1084: 0.0
+  sysZ3D1085: 0.0
   sysZ3D1086: 0.0
   sysZ3D1087: 0.0
   sysZ3D1088: 0.0
   sysZ3D1089: 0.0
-  sysZ3D1090: -0.0
-  sysZ3D1091: -0.0
-  sysZ3D1092: -0.0
+  sysZ3D1090: 0.0
+  sysZ3D1091: 0.0
+  sysZ3D1092: 0.0
   sysZ3D1093: 0.0
   sysZ3D1094: 0.0
   sysZ3D1095: 0.0
   sysZ3D1096: -2.39280000e-02
   sysZ3D1097: 0.023928
-  sysZ3D1098: -0.0
-  sysZ3D1099: -0.0
-  sysZ3D1100: -0.0
-  sysZ3D1101: -0.0
-  sysZ3D1102: -0.0
-  sysZ3D1103: -0.0
+  sysZ3D1098: 0.0
+  sysZ3D1099: 0.0
+  sysZ3D1100: 0.0
+  sysZ3D1101: 0.0
+  sysZ3D1102: 0.0
+  sysZ3D1103: 0.0
   sysZ3D1104: -2.87136000e-01
   sysZ3D1105: -0.47856
   sysZ3D1106: -9.57120000e-02
   sysZ3D1107: -2.39280000e-02
-  sysZ3D1108: -0.0
-  sysZ3D1109: -0.0
+  sysZ3D1108: 0.0
+  sysZ3D1109: 0.0
   sysZ3D1110: 0.0
   sysZ3D1111: 7.17840000e-02
   sysZ3D1112: 0.047856
@@ -14859,14 +14859,14 @@ bins:
   sysZ3D1122: -7.17840000e-02
   sysZ3D1123: -2.39280000e-02
   sysZ3D1124: -2.39280000e-02
-  sysZ3D1125: -0.0
-  sysZ3D1126: -0.0
+  sysZ3D1125: 0.0
+  sysZ3D1126: 0.0
   sysZ3D1127: -2.39280000e-02
-  sysZ3D1128: -0.0
-  sysZ3D1129: -0.0
+  sysZ3D1128: 0.0
+  sysZ3D1129: 0.0
   sysZ3D1130: 0.0
-  sysZ3D1131: -0.0
-  sysZ3D1132: -0.0
+  sysZ3D1131: 0.0
+  sysZ3D1132: 0.0
   sysZ3D1133: 0.0
   sysZ3D1134: -2.39280000e-02
   sysZ3D1135: -2.39280000e-02
@@ -14880,10 +14880,10 @@ bins:
   sysZ3D1143: 0.023928
   sysZ3D1144: 0.047856
   sysZ3D1145: 0.0
-  sysZ3D1146: -0.0
-  sysZ3D1147: -0.0
+  sysZ3D1146: 0.0
+  sysZ3D1147: 0.0
   sysZ3D1148: 0.023928
-  sysZ3D1149: -0.0
+  sysZ3D1149: 0.0
   sysZ3D1150: -2.39280000e-02
   sysZ3D1151: -2.39280000e-02
   sysZ3D1152: -2.39280000e-02
@@ -14892,22 +14892,22 @@ bins:
   sysZ3D1155: 0.023928
   sysZ3D1156: -2.39280000e-02
   sysZ3D1157: -2.39280000e-02
-  sysZ3D1158: -0.0
+  sysZ3D1158: 0.0
   sysZ3D1159: -2.39280000e-02
   sysZ3D1160: -2.39280000e-02
   sysZ3D1161: 0.023928
   sysZ3D1162: -2.39280000e-02
   sysZ3D1163: 0.0
   sysZ3D1164: 0.0
-  sysZ3D1165: -0.0
-  sysZ3D1166: -0.0
+  sysZ3D1165: 0.0
+  sysZ3D1166: 0.0
   sysZ3D1167: 0.0
-  sysZ3D1168: -0.0
+  sysZ3D1168: 0.0
   sysZ3D1169: -2.39280000e-02
   sysZ3D1170: 0.047856
   sysZ3D1171: -4.78560000e-02
   sysZ3D1172: 0.0
-  sysZ3D1173: -0.0
+  sysZ3D1173: 0.0
   sysZ3D1174: -2.39280000e-02
   sysZ3D1175: 0.0
   sysZ3D1176: 0.047856
@@ -14942,38 +14942,38 @@ bins:
   sysZ3D1205: 0.047856
   sysZ3D1206: 0.023928
   sysZ3D1207: 0.0
-  sysZ3D1208: -0.0
+  sysZ3D1208: 0.0
   sysZ3D1209: -2.39280000e-02
   sysZ3D1210: -2.39280000e-02
-  sysZ3D1211: -0.0
+  sysZ3D1211: 0.0
   sysZ3D1212: -2.39280000e-02
-  sysZ3D1213: -0.0
+  sysZ3D1213: 0.0
   sysZ3D1214: -2.39280000e-02
   sysZ3D1215: -4.78560000e-02
-  sysZ3D1216: -0.0
+  sysZ3D1216: 0.0
   sysZ3D1217: 0.095712
   sysZ3D1218: 7.17840000e-02
   sysZ3D1219: 0.023928
   sysZ3D1220: -2.39280000e-02
   sysZ3D1221: -2.39280000e-02
-  sysZ3D1222: -0.0
+  sysZ3D1222: 0.0
   sysZ3D1223: -2.39280000e-02
   sysZ3D1224: 0.0
   sysZ3D1225: 0.023928
   sysZ3D1226: 0.023928
   sysZ3D1227: 0.023928
   sysZ3D1228: 0.023928
-  sysZ3D1229: -0.0
+  sysZ3D1229: 0.0
   sysZ3D1230: 0.0
   sysZ3D1231: 0.023928
   sysZ3D1232: -2.39280000e-02
   sysZ3D1233: -2.39280000e-02
-  sysZ3D1234: -0.0
+  sysZ3D1234: 0.0
   sysZ3D1235: -2.39280000e-02
-  sysZ3D1236: -0.0
+  sysZ3D1236: 0.0
   sysZ3D1237: 0.023928
   sysZ3D1238: 0.023928
-  sysZ3D1239: -0.0
+  sysZ3D1239: 0.0
   sysZ3D1240: 0.0
   sysZ3D1241: 0.0
   sysZ3D1242: 0.0
@@ -14981,14 +14981,14 @@ bins:
   sysZ3D1244: 0.095712
   sysZ3D1245: -4.78560000e-02
   sysZ3D1246: 0.023928
-  sysZ3D1247: -0.0
+  sysZ3D1247: 0.0
   sysZ3D1248: -4.78560000e-02
   sysZ3D1249: -2.39280000e-02
-  sysZ3D1250: -0.0
+  sysZ3D1250: 0.0
   sysZ3D1251: -7.17840000e-02
   sysZ3D1252: -2.39280000e-02
-  sysZ3D1253: -0.0
-  sysZ3D1254: -0.0
+  sysZ3D1253: 0.0
+  sysZ3D1254: 0.0
   sysZ3D1255: -1.67496000e-01
   sysZ3D1256: -7.17840000e-02
   sysZ3D1257: -4.78560000e-02
@@ -15003,19 +15003,19 @@ bins:
   sysZ3D1266: -1.91424000e-01
   sysZ3D1267: -7.17840000e-02
   sysZ3D1268: 0.0
-  sysZ3D1269: -0.0
+  sysZ3D1269: 0.0
   sysZ3D1270: 0.023928
   sysZ3D1271: 0.023928
   sysZ3D1272: 0.0
-  sysZ3D1273: -0.0
+  sysZ3D1273: 0.0
   sysZ3D1274: -2.39280000e-02
   sysZ3D1275: 7.17840000e-02
   sys,uncor: 5.74272000e-01
   ATLAS_LUMI: 4.30704
 - stat: 1.19646
   sysZ3D1001: -0.07038
-  sysZ3D1002: -0.0
-  sysZ3D1003: -0.0
+  sysZ3D1002: 0.0
+  sysZ3D1003: 0.0
   sysZ3D1004: 0.0
   sysZ3D1005: 0.0
   sysZ3D1006: 0.0
@@ -15033,16 +15033,16 @@ bins:
   sysZ3D1018: 0.0
   sysZ3D1019: 0.0
   sysZ3D1020: 0.0
-  sysZ3D1021: -0.0
+  sysZ3D1021: 0.0
   sysZ3D1022: 0.0
-  sysZ3D1023: -0.0
+  sysZ3D1023: 0.0
   sysZ3D1024: 0.02346
   sysZ3D1025: -0.02346
   sysZ3D1026: 0.0
   sysZ3D1027: -0.02346
   sysZ3D1028: 0.0
   sysZ3D1029: -0.02346
-  sysZ3D1030: -0.0
+  sysZ3D1030: 0.0
   sysZ3D1031: 0.0
   sysZ3D1032: 0.0
   sysZ3D1033: 0.0
@@ -15054,81 +15054,81 @@ bins:
   sysZ3D1039: 0.0
   sysZ3D1040: 0.0
   sysZ3D1041: 0.0
-  sysZ3D1042: -0.0
+  sysZ3D1042: 0.0
   sysZ3D1043: 0.0
-  sysZ3D1044: -0.0
-  sysZ3D1045: -0.0
-  sysZ3D1046: -0.0
-  sysZ3D1047: -0.0
+  sysZ3D1044: 0.0
+  sysZ3D1045: 0.0
+  sysZ3D1046: 0.0
+  sysZ3D1047: 0.0
   sysZ3D1048: -0.02346
   sysZ3D1049: 0.0
-  sysZ3D1050: -0.0
+  sysZ3D1050: 0.0
   sysZ3D1051: 0.0
   sysZ3D1052: 0.0
-  sysZ3D1053: -0.0
+  sysZ3D1053: 0.0
   sysZ3D1054: 0.0
   sysZ3D1055: 0.0
   sysZ3D1056: 0.0
   sysZ3D1057: 0.0
   sysZ3D1058: -0.02346
-  sysZ3D1059: -0.0
-  sysZ3D1060: -0.0
+  sysZ3D1059: 0.0
+  sysZ3D1060: 0.0
   sysZ3D1061: 0.0
-  sysZ3D1062: -0.0
-  sysZ3D1063: -0.0
+  sysZ3D1062: 0.0
+  sysZ3D1063: 0.0
   sysZ3D1064: 0.0
-  sysZ3D1065: -0.0
+  sysZ3D1065: 0.0
   sysZ3D1066: 0.0
-  sysZ3D1067: -0.0
+  sysZ3D1067: 0.0
   sysZ3D1068: 0.0
-  sysZ3D1069: -0.0
+  sysZ3D1069: 0.0
   sysZ3D1070: 0.0
-  sysZ3D1071: -0.0
-  sysZ3D1072: -0.0
+  sysZ3D1071: 0.0
+  sysZ3D1072: 0.0
   sysZ3D1073: 0.0
-  sysZ3D1074: -0.0
-  sysZ3D1075: -0.0
+  sysZ3D1074: 0.0
+  sysZ3D1075: 0.0
   sysZ3D1076: 0.0
-  sysZ3D1077: -0.0
-  sysZ3D1078: -0.0
-  sysZ3D1079: -0.0
-  sysZ3D1080: -0.0
-  sysZ3D1081: -0.0
+  sysZ3D1077: 0.0
+  sysZ3D1078: 0.0
+  sysZ3D1079: 0.0
+  sysZ3D1080: 0.0
+  sysZ3D1081: 0.0
   sysZ3D1082: 0.0
-  sysZ3D1083: -0.0
+  sysZ3D1083: 0.0
   sysZ3D1084: 0.0
-  sysZ3D1085: -0.0
-  sysZ3D1086: -0.0
+  sysZ3D1085: 0.0
+  sysZ3D1086: 0.0
   sysZ3D1087: 0.0
-  sysZ3D1088: -0.0
-  sysZ3D1089: -0.0
-  sysZ3D1090: -0.0
+  sysZ3D1088: 0.0
+  sysZ3D1089: 0.0
+  sysZ3D1090: 0.0
   sysZ3D1091: 0.0
-  sysZ3D1092: -0.0
+  sysZ3D1092: 0.0
   sysZ3D1093: 0.0
   sysZ3D1094: 0.0
-  sysZ3D1095: -0.0
+  sysZ3D1095: 0.0
   sysZ3D1096: 0.0
-  sysZ3D1097: -0.0
+  sysZ3D1097: 0.0
   sysZ3D1098: 0.0
   sysZ3D1099: 0.02346
   sysZ3D1100: 0.0
   sysZ3D1101: 0.0
-  sysZ3D1102: -0.0
-  sysZ3D1103: -0.0
+  sysZ3D1102: 0.0
+  sysZ3D1103: 0.0
   sysZ3D1104: -0.28152
   sysZ3D1105: -0.4692
   sysZ3D1106: -0.09384
   sysZ3D1107: -0.02346
   sysZ3D1108: 0.0
-  sysZ3D1109: -0.0
+  sysZ3D1109: 0.0
   sysZ3D1110: 0.0
   sysZ3D1111: 0.07038
   sysZ3D1112: 0.04692
   sysZ3D1113: -0.07038
   sysZ3D1114: -0.02346
   sysZ3D1115: -0.04692
-  sysZ3D1116: -0.0
+  sysZ3D1116: 0.0
   sysZ3D1117: -0.09384
   sysZ3D1118: -0.04692
   sysZ3D1119: -0.09384
@@ -15142,23 +15142,23 @@ bins:
   sysZ3D1127: -0.02346
   sysZ3D1128: 0.0
   sysZ3D1129: 0.0
-  sysZ3D1130: -0.0
+  sysZ3D1130: 0.0
   sysZ3D1131: -0.02346
   sysZ3D1132: 0.02346
-  sysZ3D1133: -0.0
+  sysZ3D1133: 0.0
   sysZ3D1134: -0.02346
   sysZ3D1135: 0.0
   sysZ3D1136: -0.02346
-  sysZ3D1137: -0.0
+  sysZ3D1137: 0.0
   sysZ3D1138: 0.02346
   sysZ3D1139: 0.07038
   sysZ3D1140: 0.02346
-  sysZ3D1141: -0.0
+  sysZ3D1141: 0.0
   sysZ3D1142: -0.02346
   sysZ3D1143: -0.02346
   sysZ3D1144: 0.02346
   sysZ3D1145: -0.02346
-  sysZ3D1146: -0.0
+  sysZ3D1146: 0.0
   sysZ3D1147: -0.02346
   sysZ3D1148: -0.02346
   sysZ3D1149: 0.07038
@@ -15175,19 +15175,19 @@ bins:
   sysZ3D1160: -0.02346
   sysZ3D1161: -0.02346
   sysZ3D1162: 0.04692
-  sysZ3D1163: -0.0
-  sysZ3D1164: -0.0
+  sysZ3D1163: 0.0
+  sysZ3D1164: 0.0
   sysZ3D1165: 0.0
-  sysZ3D1166: -0.0
+  sysZ3D1166: 0.0
   sysZ3D1167: 0.0
-  sysZ3D1168: -0.0
+  sysZ3D1168: 0.0
   sysZ3D1169: -0.02346
   sysZ3D1170: 0.04692
   sysZ3D1171: -0.04692
-  sysZ3D1172: -0.0
-  sysZ3D1173: -0.0
+  sysZ3D1172: 0.0
+  sysZ3D1173: 0.0
   sysZ3D1174: -0.02346
-  sysZ3D1175: -0.0
+  sysZ3D1175: 0.0
   sysZ3D1176: 0.02346
   sysZ3D1177: 0.07038
   sysZ3D1178: 0.04692
@@ -15201,7 +15201,7 @@ bins:
   sysZ3D1186: 0.0
   sysZ3D1187: 0.02346
   sysZ3D1188: -0.04692
-  sysZ3D1189: -0.0
+  sysZ3D1189: 0.0
   sysZ3D1190: 0.02346
   sysZ3D1191: -0.02346
   sysZ3D1192: 0.02346
@@ -15211,7 +15211,7 @@ bins:
   sysZ3D1196: 0.02346
   sysZ3D1197: 0.04692
   sysZ3D1198: 0.04692
-  sysZ3D1199: -0.0
+  sysZ3D1199: 0.0
   sysZ3D1200: -0.04692
   sysZ3D1201: -0.07038
   sysZ3D1202: 0.0
@@ -15221,10 +15221,10 @@ bins:
   sysZ3D1206: 0.02346
   sysZ3D1207: 0.02346
   sysZ3D1208: 0.02346
-  sysZ3D1209: -0.0
+  sysZ3D1209: 0.0
   sysZ3D1210: -0.02346
-  sysZ3D1211: -0.0
-  sysZ3D1212: -0.0
+  sysZ3D1211: 0.0
+  sysZ3D1212: 0.0
   sysZ3D1213: -0.02346
   sysZ3D1214: -0.02346
   sysZ3D1215: -0.04692
@@ -15236,23 +15236,23 @@ bins:
   sysZ3D1221: -0.02346
   sysZ3D1222: -0.02346
   sysZ3D1223: -0.04692
-  sysZ3D1224: -0.0
+  sysZ3D1224: 0.0
   sysZ3D1225: 0.02346
   sysZ3D1226: 0.02346
   sysZ3D1227: 0.04692
   sysZ3D1228: 0.02346
-  sysZ3D1229: -0.0
+  sysZ3D1229: 0.0
   sysZ3D1230: 0.0
   sysZ3D1231: 0.02346
   sysZ3D1232: -0.02346
   sysZ3D1233: -0.02346
-  sysZ3D1234: -0.0
+  sysZ3D1234: 0.0
   sysZ3D1235: -0.02346
   sysZ3D1236: -0.02346
   sysZ3D1237: 0.02346
   sysZ3D1238: 0.02346
-  sysZ3D1239: -0.0
-  sysZ3D1240: -0.0
+  sysZ3D1239: 0.0
+  sysZ3D1240: 0.0
   sysZ3D1241: 0.0
   sysZ3D1242: 0.0
   sysZ3D1243: 0.0
@@ -15265,14 +15265,14 @@ bins:
   sysZ3D1250: 0.02346
   sysZ3D1251: -0.07038
   sysZ3D1252: 0.0
-  sysZ3D1253: -0.0
+  sysZ3D1253: 0.0
   sysZ3D1254: 0.0
   sysZ3D1255: -0.18768
   sysZ3D1256: 0.02346
   sysZ3D1257: 0.02346
   sysZ3D1258: -0.07038
   sysZ3D1259: 0.04692
-  sysZ3D1260: -0.0
+  sysZ3D1260: 0.0
   sysZ3D1261: 0.04692
   sysZ3D1262: 0.02346
   sysZ3D1263: 0.09384
@@ -15281,7 +15281,7 @@ bins:
   sysZ3D1266: -0.18768
   sysZ3D1267: -0.04692
   sysZ3D1268: 0.0
-  sysZ3D1269: -0.0
+  sysZ3D1269: 0.0
   sysZ3D1270: 0.02346
   sysZ3D1271: 0.02346
   sysZ3D1272: 0.0
@@ -15292,8 +15292,8 @@ bins:
   ATLAS_LUMI: 4.22280000e+00
 - stat: 1.188708
   sysZ3D1001: -9.32320000e-02
-  sysZ3D1002: -0.0
-  sysZ3D1003: -0.0
+  sysZ3D1002: 0.0
+  sysZ3D1003: 0.0
   sysZ3D1004: 0.0
   sysZ3D1005: 0.0
   sysZ3D1006: 0.0
@@ -15310,9 +15310,9 @@ bins:
   sysZ3D1017: 0.0
   sysZ3D1018: 0.0
   sysZ3D1019: 0.0
-  sysZ3D1020: -0.0
+  sysZ3D1020: 0.0
   sysZ3D1021: 2.33080000e-02
-  sysZ3D1022: -0.0
+  sysZ3D1022: 0.0
   sysZ3D1023: 2.33080000e-02
   sysZ3D1024: -2.33080000e-02
   sysZ3D1025: 4.66160000e-02
@@ -15322,67 +15322,67 @@ bins:
   sysZ3D1029: 0.0
   sysZ3D1030: -2.33080000e-02
   sysZ3D1031: 0.0
-  sysZ3D1032: -0.0
+  sysZ3D1032: 0.0
   sysZ3D1033: 0.0
-  sysZ3D1034: -0.0
+  sysZ3D1034: 0.0
   sysZ3D1035: 0.0
   sysZ3D1036: 0.0
-  sysZ3D1037: -0.0
+  sysZ3D1037: 0.0
   sysZ3D1038: 0.0
-  sysZ3D1039: -0.0
-  sysZ3D1040: -0.0
-  sysZ3D1041: -0.0
+  sysZ3D1039: 0.0
+  sysZ3D1040: 0.0
+  sysZ3D1041: 0.0
   sysZ3D1042: 0.0
   sysZ3D1043: 0.0
-  sysZ3D1044: -0.0
-  sysZ3D1045: -0.0
-  sysZ3D1046: -0.0
+  sysZ3D1044: 0.0
+  sysZ3D1045: 0.0
+  sysZ3D1046: 0.0
   sysZ3D1047: 0.0
   sysZ3D1048: 0.0
-  sysZ3D1049: -0.0
+  sysZ3D1049: 0.0
   sysZ3D1050: 2.33080000e-02
-  sysZ3D1051: -0.0
+  sysZ3D1051: 0.0
   sysZ3D1052: 0.0
   sysZ3D1053: 0.0
-  sysZ3D1054: -0.0
+  sysZ3D1054: 0.0
   sysZ3D1055: -2.33080000e-02
   sysZ3D1056: 0.0
-  sysZ3D1057: -0.0
+  sysZ3D1057: 0.0
   sysZ3D1058: 0.0
   sysZ3D1059: 0.0
-  sysZ3D1060: -0.0
-  sysZ3D1061: -0.0
-  sysZ3D1062: -0.0
+  sysZ3D1060: 0.0
+  sysZ3D1061: 0.0
+  sysZ3D1062: 0.0
   sysZ3D1063: 0.0
   sysZ3D1064: 2.33080000e-02
-  sysZ3D1065: -0.0
-  sysZ3D1066: -0.0
+  sysZ3D1065: 0.0
+  sysZ3D1066: 0.0
   sysZ3D1067: 0.0
   sysZ3D1068: 0.0
-  sysZ3D1069: -0.0
+  sysZ3D1069: 0.0
   sysZ3D1070: 0.0
-  sysZ3D1071: -0.0
-  sysZ3D1072: -0.0
+  sysZ3D1071: 0.0
+  sysZ3D1072: 0.0
   sysZ3D1073: 0.0
-  sysZ3D1074: -0.0
+  sysZ3D1074: 0.0
   sysZ3D1075: 0.0
   sysZ3D1076: 2.33080000e-02
   sysZ3D1077: -2.33080000e-02
   sysZ3D1078: 0.0
-  sysZ3D1079: -0.0
+  sysZ3D1079: 0.0
   sysZ3D1080: 0.0
-  sysZ3D1081: -0.0
+  sysZ3D1081: 0.0
   sysZ3D1082: -2.33080000e-02
   sysZ3D1083: 0.0
-  sysZ3D1084: -0.0
-  sysZ3D1085: -0.0
+  sysZ3D1084: 0.0
+  sysZ3D1085: 0.0
   sysZ3D1086: 0.0
-  sysZ3D1087: -0.0
+  sysZ3D1087: 0.0
   sysZ3D1088: 0.0
   sysZ3D1089: -2.33080000e-02
   sysZ3D1090: 0.0
   sysZ3D1091: 0.0
-  sysZ3D1092: -0.0
+  sysZ3D1092: 0.0
   sysZ3D1093: 2.33080000e-02
   sysZ3D1094: 0.0
   sysZ3D1095: 0.0
@@ -15398,14 +15398,14 @@ bins:
   sysZ3D1105: -0.46616
   sysZ3D1106: -9.32320000e-02
   sysZ3D1107: -2.33080000e-02
-  sysZ3D1108: -0.0
-  sysZ3D1109: -0.0
+  sysZ3D1108: 0.0
+  sysZ3D1109: 0.0
   sysZ3D1110: 0.0
   sysZ3D1111: 4.66160000e-02
   sysZ3D1112: 4.66160000e-02
   sysZ3D1113: -9.32320000e-02
   sysZ3D1114: -9.32320000e-02
-  sysZ3D1115: -0.0
+  sysZ3D1115: 0.0
   sysZ3D1116: -0.11654
   sysZ3D1117: -4.66160000e-02
   sysZ3D1118: -9.32320000e-02
@@ -15419,17 +15419,17 @@ bins:
   sysZ3D1126: 0.0
   sysZ3D1127: 2.33080000e-02
   sysZ3D1128: 0.0
-  sysZ3D1129: -0.0
+  sysZ3D1129: 0.0
   sysZ3D1130: 0.0
   sysZ3D1131: 0.0
   sysZ3D1132: 2.33080000e-02
   sysZ3D1133: 0.0
   sysZ3D1134: 9.32320000e-02
-  sysZ3D1135: -0.0
+  sysZ3D1135: 0.0
   sysZ3D1136: -2.33080000e-02
   sysZ3D1137: -2.33080000e-02
-  sysZ3D1138: -0.0
-  sysZ3D1139: -0.0
+  sysZ3D1138: 0.0
+  sysZ3D1139: 0.0
   sysZ3D1140: -2.33080000e-02
   sysZ3D1141: -2.33080000e-02
   sysZ3D1142: -2.33080000e-02
@@ -15438,7 +15438,7 @@ bins:
   sysZ3D1145: -4.66160000e-02
   sysZ3D1146: -2.33080000e-02
   sysZ3D1147: -2.33080000e-02
-  sysZ3D1148: -0.0
+  sysZ3D1148: 0.0
   sysZ3D1149: -4.66160000e-02
   sysZ3D1150: -2.33080000e-02
   sysZ3D1151: 2.33080000e-02
@@ -15446,30 +15446,30 @@ bins:
   sysZ3D1153: 2.33080000e-02
   sysZ3D1154: -2.33080000e-02
   sysZ3D1155: -9.32320000e-02
-  sysZ3D1156: -0.0
+  sysZ3D1156: 0.0
   sysZ3D1157: 2.33080000e-02
   sysZ3D1158: 0.0
-  sysZ3D1159: -0.0
+  sysZ3D1159: 0.0
   sysZ3D1160: 2.33080000e-02
   sysZ3D1161: -2.33080000e-02
-  sysZ3D1162: -0.0
+  sysZ3D1162: 0.0
   sysZ3D1163: 2.33080000e-02
   sysZ3D1164: 0.0
   sysZ3D1165: 0.0
-  sysZ3D1166: -0.0
+  sysZ3D1166: 0.0
   sysZ3D1167: 0.0
-  sysZ3D1168: -0.0
+  sysZ3D1168: 0.0
   sysZ3D1169: -2.33080000e-02
   sysZ3D1170: 4.66160000e-02
   sysZ3D1171: -4.66160000e-02
   sysZ3D1172: 0.0
-  sysZ3D1173: -0.0
+  sysZ3D1173: 0.0
   sysZ3D1174: -2.33080000e-02
   sysZ3D1175: 0.0
   sysZ3D1176: 0.069924
   sysZ3D1177: 0.11654
   sysZ3D1178: 0.069924
-  sysZ3D1179: -0.0
+  sysZ3D1179: 0.0
   sysZ3D1180: 0.0
   sysZ3D1181: -2.33080000e-02
   sysZ3D1182: -2.33080000e-02
@@ -15477,9 +15477,9 @@ bins:
   sysZ3D1184: -2.33080000e-02
   sysZ3D1185: 2.33080000e-02
   sysZ3D1186: 0.0
-  sysZ3D1187: -0.0
+  sysZ3D1187: 0.0
   sysZ3D1188: -6.99240000e-02
-  sysZ3D1189: -0.0
+  sysZ3D1189: 0.0
   sysZ3D1190: 2.33080000e-02
   sysZ3D1191: 2.33080000e-02
   sysZ3D1192: 2.33080000e-02
@@ -15489,7 +15489,7 @@ bins:
   sysZ3D1196: 2.33080000e-02
   sysZ3D1197: 2.33080000e-02
   sysZ3D1198: 9.32320000e-02
-  sysZ3D1199: -0.0
+  sysZ3D1199: 0.0
   sysZ3D1200: -4.66160000e-02
   sysZ3D1201: -4.66160000e-02
   sysZ3D1202: 0.0
@@ -15499,10 +15499,10 @@ bins:
   sysZ3D1206: 2.33080000e-02
   sysZ3D1207: 2.33080000e-02
   sysZ3D1208: 0.0
-  sysZ3D1209: -0.0
+  sysZ3D1209: 0.0
   sysZ3D1210: -2.33080000e-02
-  sysZ3D1211: -0.0
-  sysZ3D1212: -0.0
+  sysZ3D1211: 0.0
+  sysZ3D1212: 0.0
   sysZ3D1213: -2.33080000e-02
   sysZ3D1214: -2.33080000e-02
   sysZ3D1215: -4.66160000e-02
@@ -15510,11 +15510,11 @@ bins:
   sysZ3D1217: 4.66160000e-02
   sysZ3D1218: 0.069924
   sysZ3D1219: 2.33080000e-02
-  sysZ3D1220: -0.0
+  sysZ3D1220: 0.0
   sysZ3D1221: -2.33080000e-02
   sysZ3D1222: -2.33080000e-02
   sysZ3D1223: -4.66160000e-02
-  sysZ3D1224: -0.0
+  sysZ3D1224: 0.0
   sysZ3D1225: 0.0
   sysZ3D1226: 2.33080000e-02
   sysZ3D1227: 4.66160000e-02
@@ -15522,27 +15522,27 @@ bins:
   sysZ3D1229: 0.0
   sysZ3D1230: 2.33080000e-02
   sysZ3D1231: 2.33080000e-02
-  sysZ3D1232: -0.0
+  sysZ3D1232: 0.0
   sysZ3D1233: -2.33080000e-02
   sysZ3D1234: -2.33080000e-02
   sysZ3D1235: -2.33080000e-02
   sysZ3D1236: -2.33080000e-02
   sysZ3D1237: 0.0
   sysZ3D1238: 2.33080000e-02
-  sysZ3D1239: -0.0
-  sysZ3D1240: -0.0
-  sysZ3D1241: -0.0
+  sysZ3D1239: 0.0
+  sysZ3D1240: 0.0
+  sysZ3D1241: 0.0
   sysZ3D1242: 0.0
   sysZ3D1243: 0.0
   sysZ3D1244: 9.32320000e-02
   sysZ3D1245: -4.66160000e-02
   sysZ3D1246: 2.33080000e-02
-  sysZ3D1247: -0.0
+  sysZ3D1247: 0.0
   sysZ3D1248: -4.66160000e-02
   sysZ3D1249: -4.66160000e-02
   sysZ3D1250: 2.33080000e-02
   sysZ3D1251: -6.99240000e-02
-  sysZ3D1252: -0.0
+  sysZ3D1252: 0.0
   sysZ3D1253: -2.33080000e-02
   sysZ3D1254: 0.0
   sysZ3D1255: -0.23308
@@ -15571,7 +15571,7 @@ bins:
 - stat: 1.167594
   sysZ3D1001: -9.15760000e-02
   sysZ3D1002: 0.022894
-  sysZ3D1003: -0.0
+  sysZ3D1003: 0.0
   sysZ3D1004: 0.0
   sysZ3D1005: 0.0
   sysZ3D1006: 0.0
@@ -15589,26 +15589,26 @@ bins:
   sysZ3D1018: 0.0
   sysZ3D1019: 0.0
   sysZ3D1020: 0.0
-  sysZ3D1021: -0.0
+  sysZ3D1021: 0.0
   sysZ3D1022: 0.022894
-  sysZ3D1023: -0.0
-  sysZ3D1024: -0.0
+  sysZ3D1023: 0.0
+  sysZ3D1024: 0.0
   sysZ3D1025: -2.28940000e-02
   sysZ3D1026: 0.022894
-  sysZ3D1027: -0.0
+  sysZ3D1027: 0.0
   sysZ3D1028: 0.022894
   sysZ3D1029: -2.28940000e-02
   sysZ3D1030: 0.0
-  sysZ3D1031: -0.0
-  sysZ3D1032: -0.0
+  sysZ3D1031: 0.0
+  sysZ3D1032: 0.0
   sysZ3D1033: 0.0
   sysZ3D1034: 0.022894
   sysZ3D1035: -2.28940000e-02
   sysZ3D1036: 0.0
   sysZ3D1037: 0.0
-  sysZ3D1038: -0.0
-  sysZ3D1039: -0.0
-  sysZ3D1040: -0.0
+  sysZ3D1038: 0.0
+  sysZ3D1039: 0.0
+  sysZ3D1040: 0.0
   sysZ3D1041: 0.0
   sysZ3D1042: 0.022894
   sysZ3D1043: 0.0
@@ -15616,67 +15616,67 @@ bins:
   sysZ3D1045: 0.0
   sysZ3D1046: 0.0
   sysZ3D1047: -2.28940000e-02
-  sysZ3D1048: -0.0
-  sysZ3D1049: -0.0
-  sysZ3D1050: -0.0
-  sysZ3D1051: -0.0
+  sysZ3D1048: 0.0
+  sysZ3D1049: 0.0
+  sysZ3D1050: 0.0
+  sysZ3D1051: 0.0
   sysZ3D1052: 0.0
   sysZ3D1053: -2.28940000e-02
-  sysZ3D1054: -0.0
-  sysZ3D1055: -0.0
-  sysZ3D1056: -0.0
+  sysZ3D1054: 0.0
+  sysZ3D1055: 0.0
+  sysZ3D1056: 0.0
   sysZ3D1057: 0.022894
   sysZ3D1058: 0.0
   sysZ3D1059: 0.0
   sysZ3D1060: -2.28940000e-02
   sysZ3D1061: -2.28940000e-02
   sysZ3D1062: -2.28940000e-02
-  sysZ3D1063: -0.0
-  sysZ3D1064: -0.0
+  sysZ3D1063: 0.0
+  sysZ3D1064: 0.0
   sysZ3D1065: 0.0
-  sysZ3D1066: -0.0
+  sysZ3D1066: 0.0
   sysZ3D1067: -2.28940000e-02
-  sysZ3D1068: -0.0
-  sysZ3D1069: -0.0
+  sysZ3D1068: 0.0
+  sysZ3D1069: 0.0
   sysZ3D1070: 0.0
   sysZ3D1071: 0.0
-  sysZ3D1072: -0.0
+  sysZ3D1072: 0.0
   sysZ3D1073: 0.022894
-  sysZ3D1074: -0.0
-  sysZ3D1075: -0.0
-  sysZ3D1076: -0.0
+  sysZ3D1074: 0.0
+  sysZ3D1075: 0.0
+  sysZ3D1076: 0.0
   sysZ3D1077: -2.28940000e-02
   sysZ3D1078: 0.0
-  sysZ3D1079: -0.0
+  sysZ3D1079: 0.0
   sysZ3D1080: 0.0
   sysZ3D1081: 0.022894
-  sysZ3D1082: -0.0
+  sysZ3D1082: 0.0
   sysZ3D1083: -2.28940000e-02
   sysZ3D1084: 0.0
-  sysZ3D1085: -0.0
+  sysZ3D1085: 0.0
   sysZ3D1086: 0.022894
-  sysZ3D1087: -0.0
+  sysZ3D1087: 0.0
   sysZ3D1088: -2.28940000e-02
   sysZ3D1089: 0.0
   sysZ3D1090: 0.0
-  sysZ3D1091: -0.0
+  sysZ3D1091: 0.0
   sysZ3D1092: -2.28940000e-02
   sysZ3D1093: -2.28940000e-02
   sysZ3D1094: 0.0
-  sysZ3D1095: -0.0
+  sysZ3D1095: 0.0
   sysZ3D1096: 0.0
   sysZ3D1097: 0.022894
   sysZ3D1098: 0.0
   sysZ3D1099: 0.022894
   sysZ3D1100: 0.0
   sysZ3D1101: 0.022894
-  sysZ3D1102: -0.0
-  sysZ3D1103: -0.0
+  sysZ3D1102: 0.0
+  sysZ3D1103: 0.0
   sysZ3D1104: -2.06046000e-01
   sysZ3D1105: -4.12092000e-01
   sysZ3D1106: -9.15760000e-02
   sysZ3D1107: -2.28940000e-02
-  sysZ3D1108: -0.0
+  sysZ3D1108: 0.0
   sysZ3D1109: -2.28940000e-02
   sysZ3D1110: 0.0
   sysZ3D1111: 0.045788
@@ -15686,7 +15686,7 @@ bins:
   sysZ3D1115: -6.86820000e-02
   sysZ3D1116: -6.86820000e-02
   sysZ3D1117: -1.37364000e-01
-  sysZ3D1118: -0.0
+  sysZ3D1118: 0.0
   sysZ3D1119: -2.28940000e-02
   sysZ3D1120: -6.86820000e-02
   sysZ3D1121: -1.60258000e-01
@@ -15694,12 +15694,12 @@ bins:
   sysZ3D1123: -6.86820000e-02
   sysZ3D1124: -4.57880000e-02
   sysZ3D1125: 0.022894
-  sysZ3D1126: -0.0
+  sysZ3D1126: 0.0
   sysZ3D1127: 0.022894
   sysZ3D1128: 0.0
-  sysZ3D1129: -0.0
+  sysZ3D1129: 0.0
   sysZ3D1130: 0.022894
-  sysZ3D1131: -0.0
+  sysZ3D1131: 0.0
   sysZ3D1132: 0.022894
   sysZ3D1133: 0.022894
   sysZ3D1134: 0.0
@@ -15709,14 +15709,14 @@ bins:
   sysZ3D1138: -2.28940000e-02
   sysZ3D1139: -4.57880000e-02
   sysZ3D1140: -2.28940000e-02
-  sysZ3D1141: -0.0
+  sysZ3D1141: 0.0
   sysZ3D1142: 0.022894
   sysZ3D1143: -4.57880000e-02
   sysZ3D1144: -2.28940000e-02
   sysZ3D1145: 0.022894
   sysZ3D1146: 0.0
-  sysZ3D1147: -0.0
-  sysZ3D1148: -0.0
+  sysZ3D1147: 0.0
+  sysZ3D1148: 0.0
   sysZ3D1149: -2.28940000e-02
   sysZ3D1150: 0.045788
   sysZ3D1151: 0.022894
@@ -15736,26 +15736,26 @@ bins:
   sysZ3D1165: -2.28940000e-02
   sysZ3D1166: 0.0
   sysZ3D1167: 0.022894
-  sysZ3D1168: -0.0
+  sysZ3D1168: 0.0
   sysZ3D1169: -2.28940000e-02
   sysZ3D1170: 0.045788
   sysZ3D1171: -2.28940000e-02
-  sysZ3D1172: -0.0
-  sysZ3D1173: -0.0
+  sysZ3D1172: 0.0
+  sysZ3D1173: 0.0
   sysZ3D1174: -2.28940000e-02
-  sysZ3D1175: -0.0
+  sysZ3D1175: 0.0
   sysZ3D1176: 0.045788
   sysZ3D1177: 0.091576
   sysZ3D1178: 0.045788
   sysZ3D1179: 0.0
   sysZ3D1180: 0.0
   sysZ3D1181: -2.28940000e-02
-  sysZ3D1182: -0.0
+  sysZ3D1182: 0.0
   sysZ3D1183: 0.022894
   sysZ3D1184: -2.28940000e-02
   sysZ3D1185: 0.0
   sysZ3D1186: 0.022894
-  sysZ3D1187: -0.0
+  sysZ3D1187: 0.0
   sysZ3D1188: -4.57880000e-02
   sysZ3D1189: -2.28940000e-02
   sysZ3D1190: 0.022894
@@ -15763,12 +15763,12 @@ bins:
   sysZ3D1192: 0.022894
   sysZ3D1193: 0.022894
   sysZ3D1194: -3.20516000e-01
-  sysZ3D1195: -0.0
+  sysZ3D1195: 0.0
   sysZ3D1196: 0.0
   sysZ3D1197: 0.022894
   sysZ3D1198: 0.045788
   sysZ3D1199: 0.0
-  sysZ3D1200: -0.0
+  sysZ3D1200: 0.0
   sysZ3D1201: -2.28940000e-02
   sysZ3D1202: 0.0
   sysZ3D1203: -6.86820000e-02
@@ -15780,7 +15780,7 @@ bins:
   sysZ3D1209: -2.28940000e-02
   sysZ3D1210: -2.28940000e-02
   sysZ3D1211: 0.0
-  sysZ3D1212: -0.0
+  sysZ3D1212: 0.0
   sysZ3D1213: -2.28940000e-02
   sysZ3D1214: -2.28940000e-02
   sysZ3D1215: -4.57880000e-02
@@ -15789,10 +15789,10 @@ bins:
   sysZ3D1218: 0.022894
   sysZ3D1219: 0.022894
   sysZ3D1220: 0.0
-  sysZ3D1221: -0.0
-  sysZ3D1222: -0.0
+  sysZ3D1221: 0.0
+  sysZ3D1222: 0.0
   sysZ3D1223: -2.28940000e-02
-  sysZ3D1224: -0.0
+  sysZ3D1224: 0.0
   sysZ3D1225: 0.0
   sysZ3D1226: 0.022894
   sysZ3D1227: 0.045788
@@ -15801,14 +15801,14 @@ bins:
   sysZ3D1230: 0.022894
   sysZ3D1231: 0.022894
   sysZ3D1232: 0.0
-  sysZ3D1233: -0.0
+  sysZ3D1233: 0.0
   sysZ3D1234: -2.28940000e-02
   sysZ3D1235: -2.28940000e-02
-  sysZ3D1236: -0.0
+  sysZ3D1236: 0.0
   sysZ3D1237: 0.0
   sysZ3D1238: 0.0
-  sysZ3D1239: -0.0
-  sysZ3D1240: -0.0
+  sysZ3D1239: 0.0
+  sysZ3D1240: 0.0
   sysZ3D1241: 0.0
   sysZ3D1242: 0.0
   sysZ3D1243: 0.0
@@ -15821,7 +15821,7 @@ bins:
   sysZ3D1250: 0.022894
   sysZ3D1251: -6.86820000e-02
   sysZ3D1252: -6.86820000e-02
-  sysZ3D1253: -0.0
+  sysZ3D1253: 0.0
   sysZ3D1254: -2.28940000e-02
   sysZ3D1255: -2.74728000e-01
   sysZ3D1256: 0.022894
@@ -15837,7 +15837,7 @@ bins:
   sysZ3D1266: -2.06046000e-01
   sysZ3D1267: -6.86820000e-02
   sysZ3D1268: 0.0
-  sysZ3D1269: -0.0
+  sysZ3D1269: 0.0
   sysZ3D1270: 0.022894
   sysZ3D1271: 0.022894
   sysZ3D1272: 0.0
@@ -15849,7 +15849,7 @@ bins:
 - stat: 1.10037600e+00
   sysZ3D1001: -8.63040000e-02
   sysZ3D1002: 0.043152
-  sysZ3D1003: -0.0
+  sysZ3D1003: 0.0
   sysZ3D1004: 0.0
   sysZ3D1005: 0.0
   sysZ3D1006: 0.0
@@ -15869,82 +15869,82 @@ bins:
   sysZ3D1020: -2.15760000e-02
   sysZ3D1021: 0.0
   sysZ3D1022: 0.0
-  sysZ3D1023: -0.0
+  sysZ3D1023: 0.0
   sysZ3D1024: 0.0
-  sysZ3D1025: -0.0
+  sysZ3D1025: 0.0
   sysZ3D1026: 0.0
   sysZ3D1027: 0.0
   sysZ3D1028: 0.0
   sysZ3D1029: -2.15760000e-02
-  sysZ3D1030: -0.0
-  sysZ3D1031: -0.0
-  sysZ3D1032: -0.0
-  sysZ3D1033: -0.0
-  sysZ3D1034: -0.0
-  sysZ3D1035: -0.0
+  sysZ3D1030: 0.0
+  sysZ3D1031: 0.0
+  sysZ3D1032: 0.0
+  sysZ3D1033: 0.0
+  sysZ3D1034: 0.0
+  sysZ3D1035: 0.0
   sysZ3D1036: -2.15760000e-02
-  sysZ3D1037: -0.0
-  sysZ3D1038: -0.0
+  sysZ3D1037: 0.0
+  sysZ3D1038: 0.0
   sysZ3D1039: 0.0
-  sysZ3D1040: -0.0
+  sysZ3D1040: 0.0
   sysZ3D1041: 0.021576
-  sysZ3D1042: -0.0
-  sysZ3D1043: -0.0
+  sysZ3D1042: 0.0
+  sysZ3D1043: 0.0
   sysZ3D1044: 0.0
   sysZ3D1045: 0.0
   sysZ3D1046: -2.15760000e-02
-  sysZ3D1047: -0.0
+  sysZ3D1047: 0.0
   sysZ3D1048: 0.021576
   sysZ3D1049: -2.15760000e-02
   sysZ3D1050: 0.0
   sysZ3D1051: 0.0
-  sysZ3D1052: -0.0
+  sysZ3D1052: 0.0
   sysZ3D1053: 0.0
   sysZ3D1054: -2.15760000e-02
   sysZ3D1055: -2.15760000e-02
   sysZ3D1056: 0.0
   sysZ3D1057: -2.15760000e-02
-  sysZ3D1058: -0.0
-  sysZ3D1059: -0.0
+  sysZ3D1058: 0.0
+  sysZ3D1059: 0.0
   sysZ3D1060: 0.0
   sysZ3D1061: 0.0
   sysZ3D1062: 0.021576
   sysZ3D1063: 0.021576
-  sysZ3D1064: -0.0
+  sysZ3D1064: 0.0
   sysZ3D1065: 0.0
-  sysZ3D1066: -0.0
+  sysZ3D1066: 0.0
   sysZ3D1067: 0.0
   sysZ3D1068: 0.021576
   sysZ3D1069: 0.021576
   sysZ3D1070: 0.021576
   sysZ3D1071: 0.021576
-  sysZ3D1072: -0.0
+  sysZ3D1072: 0.0
   sysZ3D1073: 0.0
   sysZ3D1074: 0.0
-  sysZ3D1075: -0.0
+  sysZ3D1075: 0.0
   sysZ3D1076: 0.021576
   sysZ3D1077: 0.0
-  sysZ3D1078: -0.0
-  sysZ3D1079: -0.0
+  sysZ3D1078: 0.0
+  sysZ3D1079: 0.0
   sysZ3D1080: -2.15760000e-02
-  sysZ3D1081: -0.0
+  sysZ3D1081: 0.0
   sysZ3D1082: 0.0
   sysZ3D1083: 0.0
   sysZ3D1084: 0.0
   sysZ3D1085: 0.0
   sysZ3D1086: 0.021576
-  sysZ3D1087: -0.0
+  sysZ3D1087: 0.0
   sysZ3D1088: 0.021576
-  sysZ3D1089: -0.0
+  sysZ3D1089: 0.0
   sysZ3D1090: 0.021576
-  sysZ3D1091: -0.0
+  sysZ3D1091: 0.0
   sysZ3D1092: 0.0
-  sysZ3D1093: -0.0
+  sysZ3D1093: 0.0
   sysZ3D1094: -2.15760000e-02
   sysZ3D1095: 0.0
   sysZ3D1096: -2.15760000e-02
   sysZ3D1097: 0.0
-  sysZ3D1098: -0.0
+  sysZ3D1098: 0.0
   sysZ3D1099: 0.0
   sysZ3D1100: -2.15760000e-02
   sysZ3D1101: 0.0
@@ -15954,8 +15954,8 @@ bins:
   sysZ3D1105: -3.45216000e-01
   sysZ3D1106: -8.63040000e-02
   sysZ3D1107: -2.15760000e-02
-  sysZ3D1108: -0.0
-  sysZ3D1109: -0.0
+  sysZ3D1108: 0.0
+  sysZ3D1109: 0.0
   sysZ3D1110: 0.0
   sysZ3D1111: 0.043152
   sysZ3D1112: 0.021576
@@ -15964,7 +15964,7 @@ bins:
   sysZ3D1115: -8.63040000e-02
   sysZ3D1116: -1.29456000e-01
   sysZ3D1117: -1.51032000e-01
-  sysZ3D1118: -0.0
+  sysZ3D1118: 0.0
   sysZ3D1119: -2.15760000e-02
   sysZ3D1120: -2.15760000e-02
   sysZ3D1121: -6.47280000e-02
@@ -15981,21 +15981,21 @@ bins:
   sysZ3D1132: -2.15760000e-02
   sysZ3D1133: 0.0
   sysZ3D1134: -4.31520000e-02
-  sysZ3D1135: -0.0
+  sysZ3D1135: 0.0
   sysZ3D1136: -4.31520000e-02
   sysZ3D1137: 0.021576
   sysZ3D1138: 0.0
   sysZ3D1139: -6.47280000e-02
   sysZ3D1140: -2.15760000e-02
-  sysZ3D1141: -0.0
+  sysZ3D1141: 0.0
   sysZ3D1142: 0.0
   sysZ3D1143: 0.0
   sysZ3D1144: -2.15760000e-02
   sysZ3D1145: 0.0
-  sysZ3D1146: -0.0
+  sysZ3D1146: 0.0
   sysZ3D1147: -2.15760000e-02
   sysZ3D1148: -2.15760000e-02
-  sysZ3D1149: -0.0
+  sysZ3D1149: 0.0
   sysZ3D1150: 0.021576
   sysZ3D1151: 0.043152
   sysZ3D1152: -2.15760000e-02
@@ -16006,29 +16006,29 @@ bins:
   sysZ3D1157: 0.0
   sysZ3D1158: 0.0
   sysZ3D1159: 1.51032000e-01
-  sysZ3D1160: -0.0
+  sysZ3D1160: 0.0
   sysZ3D1161: -2.15760000e-02
   sysZ3D1162: -2.15760000e-02
   sysZ3D1163: 0.021576
-  sysZ3D1164: -0.0
-  sysZ3D1165: -0.0
+  sysZ3D1164: 0.0
+  sysZ3D1165: 0.0
   sysZ3D1166: 0.0
-  sysZ3D1167: -0.0
-  sysZ3D1168: -0.0
-  sysZ3D1169: -0.0
+  sysZ3D1167: 0.0
+  sysZ3D1168: 0.0
+  sysZ3D1169: 0.0
   sysZ3D1170: 0.021576
   sysZ3D1171: -2.15760000e-02
-  sysZ3D1172: -0.0
-  sysZ3D1173: -0.0
+  sysZ3D1172: 0.0
+  sysZ3D1173: 0.0
   sysZ3D1174: -2.15760000e-02
-  sysZ3D1175: -0.0
+  sysZ3D1175: 0.0
   sysZ3D1176: 0.10788
   sysZ3D1177: 0.129456
   sysZ3D1178: 0.064728
   sysZ3D1179: 0.021576
-  sysZ3D1180: -0.0
+  sysZ3D1180: 0.0
   sysZ3D1181: -2.15760000e-02
-  sysZ3D1182: -0.0
+  sysZ3D1182: 0.0
   sysZ3D1183: 0.021576
   sysZ3D1184: -2.15760000e-02
   sysZ3D1185: 0.0
@@ -16041,7 +16041,7 @@ bins:
   sysZ3D1192: 0.021576
   sysZ3D1193: 0.0
   sysZ3D1194: -3.66792000e-01
-  sysZ3D1195: -0.0
+  sysZ3D1195: 0.0
   sysZ3D1196: 0.0
   sysZ3D1197: 0.021576
   sysZ3D1198: 0.064728
@@ -16057,49 +16057,49 @@ bins:
   sysZ3D1208: 0.0
   sysZ3D1209: -2.15760000e-02
   sysZ3D1210: -2.15760000e-02
-  sysZ3D1211: -0.0
-  sysZ3D1212: -0.0
-  sysZ3D1213: -0.0
+  sysZ3D1211: 0.0
+  sysZ3D1212: 0.0
+  sysZ3D1213: 0.0
   sysZ3D1214: -2.15760000e-02
   sysZ3D1215: -4.31520000e-02
   sysZ3D1216: -4.31520000e-02
   sysZ3D1217: 0.043152
-  sysZ3D1218: -0.0
+  sysZ3D1218: 0.0
   sysZ3D1219: 0.021576
-  sysZ3D1220: -0.0
+  sysZ3D1220: 0.0
   sysZ3D1221: -2.15760000e-02
   sysZ3D1222: -2.15760000e-02
   sysZ3D1223: -2.15760000e-02
-  sysZ3D1224: -0.0
-  sysZ3D1225: -0.0
+  sysZ3D1224: 0.0
+  sysZ3D1225: 0.0
   sysZ3D1226: 0.021576
   sysZ3D1227: 0.043152
   sysZ3D1228: 0.043152
   sysZ3D1229: 0.0
   sysZ3D1230: 0.021576
   sysZ3D1231: 0.021576
-  sysZ3D1232: -0.0
+  sysZ3D1232: 0.0
   sysZ3D1233: -2.15760000e-02
-  sysZ3D1234: -0.0
+  sysZ3D1234: 0.0
   sysZ3D1235: -2.15760000e-02
-  sysZ3D1236: -0.0
-  sysZ3D1237: -0.0
+  sysZ3D1236: 0.0
+  sysZ3D1237: 0.0
   sysZ3D1238: 0.0
   sysZ3D1239: 0.0
-  sysZ3D1240: -0.0
+  sysZ3D1240: 0.0
   sysZ3D1241: 0.0
   sysZ3D1242: 0.0
   sysZ3D1243: 0.0
   sysZ3D1244: 0.043152
   sysZ3D1245: -6.47280000e-02
   sysZ3D1246: 0.0
-  sysZ3D1247: -0.0
+  sysZ3D1247: 0.0
   sysZ3D1248: -2.15760000e-02
   sysZ3D1249: -4.31520000e-02
   sysZ3D1250: 0.0
   sysZ3D1251: -8.63040000e-02
   sysZ3D1252: -4.31520000e-02
-  sysZ3D1253: -0.0
+  sysZ3D1253: 0.0
   sysZ3D1254: -2.15760000e-02
   sysZ3D1255: -2.80488000e-01
   sysZ3D1256: 0.021576
@@ -16115,7 +16115,7 @@ bins:
   sysZ3D1266: -1.94184000e-01
   sysZ3D1267: -4.31520000e-02
   sysZ3D1268: 0.0
-  sysZ3D1269: -0.0
+  sysZ3D1269: 0.0
   sysZ3D1270: 0.021576
   sysZ3D1271: 0.021576
   sysZ3D1272: 0.0
@@ -16152,11 +16152,11 @@ bins:
   sysZ3D1025: -1.76256000e-01
   sysZ3D1026: 5.87520000e-02
   sysZ3D1027: -3.91680000e-02
-  sysZ3D1028: -0.0
-  sysZ3D1029: -0.0
+  sysZ3D1028: 0.0
+  sysZ3D1029: 0.0
   sysZ3D1030: 0.019584
   sysZ3D1031: 0.0
-  sysZ3D1032: -0.0
+  sysZ3D1032: 0.0
   sysZ3D1033: 0.0
   sysZ3D1034: 0.0
   sysZ3D1035: 0.019584
@@ -16164,37 +16164,37 @@ bins:
   sysZ3D1037: -1.95840000e-02
   sysZ3D1038: 0.0
   sysZ3D1039: -1.95840000e-02
-  sysZ3D1040: -0.0
+  sysZ3D1040: 0.0
   sysZ3D1041: -1.95840000e-02
-  sysZ3D1042: -0.0
+  sysZ3D1042: 0.0
   sysZ3D1043: 0.0
-  sysZ3D1044: -0.0
+  sysZ3D1044: 0.0
   sysZ3D1045: -1.95840000e-02
   sysZ3D1046: 0.019584
-  sysZ3D1047: -0.0
+  sysZ3D1047: 0.0
   sysZ3D1048: 0.0
-  sysZ3D1049: -0.0
-  sysZ3D1050: -0.0
-  sysZ3D1051: -0.0
+  sysZ3D1049: 0.0
+  sysZ3D1050: 0.0
+  sysZ3D1051: 0.0
   sysZ3D1052: 0.019584
   sysZ3D1053: -1.95840000e-02
   sysZ3D1054: 0.0
   sysZ3D1055: 0.0
   sysZ3D1056: 0.0
-  sysZ3D1057: -0.0
-  sysZ3D1058: -0.0
+  sysZ3D1057: 0.0
+  sysZ3D1058: 0.0
   sysZ3D1059: 0.019584
-  sysZ3D1060: -0.0
+  sysZ3D1060: 0.0
   sysZ3D1061: 0.0
   sysZ3D1062: -1.95840000e-02
-  sysZ3D1063: -0.0
-  sysZ3D1064: -0.0
+  sysZ3D1063: 0.0
+  sysZ3D1064: 0.0
   sysZ3D1065: 0.0
-  sysZ3D1066: -0.0
+  sysZ3D1066: 0.0
   sysZ3D1067: 0.0
   sysZ3D1068: -1.95840000e-02
   sysZ3D1069: 0.0
-  sysZ3D1070: -0.0
+  sysZ3D1070: 0.0
   sysZ3D1071: 0.0
   sysZ3D1072: 0.0
   sysZ3D1073: 0.0
@@ -16202,38 +16202,38 @@ bins:
   sysZ3D1075: 0.019584
   sysZ3D1076: 0.0
   sysZ3D1077: 0.0
-  sysZ3D1078: -0.0
+  sysZ3D1078: 0.0
   sysZ3D1079: -1.95840000e-02
-  sysZ3D1080: -0.0
+  sysZ3D1080: 0.0
   sysZ3D1081: -1.95840000e-02
   sysZ3D1082: 0.019584
   sysZ3D1083: 0.019584
-  sysZ3D1084: -0.0
-  sysZ3D1085: -0.0
+  sysZ3D1084: 0.0
+  sysZ3D1085: 0.0
   sysZ3D1086: -1.95840000e-02
   sysZ3D1087: 0.0
   sysZ3D1088: -1.95840000e-02
-  sysZ3D1089: -0.0
+  sysZ3D1089: 0.0
   sysZ3D1090: 0.0
   sysZ3D1091: 0.019584
   sysZ3D1092: 0.019584
   sysZ3D1093: 0.0
   sysZ3D1094: 0.0
-  sysZ3D1095: -0.0
-  sysZ3D1096: -0.0
+  sysZ3D1095: 0.0
+  sysZ3D1096: 0.0
   sysZ3D1097: -1.95840000e-02
   sysZ3D1098: 0.0
   sysZ3D1099: -1.95840000e-02
   sysZ3D1100: 0.0
-  sysZ3D1101: -0.0
+  sysZ3D1101: 0.0
   sysZ3D1102: 0.0
-  sysZ3D1103: -0.0
+  sysZ3D1103: 0.0
   sysZ3D1104: -1.37088000e-01
   sysZ3D1105: -2.74176000e-01
   sysZ3D1106: -5.87520000e-02
   sysZ3D1107: -1.95840000e-02
   sysZ3D1108: -1.95840000e-02
-  sysZ3D1109: -0.0
+  sysZ3D1109: 0.0
   sysZ3D1110: 0.0
   sysZ3D1111: 0.0
   sysZ3D1112: 0.019584
@@ -16249,14 +16249,14 @@ bins:
   sysZ3D1122: -3.91680000e-02
   sysZ3D1123: -1.37088000e-01
   sysZ3D1124: -7.83360000e-02
-  sysZ3D1125: -0.0
+  sysZ3D1125: 0.0
   sysZ3D1126: -1.95840000e-02
   sysZ3D1127: 0.156672
   sysZ3D1128: -3.91680000e-02
   sysZ3D1129: 0.0
   sysZ3D1130: 0.0
   sysZ3D1131: 0.0
-  sysZ3D1132: -0.0
+  sysZ3D1132: 0.0
   sysZ3D1133: 0.019584
   sysZ3D1134: 0.019584
   sysZ3D1135: -5.87520000e-02
@@ -16273,13 +16273,13 @@ bins:
   sysZ3D1146: 0.0
   sysZ3D1147: 0.0
   sysZ3D1148: 0.019584
-  sysZ3D1149: -0.0
+  sysZ3D1149: 0.0
   sysZ3D1150: -1.95840000e-02
   sysZ3D1151: -3.91680000e-02
   sysZ3D1152: 0.039168
   sysZ3D1153: 0.0
-  sysZ3D1154: -0.0
-  sysZ3D1155: -0.0
+  sysZ3D1154: 0.0
+  sysZ3D1155: 0.0
   sysZ3D1156: 0.019584
   sysZ3D1157: 0.019584
   sysZ3D1158: 0.019584
@@ -16291,33 +16291,33 @@ bins:
   sysZ3D1164: -1.95840000e-02
   sysZ3D1165: -3.91680000e-02
   sysZ3D1166: 5.87520000e-02
-  sysZ3D1167: -0.0
-  sysZ3D1168: -0.0
-  sysZ3D1169: -0.0
+  sysZ3D1167: 0.0
+  sysZ3D1168: 0.0
+  sysZ3D1169: 0.0
   sysZ3D1170: 0.019584
   sysZ3D1171: -1.95840000e-02
-  sysZ3D1172: -0.0
-  sysZ3D1173: -0.0
-  sysZ3D1174: -0.0
-  sysZ3D1175: -0.0
+  sysZ3D1172: 0.0
+  sysZ3D1173: 0.0
+  sysZ3D1174: 0.0
+  sysZ3D1175: 0.0
   sysZ3D1176: 5.87520000e-02
   sysZ3D1177: 5.87520000e-02
   sysZ3D1178: 0.019584
   sysZ3D1179: 0.019584
-  sysZ3D1180: -0.0
+  sysZ3D1180: 0.0
   sysZ3D1181: -1.95840000e-02
   sysZ3D1182: 0.0
   sysZ3D1183: 0.0
   sysZ3D1184: -1.95840000e-02
-  sysZ3D1185: -0.0
+  sysZ3D1185: 0.0
   sysZ3D1186: 0.0
-  sysZ3D1187: -0.0
+  sysZ3D1187: 0.0
   sysZ3D1188: -3.91680000e-02
   sysZ3D1189: -1.95840000e-02
   sysZ3D1190: 0.019584
-  sysZ3D1191: -0.0
+  sysZ3D1191: 0.0
   sysZ3D1192: 0.019584
-  sysZ3D1193: -0.0
+  sysZ3D1193: 0.0
   sysZ3D1194: -3.72096000e-01
   sysZ3D1195: 0.019584
   sysZ3D1196: 0.0
@@ -16333,21 +16333,21 @@ bins:
   sysZ3D1206: 0.019584
   sysZ3D1207: 0.0
   sysZ3D1208: 0.0
-  sysZ3D1209: -0.0
+  sysZ3D1209: 0.0
   sysZ3D1210: -1.95840000e-02
-  sysZ3D1211: -0.0
-  sysZ3D1212: -0.0
-  sysZ3D1213: -0.0
+  sysZ3D1211: 0.0
+  sysZ3D1212: 0.0
+  sysZ3D1213: 0.0
   sysZ3D1214: -1.95840000e-02
   sysZ3D1215: -3.91680000e-02
   sysZ3D1216: -1.95840000e-02
   sysZ3D1217: 5.87520000e-02
   sysZ3D1218: -1.95840000e-02
   sysZ3D1219: 0.039168
-  sysZ3D1220: -0.0
-  sysZ3D1221: -0.0
+  sysZ3D1220: 0.0
+  sysZ3D1221: 0.0
   sysZ3D1222: 0.0
-  sysZ3D1223: -0.0
+  sysZ3D1223: 0.0
   sysZ3D1224: -1.95840000e-02
   sysZ3D1225: 0.0
   sysZ3D1226: 0.019584
@@ -16356,28 +16356,28 @@ bins:
   sysZ3D1229: 0.019584
   sysZ3D1230: 0.019584
   sysZ3D1231: 0.019584
-  sysZ3D1232: -0.0
-  sysZ3D1233: -0.0
-  sysZ3D1234: -0.0
+  sysZ3D1232: 0.0
+  sysZ3D1233: 0.0
+  sysZ3D1234: 0.0
   sysZ3D1235: -1.95840000e-02
-  sysZ3D1236: -0.0
+  sysZ3D1236: 0.0
   sysZ3D1237: 0.0
   sysZ3D1238: 0.0
-  sysZ3D1239: -0.0
-  sysZ3D1240: -0.0
-  sysZ3D1241: -0.0
+  sysZ3D1239: 0.0
+  sysZ3D1240: 0.0
+  sysZ3D1241: 0.0
   sysZ3D1242: 0.0
   sysZ3D1243: 0.0
   sysZ3D1244: 0.039168
   sysZ3D1245: -1.95840000e-02
   sysZ3D1246: 0.0
-  sysZ3D1247: -0.0
+  sysZ3D1247: 0.0
   sysZ3D1248: -3.91680000e-02
   sysZ3D1249: -3.91680000e-02
   sysZ3D1250: 0.019584
   sysZ3D1251: -7.83360000e-02
   sysZ3D1252: -1.95840000e-02
-  sysZ3D1253: -0.0
+  sysZ3D1253: 0.0
   sysZ3D1254: -1.95840000e-02
   sysZ3D1255: -3.32928000e-01
   sysZ3D1256: 5.87520000e-02
@@ -16385,7 +16385,7 @@ bins:
   sysZ3D1258: -3.91680000e-02
   sysZ3D1259: 5.87520000e-02
   sysZ3D1260: 5.87520000e-02
-  sysZ3D1261: -0.0
+  sysZ3D1261: 0.0
   sysZ3D1262: 0.019584
   sysZ3D1263: 1.17504000e-01
   sysZ3D1264: 2.35008000e-01
@@ -16405,7 +16405,7 @@ bins:
 - stat: 0.865176
   sysZ3D1001: -6.65520000e-02
   sysZ3D1002: 1.66380000e-02
-  sysZ3D1003: -0.0
+  sysZ3D1003: 0.0
   sysZ3D1004: 0.0
   sysZ3D1005: 0.0
   sysZ3D1006: 0.0
@@ -16422,26 +16422,26 @@ bins:
   sysZ3D1017: 0.0
   sysZ3D1018: 0.0
   sysZ3D1019: 0.0
-  sysZ3D1020: -0.0
+  sysZ3D1020: 0.0
   sysZ3D1021: -1.66380000e-02
-  sysZ3D1022: -0.0
+  sysZ3D1022: 0.0
   sysZ3D1023: -9.98280000e-02
   sysZ3D1024: 6.65520000e-02
   sysZ3D1025: -1.83018000e-01
   sysZ3D1026: 6.65520000e-02
   sysZ3D1027: -3.32760000e-02
-  sysZ3D1028: -0.0
+  sysZ3D1028: 0.0
   sysZ3D1029: -1.66380000e-02
   sysZ3D1030: -1.66380000e-02
   sysZ3D1031: 1.66380000e-02
-  sysZ3D1032: -0.0
+  sysZ3D1032: 0.0
   sysZ3D1033: 0.0
-  sysZ3D1034: -0.0
-  sysZ3D1035: -0.0
-  sysZ3D1036: -0.0
-  sysZ3D1037: -0.0
-  sysZ3D1038: -0.0
-  sysZ3D1039: -0.0
+  sysZ3D1034: 0.0
+  sysZ3D1035: 0.0
+  sysZ3D1036: 0.0
+  sysZ3D1037: 0.0
+  sysZ3D1038: 0.0
+  sysZ3D1039: 0.0
   sysZ3D1040: -1.66380000e-02
   sysZ3D1041: 1.66380000e-02
   sysZ3D1042: 1.66380000e-02
@@ -16450,37 +16450,37 @@ bins:
   sysZ3D1045: 1.66380000e-02
   sysZ3D1046: -1.66380000e-02
   sysZ3D1047: 0.0
-  sysZ3D1048: -0.0
+  sysZ3D1048: 0.0
   sysZ3D1049: 0.0
-  sysZ3D1050: -0.0
+  sysZ3D1050: 0.0
   sysZ3D1051: 1.66380000e-02
   sysZ3D1052: 1.66380000e-02
   sysZ3D1053: 1.66380000e-02
   sysZ3D1054: 0.0
   sysZ3D1055: 1.66380000e-02
   sysZ3D1056: -1.66380000e-02
-  sysZ3D1057: -0.0
-  sysZ3D1058: -0.0
+  sysZ3D1057: 0.0
+  sysZ3D1058: 0.0
   sysZ3D1059: 1.66380000e-02
   sysZ3D1060: 0.0
-  sysZ3D1061: -0.0
+  sysZ3D1061: 0.0
   sysZ3D1062: 0.0
-  sysZ3D1063: -0.0
-  sysZ3D1064: -0.0
+  sysZ3D1063: 0.0
+  sysZ3D1064: 0.0
   sysZ3D1065: -1.66380000e-02
   sysZ3D1066: -1.66380000e-02
   sysZ3D1067: 0.0
   sysZ3D1068: -1.66380000e-02
   sysZ3D1069: 1.66380000e-02
-  sysZ3D1070: -0.0
+  sysZ3D1070: 0.0
   sysZ3D1071: 0.0
   sysZ3D1072: 0.0
   sysZ3D1073: 0.0
-  sysZ3D1074: -0.0
-  sysZ3D1075: -0.0
+  sysZ3D1074: 0.0
+  sysZ3D1075: 0.0
   sysZ3D1076: 0.0
   sysZ3D1077: 0.0
-  sysZ3D1078: -0.0
+  sysZ3D1078: 0.0
   sysZ3D1079: 1.66380000e-02
   sysZ3D1080: -1.66380000e-02
   sysZ3D1081: 1.66380000e-02
@@ -16491,27 +16491,27 @@ bins:
   sysZ3D1086: 1.66380000e-02
   sysZ3D1087: 0.0
   sysZ3D1088: 0.0
-  sysZ3D1089: -0.0
+  sysZ3D1089: 0.0
   sysZ3D1090: -3.32760000e-02
   sysZ3D1091: 1.66380000e-02
-  sysZ3D1092: -0.0
+  sysZ3D1092: 0.0
   sysZ3D1093: 0.0
   sysZ3D1094: 1.66380000e-02
-  sysZ3D1095: -0.0
+  sysZ3D1095: 0.0
   sysZ3D1096: 1.66380000e-02
-  sysZ3D1097: -0.0
+  sysZ3D1097: 0.0
   sysZ3D1098: -1.66380000e-02
   sysZ3D1099: -1.66380000e-02
   sysZ3D1100: 0.0
   sysZ3D1101: -1.66380000e-02
   sysZ3D1102: -1.66380000e-02
-  sysZ3D1103: -0.0
+  sysZ3D1103: 0.0
   sysZ3D1104: -8.31900000e-02
   sysZ3D1105: -1.99656000e-01
   sysZ3D1106: -6.65520000e-02
-  sysZ3D1107: -0.0
+  sysZ3D1107: 0.0
   sysZ3D1108: -1.66380000e-02
-  sysZ3D1109: -0.0
+  sysZ3D1109: 0.0
   sysZ3D1110: 0.0
   sysZ3D1111: 0.0
   sysZ3D1112: 0.0
@@ -16539,22 +16539,22 @@ bins:
   sysZ3D1134: -3.32760000e-02
   sysZ3D1135: 0.0
   sysZ3D1136: -4.99140000e-02
-  sysZ3D1137: -0.0
-  sysZ3D1138: -0.0
+  sysZ3D1137: 0.0
+  sysZ3D1138: 0.0
   sysZ3D1139: 1.66380000e-02
   sysZ3D1140: 3.32760000e-02
   sysZ3D1141: 1.66380000e-02
   sysZ3D1142: -1.66380000e-02
-  sysZ3D1143: -0.0
-  sysZ3D1144: -0.0
+  sysZ3D1143: 0.0
+  sysZ3D1144: 0.0
   sysZ3D1145: -1.66380000e-02
-  sysZ3D1146: -0.0
-  sysZ3D1147: -0.0
-  sysZ3D1148: -0.0
-  sysZ3D1149: -0.0
-  sysZ3D1150: -0.0
+  sysZ3D1146: 0.0
+  sysZ3D1147: 0.0
+  sysZ3D1148: 0.0
+  sysZ3D1149: 0.0
+  sysZ3D1150: 0.0
   sysZ3D1151: -1.66380000e-02
-  sysZ3D1152: -0.0
+  sysZ3D1152: 0.0
   sysZ3D1153: 1.66380000e-02
   sysZ3D1154: -1.66380000e-02
   sysZ3D1155: -3.32760000e-02
@@ -16563,44 +16563,44 @@ bins:
   sysZ3D1158: -4.99140000e-02
   sysZ3D1159: 3.32760000e-02
   sysZ3D1160: 1.66380000e-02
-  sysZ3D1161: -0.0
+  sysZ3D1161: 0.0
   sysZ3D1162: 0.049914
   sysZ3D1163: -4.99140000e-02
   sysZ3D1164: -3.32760000e-02
   sysZ3D1165: -4.99140000e-02
   sysZ3D1166: 6.65520000e-02
   sysZ3D1167: 0.049914
-  sysZ3D1168: -0.0
-  sysZ3D1169: -0.0
+  sysZ3D1168: 0.0
+  sysZ3D1169: 0.0
   sysZ3D1170: 0.0
-  sysZ3D1171: -0.0
-  sysZ3D1172: -0.0
-  sysZ3D1173: -0.0
+  sysZ3D1171: 0.0
+  sysZ3D1172: 0.0
+  sysZ3D1173: 0.0
   sysZ3D1174: 0.0
-  sysZ3D1175: -0.0
+  sysZ3D1175: 0.0
   sysZ3D1176: 3.32760000e-02
   sysZ3D1177: 1.66380000e-02
   sysZ3D1178: 0.0
   sysZ3D1179: 1.66380000e-02
-  sysZ3D1180: -0.0
-  sysZ3D1181: -0.0
+  sysZ3D1180: 0.0
+  sysZ3D1181: 0.0
   sysZ3D1182: 0.0
   sysZ3D1183: 0.0
   sysZ3D1184: -1.66380000e-02
-  sysZ3D1185: -0.0
+  sysZ3D1185: 0.0
   sysZ3D1186: 0.0
-  sysZ3D1187: -0.0
+  sysZ3D1187: 0.0
   sysZ3D1188: -1.66380000e-02
   sysZ3D1189: -1.66380000e-02
   sysZ3D1190: 0.0
-  sysZ3D1191: -0.0
+  sysZ3D1191: 0.0
   sysZ3D1192: 0.0
   sysZ3D1193: -1.66380000e-02
   sysZ3D1194: -3.49398000e-01
   sysZ3D1195: 1.66380000e-02
   sysZ3D1196: 0.0
   sysZ3D1197: 1.66380000e-02
-  sysZ3D1198: -0.0
+  sysZ3D1198: 0.0
   sysZ3D1199: -1.66380000e-02
   sysZ3D1200: -3.32760000e-02
   sysZ3D1201: -3.32760000e-02
@@ -16610,20 +16610,20 @@ bins:
   sysZ3D1205: 0.0
   sysZ3D1206: 1.66380000e-02
   sysZ3D1207: 0.0
-  sysZ3D1208: -0.0
-  sysZ3D1209: -0.0
+  sysZ3D1208: 0.0
+  sysZ3D1209: 0.0
   sysZ3D1210: -1.66380000e-02
-  sysZ3D1211: -0.0
+  sysZ3D1211: 0.0
   sysZ3D1212: 0.0
   sysZ3D1213: 0.0
   sysZ3D1214: -1.66380000e-02
   sysZ3D1215: -4.99140000e-02
-  sysZ3D1216: -0.0
+  sysZ3D1216: 0.0
   sysZ3D1217: 0.049914
   sysZ3D1218: -4.99140000e-02
   sysZ3D1219: 3.32760000e-02
-  sysZ3D1220: -0.0
-  sysZ3D1221: -0.0
+  sysZ3D1220: 0.0
+  sysZ3D1221: 0.0
   sysZ3D1222: 0.0
   sysZ3D1223: 1.66380000e-02
   sysZ3D1224: 0.0
@@ -16634,24 +16634,24 @@ bins:
   sysZ3D1229: 0.0
   sysZ3D1230: 1.66380000e-02
   sysZ3D1231: 3.32760000e-02
-  sysZ3D1232: -0.0
-  sysZ3D1233: -0.0
-  sysZ3D1234: -0.0
+  sysZ3D1232: 0.0
+  sysZ3D1233: 0.0
+  sysZ3D1234: 0.0
   sysZ3D1235: 0.0
   sysZ3D1236: 0.0
-  sysZ3D1237: -0.0
+  sysZ3D1237: 0.0
   sysZ3D1238: 1.66380000e-02
-  sysZ3D1239: -0.0
-  sysZ3D1240: -0.0
-  sysZ3D1241: -0.0
+  sysZ3D1239: 0.0
+  sysZ3D1240: 0.0
+  sysZ3D1241: 0.0
   sysZ3D1242: 0.0
   sysZ3D1243: 0.0
   sysZ3D1244: 1.66380000e-02
   sysZ3D1245: -3.32760000e-02
   sysZ3D1246: 1.66380000e-02
-  sysZ3D1247: -0.0
+  sysZ3D1247: 0.0
   sysZ3D1248: -3.32760000e-02
-  sysZ3D1249: -0.0
+  sysZ3D1249: 0.0
   sysZ3D1250: 3.32760000e-02
   sysZ3D1251: -8.31900000e-02
   sysZ3D1252: 3.32760000e-02
@@ -16660,7 +16660,7 @@ bins:
   sysZ3D1255: -3.66036000e-01
   sysZ3D1256: 3.32760000e-02
   sysZ3D1257: 0.0
-  sysZ3D1258: -0.0
+  sysZ3D1258: 0.0
   sysZ3D1259: 1.66380000e-02
   sysZ3D1260: 0.049914
   sysZ3D1261: 1.66380000e-02
@@ -16671,7 +16671,7 @@ bins:
   sysZ3D1266: -1.83018000e-01
   sysZ3D1267: -3.32760000e-02
   sysZ3D1268: 0.0
-  sysZ3D1269: -0.0
+  sysZ3D1269: 0.0
   sysZ3D1270: 0.0
   sysZ3D1271: 3.32760000e-02
   sysZ3D1272: 1.66380000e-02
@@ -16683,7 +16683,7 @@ bins:
 - stat: 0.74195
   sysZ3D1001: -0.06745
   sysZ3D1002: 0.01349
-  sysZ3D1003: -0.0
+  sysZ3D1003: 0.0
   sysZ3D1004: 0.0
   sysZ3D1005: 0.0
   sysZ3D1006: 0.0
@@ -16713,22 +16713,22 @@ bins:
   sysZ3D1030: 0.01349
   sysZ3D1031: 0.01349
   sysZ3D1032: 0.0
-  sysZ3D1033: -0.0
+  sysZ3D1033: 0.0
   sysZ3D1034: 0.0
   sysZ3D1035: -0.01349
-  sysZ3D1036: -0.0
+  sysZ3D1036: 0.0
   sysZ3D1037: 0.01349
   sysZ3D1038: 0.0
   sysZ3D1039: -0.01349
   sysZ3D1040: 0.01349
   sysZ3D1041: 0.01349
   sysZ3D1042: 0.01349
-  sysZ3D1043: -0.0
+  sysZ3D1043: 0.0
   sysZ3D1044: 0.0
-  sysZ3D1045: -0.0
-  sysZ3D1046: -0.0
-  sysZ3D1047: -0.0
-  sysZ3D1048: -0.0
+  sysZ3D1045: 0.0
+  sysZ3D1046: 0.0
+  sysZ3D1047: 0.0
+  sysZ3D1048: 0.0
   sysZ3D1049: 0.0
   sysZ3D1050: 0.0
   sysZ3D1051: 0.01349
@@ -16739,7 +16739,7 @@ bins:
   sysZ3D1056: -0.01349
   sysZ3D1057: 0.0
   sysZ3D1058: 0.0
-  sysZ3D1059: -0.0
+  sysZ3D1059: 0.0
   sysZ3D1060: 0.0
   sysZ3D1061: 0.0
   sysZ3D1062: 0.01349
@@ -16758,21 +16758,21 @@ bins:
   sysZ3D1075: 0.04047
   sysZ3D1076: 0.01349
   sysZ3D1077: 0.02698
-  sysZ3D1078: -0.0
+  sysZ3D1078: 0.0
   sysZ3D1079: 0.0
   sysZ3D1080: -0.01349
-  sysZ3D1081: -0.0
-  sysZ3D1082: -0.0
-  sysZ3D1083: -0.0
+  sysZ3D1081: 0.0
+  sysZ3D1082: 0.0
+  sysZ3D1083: 0.0
   sysZ3D1084: 0.01349
   sysZ3D1085: -0.01349
   sysZ3D1086: 0.01349
   sysZ3D1087: 0.0
   sysZ3D1088: -0.01349
-  sysZ3D1089: -0.0
+  sysZ3D1089: 0.0
   sysZ3D1090: 0.01349
   sysZ3D1091: 0.01349
-  sysZ3D1092: -0.0
+  sysZ3D1092: 0.0
   sysZ3D1093: 0.01349
   sysZ3D1094: 0.01349
   sysZ3D1095: -0.01349
@@ -16787,17 +16787,17 @@ bins:
   sysZ3D1104: -0.05396
   sysZ3D1105: -0.1349
   sysZ3D1106: -0.04047
-  sysZ3D1107: -0.0
+  sysZ3D1107: 0.0
   sysZ3D1108: -0.01349
-  sysZ3D1109: -0.0
+  sysZ3D1109: 0.0
   sysZ3D1110: 0.0
-  sysZ3D1111: -0.0
+  sysZ3D1111: 0.0
   sysZ3D1112: 0.0
   sysZ3D1113: -0.04047
   sysZ3D1114: -0.25631
   sysZ3D1115: -0.22933
   sysZ3D1116: -0.09443
-  sysZ3D1117: -0.0
+  sysZ3D1117: 0.0
   sysZ3D1118: 0.01349
   sysZ3D1119: -0.01349
   sysZ3D1120: 0.01349
@@ -16806,10 +16806,10 @@ bins:
   sysZ3D1123: -0.10792
   sysZ3D1124: -0.2698
   sysZ3D1125: 0.01349
-  sysZ3D1126: -0.0
+  sysZ3D1126: 0.0
   sysZ3D1127: 1.75370000e-01
-  sysZ3D1128: -0.0
-  sysZ3D1129: -0.0
+  sysZ3D1128: 0.0
+  sysZ3D1129: 0.0
   sysZ3D1130: -0.01349
   sysZ3D1131: 0.0
   sysZ3D1132: -0.06745
@@ -16822,29 +16822,29 @@ bins:
   sysZ3D1139: 0.0
   sysZ3D1140: -0.01349
   sysZ3D1141: 0.0
-  sysZ3D1142: -0.0
+  sysZ3D1142: 0.0
   sysZ3D1143: 0.0
-  sysZ3D1144: -0.0
-  sysZ3D1145: -0.0
-  sysZ3D1146: -0.0
-  sysZ3D1147: -0.0
+  sysZ3D1144: 0.0
+  sysZ3D1145: 0.0
+  sysZ3D1146: 0.0
+  sysZ3D1147: 0.0
   sysZ3D1148: -0.01349
   sysZ3D1149: -0.01349
   sysZ3D1150: 0.0
-  sysZ3D1151: -0.0
-  sysZ3D1152: -0.0
+  sysZ3D1151: 0.0
+  sysZ3D1152: 0.0
   sysZ3D1153: 0.0
-  sysZ3D1154: -0.0
+  sysZ3D1154: 0.0
   sysZ3D1155: -0.01349
   sysZ3D1156: -0.01349
   sysZ3D1157: -0.01349
   sysZ3D1158: -0.01349
   sysZ3D1159: 0.14839
-  sysZ3D1160: -0.0
+  sysZ3D1160: 0.0
   sysZ3D1161: -0.01349
   sysZ3D1162: -0.01349
   sysZ3D1163: -0.02698
-  sysZ3D1164: -0.0
+  sysZ3D1164: 0.0
   sysZ3D1165: -0.01349
   sysZ3D1166: -0.06745
   sysZ3D1167: -0.01349
@@ -16855,7 +16855,7 @@ bins:
   sysZ3D1172: -0.01349
   sysZ3D1173: -0.01349
   sysZ3D1174: 0.01349
-  sysZ3D1175: -0.0
+  sysZ3D1175: 0.0
   sysZ3D1176: 0.05396
   sysZ3D1177: 0.02698
   sysZ3D1178: 0.01349
@@ -16867,8 +16867,8 @@ bins:
   sysZ3D1184: -0.01349
   sysZ3D1185: 0.0
   sysZ3D1186: 0.0
-  sysZ3D1187: -0.0
-  sysZ3D1188: -0.0
+  sysZ3D1187: 0.0
+  sysZ3D1188: 0.0
   sysZ3D1189: -0.01349
   sysZ3D1190: 0.01349
   sysZ3D1191: -0.01349
@@ -16876,7 +16876,7 @@ bins:
   sysZ3D1193: -0.01349
   sysZ3D1194: -0.32376
   sysZ3D1195: 0.0
-  sysZ3D1196: -0.0
+  sysZ3D1196: 0.0
   sysZ3D1197: 0.0
   sysZ3D1198: -0.01349
   sysZ3D1199: -0.02698
@@ -16888,10 +16888,10 @@ bins:
   sysZ3D1205: 0.0
   sysZ3D1206: 0.01349
   sysZ3D1207: 0.0
-  sysZ3D1208: -0.0
+  sysZ3D1208: 0.0
   sysZ3D1209: -0.01349
   sysZ3D1210: -0.01349
-  sysZ3D1211: -0.0
+  sysZ3D1211: 0.0
   sysZ3D1212: 0.0
   sysZ3D1213: 0.01349
   sysZ3D1214: 0.02698
@@ -16909,25 +16909,25 @@ bins:
   sysZ3D1226: 0.02698
   sysZ3D1227: 0.02698
   sysZ3D1228: -0.01349
-  sysZ3D1229: -0.0
+  sysZ3D1229: 0.0
   sysZ3D1230: 0.01349
   sysZ3D1231: 0.02698
   sysZ3D1232: 0.0
-  sysZ3D1233: -0.0
-  sysZ3D1234: -0.0
-  sysZ3D1235: -0.0
+  sysZ3D1233: 0.0
+  sysZ3D1234: 0.0
+  sysZ3D1235: 0.0
   sysZ3D1236: 0.0
   sysZ3D1237: 0.0
   sysZ3D1238: 0.01349
-  sysZ3D1239: -0.0
-  sysZ3D1240: -0.0
-  sysZ3D1241: -0.0
+  sysZ3D1239: 0.0
+  sysZ3D1240: 0.0
+  sysZ3D1241: 0.0
   sysZ3D1242: 0.0
   sysZ3D1243: 0.0
   sysZ3D1244: 0.0
   sysZ3D1245: 0.0
   sysZ3D1246: 0.02698
-  sysZ3D1247: -0.0
+  sysZ3D1247: 0.0
   sysZ3D1248: -0.04047
   sysZ3D1249: -0.01349
   sysZ3D1250: 0.01349
@@ -16945,7 +16945,7 @@ bins:
   sysZ3D1262: 0.01349
   sysZ3D1263: 0.08094
   sysZ3D1264: 0.18886
-  sysZ3D1265: -0.0
+  sysZ3D1265: 0.0
   sysZ3D1266: -0.16188
   sysZ3D1267: -0.01349
   sysZ3D1268: 0.0
@@ -16979,14 +16979,14 @@ bins:
   sysZ3D1018: 0.0
   sysZ3D1019: 0.0
   sysZ3D1020: 0.0
-  sysZ3D1021: -0.0
+  sysZ3D1021: 0.0
   sysZ3D1022: 0.0
   sysZ3D1023: -0.12792
   sysZ3D1024: 8.85600000e-02
   sysZ3D1025: -0.22632
   sysZ3D1026: 7.87200000e-02
   sysZ3D1027: -5.90400000e-02
-  sysZ3D1028: -0.0
+  sysZ3D1028: 0.0
   sysZ3D1029: -9.84000000e-03
   sysZ3D1030: 9.84000000e-03
   sysZ3D1031: 0.0
@@ -17003,34 +17003,34 @@ bins:
   sysZ3D1042: 0.0
   sysZ3D1043: 9.84000000e-03
   sysZ3D1044: 9.84000000e-03
-  sysZ3D1045: -0.0
+  sysZ3D1045: 0.0
   sysZ3D1046: 9.84000000e-03
   sysZ3D1047: -9.84000000e-03
   sysZ3D1048: 9.84000000e-03
-  sysZ3D1049: -0.0
-  sysZ3D1050: -0.0
-  sysZ3D1051: -0.0
+  sysZ3D1049: 0.0
+  sysZ3D1050: 0.0
+  sysZ3D1051: 0.0
   sysZ3D1052: -9.84000000e-03
   sysZ3D1053: -9.84000000e-03
   sysZ3D1054: -9.84000000e-03
-  sysZ3D1055: -0.0
+  sysZ3D1055: 0.0
   sysZ3D1056: 9.84000000e-03
-  sysZ3D1057: -0.0
-  sysZ3D1058: -0.0
-  sysZ3D1059: -0.0
+  sysZ3D1057: 0.0
+  sysZ3D1058: 0.0
+  sysZ3D1059: 0.0
   sysZ3D1060: 0.0
   sysZ3D1061: -9.84000000e-03
   sysZ3D1062: 0.0
   sysZ3D1063: -9.84000000e-03
   sysZ3D1064: 0.0
-  sysZ3D1065: -0.0
+  sysZ3D1065: 0.0
   sysZ3D1066: -9.84000000e-03
   sysZ3D1067: 0.0
-  sysZ3D1068: -0.0
+  sysZ3D1068: 0.0
   sysZ3D1069: 9.84000000e-03
   sysZ3D1070: 9.84000000e-03
   sysZ3D1071: -9.84000000e-03
-  sysZ3D1072: -0.0
+  sysZ3D1072: 0.0
   sysZ3D1073: 9.84000000e-03
   sysZ3D1074: 1.96800000e-02
   sysZ3D1075: 1.96800000e-02
@@ -17041,21 +17041,21 @@ bins:
   sysZ3D1080: -1.96800000e-02
   sysZ3D1081: -1.96800000e-02
   sysZ3D1082: 0.0
-  sysZ3D1083: -0.0
-  sysZ3D1084: -0.0
+  sysZ3D1083: 0.0
+  sysZ3D1084: 0.0
   sysZ3D1085: 0.0
   sysZ3D1086: -9.84000000e-03
   sysZ3D1087: 1.96800000e-02
   sysZ3D1088: 9.84000000e-03
-  sysZ3D1089: -0.0
+  sysZ3D1089: 0.0
   sysZ3D1090: -9.84000000e-03
   sysZ3D1091: 1.96800000e-02
   sysZ3D1092: 9.84000000e-03
   sysZ3D1093: 1.96800000e-02
   sysZ3D1094: 0.0
   sysZ3D1095: -1.96800000e-02
-  sysZ3D1096: -0.0
-  sysZ3D1097: -0.0
+  sysZ3D1096: 0.0
+  sysZ3D1097: 0.0
   sysZ3D1098: -1.96800000e-02
   sysZ3D1099: 9.84000000e-03
   sysZ3D1100: 9.84000000e-03
@@ -17065,11 +17065,11 @@ bins:
   sysZ3D1104: -2.95200000e-02
   sysZ3D1105: -7.87200000e-02
   sysZ3D1106: -2.95200000e-02
-  sysZ3D1107: -0.0
+  sysZ3D1107: 0.0
   sysZ3D1108: 0.0
   sysZ3D1109: 0.0
   sysZ3D1110: 0.0
-  sysZ3D1111: -0.0
+  sysZ3D1111: 0.0
   sysZ3D1112: 0.0
   sysZ3D1113: -1.96800000e-02
   sysZ3D1114: -3.54240000e-01
@@ -17077,7 +17077,7 @@ bins:
   sysZ3D1116: -2.95200000e-02
   sysZ3D1117: 9.84000000e-03
   sysZ3D1118: 0.0
-  sysZ3D1119: -0.0
+  sysZ3D1119: 0.0
   sysZ3D1120: 0.0
   sysZ3D1121: 9.84000000e-03
   sysZ3D1122: 1.96800000e-02
@@ -17095,27 +17095,27 @@ bins:
   sysZ3D1134: -2.95200000e-02
   sysZ3D1135: 9.84000000e-03
   sysZ3D1136: -9.84000000e-03
-  sysZ3D1137: -0.0
+  sysZ3D1137: 0.0
   sysZ3D1138: -9.84000000e-03
   sysZ3D1139: -9.84000000e-03
-  sysZ3D1140: -0.0
+  sysZ3D1140: 0.0
   sysZ3D1141: 0.0
-  sysZ3D1142: -0.0
+  sysZ3D1142: 0.0
   sysZ3D1143: 0.0
   sysZ3D1144: -9.84000000e-03
-  sysZ3D1145: -0.0
+  sysZ3D1145: 0.0
   sysZ3D1146: 0.0
   sysZ3D1147: 0.0
-  sysZ3D1148: -0.0
-  sysZ3D1149: -0.0
+  sysZ3D1148: 0.0
+  sysZ3D1149: 0.0
   sysZ3D1150: 0.0
   sysZ3D1151: -9.84000000e-03
-  sysZ3D1152: -0.0
+  sysZ3D1152: 0.0
   sysZ3D1153: -9.84000000e-03
   sysZ3D1154: 9.84000000e-03
-  sysZ3D1155: -0.0
+  sysZ3D1155: 0.0
   sysZ3D1156: -9.84000000e-03
-  sysZ3D1157: -0.0
+  sysZ3D1157: 0.0
   sysZ3D1158: 9.84000000e-03
   sysZ3D1159: 1.96800000e-02
   sysZ3D1160: 9.84000000e-03
@@ -17129,29 +17129,29 @@ bins:
   sysZ3D1168: -9.84000000e-03
   sysZ3D1169: 0.0
   sysZ3D1170: -9.84000000e-03
-  sysZ3D1171: -0.0
-  sysZ3D1172: -0.0
-  sysZ3D1173: -0.0
-  sysZ3D1174: -0.0
+  sysZ3D1171: 0.0
+  sysZ3D1172: 0.0
+  sysZ3D1173: 0.0
+  sysZ3D1174: 0.0
   sysZ3D1175: 0.0
   sysZ3D1176: 1.96800000e-02
   sysZ3D1177: 9.84000000e-03
   sysZ3D1178: 0.0
-  sysZ3D1179: -0.0
-  sysZ3D1180: -0.0
+  sysZ3D1179: 0.0
+  sysZ3D1180: 0.0
   sysZ3D1181: 0.0
   sysZ3D1182: 0.0
   sysZ3D1183: 0.0
-  sysZ3D1184: -0.0
-  sysZ3D1185: -0.0
-  sysZ3D1186: -0.0
+  sysZ3D1184: 0.0
+  sysZ3D1185: 0.0
+  sysZ3D1186: 0.0
   sysZ3D1187: 0.0
   sysZ3D1188: -9.84000000e-03
   sysZ3D1189: 0.0
   sysZ3D1190: 0.0
-  sysZ3D1191: -0.0
-  sysZ3D1192: -0.0
-  sysZ3D1193: -0.0
+  sysZ3D1191: 0.0
+  sysZ3D1192: 0.0
+  sysZ3D1193: 0.0
   sysZ3D1194: -0.25584
   sysZ3D1195: -9.84000000e-03
   sysZ3D1196: -9.84000000e-03
@@ -17163,18 +17163,18 @@ bins:
   sysZ3D1202: 0.0
   sysZ3D1203: 2.95200000e-02
   sysZ3D1204: -9.84000000e-03
-  sysZ3D1205: -0.0
+  sysZ3D1205: 0.0
   sysZ3D1206: 9.84000000e-03
   sysZ3D1207: 0.0
   sysZ3D1208: -9.84000000e-03
   sysZ3D1209: -9.84000000e-03
   sysZ3D1210: -1.96800000e-02
-  sysZ3D1211: -0.0
+  sysZ3D1211: 0.0
   sysZ3D1212: 0.0
   sysZ3D1213: 1.96800000e-02
   sysZ3D1214: 3.93600000e-02
   sysZ3D1215: -9.84000000e-03
-  sysZ3D1216: -0.0
+  sysZ3D1216: 0.0
   sysZ3D1217: 5.90400000e-02
   sysZ3D1218: -0.0492
   sysZ3D1219: 9.84000000e-03
@@ -17192,14 +17192,14 @@ bins:
   sysZ3D1231: 9.84000000e-03
   sysZ3D1232: 9.84000000e-03
   sysZ3D1233: 0.0
-  sysZ3D1234: -0.0
+  sysZ3D1234: 0.0
   sysZ3D1235: 0.0
   sysZ3D1236: 0.0
   sysZ3D1237: 9.84000000e-03
   sysZ3D1238: 9.84000000e-03
-  sysZ3D1239: -0.0
-  sysZ3D1240: -0.0
-  sysZ3D1241: -0.0
+  sysZ3D1239: 0.0
+  sysZ3D1240: 0.0
+  sysZ3D1241: 0.0
   sysZ3D1242: 0.0
   sysZ3D1243: 0.0
   sysZ3D1244: -1.96800000e-02
@@ -17207,7 +17207,7 @@ bins:
   sysZ3D1246: 1.96800000e-02
   sysZ3D1247: -9.84000000e-03
   sysZ3D1248: -3.93600000e-02
-  sysZ3D1249: -0.0
+  sysZ3D1249: 0.0
   sysZ3D1250: 0.0
   sysZ3D1251: -0.0984
   sysZ3D1252: -9.84000000e-03
@@ -17219,15 +17219,15 @@ bins:
   sysZ3D1258: 9.84000000e-03
   sysZ3D1259: 1.96800000e-02
   sysZ3D1260: 1.96800000e-02
-  sysZ3D1261: -0.0
+  sysZ3D1261: 0.0
   sysZ3D1262: 9.84000000e-03
   sysZ3D1263: 0.0492
   sysZ3D1264: 0.0984
   sysZ3D1265: 9.84000000e-03
   sysZ3D1266: -1.18080000e-01
   sysZ3D1267: -9.84000000e-03
-  sysZ3D1268: -0.0
-  sysZ3D1269: -0.0
+  sysZ3D1268: 0.0
+  sysZ3D1269: 0.0
   sysZ3D1270: 9.84000000e-03
   sysZ3D1271: 2.95200000e-02
   sysZ3D1272: 9.84000000e-03
@@ -17238,7 +17238,7 @@ bins:
   ATLAS_LUMI: 1.77120000e+00
 - stat: 0.386054
   sysZ3D1001: -4.03340000e-02
-  sysZ3D1002: -0.0
+  sysZ3D1002: 0.0
   sysZ3D1003: -5.76200000e-03
   sysZ3D1004: 0.0
   sysZ3D1005: 0.0
@@ -17291,14 +17291,14 @@ bins:
   sysZ3D1052: 0.0
   sysZ3D1053: 0.005762
   sysZ3D1054: -5.76200000e-03
-  sysZ3D1055: -0.0
+  sysZ3D1055: 0.0
   sysZ3D1056: 0.0
-  sysZ3D1057: -0.0
+  sysZ3D1057: 0.0
   sysZ3D1058: -5.76200000e-03
   sysZ3D1059: 0.0
   sysZ3D1060: -1.15240000e-02
   sysZ3D1061: -5.76200000e-03
-  sysZ3D1062: -0.0
+  sysZ3D1062: 0.0
   sysZ3D1063: -5.76200000e-03
   sysZ3D1064: -5.76200000e-03
   sysZ3D1065: 0.011524
@@ -17314,8 +17314,8 @@ bins:
   sysZ3D1075: 0.005762
   sysZ3D1076: 0.0
   sysZ3D1077: -5.76200000e-03
-  sysZ3D1078: -0.0
-  sysZ3D1079: -0.0
+  sysZ3D1078: 0.0
+  sysZ3D1079: 0.0
   sysZ3D1080: -1.72860000e-02
   sysZ3D1081: -1.72860000e-02
   sysZ3D1082: 0.005762
@@ -17326,12 +17326,12 @@ bins:
   sysZ3D1087: 0.005762
   sysZ3D1088: -5.76200000e-03
   sysZ3D1089: -1.15240000e-02
-  sysZ3D1090: -0.0
+  sysZ3D1090: 0.0
   sysZ3D1091: 0.011524
   sysZ3D1092: 0.0
   sysZ3D1093: -5.76200000e-03
   sysZ3D1094: -5.76200000e-03
-  sysZ3D1095: -0.0
+  sysZ3D1095: 0.0
   sysZ3D1096: 0.0
   sysZ3D1097: -1.15240000e-02
   sysZ3D1098: 0.005762
@@ -17343,9 +17343,9 @@ bins:
   sysZ3D1104: -1.72860000e-02
   sysZ3D1105: -4.03340000e-02
   sysZ3D1106: -1.72860000e-02
-  sysZ3D1107: -0.0
-  sysZ3D1108: -0.0
-  sysZ3D1109: -0.0
+  sysZ3D1107: 0.0
+  sysZ3D1108: 0.0
+  sysZ3D1109: 0.0
   sysZ3D1110: 0.0
   sysZ3D1111: 0.0
   sysZ3D1112: 0.0
@@ -17354,7 +17354,7 @@ bins:
   sysZ3D1115: -1.15240000e-02
   sysZ3D1116: 0.011524
   sysZ3D1117: 0.005762
-  sysZ3D1118: -0.0
+  sysZ3D1118: 0.0
   sysZ3D1119: -5.76200000e-03
   sysZ3D1120: 0.005762
   sysZ3D1121: 0.005762
@@ -17377,58 +17377,58 @@ bins:
   sysZ3D1138: -5.76200000e-03
   sysZ3D1139: 0.005762
   sysZ3D1140: -5.76200000e-03
-  sysZ3D1141: -0.0
-  sysZ3D1142: -0.0
-  sysZ3D1143: -0.0
+  sysZ3D1141: 0.0
+  sysZ3D1142: 0.0
+  sysZ3D1143: 0.0
   sysZ3D1144: -5.76200000e-03
   sysZ3D1145: -5.76200000e-03
   sysZ3D1146: 0.0
   sysZ3D1147: 0.0
-  sysZ3D1148: -0.0
-  sysZ3D1149: -0.0
+  sysZ3D1148: 0.0
+  sysZ3D1149: 0.0
   sysZ3D1150: 0.0
   sysZ3D1151: -5.76200000e-03
-  sysZ3D1152: -0.0
-  sysZ3D1153: -0.0
+  sysZ3D1152: 0.0
+  sysZ3D1153: 0.0
   sysZ3D1154: 0.0
-  sysZ3D1155: -0.0
+  sysZ3D1155: 0.0
   sysZ3D1156: -5.76200000e-03
   sysZ3D1157: 0.0
-  sysZ3D1158: -0.0
+  sysZ3D1158: 0.0
   sysZ3D1159: -2.30480000e-02
-  sysZ3D1160: -0.0
+  sysZ3D1160: 0.0
   sysZ3D1161: 0.011524
   sysZ3D1162: -5.76200000e-03
   sysZ3D1163: -5.76200000e-03
   sysZ3D1164: 0.011524
   sysZ3D1165: -1.15240000e-02
-  sysZ3D1166: -0.0
+  sysZ3D1166: 0.0
   sysZ3D1167: -4.03340000e-02
-  sysZ3D1168: -0.0
-  sysZ3D1169: -0.0
+  sysZ3D1168: 0.0
+  sysZ3D1169: 0.0
   sysZ3D1170: -5.76200000e-03
-  sysZ3D1171: -0.0
-  sysZ3D1172: -0.0
+  sysZ3D1171: 0.0
+  sysZ3D1172: 0.0
   sysZ3D1173: 0.005762
   sysZ3D1174: 0.0
   sysZ3D1175: 0.0
-  sysZ3D1176: -0.0
-  sysZ3D1177: -0.0
+  sysZ3D1176: 0.0
+  sysZ3D1177: 0.0
   sysZ3D1178: 0.0
   sysZ3D1179: -5.76200000e-03
-  sysZ3D1180: -0.0
+  sysZ3D1180: 0.0
   sysZ3D1181: 0.0
-  sysZ3D1182: -0.0
+  sysZ3D1182: 0.0
   sysZ3D1183: -5.76200000e-03
   sysZ3D1184: 0.005762
   sysZ3D1185: 0.0
-  sysZ3D1186: -0.0
+  sysZ3D1186: 0.0
   sysZ3D1187: 0.005762
   sysZ3D1188: 0.0
-  sysZ3D1189: -0.0
+  sysZ3D1189: 0.0
   sysZ3D1190: -5.76200000e-03
-  sysZ3D1191: -0.0
-  sysZ3D1192: -0.0
+  sysZ3D1191: 0.0
+  sysZ3D1192: 0.0
   sysZ3D1193: 0.0
   sysZ3D1194: -1.49812000e-01
   sysZ3D1195: -1.15240000e-02
@@ -17447,7 +17447,7 @@ bins:
   sysZ3D1208: -5.76200000e-03
   sysZ3D1209: -5.76200000e-03
   sysZ3D1210: -1.15240000e-02
-  sysZ3D1211: -0.0
+  sysZ3D1211: 0.0
   sysZ3D1212: 0.0
   sysZ3D1213: 0.023048
   sysZ3D1214: 0.05762
@@ -17471,13 +17471,13 @@ bins:
   sysZ3D1232: 0.005762
   sysZ3D1233: 0.005762
   sysZ3D1234: 0.0
-  sysZ3D1235: -0.0
+  sysZ3D1235: 0.0
   sysZ3D1236: 0.0
   sysZ3D1237: 0.005762
   sysZ3D1238: 0.005762
-  sysZ3D1239: -0.0
+  sysZ3D1239: 0.0
   sysZ3D1240: 0.0
-  sysZ3D1241: -0.0
+  sysZ3D1241: 0.0
   sysZ3D1242: 0.0
   sysZ3D1243: 0.0
   sysZ3D1244: -1.72860000e-02
@@ -17504,7 +17504,7 @@ bins:
   sysZ3D1265: 3.45720000e-02
   sysZ3D1266: -7.49060000e-02
   sysZ3D1267: -1.15240000e-02
-  sysZ3D1268: -0.0
+  sysZ3D1268: 0.0
   sysZ3D1269: -5.76200000e-03
   sysZ3D1270: 0.005762
   sysZ3D1271: 0.023048
@@ -17536,7 +17536,7 @@ bins:
   sysZ3D1019: 0.0
   sysZ3D1020: 5.54400000e-03
   sysZ3D1021: -1.29360000e-02
-  sysZ3D1022: -0.0
+  sysZ3D1022: 0.0
   sysZ3D1023: -4.98960000e-02
   sysZ3D1024: 0.03696
   sysZ3D1025: -9.05520000e-02
@@ -17550,11 +17550,11 @@ bins:
   sysZ3D1033: -1.84800000e-03
   sysZ3D1034: 0.0
   sysZ3D1035: 5.54400000e-03
-  sysZ3D1036: -0.0
+  sysZ3D1036: 0.0
   sysZ3D1037: 0.003696
   sysZ3D1038: 5.54400000e-03
   sysZ3D1039: -3.69600000e-03
-  sysZ3D1040: -0.0
+  sysZ3D1040: 0.0
   sysZ3D1041: -1.84800000e-03
   sysZ3D1042: 0.001848
   sysZ3D1043: -1.84800000e-03
@@ -17578,7 +17578,7 @@ bins:
   sysZ3D1061: -1.84800000e-03
   sysZ3D1062: -3.69600000e-03
   sysZ3D1063: 0.001848
-  sysZ3D1064: -0.0
+  sysZ3D1064: 0.0
   sysZ3D1065: 0.003696
   sysZ3D1066: 0.0
   sysZ3D1067: -1.84800000e-03
@@ -17592,12 +17592,12 @@ bins:
   sysZ3D1075: 0.0
   sysZ3D1076: 5.54400000e-03
   sysZ3D1077: 0.0
-  sysZ3D1078: -0.0
+  sysZ3D1078: 0.0
   sysZ3D1079: 0.001848
   sysZ3D1080: -5.54400000e-03
   sysZ3D1081: -7.39200000e-03
   sysZ3D1082: 0.001848
-  sysZ3D1083: -0.0
+  sysZ3D1083: 0.0
   sysZ3D1084: -3.69600000e-03
   sysZ3D1085: -1.84800000e-03
   sysZ3D1086: 0.003696
@@ -17612,21 +17612,21 @@ bins:
   sysZ3D1095: -1.84800000e-03
   sysZ3D1096: 0.00924
   sysZ3D1097: 0.001848
-  sysZ3D1098: -0.0
+  sysZ3D1098: 0.0
   sysZ3D1099: -1.84800000e-03
-  sysZ3D1100: -0.0
+  sysZ3D1100: 0.0
   sysZ3D1101: -3.69600000e-03
   sysZ3D1102: 0.001848
-  sysZ3D1103: -0.0
+  sysZ3D1103: 0.0
   sysZ3D1104: -5.54400000e-03
   sysZ3D1105: -1.29360000e-02
   sysZ3D1106: -5.54400000e-03
-  sysZ3D1107: -0.0
+  sysZ3D1107: 0.0
   sysZ3D1108: 0.0
   sysZ3D1109: 0.0
   sysZ3D1110: 0.0
   sysZ3D1111: 0.0
-  sysZ3D1112: -0.0
+  sysZ3D1112: 0.0
   sysZ3D1113: 0.016632
   sysZ3D1114: -9.79440000e-02
   sysZ3D1115: 0.033264
@@ -17643,7 +17643,7 @@ bins:
   sysZ3D1126: -2.40240000e-02
   sysZ3D1127: 0.031416
   sysZ3D1128: -3.69600000e-03
-  sysZ3D1129: -0.0
+  sysZ3D1129: 0.0
   sysZ3D1130: -0.00924
   sysZ3D1131: 0.014784
   sysZ3D1132: -3.69600000e-03
@@ -17656,23 +17656,23 @@ bins:
   sysZ3D1139: 0.001848
   sysZ3D1140: -3.69600000e-03
   sysZ3D1141: -1.84800000e-03
-  sysZ3D1142: -0.0
+  sysZ3D1142: 0.0
   sysZ3D1143: 0.0
   sysZ3D1144: -1.84800000e-03
   sysZ3D1145: -1.84800000e-03
-  sysZ3D1146: -0.0
+  sysZ3D1146: 0.0
   sysZ3D1147: 0.001848
   sysZ3D1148: 0.0
   sysZ3D1149: 0.0
-  sysZ3D1150: -0.0
+  sysZ3D1150: 0.0
   sysZ3D1151: -1.84800000e-03
   sysZ3D1152: 0.0
   sysZ3D1153: -1.84800000e-03
   sysZ3D1154: 0.0
   sysZ3D1155: -1.84800000e-03
   sysZ3D1156: -1.84800000e-03
-  sysZ3D1157: -0.0
-  sysZ3D1158: -0.0
+  sysZ3D1157: 0.0
+  sysZ3D1158: 0.0
   sysZ3D1159: -5.54400000e-03
   sysZ3D1160: 0.001848
   sysZ3D1161: -3.69600000e-03
@@ -17687,32 +17687,32 @@ bins:
   sysZ3D1170: -1.84800000e-03
   sysZ3D1171: 0.001848
   sysZ3D1172: 0.001848
-  sysZ3D1173: -0.0
+  sysZ3D1173: 0.0
   sysZ3D1174: -1.84800000e-03
-  sysZ3D1175: -0.0
+  sysZ3D1175: 0.0
   sysZ3D1176: 0.003696
   sysZ3D1177: 0.003696
   sysZ3D1178: 0.0
   sysZ3D1179: -3.69600000e-03
-  sysZ3D1180: -0.0
+  sysZ3D1180: 0.0
   sysZ3D1181: 0.0
-  sysZ3D1182: -0.0
-  sysZ3D1183: -0.0
+  sysZ3D1182: 0.0
+  sysZ3D1183: 0.0
   sysZ3D1184: 0.001848
   sysZ3D1185: 0.003696
   sysZ3D1186: 0.0
   sysZ3D1187: 0.001848
   sysZ3D1188: -1.84800000e-03
-  sysZ3D1189: -0.0
+  sysZ3D1189: 0.0
   sysZ3D1190: -1.84800000e-03
   sysZ3D1191: 0.001848
-  sysZ3D1192: -0.0
+  sysZ3D1192: 0.0
   sysZ3D1193: 5.54400000e-03
   sysZ3D1194: -7.94640000e-02
   sysZ3D1195: -3.69600000e-03
   sysZ3D1196: -1.84800000e-03
   sysZ3D1197: 0.001848
-  sysZ3D1198: -0.0
+  sysZ3D1198: 0.0
   sysZ3D1199: -7.39200000e-03
   sysZ3D1200: -1.47840000e-02
   sysZ3D1201: -1.29360000e-02
@@ -17748,14 +17748,14 @@ bins:
   sysZ3D1231: 0.0
   sysZ3D1232: 0.003696
   sysZ3D1233: 0.0
-  sysZ3D1234: -0.0
+  sysZ3D1234: 0.0
   sysZ3D1235: -1.84800000e-03
   sysZ3D1236: 0.001848
   sysZ3D1237: 0.003696
   sysZ3D1238: 0.001848
-  sysZ3D1239: -0.0
-  sysZ3D1240: -0.0
-  sysZ3D1241: -0.0
+  sysZ3D1239: 0.0
+  sysZ3D1240: 0.0
+  sysZ3D1241: 0.0
   sysZ3D1242: 0.0
   sysZ3D1243: 0.0
   sysZ3D1244: 0.0
@@ -17772,17 +17772,17 @@ bins:
   sysZ3D1255: -9.60960000e-02
   sysZ3D1256: 0.001848
   sysZ3D1257: 0.029568
-  sysZ3D1258: -0.0
+  sysZ3D1258: 0.0
   sysZ3D1259: 2.21760000e-02
   sysZ3D1260: 1.10880000e-02
-  sysZ3D1261: -0.0
+  sysZ3D1261: 0.0
   sysZ3D1262: 0.003696
   sysZ3D1263: 0.01848
   sysZ3D1264: 0.03696
   sysZ3D1265: 1.29360000e-02
   sysZ3D1266: -2.77200000e-02
   sysZ3D1267: -0.00924
-  sysZ3D1268: -0.0
+  sysZ3D1268: 0.0
   sysZ3D1269: -3.69600000e-03
   sysZ3D1270: 0.003696
   sysZ3D1271: 0.00924
@@ -17815,78 +17815,78 @@ bins:
   sysZ3D1020: 0.0
   sysZ3D1021: 0.0
   sysZ3D1022: 0.0
-  sysZ3D1023: -0.0
+  sysZ3D1023: 0.0
   sysZ3D1024: 0.0
-  sysZ3D1025: -0.0
+  sysZ3D1025: 0.0
   sysZ3D1026: 0.0
-  sysZ3D1027: -0.0
-  sysZ3D1028: -0.0
-  sysZ3D1029: -0.0
+  sysZ3D1027: 0.0
+  sysZ3D1028: 0.0
+  sysZ3D1029: 0.0
   sysZ3D1030: 0.0
   sysZ3D1031: 0.0
-  sysZ3D1032: -0.0
+  sysZ3D1032: 0.0
   sysZ3D1033: 4.84400000e-03
-  sysZ3D1034: -0.0
-  sysZ3D1035: -0.0
-  sysZ3D1036: -0.0
-  sysZ3D1037: -0.0
-  sysZ3D1038: -0.0
+  sysZ3D1034: 0.0
+  sysZ3D1035: 0.0
+  sysZ3D1036: 0.0
+  sysZ3D1037: 0.0
+  sysZ3D1038: 0.0
   sysZ3D1039: 4.84400000e-03
-  sysZ3D1040: -0.0
+  sysZ3D1040: 0.0
   sysZ3D1041: 0.0
-  sysZ3D1042: -0.0
+  sysZ3D1042: 0.0
   sysZ3D1043: 0.0
   sysZ3D1044: 0.0
   sysZ3D1045: 0.0
   sysZ3D1046: 0.0
   sysZ3D1047: 0.0
-  sysZ3D1048: -0.0
+  sysZ3D1048: 0.0
   sysZ3D1049: -4.84400000e-03
   sysZ3D1050: 0.0
-  sysZ3D1051: -0.0
-  sysZ3D1052: -0.0
-  sysZ3D1053: -0.0
-  sysZ3D1054: -0.0
-  sysZ3D1055: -0.0
+  sysZ3D1051: 0.0
+  sysZ3D1052: 0.0
+  sysZ3D1053: 0.0
+  sysZ3D1054: 0.0
+  sysZ3D1055: 0.0
   sysZ3D1056: 4.84400000e-03
-  sysZ3D1057: -0.0
-  sysZ3D1058: -0.0
+  sysZ3D1057: 0.0
+  sysZ3D1058: 0.0
   sysZ3D1059: 0.0
-  sysZ3D1060: -0.0
-  sysZ3D1061: -0.0
-  sysZ3D1062: -0.0
+  sysZ3D1060: 0.0
+  sysZ3D1061: 0.0
+  sysZ3D1062: 0.0
   sysZ3D1063: 0.0
-  sysZ3D1064: -0.0
+  sysZ3D1064: 0.0
   sysZ3D1065: -4.84400000e-03
   sysZ3D1066: 0.0
   sysZ3D1067: 0.0
-  sysZ3D1068: -0.0
+  sysZ3D1068: 0.0
   sysZ3D1069: -4.84400000e-03
   sysZ3D1070: 0.0
-  sysZ3D1071: -0.0
-  sysZ3D1072: -0.0
+  sysZ3D1071: 0.0
+  sysZ3D1072: 0.0
   sysZ3D1073: 0.0
-  sysZ3D1074: -0.0
-  sysZ3D1075: -0.0
+  sysZ3D1074: 0.0
+  sysZ3D1075: 0.0
   sysZ3D1076: 0.0
   sysZ3D1077: 0.0
   sysZ3D1078: 0.0
   sysZ3D1079: 0.0
   sysZ3D1080: 0.0
   sysZ3D1081: 0.0
-  sysZ3D1082: -0.0
+  sysZ3D1082: 0.0
   sysZ3D1083: 0.0
-  sysZ3D1084: -0.0
+  sysZ3D1084: 0.0
   sysZ3D1085: 0.0
-  sysZ3D1086: -0.0
+  sysZ3D1086: 0.0
   sysZ3D1087: 0.0
   sysZ3D1088: 0.0
   sysZ3D1089: 0.0
-  sysZ3D1090: -0.0
+  sysZ3D1090: 0.0
   sysZ3D1091: 4.84400000e-03
-  sysZ3D1092: -0.0
+  sysZ3D1092: 0.0
   sysZ3D1093: 0.0
-  sysZ3D1094: -0.0
+  sysZ3D1094: 0.0
   sysZ3D1095: 0.0
   sysZ3D1096: 0.0
   sysZ3D1097: 0.0
@@ -17894,13 +17894,13 @@ bins:
   sysZ3D1099: 0.0
   sysZ3D1100: 0.0
   sysZ3D1101: -4.84400000e-03
-  sysZ3D1102: -0.0
-  sysZ3D1103: -0.0
+  sysZ3D1102: 0.0
+  sysZ3D1103: 0.0
   sysZ3D1104: -2.42200000e-01
   sysZ3D1105: -0.29064
   sysZ3D1106: -6.29720000e-02
   sysZ3D1107: -1.93760000e-02
-  sysZ3D1108: -0.0
+  sysZ3D1108: 0.0
   sysZ3D1109: -4.84400000e-03
   sysZ3D1110: 0.0
   sysZ3D1111: 4.84400000e-03
@@ -17910,27 +17910,27 @@ bins:
   sysZ3D1115: 0.0
   sysZ3D1116: -4.84400000e-03
   sysZ3D1117: -1.93760000e-02
-  sysZ3D1118: -0.0
+  sysZ3D1118: 0.0
   sysZ3D1119: -4.84400000e-03
   sysZ3D1120: -9.68800000e-03
-  sysZ3D1121: -0.0
-  sysZ3D1122: -0.0
+  sysZ3D1121: 0.0
+  sysZ3D1122: 0.0
   sysZ3D1123: 0.0
   sysZ3D1124: -1.93760000e-02
   sysZ3D1125: -4.84400000e-03
-  sysZ3D1126: -0.0
+  sysZ3D1126: 0.0
   sysZ3D1127: -1.45320000e-02
   sysZ3D1128: 0.0
   sysZ3D1129: 4.84400000e-03
   sysZ3D1130: 0.0
   sysZ3D1131: 4.84400000e-03
-  sysZ3D1132: -0.0
+  sysZ3D1132: 0.0
   sysZ3D1133: 4.84400000e-03
   sysZ3D1134: 1.45320000e-02
-  sysZ3D1135: -0.0
+  sysZ3D1135: 0.0
   sysZ3D1136: 4.84400000e-03
-  sysZ3D1137: -0.0
-  sysZ3D1138: -0.0
+  sysZ3D1137: 0.0
+  sysZ3D1138: 0.0
   sysZ3D1139: 0.0
   sysZ3D1140: -1.45320000e-02
   sysZ3D1141: 4.84400000e-03
@@ -17949,7 +17949,7 @@ bins:
   sysZ3D1154: -4.84400000e-03
   sysZ3D1155: -4.84400000e-03
   sysZ3D1156: 0.0
-  sysZ3D1157: -0.0
+  sysZ3D1157: 0.0
   sysZ3D1158: 0.0
   sysZ3D1159: -9.68800000e-03
   sysZ3D1160: -9.68800000e-03
@@ -17957,17 +17957,17 @@ bins:
   sysZ3D1162: 0.0
   sysZ3D1163: -4.84400000e-03
   sysZ3D1164: -4.84400000e-03
-  sysZ3D1165: -0.0
-  sysZ3D1166: -0.0
+  sysZ3D1165: 0.0
+  sysZ3D1166: 0.0
   sysZ3D1167: 0.0
   sysZ3D1168: -4.84400000e-03
   sysZ3D1169: -9.68800000e-03
   sysZ3D1170: 1.93760000e-02
   sysZ3D1171: -1.93760000e-02
-  sysZ3D1172: -0.0
-  sysZ3D1173: -0.0
+  sysZ3D1172: 0.0
+  sysZ3D1173: 0.0
   sysZ3D1174: -1.93760000e-02
-  sysZ3D1175: -0.0
+  sysZ3D1175: 0.0
   sysZ3D1176: 9.68800000e-03
   sysZ3D1177: 2.90640000e-02
   sysZ3D1178: 0.02422
@@ -18000,40 +18000,40 @@ bins:
   sysZ3D1205: 4.84400000e-03
   sysZ3D1206: 0.0
   sysZ3D1207: 0.0
-  sysZ3D1208: -0.0
-  sysZ3D1209: -0.0
-  sysZ3D1210: -0.0
-  sysZ3D1211: -0.0
+  sysZ3D1208: 0.0
+  sysZ3D1209: 0.0
+  sysZ3D1210: 0.0
+  sysZ3D1211: 0.0
   sysZ3D1212: 0.0
   sysZ3D1213: 0.0
-  sysZ3D1214: -0.0
+  sysZ3D1214: 0.0
   sysZ3D1215: -4.84400000e-03
-  sysZ3D1216: -0.0
+  sysZ3D1216: 0.0
   sysZ3D1217: 4.84400000e-03
   sysZ3D1218: 0.0
   sysZ3D1219: 4.84400000e-03
-  sysZ3D1220: -0.0
+  sysZ3D1220: 0.0
   sysZ3D1221: -4.84400000e-03
   sysZ3D1222: 0.0
   sysZ3D1223: -4.84400000e-03
-  sysZ3D1224: -0.0
-  sysZ3D1225: -0.0
+  sysZ3D1224: 0.0
+  sysZ3D1225: 0.0
   sysZ3D1226: 0.0
   sysZ3D1227: 0.0
-  sysZ3D1228: -0.0
-  sysZ3D1229: -0.0
+  sysZ3D1228: 0.0
+  sysZ3D1229: 0.0
   sysZ3D1230: 0.0
   sysZ3D1231: 4.84400000e-03
-  sysZ3D1232: -0.0
+  sysZ3D1232: 0.0
   sysZ3D1233: 0.0
   sysZ3D1234: 0.0
   sysZ3D1235: -4.84400000e-03
   sysZ3D1236: 4.84400000e-03
   sysZ3D1237: 4.84400000e-03
   sysZ3D1238: 0.0
-  sysZ3D1239: -0.0
-  sysZ3D1240: -0.0
-  sysZ3D1241: -0.0
+  sysZ3D1239: 0.0
+  sysZ3D1240: 0.0
+  sysZ3D1241: 0.0
   sysZ3D1242: 0.0
   sysZ3D1243: 0.0
   sysZ3D1244: 9.68800000e-03
@@ -18053,18 +18053,18 @@ bins:
   sysZ3D1258: -4.84400000e-03
   sysZ3D1259: 9.68800000e-03
   sysZ3D1260: -4.84400000e-03
-  sysZ3D1261: -0.0
-  sysZ3D1262: -0.0
+  sysZ3D1261: 0.0
+  sysZ3D1262: 0.0
   sysZ3D1263: 4.84400000e-03
   sysZ3D1264: 0.02422
   sysZ3D1265: -1.45320000e-02
   sysZ3D1266: -2.90640000e-02
   sysZ3D1267: -9.68800000e-03
   sysZ3D1268: 0.0
-  sysZ3D1269: -0.0
+  sysZ3D1269: 0.0
   sysZ3D1270: 9.68800000e-03
   sysZ3D1271: -4.84400000e-03
-  sysZ3D1272: -0.0
+  sysZ3D1272: 0.0
   sysZ3D1273: -4.84400000e-03
   sysZ3D1274: -3.39080000e-02
   sysZ3D1275: 0.02422
@@ -18072,7 +18072,7 @@ bins:
   ATLAS_LUMI: 8.71920000e-01
 - stat: 3.92452000e-01
   sysZ3D1001: -1.43580000e-02
-  sysZ3D1002: -0.0
+  sysZ3D1002: 0.0
   sysZ3D1003: 0.004786
   sysZ3D1004: 0.0
   sysZ3D1005: 0.0
@@ -18090,95 +18090,95 @@ bins:
   sysZ3D1017: 0.0
   sysZ3D1018: 0.0
   sysZ3D1019: 0.0
-  sysZ3D1020: -0.0
+  sysZ3D1020: 0.0
   sysZ3D1021: 0.0
   sysZ3D1022: 0.0
   sysZ3D1023: 0.004786
-  sysZ3D1024: -0.0
+  sysZ3D1024: 0.0
   sysZ3D1025: 0.004786
-  sysZ3D1026: -0.0
+  sysZ3D1026: 0.0
   sysZ3D1027: 0.0
   sysZ3D1028: 0.0
-  sysZ3D1029: -0.0
-  sysZ3D1030: -0.0
-  sysZ3D1031: -0.0
+  sysZ3D1029: 0.0
+  sysZ3D1030: 0.0
+  sysZ3D1031: 0.0
   sysZ3D1032: -4.78600000e-03
-  sysZ3D1033: -0.0
+  sysZ3D1033: 0.0
   sysZ3D1034: -4.78600000e-03
   sysZ3D1035: 0.0
   sysZ3D1036: 0.0
-  sysZ3D1037: -0.0
-  sysZ3D1038: -0.0
+  sysZ3D1037: 0.0
+  sysZ3D1038: 0.0
   sysZ3D1039: 0.0
   sysZ3D1040: 0.004786
-  sysZ3D1041: -0.0
+  sysZ3D1041: 0.0
   sysZ3D1042: 0.0
-  sysZ3D1043: -0.0
+  sysZ3D1043: 0.0
   sysZ3D1044: 0.0
-  sysZ3D1045: -0.0
-  sysZ3D1046: -0.0
-  sysZ3D1047: -0.0
-  sysZ3D1048: -0.0
+  sysZ3D1045: 0.0
+  sysZ3D1046: 0.0
+  sysZ3D1047: 0.0
+  sysZ3D1048: 0.0
   sysZ3D1049: 0.0
   sysZ3D1050: 0.0
   sysZ3D1051: 0.0
-  sysZ3D1052: -0.0
-  sysZ3D1053: -0.0
-  sysZ3D1054: -0.0
-  sysZ3D1055: -0.0
+  sysZ3D1052: 0.0
+  sysZ3D1053: 0.0
+  sysZ3D1054: 0.0
+  sysZ3D1055: 0.0
   sysZ3D1056: 0.0
   sysZ3D1057: 0.0
-  sysZ3D1058: -0.0
+  sysZ3D1058: 0.0
   sysZ3D1059: 0.0
-  sysZ3D1060: -0.0
+  sysZ3D1060: 0.0
   sysZ3D1061: 0.0
   sysZ3D1062: 0.0
-  sysZ3D1063: -0.0
+  sysZ3D1063: 0.0
   sysZ3D1064: 0.0
-  sysZ3D1065: -0.0
+  sysZ3D1065: 0.0
   sysZ3D1066: 0.0
-  sysZ3D1067: -0.0
+  sysZ3D1067: 0.0
   sysZ3D1068: 0.0
   sysZ3D1069: 0.0
-  sysZ3D1070: -0.0
+  sysZ3D1070: 0.0
   sysZ3D1071: 0.0
-  sysZ3D1072: -0.0
+  sysZ3D1072: 0.0
   sysZ3D1073: 0.0
   sysZ3D1074: 0.0
-  sysZ3D1075: -0.0
+  sysZ3D1075: 0.0
   sysZ3D1076: 0.0
-  sysZ3D1077: -0.0
+  sysZ3D1077: 0.0
   sysZ3D1078: 0.0
-  sysZ3D1079: -0.0
+  sysZ3D1079: 0.0
   sysZ3D1080: 0.0
-  sysZ3D1081: -0.0
-  sysZ3D1082: -0.0
-  sysZ3D1083: -0.0
+  sysZ3D1081: 0.0
+  sysZ3D1082: 0.0
+  sysZ3D1083: 0.0
   sysZ3D1084: 0.0
-  sysZ3D1085: -0.0
+  sysZ3D1085: 0.0
   sysZ3D1086: 0.0
-  sysZ3D1087: -0.0
-  sysZ3D1088: -0.0
+  sysZ3D1087: 0.0
+  sysZ3D1088: 0.0
   sysZ3D1089: 0.0
   sysZ3D1090: 0.0
-  sysZ3D1091: -0.0
+  sysZ3D1091: 0.0
   sysZ3D1092: 0.004786
   sysZ3D1093: -4.78600000e-03
   sysZ3D1094: 0.0
   sysZ3D1095: 0.0
   sysZ3D1096: 0.0
   sysZ3D1097: 0.0
-  sysZ3D1098: -0.0
-  sysZ3D1099: -0.0
+  sysZ3D1098: 0.0
+  sysZ3D1099: 0.0
   sysZ3D1100: 0.004786
   sysZ3D1101: 0.0
   sysZ3D1102: 0.0
-  sysZ3D1103: -0.0
+  sysZ3D1103: 0.0
   sysZ3D1104: -2.34514000e-01
   sysZ3D1105: -2.96732000e-01
   sysZ3D1106: -6.22180000e-02
   sysZ3D1107: -0.02393
-  sysZ3D1108: -0.0
+  sysZ3D1108: 0.0
   sysZ3D1109: -9.57200000e-03
   sysZ3D1110: 0.0
   sysZ3D1111: 0.009572
@@ -18186,8 +18186,8 @@ bins:
   sysZ3D1113: 0.0
   sysZ3D1114: -0.02393
   sysZ3D1115: -4.78600000e-03
-  sysZ3D1116: -0.0
-  sysZ3D1117: -0.0
+  sysZ3D1116: 0.0
+  sysZ3D1117: 0.0
   sysZ3D1118: 0.009572
   sysZ3D1119: 0.004786
   sysZ3D1120: 0.014358
@@ -18211,19 +18211,19 @@ bins:
   sysZ3D1138: 0.004786
   sysZ3D1139: -1.91440000e-02
   sysZ3D1140: -9.57200000e-03
-  sysZ3D1141: -0.0
+  sysZ3D1141: 0.0
   sysZ3D1142: 0.009572
   sysZ3D1143: -4.78600000e-03
   sysZ3D1144: 0.0
   sysZ3D1145: 0.0
-  sysZ3D1146: -0.0
+  sysZ3D1146: 0.0
   sysZ3D1147: -4.78600000e-03
   sysZ3D1148: -4.78600000e-03
-  sysZ3D1149: -0.0
+  sysZ3D1149: 0.0
   sysZ3D1150: 0.0
   sysZ3D1151: -1.43580000e-02
   sysZ3D1152: -4.78600000e-03
-  sysZ3D1153: -0.0
+  sysZ3D1153: 0.0
   sysZ3D1154: -9.57200000e-03
   sysZ3D1155: -4.78600000e-03
   sysZ3D1156: 0.0
@@ -18242,10 +18242,10 @@ bins:
   sysZ3D1169: -9.57200000e-03
   sysZ3D1170: 0.019144
   sysZ3D1171: -1.91440000e-02
-  sysZ3D1172: -0.0
-  sysZ3D1173: -0.0
+  sysZ3D1172: 0.0
+  sysZ3D1173: 0.0
   sysZ3D1174: -1.91440000e-02
-  sysZ3D1175: -0.0
+  sysZ3D1175: 0.0
   sysZ3D1176: 0.009572
   sysZ3D1177: 0.028716
   sysZ3D1178: 0.02393
@@ -18271,24 +18271,24 @@ bins:
   sysZ3D1198: 0.004786
   sysZ3D1199: -4.78600000e-03
   sysZ3D1200: -4.78600000e-03
-  sysZ3D1201: -0.0
+  sysZ3D1201: 0.0
   sysZ3D1202: 0.0
-  sysZ3D1203: -0.0
+  sysZ3D1203: 0.0
   sysZ3D1204: 0.0
   sysZ3D1205: 0.0
   sysZ3D1206: 0.004786
   sysZ3D1207: 0.0
-  sysZ3D1208: -0.0
-  sysZ3D1209: -0.0
+  sysZ3D1208: 0.0
+  sysZ3D1209: 0.0
   sysZ3D1210: -4.78600000e-03
-  sysZ3D1211: -0.0
-  sysZ3D1212: -0.0
+  sysZ3D1211: 0.0
+  sysZ3D1212: 0.0
   sysZ3D1213: 0.0
-  sysZ3D1214: -0.0
+  sysZ3D1214: 0.0
   sysZ3D1215: -4.78600000e-03
   sysZ3D1216: 0.0
   sysZ3D1217: 0.004786
-  sysZ3D1218: -0.0
+  sysZ3D1218: 0.0
   sysZ3D1219: 0.004786
   sysZ3D1220: 0.0
   sysZ3D1221: -4.78600000e-03
@@ -18297,37 +18297,37 @@ bins:
   sysZ3D1224: 0.004786
   sysZ3D1225: 0.0
   sysZ3D1226: 0.004786
-  sysZ3D1227: -0.0
-  sysZ3D1228: -0.0
-  sysZ3D1229: -0.0
+  sysZ3D1227: 0.0
+  sysZ3D1228: 0.0
+  sysZ3D1229: 0.0
   sysZ3D1230: 0.0
   sysZ3D1231: 0.004786
-  sysZ3D1232: -0.0
-  sysZ3D1233: -0.0
+  sysZ3D1232: 0.0
+  sysZ3D1233: 0.0
   sysZ3D1234: 0.0
   sysZ3D1235: -4.78600000e-03
   sysZ3D1236: 0.004786
   sysZ3D1237: 0.0
   sysZ3D1238: 0.0
-  sysZ3D1239: -0.0
-  sysZ3D1240: -0.0
-  sysZ3D1241: -0.0
+  sysZ3D1239: 0.0
+  sysZ3D1240: 0.0
+  sysZ3D1241: 0.0
   sysZ3D1242: 0.0
   sysZ3D1243: 0.0
   sysZ3D1244: 0.014358
   sysZ3D1245: -4.78600000e-03
   sysZ3D1246: 0.004786
-  sysZ3D1247: -0.0
+  sysZ3D1247: 0.0
   sysZ3D1248: -4.78600000e-03
   sysZ3D1249: -4.78600000e-03
   sysZ3D1250: 0.0
   sysZ3D1251: -9.57200000e-03
   sysZ3D1252: -9.57200000e-03
   sysZ3D1253: 0.0
-  sysZ3D1254: -0.0
+  sysZ3D1254: 0.0
   sysZ3D1255: 0.0
   sysZ3D1256: 0.009572
-  sysZ3D1257: -0.0
+  sysZ3D1257: 0.0
   sysZ3D1258: -9.57200000e-03
   sysZ3D1259: 0.009572
   sysZ3D1260: -4.78600000e-03
@@ -18339,10 +18339,10 @@ bins:
   sysZ3D1266: -3.35020000e-02
   sysZ3D1267: -9.57200000e-03
   sysZ3D1268: 0.0
-  sysZ3D1269: -0.0
+  sysZ3D1269: 0.0
   sysZ3D1270: 0.004786
-  sysZ3D1271: -0.0
-  sysZ3D1272: -0.0
+  sysZ3D1271: 0.0
+  sysZ3D1272: 0.0
   sysZ3D1273: -4.78600000e-03
   sysZ3D1274: 0.019144
   sysZ3D1275: 0.02393
@@ -18378,30 +18378,30 @@ bins:
   sysZ3D1027: -4.73800000e-03
   sysZ3D1028: -4.73800000e-03
   sysZ3D1029: 0.0
-  sysZ3D1030: -0.0
+  sysZ3D1030: 0.0
   sysZ3D1031: 0.0
   sysZ3D1032: 0.0
   sysZ3D1033: 0.0
   sysZ3D1034: 0.0
-  sysZ3D1035: -0.0
+  sysZ3D1035: 0.0
   sysZ3D1036: 0.004738
-  sysZ3D1037: -0.0
+  sysZ3D1037: 0.0
   sysZ3D1038: 0.0
   sysZ3D1039: -4.73800000e-03
   sysZ3D1040: -4.73800000e-03
   sysZ3D1041: 0.0
   sysZ3D1042: 0.0
-  sysZ3D1043: -0.0
+  sysZ3D1043: 0.0
   sysZ3D1044: 0.0
   sysZ3D1045: -4.73800000e-03
   sysZ3D1046: 0.0
-  sysZ3D1047: -0.0
+  sysZ3D1047: 0.0
   sysZ3D1048: 0.004738
-  sysZ3D1049: -0.0
-  sysZ3D1050: -0.0
-  sysZ3D1051: -0.0
+  sysZ3D1049: 0.0
+  sysZ3D1050: 0.0
+  sysZ3D1051: 0.0
   sysZ3D1052: 0.0
-  sysZ3D1053: -0.0
+  sysZ3D1053: 0.0
   sysZ3D1054: 0.0
   sysZ3D1055: 0.0
   sysZ3D1056: 0.0
@@ -18409,49 +18409,49 @@ bins:
   sysZ3D1058: -4.73800000e-03
   sysZ3D1059: 0.0
   sysZ3D1060: 0.0
-  sysZ3D1061: -0.0
+  sysZ3D1061: 0.0
   sysZ3D1062: 0.0
   sysZ3D1063: 0.0
-  sysZ3D1064: -0.0
+  sysZ3D1064: 0.0
   sysZ3D1065: 0.0
   sysZ3D1066: 0.0
   sysZ3D1067: 0.004738
-  sysZ3D1068: -0.0
-  sysZ3D1069: -0.0
-  sysZ3D1070: -0.0
-  sysZ3D1071: -0.0
+  sysZ3D1068: 0.0
+  sysZ3D1069: 0.0
+  sysZ3D1070: 0.0
+  sysZ3D1071: 0.0
   sysZ3D1072: 0.0
   sysZ3D1073: 0.0
-  sysZ3D1074: -0.0
+  sysZ3D1074: 0.0
   sysZ3D1075: 0.0
   sysZ3D1076: 0.0
   sysZ3D1077: 0.0
-  sysZ3D1078: -0.0
+  sysZ3D1078: 0.0
   sysZ3D1079: 0.004738
-  sysZ3D1080: -0.0
-  sysZ3D1081: -0.0
-  sysZ3D1082: -0.0
-  sysZ3D1083: -0.0
-  sysZ3D1084: -0.0
-  sysZ3D1085: -0.0
+  sysZ3D1080: 0.0
+  sysZ3D1081: 0.0
+  sysZ3D1082: 0.0
+  sysZ3D1083: 0.0
+  sysZ3D1084: 0.0
+  sysZ3D1085: 0.0
   sysZ3D1086: 0.0
   sysZ3D1087: 0.0
   sysZ3D1088: 0.0
   sysZ3D1089: 0.0
-  sysZ3D1090: -0.0
-  sysZ3D1091: -0.0
-  sysZ3D1092: -0.0
+  sysZ3D1090: 0.0
+  sysZ3D1091: 0.0
+  sysZ3D1092: 0.0
   sysZ3D1093: 0.0
   sysZ3D1094: 0.0
   sysZ3D1095: 0.0
   sysZ3D1096: 0.0
-  sysZ3D1097: -0.0
-  sysZ3D1098: -0.0
-  sysZ3D1099: -0.0
-  sysZ3D1100: -0.0
-  sysZ3D1101: -0.0
+  sysZ3D1097: 0.0
+  sysZ3D1098: 0.0
+  sysZ3D1099: 0.0
+  sysZ3D1100: 0.0
+  sysZ3D1101: 0.0
   sysZ3D1102: 0.004738
-  sysZ3D1103: -0.0
+  sysZ3D1103: 0.0
   sysZ3D1104: -2.17948000e-01
   sysZ3D1105: -2.98494000e-01
   sysZ3D1106: -6.15940000e-02
@@ -18461,7 +18461,7 @@ bins:
   sysZ3D1110: 0.0
   sysZ3D1111: 0.02369
   sysZ3D1112: 0.009476
-  sysZ3D1113: -0.0
+  sysZ3D1113: 0.0
   sysZ3D1114: -9.47600000e-03
   sysZ3D1115: 0.004738
   sysZ3D1116: -9.47600000e-03
@@ -18478,29 +18478,29 @@ bins:
   sysZ3D1127: -9.47600000e-03
   sysZ3D1128: -4.73800000e-03
   sysZ3D1129: 0.004738
-  sysZ3D1130: -0.0
+  sysZ3D1130: 0.0
   sysZ3D1131: 0.0
-  sysZ3D1132: -0.0
+  sysZ3D1132: 0.0
   sysZ3D1133: 0.004738
   sysZ3D1134: 0.02369
   sysZ3D1135: 0.009476
   sysZ3D1136: -9.47600000e-03
   sysZ3D1137: 0.0
-  sysZ3D1138: -0.0
+  sysZ3D1138: 0.0
   sysZ3D1139: -9.47600000e-03
   sysZ3D1140: 0.004738
   sysZ3D1141: 0.004738
   sysZ3D1142: -4.73800000e-03
-  sysZ3D1143: -0.0
+  sysZ3D1143: 0.0
   sysZ3D1144: -4.73800000e-03
   sysZ3D1145: -4.73800000e-03
-  sysZ3D1146: -0.0
+  sysZ3D1146: 0.0
   sysZ3D1147: 0.004738
   sysZ3D1148: 0.0
   sysZ3D1149: -9.47600000e-03
   sysZ3D1150: -4.73800000e-03
-  sysZ3D1151: -0.0
-  sysZ3D1152: -0.0
+  sysZ3D1151: 0.0
+  sysZ3D1152: 0.0
   sysZ3D1153: -4.73800000e-03
   sysZ3D1154: 0.0
   sysZ3D1155: 0.004738
@@ -18509,9 +18509,9 @@ bins:
   sysZ3D1158: -4.73800000e-03
   sysZ3D1159: -1.42140000e-02
   sysZ3D1160: 0.0
-  sysZ3D1161: -0.0
+  sysZ3D1161: 0.0
   sysZ3D1162: 0.004738
-  sysZ3D1163: -0.0
+  sysZ3D1163: 0.0
   sysZ3D1164: -9.47600000e-03
   sysZ3D1165: 0.004738
   sysZ3D1166: 0.004738
@@ -18520,10 +18520,10 @@ bins:
   sysZ3D1169: -9.47600000e-03
   sysZ3D1170: 0.018952
   sysZ3D1171: -1.89520000e-02
-  sysZ3D1172: -0.0
-  sysZ3D1173: -0.0
+  sysZ3D1172: 0.0
+  sysZ3D1173: 0.0
   sysZ3D1174: -0.02369
-  sysZ3D1175: -0.0
+  sysZ3D1175: 0.0
   sysZ3D1176: 0.004738
   sysZ3D1177: 2.84280000e-02
   sysZ3D1178: 0.02369
@@ -18543,7 +18543,7 @@ bins:
   sysZ3D1192: 0.009476
   sysZ3D1193: 1.42140000e-02
   sysZ3D1194: -2.84280000e-02
-  sysZ3D1195: -0.0
+  sysZ3D1195: 0.0
   sysZ3D1196: 0.004738
   sysZ3D1197: 0.004738
   sysZ3D1198: 0.009476
@@ -18551,18 +18551,18 @@ bins:
   sysZ3D1200: -9.47600000e-03
   sysZ3D1201: -4.73800000e-03
   sysZ3D1202: 0.0
-  sysZ3D1203: -0.0
-  sysZ3D1204: -0.0
-  sysZ3D1205: -0.0
+  sysZ3D1203: 0.0
+  sysZ3D1204: 0.0
+  sysZ3D1205: 0.0
   sysZ3D1206: 0.004738
   sysZ3D1207: 0.004738
-  sysZ3D1208: -0.0
+  sysZ3D1208: 0.0
   sysZ3D1209: -4.73800000e-03
-  sysZ3D1210: -0.0
-  sysZ3D1211: -0.0
+  sysZ3D1210: 0.0
+  sysZ3D1211: 0.0
   sysZ3D1212: 0.0
-  sysZ3D1213: -0.0
-  sysZ3D1214: -0.0
+  sysZ3D1213: 0.0
+  sysZ3D1214: 0.0
   sysZ3D1215: -4.73800000e-03
   sysZ3D1216: -4.73800000e-03
   sysZ3D1217: 0.0
@@ -18575,40 +18575,40 @@ bins:
   sysZ3D1224: 0.0
   sysZ3D1225: 0.0
   sysZ3D1226: 0.0
-  sysZ3D1227: -0.0
+  sysZ3D1227: 0.0
   sysZ3D1228: 0.0
   sysZ3D1229: 0.0
   sysZ3D1230: 0.0
   sysZ3D1231: 0.004738
   sysZ3D1232: 0.0
-  sysZ3D1233: -0.0
-  sysZ3D1234: -0.0
+  sysZ3D1233: 0.0
+  sysZ3D1234: 0.0
   sysZ3D1235: -4.73800000e-03
   sysZ3D1236: 0.004738
   sysZ3D1237: 0.0
   sysZ3D1238: 0.004738
-  sysZ3D1239: -0.0
-  sysZ3D1240: -0.0
-  sysZ3D1241: -0.0
+  sysZ3D1239: 0.0
+  sysZ3D1240: 0.0
+  sysZ3D1241: 0.0
   sysZ3D1242: 0.0
   sysZ3D1243: 0.0
   sysZ3D1244: 0.004738
   sysZ3D1245: -4.73800000e-03
   sysZ3D1246: 0.004738
-  sysZ3D1247: -0.0
+  sysZ3D1247: 0.0
   sysZ3D1248: -4.73800000e-03
   sysZ3D1249: -9.47600000e-03
   sysZ3D1250: 0.004738
   sysZ3D1251: -9.47600000e-03
   sysZ3D1252: -9.47600000e-03
-  sysZ3D1253: -0.0
+  sysZ3D1253: 0.0
   sysZ3D1254: -4.73800000e-03
   sysZ3D1255: -9.47600000e-03
   sysZ3D1256: 0.018952
   sysZ3D1257: -9.47600000e-03
   sysZ3D1258: -9.47600000e-03
   sysZ3D1259: 1.42140000e-02
-  sysZ3D1260: -0.0
+  sysZ3D1260: 0.0
   sysZ3D1261: 0.0
   sysZ3D1262: -4.73800000e-03
   sysZ3D1263: 0.004738
@@ -18617,11 +18617,11 @@ bins:
   sysZ3D1266: -2.84280000e-02
   sysZ3D1267: -1.42140000e-02
   sysZ3D1268: 0.0
-  sysZ3D1269: -0.0
+  sysZ3D1269: 0.0
   sysZ3D1270: 0.004738
   sysZ3D1271: 0.004738
-  sysZ3D1272: -0.0
-  sysZ3D1273: -0.0
+  sysZ3D1272: 0.0
+  sysZ3D1273: 0.0
   sysZ3D1274: -9.47600000e-03
   sysZ3D1275: 0.02369
   sys,uncor: 0.151616
@@ -18646,7 +18646,7 @@ bins:
   sysZ3D1017: 0.0
   sysZ3D1018: 0.0
   sysZ3D1019: 0.0
-  sysZ3D1020: -0.0
+  sysZ3D1020: 0.0
   sysZ3D1021: 0.0
   sysZ3D1022: 0.0
   sysZ3D1023: 0.004772
@@ -18658,88 +18658,88 @@ bins:
   sysZ3D1029: 0.004772
   sysZ3D1030: 0.0
   sysZ3D1031: -4.77200000e-03
-  sysZ3D1032: -0.0
+  sysZ3D1032: 0.0
   sysZ3D1033: -4.77200000e-03
   sysZ3D1034: 0.0
   sysZ3D1035: 0.0
   sysZ3D1036: -4.77200000e-03
   sysZ3D1037: 0.0
-  sysZ3D1038: -0.0
+  sysZ3D1038: 0.0
   sysZ3D1039: 0.0
   sysZ3D1040: 0.004772
   sysZ3D1041: 0.0
-  sysZ3D1042: -0.0
+  sysZ3D1042: 0.0
   sysZ3D1043: 0.0
   sysZ3D1044: 0.0
   sysZ3D1045: 0.0
   sysZ3D1046: 0.0
-  sysZ3D1047: -0.0
+  sysZ3D1047: 0.0
   sysZ3D1048: 0.0
-  sysZ3D1049: -0.0
+  sysZ3D1049: 0.0
   sysZ3D1050: 0.0
-  sysZ3D1051: -0.0
+  sysZ3D1051: 0.0
   sysZ3D1052: 0.0
   sysZ3D1053: -4.77200000e-03
   sysZ3D1054: 0.0
-  sysZ3D1055: -0.0
-  sysZ3D1056: -0.0
+  sysZ3D1055: 0.0
+  sysZ3D1056: 0.0
   sysZ3D1057: -4.77200000e-03
   sysZ3D1058: 0.0
   sysZ3D1059: -4.77200000e-03
-  sysZ3D1060: -0.0
-  sysZ3D1061: -0.0
-  sysZ3D1062: -0.0
+  sysZ3D1060: 0.0
+  sysZ3D1061: 0.0
+  sysZ3D1062: 0.0
   sysZ3D1063: 0.0
   sysZ3D1064: 0.0
-  sysZ3D1065: -0.0
-  sysZ3D1066: -0.0
-  sysZ3D1067: -0.0
+  sysZ3D1065: 0.0
+  sysZ3D1066: 0.0
+  sysZ3D1067: 0.0
   sysZ3D1068: 0.004772
-  sysZ3D1069: -0.0
-  sysZ3D1070: -0.0
+  sysZ3D1069: 0.0
+  sysZ3D1070: 0.0
   sysZ3D1071: 0.004772
   sysZ3D1072: 0.004772
   sysZ3D1073: 0.0
-  sysZ3D1074: -0.0
+  sysZ3D1074: 0.0
   sysZ3D1075: 0.0
-  sysZ3D1076: -0.0
+  sysZ3D1076: 0.0
   sysZ3D1077: 0.0
   sysZ3D1078: 0.0
   sysZ3D1079: -4.77200000e-03
   sysZ3D1080: 0.0
   sysZ3D1081: 0.0
-  sysZ3D1082: -0.0
-  sysZ3D1083: -0.0
+  sysZ3D1082: 0.0
+  sysZ3D1083: 0.0
   sysZ3D1084: 0.0
-  sysZ3D1085: -0.0
-  sysZ3D1086: -0.0
+  sysZ3D1085: 0.0
+  sysZ3D1086: 0.0
   sysZ3D1087: 0.0
   sysZ3D1088: 0.0
-  sysZ3D1089: -0.0
+  sysZ3D1089: 0.0
   sysZ3D1090: 0.0
-  sysZ3D1091: -0.0
+  sysZ3D1091: 0.0
   sysZ3D1092: 0.004772
-  sysZ3D1093: -0.0
-  sysZ3D1094: -0.0
+  sysZ3D1093: 0.0
+  sysZ3D1094: 0.0
   sysZ3D1095: 0.0
-  sysZ3D1096: -0.0
+  sysZ3D1096: 0.0
   sysZ3D1097: -4.77200000e-03
   sysZ3D1098: 0.0
   sysZ3D1099: 0.0
-  sysZ3D1100: -0.0
-  sysZ3D1101: -0.0
-  sysZ3D1102: -0.0
+  sysZ3D1100: 0.0
+  sysZ3D1101: 0.0
+  sysZ3D1102: 0.0
   sysZ3D1103: -4.77200000e-03
   sysZ3D1104: -1.95652000e-01
   sysZ3D1105: -2.72004000e-01
   sysZ3D1106: -6.68080000e-02
   sysZ3D1107: -1.43160000e-02
   sysZ3D1108: -4.77200000e-03
-  sysZ3D1109: -0.0
+  sysZ3D1109: 0.0
   sysZ3D1110: 0.0
   sysZ3D1111: -9.54400000e-03
   sysZ3D1112: 0.004772
-  sysZ3D1113: -0.0
+  sysZ3D1113: 0.0
   sysZ3D1114: -0.02386
   sysZ3D1115: -4.77200000e-03
   sysZ3D1116: -9.54400000e-03
@@ -18760,26 +18760,26 @@ bins:
   sysZ3D1131: 0.004772
   sysZ3D1132: 1.43160000e-02
   sysZ3D1133: -1.43160000e-02
-  sysZ3D1134: -0.0
+  sysZ3D1134: 0.0
   sysZ3D1135: 0.004772
   sysZ3D1136: -4.77200000e-03
   sysZ3D1137: 0.004772
   sysZ3D1138: -9.54400000e-03
   sysZ3D1139: 0.0
   sysZ3D1140: -1.43160000e-02
-  sysZ3D1141: -0.0
+  sysZ3D1141: 0.0
   sysZ3D1142: -1.43160000e-02
   sysZ3D1143: 0.004772
   sysZ3D1144: 1.43160000e-02
   sysZ3D1145: 0.004772
   sysZ3D1146: 0.004772
   sysZ3D1147: -4.77200000e-03
-  sysZ3D1148: -0.0
+  sysZ3D1148: 0.0
   sysZ3D1149: 0.019088
   sysZ3D1150: -1.43160000e-02
   sysZ3D1151: -4.77200000e-03
   sysZ3D1152: -4.77200000e-03
-  sysZ3D1153: -0.0
+  sysZ3D1153: 0.0
   sysZ3D1154: 0.0
   sysZ3D1155: 0.009544
   sysZ3D1156: -9.54400000e-03
@@ -18798,8 +18798,8 @@ bins:
   sysZ3D1169: -9.54400000e-03
   sysZ3D1170: 0.019088
   sysZ3D1171: -1.90880000e-02
-  sysZ3D1172: -0.0
-  sysZ3D1173: -0.0
+  sysZ3D1172: 0.0
+  sysZ3D1173: 0.0
   sysZ3D1174: -1.90880000e-02
   sysZ3D1175: 0.0
   sysZ3D1176: 0.019088
@@ -18821,69 +18821,69 @@ bins:
   sysZ3D1192: 0.009544
   sysZ3D1193: 1.43160000e-02
   sysZ3D1194: -3.34040000e-02
-  sysZ3D1195: -0.0
+  sysZ3D1195: 0.0
   sysZ3D1196: 0.004772
   sysZ3D1197: 0.004772
   sysZ3D1198: 0.019088
   sysZ3D1199: -4.77200000e-03
-  sysZ3D1200: -0.0
+  sysZ3D1200: 0.0
   sysZ3D1201: 0.0
   sysZ3D1202: 0.0
   sysZ3D1203: -4.77200000e-03
-  sysZ3D1204: -0.0
+  sysZ3D1204: 0.0
   sysZ3D1205: 0.004772
   sysZ3D1206: 0.0
   sysZ3D1207: 0.004772
-  sysZ3D1208: -0.0
+  sysZ3D1208: 0.0
   sysZ3D1209: 0.0
   sysZ3D1210: 0.0
-  sysZ3D1211: -0.0
+  sysZ3D1211: 0.0
   sysZ3D1212: 0.0
-  sysZ3D1213: -0.0
-  sysZ3D1214: -0.0
+  sysZ3D1213: 0.0
+  sysZ3D1214: 0.0
   sysZ3D1215: -4.77200000e-03
   sysZ3D1216: -9.54400000e-03
   sysZ3D1217: 0.009544
-  sysZ3D1218: -0.0
+  sysZ3D1218: 0.0
   sysZ3D1219: 0.0
-  sysZ3D1220: -0.0
+  sysZ3D1220: 0.0
   sysZ3D1221: -4.77200000e-03
   sysZ3D1222: -4.77200000e-03
-  sysZ3D1223: -0.0
+  sysZ3D1223: 0.0
   sysZ3D1224: -4.77200000e-03
   sysZ3D1225: 0.0
   sysZ3D1226: 0.0
   sysZ3D1227: 0.004772
-  sysZ3D1228: -0.0
+  sysZ3D1228: 0.0
   sysZ3D1229: 0.0
   sysZ3D1230: 0.0
   sysZ3D1231: 0.004772
-  sysZ3D1232: -0.0
-  sysZ3D1233: -0.0
+  sysZ3D1232: 0.0
+  sysZ3D1233: 0.0
   sysZ3D1234: 0.0
   sysZ3D1235: -4.77200000e-03
   sysZ3D1236: -4.77200000e-03
   sysZ3D1237: 0.0
-  sysZ3D1238: -0.0
-  sysZ3D1239: -0.0
-  sysZ3D1240: -0.0
+  sysZ3D1238: 0.0
+  sysZ3D1239: 0.0
+  sysZ3D1240: 0.0
   sysZ3D1241: 0.0
   sysZ3D1242: 0.0
   sysZ3D1243: 0.0
   sysZ3D1244: 0.004772
   sysZ3D1245: -4.77200000e-03
-  sysZ3D1246: -0.0
+  sysZ3D1246: 0.0
   sysZ3D1247: -4.77200000e-03
   sysZ3D1248: 0.004772
   sysZ3D1249: -4.77200000e-03
   sysZ3D1250: 0.0
   sysZ3D1251: -9.54400000e-03
   sysZ3D1252: -9.54400000e-03
-  sysZ3D1253: -0.0
+  sysZ3D1253: 0.0
   sysZ3D1254: 0.009544
   sysZ3D1255: -1.90880000e-02
   sysZ3D1256: 0.004772
-  sysZ3D1257: -0.0
+  sysZ3D1257: 0.0
   sysZ3D1258: -9.54400000e-03
   sysZ3D1259: 0.004772
   sysZ3D1260: 0.004772
@@ -18898,8 +18898,8 @@ bins:
   sysZ3D1269: 0.0
   sysZ3D1270: 0.004772
   sysZ3D1271: 0.0
-  sysZ3D1272: -0.0
-  sysZ3D1273: -0.0
+  sysZ3D1272: 0.0
+  sysZ3D1273: 0.0
   sysZ3D1274: -1.90880000e-02
   sysZ3D1275: 2.86320000e-02
   sys,uncor: 0.14316
@@ -18932,87 +18932,87 @@ bins:
   sysZ3D1025: -9.07200000e-03
   sysZ3D1026: 0.004536
   sysZ3D1027: -4.53600000e-03
-  sysZ3D1028: -0.0
-  sysZ3D1029: -0.0
-  sysZ3D1030: -0.0
-  sysZ3D1031: -0.0
+  sysZ3D1028: 0.0
+  sysZ3D1029: 0.0
+  sysZ3D1030: 0.0
+  sysZ3D1031: 0.0
   sysZ3D1032: 0.0
-  sysZ3D1033: -0.0
+  sysZ3D1033: 0.0
   sysZ3D1034: -4.53600000e-03
-  sysZ3D1035: -0.0
+  sysZ3D1035: 0.0
   sysZ3D1036: 0.004536
-  sysZ3D1037: -0.0
+  sysZ3D1037: 0.0
   sysZ3D1038: -4.53600000e-03
-  sysZ3D1039: -0.0
-  sysZ3D1040: -0.0
-  sysZ3D1041: -0.0
-  sysZ3D1042: -0.0
-  sysZ3D1043: -0.0
+  sysZ3D1039: 0.0
+  sysZ3D1040: 0.0
+  sysZ3D1041: 0.0
+  sysZ3D1042: 0.0
+  sysZ3D1043: 0.0
   sysZ3D1044: -4.53600000e-03
   sysZ3D1045: -4.53600000e-03
-  sysZ3D1046: -0.0
-  sysZ3D1047: -0.0
-  sysZ3D1048: -0.0
+  sysZ3D1046: 0.0
+  sysZ3D1047: 0.0
+  sysZ3D1048: 0.0
   sysZ3D1049: -4.53600000e-03
-  sysZ3D1050: -0.0
+  sysZ3D1050: 0.0
   sysZ3D1051: -4.53600000e-03
   sysZ3D1052: 0.0
   sysZ3D1053: 0.0
-  sysZ3D1054: -0.0
+  sysZ3D1054: 0.0
   sysZ3D1055: 0.0
   sysZ3D1056: 0.0
-  sysZ3D1057: -0.0
-  sysZ3D1058: -0.0
+  sysZ3D1057: 0.0
+  sysZ3D1058: 0.0
   sysZ3D1059: 0.004536
   sysZ3D1060: 0.0
   sysZ3D1061: 0.004536
   sysZ3D1062: 0.0
-  sysZ3D1063: -0.0
+  sysZ3D1063: 0.0
   sysZ3D1064: 0.004536
   sysZ3D1065: 0.004536
-  sysZ3D1066: -0.0
+  sysZ3D1066: 0.0
   sysZ3D1067: 0.0
   sysZ3D1068: -4.53600000e-03
   sysZ3D1069: -4.53600000e-03
-  sysZ3D1070: -0.0
-  sysZ3D1071: -0.0
+  sysZ3D1070: 0.0
+  sysZ3D1071: 0.0
   sysZ3D1072: 0.0
-  sysZ3D1073: -0.0
+  sysZ3D1073: 0.0
   sysZ3D1074: 0.0
   sysZ3D1075: 0.0
   sysZ3D1076: 0.0
   sysZ3D1077: 0.004536
-  sysZ3D1078: -0.0
+  sysZ3D1078: 0.0
   sysZ3D1079: 0.0
-  sysZ3D1080: -0.0
-  sysZ3D1081: -0.0
-  sysZ3D1082: -0.0
+  sysZ3D1080: 0.0
+  sysZ3D1081: 0.0
+  sysZ3D1082: 0.0
   sysZ3D1083: 0.0
-  sysZ3D1084: -0.0
+  sysZ3D1084: 0.0
   sysZ3D1085: 0.0
-  sysZ3D1086: -0.0
-  sysZ3D1087: -0.0
+  sysZ3D1086: 0.0
+  sysZ3D1087: 0.0
   sysZ3D1088: 0.0
-  sysZ3D1089: -0.0
+  sysZ3D1089: 0.0
   sysZ3D1090: 0.0
   sysZ3D1091: -4.53600000e-03
-  sysZ3D1092: -0.0
+  sysZ3D1092: 0.0
   sysZ3D1093: 0.0
   sysZ3D1094: 0.0
-  sysZ3D1095: -0.0
-  sysZ3D1096: -0.0
-  sysZ3D1097: -0.0
-  sysZ3D1098: -0.0
+  sysZ3D1095: 0.0
+  sysZ3D1096: 0.0
+  sysZ3D1097: 0.0
+  sysZ3D1098: 0.0
   sysZ3D1099: 0.0
   sysZ3D1100: 0.0
-  sysZ3D1101: -0.0
-  sysZ3D1102: -0.0
+  sysZ3D1101: 0.0
+  sysZ3D1102: 0.0
   sysZ3D1103: 0.0
   sysZ3D1104: -1.67832000e-01
   sysZ3D1105: -2.31336000e-01
   sysZ3D1106: -6.35040000e-02
   sysZ3D1107: -1.36080000e-02
-  sysZ3D1108: -0.0
+  sysZ3D1108: 0.0
   sysZ3D1109: -4.53600000e-03
   sysZ3D1110: 0.0
   sysZ3D1111: 0.018144
@@ -19035,12 +19035,12 @@ bins:
   sysZ3D1128: 0.004536
   sysZ3D1129: 0.004536
   sysZ3D1130: 0.009072
-  sysZ3D1131: -0.0
+  sysZ3D1131: 0.0
   sysZ3D1132: 0.004536
   sysZ3D1133: -4.53600000e-03
   sysZ3D1134: 0.018144
   sysZ3D1135: 0.004536
-  sysZ3D1136: -0.0
+  sysZ3D1136: 0.0
   sysZ3D1137: -4.53600000e-03
   sysZ3D1138: -4.53600000e-03
   sysZ3D1139: 0.004536
@@ -19050,18 +19050,18 @@ bins:
   sysZ3D1143: 0.004536
   sysZ3D1144: 0.004536
   sysZ3D1145: -4.53600000e-03
-  sysZ3D1146: -0.0
+  sysZ3D1146: 0.0
   sysZ3D1147: 0.0
   sysZ3D1148: 0.004536
   sysZ3D1149: 1.36080000e-02
   sysZ3D1150: -4.53600000e-03
   sysZ3D1151: -4.53600000e-03
-  sysZ3D1152: -0.0
+  sysZ3D1152: 0.0
   sysZ3D1153: 0.004536
   sysZ3D1154: 0.004536
   sysZ3D1155: -4.53600000e-03
   sysZ3D1156: 0.004536
-  sysZ3D1157: -0.0
+  sysZ3D1157: 0.0
   sysZ3D1158: 0.0
   sysZ3D1159: 0.004536
   sysZ3D1160: 1.36080000e-02
@@ -19070,26 +19070,26 @@ bins:
   sysZ3D1163: -4.53600000e-03
   sysZ3D1164: -9.07200000e-03
   sysZ3D1165: 0.0
-  sysZ3D1166: -0.0
+  sysZ3D1166: 0.0
   sysZ3D1167: 0.004536
   sysZ3D1168: -4.53600000e-03
   sysZ3D1169: -9.07200000e-03
   sysZ3D1170: 0.018144
   sysZ3D1171: -1.36080000e-02
-  sysZ3D1172: -0.0
-  sysZ3D1173: -0.0
+  sysZ3D1172: 0.0
+  sysZ3D1173: 0.0
   sysZ3D1174: -1.81440000e-02
-  sysZ3D1175: -0.0
+  sysZ3D1175: 0.0
   sysZ3D1176: 0.02268
   sysZ3D1177: 4.08240000e-02
   sysZ3D1178: 0.02268
   sysZ3D1179: 0.004536
-  sysZ3D1180: -0.0
+  sysZ3D1180: 0.0
   sysZ3D1181: -9.07200000e-03
   sysZ3D1182: -4.53600000e-03
   sysZ3D1183: 1.36080000e-02
   sysZ3D1184: -9.07200000e-03
-  sysZ3D1185: -0.0
+  sysZ3D1185: 0.0
   sysZ3D1186: 0.004536
   sysZ3D1187: 0.0
   sysZ3D1188: -0.02268
@@ -19099,7 +19099,7 @@ bins:
   sysZ3D1192: 0.009072
   sysZ3D1193: 1.36080000e-02
   sysZ3D1194: -3.62880000e-02
-  sysZ3D1195: -0.0
+  sysZ3D1195: 0.0
   sysZ3D1196: 0.004536
   sysZ3D1197: 0.004536
   sysZ3D1198: 1.36080000e-02
@@ -19108,27 +19108,27 @@ bins:
   sysZ3D1201: -4.53600000e-03
   sysZ3D1202: 0.0
   sysZ3D1203: -4.53600000e-03
-  sysZ3D1204: -0.0
+  sysZ3D1204: 0.0
   sysZ3D1205: 0.004536
   sysZ3D1206: 0.004536
   sysZ3D1207: 0.004536
   sysZ3D1208: 0.0
-  sysZ3D1209: -0.0
-  sysZ3D1210: -0.0
+  sysZ3D1209: 0.0
+  sysZ3D1210: 0.0
   sysZ3D1211: 0.0
-  sysZ3D1212: -0.0
-  sysZ3D1213: -0.0
+  sysZ3D1212: 0.0
+  sysZ3D1213: 0.0
   sysZ3D1214: -4.53600000e-03
   sysZ3D1215: -4.53600000e-03
   sysZ3D1216: -4.53600000e-03
   sysZ3D1217: 0.004536
-  sysZ3D1218: -0.0
+  sysZ3D1218: 0.0
   sysZ3D1219: 0.004536
   sysZ3D1220: -4.53600000e-03
   sysZ3D1221: -4.53600000e-03
-  sysZ3D1222: -0.0
+  sysZ3D1222: 0.0
   sysZ3D1223: -9.07200000e-03
-  sysZ3D1224: -0.0
+  sysZ3D1224: 0.0
   sysZ3D1225: 0.0
   sysZ3D1226: 0.004536
   sysZ3D1227: 0.0
@@ -19136,16 +19136,16 @@ bins:
   sysZ3D1229: 0.0
   sysZ3D1230: 0.0
   sysZ3D1231: 0.004536
-  sysZ3D1232: -0.0
-  sysZ3D1233: -0.0
-  sysZ3D1234: -0.0
+  sysZ3D1232: 0.0
+  sysZ3D1233: 0.0
+  sysZ3D1234: 0.0
   sysZ3D1235: 0.004536
-  sysZ3D1236: -0.0
-  sysZ3D1237: -0.0
+  sysZ3D1236: 0.0
+  sysZ3D1237: 0.0
   sysZ3D1238: 0.004536
-  sysZ3D1239: -0.0
-  sysZ3D1240: -0.0
-  sysZ3D1241: -0.0
+  sysZ3D1239: 0.0
+  sysZ3D1240: 0.0
+  sysZ3D1241: 0.0
   sysZ3D1242: 0.0
   sysZ3D1243: 0.0
   sysZ3D1244: 0.009072
@@ -19153,7 +19153,7 @@ bins:
   sysZ3D1246: -4.53600000e-03
   sysZ3D1247: -4.53600000e-03
   sysZ3D1248: -4.53600000e-03
-  sysZ3D1249: -0.0
+  sysZ3D1249: 0.0
   sysZ3D1250: 0.004536
   sysZ3D1251: -9.07200000e-03
   sysZ3D1252: -1.81440000e-02
@@ -19165,8 +19165,8 @@ bins:
   sysZ3D1258: -9.07200000e-03
   sysZ3D1259: 0.009072
   sysZ3D1260: 0.004536
-  sysZ3D1261: -0.0
-  sysZ3D1262: -0.0
+  sysZ3D1261: 0.0
+  sysZ3D1262: 0.0
   sysZ3D1263: 0.004536
   sysZ3D1264: 2.72160000e-02
   sysZ3D1265: -9.07200000e-03
@@ -19176,7 +19176,7 @@ bins:
   sysZ3D1269: 0.0
   sysZ3D1270: 0.004536
   sysZ3D1271: 0.004536
-  sysZ3D1272: -0.0
+  sysZ3D1272: 0.0
   sysZ3D1273: -4.53600000e-03
   sysZ3D1274: -4.08240000e-02
   sysZ3D1275: 2.72160000e-02
@@ -19202,95 +19202,95 @@ bins:
   sysZ3D1017: 0.0
   sysZ3D1018: 0.0
   sysZ3D1019: 0.0
-  sysZ3D1020: -0.0
-  sysZ3D1021: -0.0
-  sysZ3D1022: -0.0
-  sysZ3D1023: -0.0
+  sysZ3D1020: 0.0
+  sysZ3D1021: 0.0
+  sysZ3D1022: 0.0
+  sysZ3D1023: 0.0
   sysZ3D1024: 0.004226
   sysZ3D1025: -8.45200000e-03
   sysZ3D1026: 0.0
-  sysZ3D1027: -0.0
+  sysZ3D1027: 0.0
   sysZ3D1028: 0.004226
-  sysZ3D1029: -0.0
+  sysZ3D1029: 0.0
   sysZ3D1030: 0.0
   sysZ3D1031: 0.0
   sysZ3D1032: 0.0
-  sysZ3D1033: -0.0
-  sysZ3D1034: -0.0
+  sysZ3D1033: 0.0
+  sysZ3D1034: 0.0
   sysZ3D1035: 0.004226
-  sysZ3D1036: -0.0
+  sysZ3D1036: 0.0
   sysZ3D1037: 0.0
   sysZ3D1038: 0.004226
   sysZ3D1039: 0.0
   sysZ3D1040: 0.004226
   sysZ3D1041: 0.0
-  sysZ3D1042: -0.0
+  sysZ3D1042: 0.0
   sysZ3D1043: 0.0
   sysZ3D1044: 0.0
-  sysZ3D1045: -0.0
+  sysZ3D1045: 0.0
   sysZ3D1046: 0.0
   sysZ3D1047: 0.0
   sysZ3D1048: 0.004226
-  sysZ3D1049: -0.0
+  sysZ3D1049: 0.0
   sysZ3D1050: 0.0
-  sysZ3D1051: -0.0
+  sysZ3D1051: 0.0
   sysZ3D1052: -4.22600000e-03
   sysZ3D1053: 0.004226
   sysZ3D1054: 0.0
-  sysZ3D1055: -0.0
-  sysZ3D1056: -0.0
+  sysZ3D1055: 0.0
+  sysZ3D1056: 0.0
   sysZ3D1057: 0.0
   sysZ3D1058: 0.0
   sysZ3D1059: 0.0
   sysZ3D1060: 0.0
   sysZ3D1061: -4.22600000e-03
   sysZ3D1062: 0.0
-  sysZ3D1063: -0.0
+  sysZ3D1063: 0.0
   sysZ3D1064: 0.004226
   sysZ3D1065: -4.22600000e-03
   sysZ3D1066: 0.0
   sysZ3D1067: 0.0
-  sysZ3D1068: -0.0
+  sysZ3D1068: 0.0
   sysZ3D1069: -4.22600000e-03
-  sysZ3D1070: -0.0
-  sysZ3D1071: -0.0
-  sysZ3D1072: -0.0
-  sysZ3D1073: -0.0
+  sysZ3D1070: 0.0
+  sysZ3D1071: 0.0
+  sysZ3D1072: 0.0
+  sysZ3D1073: 0.0
   sysZ3D1074: 0.004226
   sysZ3D1075: -4.22600000e-03
-  sysZ3D1076: -0.0
+  sysZ3D1076: 0.0
   sysZ3D1077: -4.22600000e-03
   sysZ3D1078: 0.0
-  sysZ3D1079: -0.0
-  sysZ3D1080: -0.0
+  sysZ3D1079: 0.0
+  sysZ3D1080: 0.0
   sysZ3D1081: 0.0
   sysZ3D1082: 0.004226
   sysZ3D1083: 0.004226
   sysZ3D1084: 0.004226
   sysZ3D1085: 0.0
-  sysZ3D1086: -0.0
+  sysZ3D1086: 0.0
   sysZ3D1087: 0.0
   sysZ3D1088: 0.0
-  sysZ3D1089: -0.0
+  sysZ3D1089: 0.0
   sysZ3D1090: 0.0
   sysZ3D1091: 0.0
   sysZ3D1092: 0.0
-  sysZ3D1093: -0.0
-  sysZ3D1094: -0.0
+  sysZ3D1093: 0.0
+  sysZ3D1094: 0.0
   sysZ3D1095: -4.22600000e-03
   sysZ3D1096: 0.0
   sysZ3D1097: 0.0
   sysZ3D1098: 0.004226
-  sysZ3D1099: -0.0
+  sysZ3D1099: 0.0
   sysZ3D1100: 0.0
   sysZ3D1101: 0.0
-  sysZ3D1102: -0.0
+  sysZ3D1102: 0.0
   sysZ3D1103: -4.22600000e-03
   sysZ3D1104: -1.31006000e-01
   sysZ3D1105: -1.94396000e-01
   sysZ3D1106: -5.49380000e-02
   sysZ3D1107: -1.26780000e-02
-  sysZ3D1108: -0.0
+  sysZ3D1108: 0.0
   sysZ3D1109: -4.22600000e-03
   sysZ3D1110: 0.0
   sysZ3D1111: 0.008452
@@ -19306,16 +19306,16 @@ bins:
   sysZ3D1121: -2.95820000e-02
   sysZ3D1122: 0.008452
   sysZ3D1123: -1.26780000e-02
-  sysZ3D1124: -0.0
-  sysZ3D1125: -0.0
-  sysZ3D1126: -0.0
+  sysZ3D1124: 0.0
+  sysZ3D1125: 0.0
+  sysZ3D1126: 0.0
   sysZ3D1127: -4.22600000e-03
   sysZ3D1128: 0.004226
   sysZ3D1129: -4.22600000e-03
   sysZ3D1130: -4.22600000e-03
   sysZ3D1131: -4.22600000e-03
   sysZ3D1132: -8.45200000e-03
-  sysZ3D1133: -0.0
+  sysZ3D1133: 0.0
   sysZ3D1134: -8.45200000e-03
   sysZ3D1135: -8.45200000e-03
   sysZ3D1136: 0.004226
@@ -19328,14 +19328,14 @@ bins:
   sysZ3D1143: 0.0
   sysZ3D1144: -8.45200000e-03
   sysZ3D1145: 1.26780000e-02
-  sysZ3D1146: -0.0
+  sysZ3D1146: 0.0
   sysZ3D1147: 0.0
   sysZ3D1148: -8.45200000e-03
   sysZ3D1149: -4.22600000e-03
   sysZ3D1150: -4.22600000e-03
   sysZ3D1151: 0.004226
   sysZ3D1152: -4.22600000e-03
-  sysZ3D1153: -0.0
+  sysZ3D1153: 0.0
   sysZ3D1154: 0.0
   sysZ3D1155: 1.26780000e-02
   sysZ3D1156: 0.004226
@@ -19347,7 +19347,7 @@ bins:
   sysZ3D1162: 0.004226
   sysZ3D1163: 2.53560000e-02
   sysZ3D1164: -8.45200000e-03
-  sysZ3D1165: -0.0
+  sysZ3D1165: 0.0
   sysZ3D1166: 0.02113
   sysZ3D1167: -4.22600000e-03
   sysZ3D1168: -4.22600000e-03
@@ -19364,12 +19364,12 @@ bins:
   sysZ3D1179: 0.008452
   sysZ3D1180: -4.22600000e-03
   sysZ3D1181: -8.45200000e-03
-  sysZ3D1182: -0.0
+  sysZ3D1182: 0.0
   sysZ3D1183: 0.008452
   sysZ3D1184: -1.69040000e-02
   sysZ3D1185: -4.22600000e-03
   sysZ3D1186: 0.004226
-  sysZ3D1187: -0.0
+  sysZ3D1187: 0.0
   sysZ3D1188: -1.69040000e-02
   sysZ3D1189: -8.45200000e-03
   sysZ3D1190: 0.008452
@@ -19383,47 +19383,47 @@ bins:
   sysZ3D1198: 1.26780000e-02
   sysZ3D1199: -4.22600000e-03
   sysZ3D1200: -4.22600000e-03
-  sysZ3D1201: -0.0
+  sysZ3D1201: 0.0
   sysZ3D1202: 0.0
-  sysZ3D1203: -0.0
+  sysZ3D1203: 0.0
   sysZ3D1204: -4.22600000e-03
   sysZ3D1205: 0.0
   sysZ3D1206: 0.0
   sysZ3D1207: 0.004226
-  sysZ3D1208: -0.0
-  sysZ3D1209: -0.0
+  sysZ3D1208: 0.0
+  sysZ3D1209: 0.0
   sysZ3D1210: -4.22600000e-03
   sysZ3D1211: 0.0
   sysZ3D1212: 0.0
-  sysZ3D1213: -0.0
-  sysZ3D1214: -0.0
+  sysZ3D1213: 0.0
+  sysZ3D1214: 0.0
   sysZ3D1215: -4.22600000e-03
-  sysZ3D1216: -0.0
+  sysZ3D1216: 0.0
   sysZ3D1217: 0.0
   sysZ3D1218: -4.22600000e-03
   sysZ3D1219: 0.004226
   sysZ3D1220: 0.0
   sysZ3D1221: -4.22600000e-03
-  sysZ3D1222: -0.0
+  sysZ3D1222: 0.0
   sysZ3D1223: -4.22600000e-03
   sysZ3D1224: 0.004226
   sysZ3D1225: 0.004226
-  sysZ3D1226: -0.0
+  sysZ3D1226: 0.0
   sysZ3D1227: -4.22600000e-03
-  sysZ3D1228: -0.0
+  sysZ3D1228: 0.0
   sysZ3D1229: 0.0
   sysZ3D1230: 0.0
   sysZ3D1231: 0.0
   sysZ3D1232: 0.0
-  sysZ3D1233: -0.0
-  sysZ3D1234: -0.0
+  sysZ3D1233: 0.0
+  sysZ3D1234: 0.0
   sysZ3D1235: -4.22600000e-03
   sysZ3D1236: 0.004226
   sysZ3D1237: 0.004226
   sysZ3D1238: 0.0
-  sysZ3D1239: -0.0
-  sysZ3D1240: -0.0
-  sysZ3D1241: -0.0
+  sysZ3D1239: 0.0
+  sysZ3D1240: 0.0
+  sysZ3D1241: 0.0
   sysZ3D1242: 0.0
   sysZ3D1243: 0.0
   sysZ3D1244: 0.004226
@@ -19439,7 +19439,7 @@ bins:
   sysZ3D1254: -4.22600000e-03
   sysZ3D1255: -1.26780000e-02
   sysZ3D1256: 0.004226
-  sysZ3D1257: -0.0
+  sysZ3D1257: 0.0
   sysZ3D1258: -4.22600000e-03
   sysZ3D1259: 0.004226
   sysZ3D1260: 0.0
@@ -19451,10 +19451,10 @@ bins:
   sysZ3D1266: -2.95820000e-02
   sysZ3D1267: -1.26780000e-02
   sysZ3D1268: 0.0
-  sysZ3D1269: -0.0
+  sysZ3D1269: 0.0
   sysZ3D1270: 0.004226
   sysZ3D1271: 0.004226
-  sysZ3D1272: -0.0
+  sysZ3D1272: 0.0
   sysZ3D1273: -8.45200000e-03
   sysZ3D1274: -0.02113
   sysZ3D1275: 2.53560000e-02
@@ -19480,7 +19480,7 @@ bins:
   sysZ3D1017: 0.0
   sysZ3D1018: 0.0
   sysZ3D1019: 0.0
-  sysZ3D1020: -0.0
+  sysZ3D1020: 0.0
   sysZ3D1021: -3.84400000e-03
   sysZ3D1022: 0.0
   sysZ3D1023: -1.15320000e-02
@@ -19491,94 +19491,94 @@ bins:
   sysZ3D1028: -3.84400000e-03
   sysZ3D1029: 0.0
   sysZ3D1030: -3.84400000e-03
-  sysZ3D1031: -0.0
+  sysZ3D1031: 0.0
   sysZ3D1032: 0.0
-  sysZ3D1033: -0.0
+  sysZ3D1033: 0.0
   sysZ3D1034: -3.84400000e-03
   sysZ3D1035: -3.84400000e-03
   sysZ3D1036: 0.0
   sysZ3D1037: 3.84400000e-03
-  sysZ3D1038: -0.0
+  sysZ3D1038: 0.0
   sysZ3D1039: 0.0
   sysZ3D1040: 3.84400000e-03
   sysZ3D1041: 0.0
-  sysZ3D1042: -0.0
-  sysZ3D1043: -0.0
-  sysZ3D1044: -0.0
+  sysZ3D1042: 0.0
+  sysZ3D1043: 0.0
+  sysZ3D1044: 0.0
   sysZ3D1045: 3.84400000e-03
-  sysZ3D1046: -0.0
-  sysZ3D1047: -0.0
+  sysZ3D1046: 0.0
+  sysZ3D1047: 0.0
   sysZ3D1048: 0.0
   sysZ3D1049: 3.84400000e-03
   sysZ3D1050: 0.0
-  sysZ3D1051: -0.0
-  sysZ3D1052: -0.0
+  sysZ3D1051: 0.0
+  sysZ3D1052: 0.0
   sysZ3D1053: 3.84400000e-03
   sysZ3D1054: 3.84400000e-03
-  sysZ3D1055: -0.0
+  sysZ3D1055: 0.0
   sysZ3D1056: 0.0
-  sysZ3D1057: -0.0
+  sysZ3D1057: 0.0
   sysZ3D1058: -3.84400000e-03
   sysZ3D1059: -3.84400000e-03
   sysZ3D1060: 0.0
   sysZ3D1061: 3.84400000e-03
   sysZ3D1062: 0.0
   sysZ3D1063: 0.0
-  sysZ3D1064: -0.0
-  sysZ3D1065: -0.0
+  sysZ3D1064: 0.0
+  sysZ3D1065: 0.0
   sysZ3D1066: -3.84400000e-03
   sysZ3D1067: 0.0
   sysZ3D1068: 3.84400000e-03
   sysZ3D1069: 0.0
-  sysZ3D1070: -0.0
-  sysZ3D1071: -0.0
+  sysZ3D1070: 0.0
+  sysZ3D1071: 0.0
   sysZ3D1072: 0.0
   sysZ3D1073: 0.0
   sysZ3D1074: -3.84400000e-03
   sysZ3D1075: 3.84400000e-03
-  sysZ3D1076: -0.0
+  sysZ3D1076: 0.0
   sysZ3D1077: 0.0
   sysZ3D1078: -3.84400000e-03
-  sysZ3D1079: -0.0
+  sysZ3D1079: 0.0
   sysZ3D1080: -3.84400000e-03
   sysZ3D1081: 0.0
   sysZ3D1082: 0.0
   sysZ3D1083: -3.84400000e-03
   sysZ3D1084: 0.0
-  sysZ3D1085: -0.0
+  sysZ3D1085: 0.0
   sysZ3D1086: 0.0
   sysZ3D1087: 0.0
-  sysZ3D1088: -0.0
-  sysZ3D1089: -0.0
+  sysZ3D1088: 0.0
+  sysZ3D1089: 0.0
   sysZ3D1090: 3.84400000e-03
-  sysZ3D1091: -0.0
+  sysZ3D1091: 0.0
   sysZ3D1092: -3.84400000e-03
   sysZ3D1093: 3.84400000e-03
-  sysZ3D1094: -0.0
+  sysZ3D1094: 0.0
   sysZ3D1095: 0.0
   sysZ3D1096: 0.0
-  sysZ3D1097: -0.0
+  sysZ3D1097: 0.0
   sysZ3D1098: -3.84400000e-03
   sysZ3D1099: 0.0
   sysZ3D1100: -3.84400000e-03
   sysZ3D1101: 0.0
-  sysZ3D1102: -0.0
+  sysZ3D1102: 0.0
   sysZ3D1103: 0.0
   sysZ3D1104: -0.0961
   sysZ3D1105: -1.49916000e-01
   sysZ3D1106: -4.61280000e-02
   sysZ3D1107: -7.68800000e-03
-  sysZ3D1108: -0.0
-  sysZ3D1109: -0.0
+  sysZ3D1108: 0.0
+  sysZ3D1109: 0.0
   sysZ3D1110: 0.0
-  sysZ3D1111: -0.0
+  sysZ3D1111: 0.0
   sysZ3D1112: 3.84400000e-03
   sysZ3D1113: -3.84400000e-03
   sysZ3D1114: -7.68800000e-03
   sysZ3D1115: 0.0
   sysZ3D1116: -1.15320000e-02
   sysZ3D1117: -7.68800000e-03
-  sysZ3D1118: -0.0
+  sysZ3D1118: 0.0
   sysZ3D1119: -3.84400000e-03
   sysZ3D1120: -7.68800000e-03
   sysZ3D1121: -1.15320000e-02
@@ -19586,7 +19586,7 @@ bins:
   sysZ3D1123: -0.01922
   sysZ3D1124: -3.84400000e-03
   sysZ3D1125: -7.68800000e-03
-  sysZ3D1126: -0.0
+  sysZ3D1126: 0.0
   sysZ3D1127: 0.0
   sysZ3D1128: 3.84400000e-03
   sysZ3D1129: 0.0
@@ -19598,25 +19598,25 @@ bins:
   sysZ3D1135: 2.30640000e-02
   sysZ3D1136: -7.68800000e-03
   sysZ3D1137: 7.68800000e-03
-  sysZ3D1138: -0.0
+  sysZ3D1138: 0.0
   sysZ3D1139: 3.84400000e-03
   sysZ3D1140: 3.84400000e-03
   sysZ3D1141: -3.84400000e-03
-  sysZ3D1142: -0.0
+  sysZ3D1142: 0.0
   sysZ3D1143: 0.0
   sysZ3D1144: 3.84400000e-03
-  sysZ3D1145: -0.0
+  sysZ3D1145: 0.0
   sysZ3D1146: 0.0
-  sysZ3D1147: -0.0
+  sysZ3D1147: 0.0
   sysZ3D1148: 0.0
   sysZ3D1149: 3.84400000e-03
   sysZ3D1150: 3.84400000e-03
-  sysZ3D1151: -0.0
+  sysZ3D1151: 0.0
   sysZ3D1152: 3.84400000e-03
   sysZ3D1153: -3.84400000e-03
   sysZ3D1154: -3.84400000e-03
   sysZ3D1155: 3.84400000e-03
-  sysZ3D1156: -0.0
+  sysZ3D1156: 0.0
   sysZ3D1157: 0.0
   sysZ3D1158: 7.68800000e-03
   sysZ3D1159: 0.0
@@ -19642,7 +19642,7 @@ bins:
   sysZ3D1179: 1.15320000e-02
   sysZ3D1180: -3.84400000e-03
   sysZ3D1181: -7.68800000e-03
-  sysZ3D1182: -0.0
+  sysZ3D1182: 0.0
   sysZ3D1183: 7.68800000e-03
   sysZ3D1184: -1.53760000e-02
   sysZ3D1185: -7.68800000e-03
@@ -19656,23 +19656,23 @@ bins:
   sysZ3D1193: -3.84400000e-03
   sysZ3D1194: -3.45960000e-02
   sysZ3D1195: 0.0
-  sysZ3D1196: -0.0
+  sysZ3D1196: 0.0
   sysZ3D1197: 3.84400000e-03
   sysZ3D1198: 7.68800000e-03
-  sysZ3D1199: -0.0
-  sysZ3D1200: -0.0
+  sysZ3D1199: 0.0
+  sysZ3D1200: 0.0
   sysZ3D1201: -3.84400000e-03
   sysZ3D1202: 0.0
   sysZ3D1203: 0.0
   sysZ3D1204: 0.0
-  sysZ3D1205: -0.0
+  sysZ3D1205: 0.0
   sysZ3D1206: 0.0
   sysZ3D1207: 0.0
-  sysZ3D1208: -0.0
-  sysZ3D1209: -0.0
+  sysZ3D1208: 0.0
+  sysZ3D1209: 0.0
   sysZ3D1210: -3.84400000e-03
-  sysZ3D1211: -0.0
-  sysZ3D1212: -0.0
+  sysZ3D1211: 0.0
+  sysZ3D1212: 0.0
   sysZ3D1213: 0.0
   sysZ3D1214: 0.0
   sysZ3D1215: -3.84400000e-03
@@ -19680,23 +19680,23 @@ bins:
   sysZ3D1217: 3.84400000e-03
   sysZ3D1218: 0.0
   sysZ3D1219: 3.84400000e-03
-  sysZ3D1220: -0.0
+  sysZ3D1220: 0.0
   sysZ3D1221: 0.0
-  sysZ3D1222: -0.0
-  sysZ3D1223: -0.0
+  sysZ3D1222: 0.0
+  sysZ3D1223: 0.0
   sysZ3D1224: -3.84400000e-03
-  sysZ3D1225: -0.0
+  sysZ3D1225: 0.0
   sysZ3D1226: 0.0
   sysZ3D1227: -3.84400000e-03
   sysZ3D1228: -3.84400000e-03
   sysZ3D1229: 0.0
-  sysZ3D1230: -0.0
+  sysZ3D1230: 0.0
   sysZ3D1231: 0.0
-  sysZ3D1232: -0.0
-  sysZ3D1233: -0.0
-  sysZ3D1234: -0.0
-  sysZ3D1235: -0.0
-  sysZ3D1236: -0.0
+  sysZ3D1232: 0.0
+  sysZ3D1233: 0.0
+  sysZ3D1234: 0.0
+  sysZ3D1235: 0.0
+  sysZ3D1236: 0.0
   sysZ3D1237: 0.0
   sysZ3D1238: 0.0
   sysZ3D1239: 0.0
@@ -19707,18 +19707,18 @@ bins:
   sysZ3D1244: 3.84400000e-03
   sysZ3D1245: -7.68800000e-03
   sysZ3D1246: 7.68800000e-03
-  sysZ3D1247: -0.0
+  sysZ3D1247: 0.0
   sysZ3D1248: 3.84400000e-03
   sysZ3D1249: -3.84400000e-03
-  sysZ3D1250: -0.0
+  sysZ3D1250: 0.0
   sysZ3D1251: -3.84400000e-03
   sysZ3D1252: -3.84400000e-03
-  sysZ3D1253: -0.0
-  sysZ3D1254: -0.0
+  sysZ3D1253: 0.0
+  sysZ3D1254: 0.0
   sysZ3D1255: -0.01922
   sysZ3D1256: 3.84400000e-03
   sysZ3D1257: 3.84400000e-03
-  sysZ3D1258: -0.0
+  sysZ3D1258: 0.0
   sysZ3D1259: 3.84400000e-03
   sysZ3D1260: 3.84400000e-03
   sysZ3D1261: 3.84400000e-03
@@ -19732,7 +19732,7 @@ bins:
   sysZ3D1269: 0.0
   sysZ3D1270: 3.84400000e-03
   sysZ3D1271: 7.68800000e-03
-  sysZ3D1272: -0.0
+  sysZ3D1272: 0.0
   sysZ3D1273: -7.68800000e-03
   sysZ3D1274: -7.68800000e-03
   sysZ3D1275: 2.69080000e-02
@@ -19764,66 +19764,66 @@ bins:
   sysZ3D1023: 3.22800000e-03
   sysZ3D1024: -3.22800000e-03
   sysZ3D1025: 6.45600000e-03
-  sysZ3D1026: -0.0
-  sysZ3D1027: -0.0
+  sysZ3D1026: 0.0
+  sysZ3D1027: 0.0
   sysZ3D1028: 3.22800000e-03
   sysZ3D1029: -3.22800000e-03
-  sysZ3D1030: -0.0
-  sysZ3D1031: -0.0
-  sysZ3D1032: -0.0
+  sysZ3D1030: 0.0
+  sysZ3D1031: 0.0
+  sysZ3D1032: 0.0
   sysZ3D1033: 3.22800000e-03
   sysZ3D1034: 0.0
   sysZ3D1035: 3.22800000e-03
   sysZ3D1036: 0.0
-  sysZ3D1037: -0.0
+  sysZ3D1037: 0.0
   sysZ3D1038: 0.0
   sysZ3D1039: -3.22800000e-03
   sysZ3D1040: 0.0
   sysZ3D1041: 0.0
-  sysZ3D1042: -0.0
-  sysZ3D1043: -0.0
-  sysZ3D1044: -0.0
+  sysZ3D1042: 0.0
+  sysZ3D1043: 0.0
+  sysZ3D1044: 0.0
   sysZ3D1045: 0.0
-  sysZ3D1046: -0.0
-  sysZ3D1047: -0.0
-  sysZ3D1048: -0.0
+  sysZ3D1046: 0.0
+  sysZ3D1047: 0.0
+  sysZ3D1048: 0.0
   sysZ3D1049: 0.0
-  sysZ3D1050: -0.0
+  sysZ3D1050: 0.0
   sysZ3D1051: -3.22800000e-03
   sysZ3D1052: -3.22800000e-03
   sysZ3D1053: 3.22800000e-03
-  sysZ3D1054: -0.0
+  sysZ3D1054: 0.0
   sysZ3D1055: -3.22800000e-03
-  sysZ3D1056: -0.0
+  sysZ3D1056: 0.0
   sysZ3D1057: 0.0
   sysZ3D1058: 0.0
-  sysZ3D1059: -0.0
-  sysZ3D1060: -0.0
-  sysZ3D1061: -0.0
+  sysZ3D1059: 0.0
+  sysZ3D1060: 0.0
+  sysZ3D1061: 0.0
   sysZ3D1062: 0.0
-  sysZ3D1063: -0.0
+  sysZ3D1063: 0.0
   sysZ3D1064: 3.22800000e-03
   sysZ3D1065: 3.22800000e-03
   sysZ3D1066: 3.22800000e-03
-  sysZ3D1067: -0.0
+  sysZ3D1067: 0.0
   sysZ3D1068: 0.0
   sysZ3D1069: -3.22800000e-03
   sysZ3D1070: 0.0
   sysZ3D1071: 3.22800000e-03
-  sysZ3D1072: -0.0
+  sysZ3D1072: 0.0
   sysZ3D1073: 3.22800000e-03
   sysZ3D1074: 3.22800000e-03
   sysZ3D1075: 3.22800000e-03
-  sysZ3D1076: -0.0
+  sysZ3D1076: 0.0
   sysZ3D1077: 0.0
   sysZ3D1078: 3.22800000e-03
   sysZ3D1079: -3.22800000e-03
-  sysZ3D1080: -0.0
+  sysZ3D1080: 0.0
   sysZ3D1081: 0.0
-  sysZ3D1082: -0.0
+  sysZ3D1082: 0.0
   sysZ3D1083: 3.22800000e-03
   sysZ3D1084: 0.0
-  sysZ3D1085: -0.0
+  sysZ3D1085: 0.0
   sysZ3D1086: 6.45600000e-03
   sysZ3D1087: -3.22800000e-03
   sysZ3D1088: 0.0
@@ -19834,10 +19834,10 @@ bins:
   sysZ3D1093: 0.0
   sysZ3D1094: 0.0
   sysZ3D1095: 3.22800000e-03
-  sysZ3D1096: -0.0
+  sysZ3D1096: 0.0
   sysZ3D1097: 0.0
   sysZ3D1098: 3.22800000e-03
-  sysZ3D1099: -0.0
+  sysZ3D1099: 0.0
   sysZ3D1100: 3.22800000e-03
   sysZ3D1101: 3.22800000e-03
   sysZ3D1102: 3.22800000e-03
@@ -19846,7 +19846,7 @@ bins:
   sysZ3D1105: -1.03296000e-01
   sysZ3D1106: -3.87360000e-02
   sysZ3D1107: -6.45600000e-03
-  sysZ3D1108: -0.0
+  sysZ3D1108: 0.0
   sysZ3D1109: -6.45600000e-03
   sysZ3D1110: 0.0
   sysZ3D1111: 3.22800000e-03
@@ -19857,8 +19857,8 @@ bins:
   sysZ3D1116: -3.22800000e-03
   sysZ3D1117: -9.68400000e-03
   sysZ3D1118: -3.22800000e-03
-  sysZ3D1119: -0.0
-  sysZ3D1120: -0.0
+  sysZ3D1119: 0.0
+  sysZ3D1120: 0.0
   sysZ3D1121: 3.22800000e-03
   sysZ3D1122: -6.45600000e-03
   sysZ3D1123: -6.45600000e-03
@@ -19880,14 +19880,14 @@ bins:
   sysZ3D1139: 6.45600000e-03
   sysZ3D1140: 0.0
   sysZ3D1141: 3.22800000e-03
-  sysZ3D1142: -0.0
+  sysZ3D1142: 0.0
   sysZ3D1143: 3.22800000e-03
   sysZ3D1144: 0.0
   sysZ3D1145: -3.22800000e-03
   sysZ3D1146: 0.0
-  sysZ3D1147: -0.0
+  sysZ3D1147: 0.0
   sysZ3D1148: 0.0
-  sysZ3D1149: -0.0
+  sysZ3D1149: 0.0
   sysZ3D1150: 0.0
   sysZ3D1151: 3.22800000e-03
   sysZ3D1152: 0.0
@@ -19929,7 +19929,7 @@ bins:
   sysZ3D1188: -1.29120000e-02
   sysZ3D1189: -9.68400000e-03
   sysZ3D1190: 6.45600000e-03
-  sysZ3D1191: -0.0
+  sysZ3D1191: 0.0
   sysZ3D1192: 6.45600000e-03
   sysZ3D1193: -3.22800000e-03
   sysZ3D1194: -0.03228
@@ -19937,7 +19937,7 @@ bins:
   sysZ3D1196: 0.0
   sysZ3D1197: 3.22800000e-03
   sysZ3D1198: 3.22800000e-03
-  sysZ3D1199: -0.0
+  sysZ3D1199: 0.0
   sysZ3D1200: -3.22800000e-03
   sysZ3D1201: -3.22800000e-03
   sysZ3D1202: 0.0
@@ -19947,10 +19947,10 @@ bins:
   sysZ3D1206: 0.0
   sysZ3D1207: 0.0
   sysZ3D1208: 3.22800000e-03
-  sysZ3D1209: -0.0
+  sysZ3D1209: 0.0
   sysZ3D1210: -3.22800000e-03
   sysZ3D1211: 0.0
-  sysZ3D1212: -0.0
+  sysZ3D1212: 0.0
   sysZ3D1213: 0.0
   sysZ3D1214: 0.0
   sysZ3D1215: -3.22800000e-03
@@ -19958,26 +19958,26 @@ bins:
   sysZ3D1217: 0.0
   sysZ3D1218: -6.45600000e-03
   sysZ3D1219: 3.22800000e-03
-  sysZ3D1220: -0.0
-  sysZ3D1221: -0.0
+  sysZ3D1220: 0.0
+  sysZ3D1221: 0.0
   sysZ3D1222: 0.0
   sysZ3D1223: -3.22800000e-03
-  sysZ3D1224: -0.0
-  sysZ3D1225: -0.0
+  sysZ3D1224: 0.0
+  sysZ3D1225: 0.0
   sysZ3D1226: 3.22800000e-03
-  sysZ3D1227: -0.0
+  sysZ3D1227: 0.0
   sysZ3D1228: 0.0
   sysZ3D1229: 0.0
-  sysZ3D1230: -0.0
+  sysZ3D1230: 0.0
   sysZ3D1231: 3.22800000e-03
-  sysZ3D1232: -0.0
-  sysZ3D1233: -0.0
-  sysZ3D1234: -0.0
-  sysZ3D1235: -0.0
-  sysZ3D1236: -0.0
+  sysZ3D1232: 0.0
+  sysZ3D1233: 0.0
+  sysZ3D1234: 0.0
+  sysZ3D1235: 0.0
+  sysZ3D1236: 0.0
   sysZ3D1237: 0.0
   sysZ3D1238: 3.22800000e-03
-  sysZ3D1239: -0.0
+  sysZ3D1239: 0.0
   sysZ3D1240: 0.0
   sysZ3D1241: 0.0
   sysZ3D1242: 0.0
@@ -19985,21 +19985,21 @@ bins:
   sysZ3D1244: 3.22800000e-03
   sysZ3D1245: -6.45600000e-03
   sysZ3D1246: 0.0
-  sysZ3D1247: -0.0
+  sysZ3D1247: 0.0
   sysZ3D1248: 0.0
-  sysZ3D1249: -0.0
+  sysZ3D1249: 0.0
   sysZ3D1250: 0.0
   sysZ3D1251: -3.22800000e-03
   sysZ3D1252: 3.22800000e-03
   sysZ3D1253: 3.22800000e-03
-  sysZ3D1254: -0.0
+  sysZ3D1254: 0.0
   sysZ3D1255: -0.01614
   sysZ3D1256: 0.0
   sysZ3D1257: 9.68400000e-03
-  sysZ3D1258: -0.0
+  sysZ3D1258: 0.0
   sysZ3D1259: 6.45600000e-03
   sysZ3D1260: 0.0
-  sysZ3D1261: -0.0
+  sysZ3D1261: 0.0
   sysZ3D1262: 3.22800000e-03
   sysZ3D1263: 9.68400000e-03
   sysZ3D1264: 2.58240000e-02
@@ -20007,10 +20007,10 @@ bins:
   sysZ3D1266: -2.58240000e-02
   sysZ3D1267: -6.45600000e-03
   sysZ3D1268: 0.0
-  sysZ3D1269: -0.0
+  sysZ3D1269: 0.0
   sysZ3D1270: 3.22800000e-03
   sysZ3D1271: 6.45600000e-03
-  sysZ3D1272: -0.0
+  sysZ3D1272: 0.0
   sysZ3D1273: -3.22800000e-03
   sysZ3D1274: -9.68400000e-03
   sysZ3D1275: 2.58240000e-02
@@ -20038,7 +20038,7 @@ bins:
   sysZ3D1019: 0.0
   sysZ3D1020: -2.65800000e-03
   sysZ3D1021: 0.002658
-  sysZ3D1022: -0.0
+  sysZ3D1022: 0.0
   sysZ3D1023: 0.002658
   sysZ3D1024: -2.65800000e-03
   sysZ3D1025: 7.97400000e-03
@@ -20048,75 +20048,75 @@ bins:
   sysZ3D1029: 0.002658
   sysZ3D1030: 0.0
   sysZ3D1031: 0.0
-  sysZ3D1032: -0.0
+  sysZ3D1032: 0.0
   sysZ3D1033: 0.0
   sysZ3D1034: 0.002658
-  sysZ3D1035: -0.0
+  sysZ3D1035: 0.0
   sysZ3D1036: 0.002658
   sysZ3D1037: 0.002658
   sysZ3D1038: 0.0
   sysZ3D1039: -2.65800000e-03
   sysZ3D1040: -2.65800000e-03
-  sysZ3D1041: -0.0
+  sysZ3D1041: 0.0
   sysZ3D1042: 0.002658
-  sysZ3D1043: -0.0
+  sysZ3D1043: 0.0
   sysZ3D1044: -2.65800000e-03
   sysZ3D1045: 0.002658
   sysZ3D1046: -2.65800000e-03
   sysZ3D1047: -2.65800000e-03
   sysZ3D1048: 0.0
-  sysZ3D1049: -0.0
+  sysZ3D1049: 0.0
   sysZ3D1050: 0.0
   sysZ3D1051: 0.0
   sysZ3D1052: -2.65800000e-03
   sysZ3D1053: 0.0
-  sysZ3D1054: -0.0
+  sysZ3D1054: 0.0
   sysZ3D1055: 0.0
-  sysZ3D1056: -0.0
-  sysZ3D1057: -0.0
+  sysZ3D1056: 0.0
+  sysZ3D1057: 0.0
   sysZ3D1058: -2.65800000e-03
   sysZ3D1059: -2.65800000e-03
   sysZ3D1060: 0.0
-  sysZ3D1061: -0.0
+  sysZ3D1061: 0.0
   sysZ3D1062: -2.65800000e-03
   sysZ3D1063: 0.002658
-  sysZ3D1064: -0.0
-  sysZ3D1065: -0.0
+  sysZ3D1064: 0.0
+  sysZ3D1065: 0.0
   sysZ3D1066: 0.0
-  sysZ3D1067: -0.0
+  sysZ3D1067: 0.0
   sysZ3D1068: 0.0
   sysZ3D1069: 0.002658
   sysZ3D1070: -2.65800000e-03
-  sysZ3D1071: -0.0
+  sysZ3D1071: 0.0
   sysZ3D1072: -2.65800000e-03
   sysZ3D1073: 0.0
   sysZ3D1074: -2.65800000e-03
   sysZ3D1075: -2.65800000e-03
   sysZ3D1076: -2.65800000e-03
   sysZ3D1077: -2.65800000e-03
-  sysZ3D1078: -0.0
-  sysZ3D1079: -0.0
+  sysZ3D1078: 0.0
+  sysZ3D1079: 0.0
   sysZ3D1080: 0.0
   sysZ3D1081: -2.65800000e-03
   sysZ3D1082: 0.0
-  sysZ3D1083: -0.0
-  sysZ3D1084: -0.0
+  sysZ3D1083: 0.0
+  sysZ3D1084: 0.0
   sysZ3D1085: 0.0
   sysZ3D1086: 0.0
   sysZ3D1087: -5.31600000e-03
-  sysZ3D1088: -0.0
-  sysZ3D1089: -0.0
+  sysZ3D1088: 0.0
+  sysZ3D1089: 0.0
   sysZ3D1090: -2.65800000e-03
   sysZ3D1091: 0.002658
   sysZ3D1092: 0.002658
-  sysZ3D1093: -0.0
+  sysZ3D1093: 0.0
   sysZ3D1094: -2.65800000e-03
-  sysZ3D1095: -0.0
+  sysZ3D1095: 0.0
   sysZ3D1096: 0.0
   sysZ3D1097: 0.0
   sysZ3D1098: 0.002658
-  sysZ3D1099: -0.0
-  sysZ3D1100: -0.0
+  sysZ3D1099: 0.0
+  sysZ3D1100: 0.0
   sysZ3D1101: -2.65800000e-03
   sysZ3D1102: 0.0
   sysZ3D1103: 0.0
@@ -20142,9 +20142,9 @@ bins:
   sysZ3D1123: -0.01329
   sysZ3D1124: -1.59480000e-02
   sysZ3D1125: -1.06320000e-02
-  sysZ3D1126: -0.0
+  sysZ3D1126: 0.0
   sysZ3D1127: 0.002658
-  sysZ3D1128: -0.0
+  sysZ3D1128: 0.0
   sysZ3D1129: 0.002658
   sysZ3D1130: -1.86060000e-02
   sysZ3D1131: -2.65800000e-03
@@ -20152,7 +20152,7 @@ bins:
   sysZ3D1133: 0.0
   sysZ3D1134: -2.65800000e-03
   sysZ3D1135: -2.65800000e-03
-  sysZ3D1136: -0.0
+  sysZ3D1136: 0.0
   sysZ3D1137: -5.31600000e-03
   sysZ3D1138: 0.005316
   sysZ3D1139: 0.002658
@@ -20163,20 +20163,20 @@ bins:
   sysZ3D1144: 0.0
   sysZ3D1145: 0.0
   sysZ3D1146: 0.0
-  sysZ3D1147: -0.0
+  sysZ3D1147: 0.0
   sysZ3D1148: 0.0
   sysZ3D1149: 0.002658
   sysZ3D1150: 0.0
   sysZ3D1151: 0.0
   sysZ3D1152: 0.0
   sysZ3D1153: 0.0
-  sysZ3D1154: -0.0
+  sysZ3D1154: 0.0
   sysZ3D1155: 0.01329
   sysZ3D1156: 0.005316
   sysZ3D1157: -2.65800000e-03
-  sysZ3D1158: -0.0
+  sysZ3D1158: 0.0
   sysZ3D1159: -1.59480000e-02
-  sysZ3D1160: -0.0
+  sysZ3D1160: 0.0
   sysZ3D1161: 7.97400000e-03
   sysZ3D1162: -5.31600000e-03
   sysZ3D1163: -7.97400000e-03
@@ -20191,10 +20191,10 @@ bins:
   sysZ3D1172: -5.31600000e-03
   sysZ3D1173: -2.65800000e-03
   sysZ3D1174: 0.0
-  sysZ3D1175: -0.0
+  sysZ3D1175: 0.0
   sysZ3D1176: 0.02658
   sysZ3D1177: 0.023922
-  sysZ3D1178: -0.0
+  sysZ3D1178: 0.0
   sysZ3D1179: 1.59480000e-02
   sysZ3D1180: -7.97400000e-03
   sysZ3D1181: -5.31600000e-03
@@ -20202,7 +20202,7 @@ bins:
   sysZ3D1183: 0.005316
   sysZ3D1184: -0.01329
   sysZ3D1185: -5.31600000e-03
-  sysZ3D1186: -0.0
+  sysZ3D1186: 0.0
   sysZ3D1187: 0.005316
   sysZ3D1188: -7.97400000e-03
   sysZ3D1189: -7.97400000e-03
@@ -20220,15 +20220,15 @@ bins:
   sysZ3D1201: -7.97400000e-03
   sysZ3D1202: 0.0
   sysZ3D1203: 7.97400000e-03
-  sysZ3D1204: -0.0
+  sysZ3D1204: 0.0
   sysZ3D1205: 0.0
   sysZ3D1206: 0.0
   sysZ3D1207: 0.0
-  sysZ3D1208: -0.0
-  sysZ3D1209: -0.0
+  sysZ3D1208: 0.0
+  sysZ3D1209: 0.0
   sysZ3D1210: -2.65800000e-03
-  sysZ3D1211: -0.0
-  sysZ3D1212: -0.0
+  sysZ3D1211: 0.0
+  sysZ3D1212: 0.0
   sysZ3D1213: 0.0
   sysZ3D1214: -2.65800000e-03
   sysZ3D1215: -2.65800000e-03
@@ -20237,36 +20237,36 @@ bins:
   sysZ3D1218: -7.97400000e-03
   sysZ3D1219: 0.002658
   sysZ3D1220: 0.0
-  sysZ3D1221: -0.0
+  sysZ3D1221: 0.0
   sysZ3D1222: 0.0
-  sysZ3D1223: -0.0
+  sysZ3D1223: 0.0
   sysZ3D1224: 0.0
   sysZ3D1225: 0.002658
   sysZ3D1226: -2.65800000e-03
   sysZ3D1227: -5.31600000e-03
   sysZ3D1228: 0.0
-  sysZ3D1229: -0.0
+  sysZ3D1229: 0.0
   sysZ3D1230: 0.0
   sysZ3D1231: 0.0
   sysZ3D1232: 0.0
-  sysZ3D1233: -0.0
-  sysZ3D1234: -0.0
-  sysZ3D1235: -0.0
+  sysZ3D1233: 0.0
+  sysZ3D1234: 0.0
+  sysZ3D1235: 0.0
   sysZ3D1236: 0.0
   sysZ3D1237: 0.002658
-  sysZ3D1238: -0.0
+  sysZ3D1238: 0.0
   sysZ3D1239: 0.0
   sysZ3D1240: 0.0
-  sysZ3D1241: -0.0
+  sysZ3D1241: 0.0
   sysZ3D1242: 0.0
   sysZ3D1243: 0.0
-  sysZ3D1244: -0.0
-  sysZ3D1245: -0.0
+  sysZ3D1244: 0.0
+  sysZ3D1245: 0.0
   sysZ3D1246: 0.002658
-  sysZ3D1247: -0.0
+  sysZ3D1247: 0.0
   sysZ3D1248: -5.31600000e-03
-  sysZ3D1249: -0.0
-  sysZ3D1250: -0.0
+  sysZ3D1249: 0.0
+  sysZ3D1250: 0.0
   sysZ3D1251: -7.97400000e-03
   sysZ3D1252: 0.002658
   sysZ3D1253: 0.0
@@ -20288,8 +20288,8 @@ bins:
   sysZ3D1269: 0.0
   sysZ3D1270: 0.002658
   sysZ3D1271: 7.97400000e-03
-  sysZ3D1272: -0.0
-  sysZ3D1273: -0.0
+  sysZ3D1272: 0.0
+  sysZ3D1273: 0.0
   sysZ3D1274: -1.59480000e-02
   sysZ3D1275: 0.02658
   sys,uncor: 1.27584000e-01
@@ -20323,8 +20323,8 @@ bins:
   sysZ3D1026: 1.93200000e-03
   sysZ3D1027: -5.79600000e-03
   sysZ3D1028: 1.93200000e-03
-  sysZ3D1029: -0.0
-  sysZ3D1030: -0.0
+  sysZ3D1029: 0.0
+  sysZ3D1030: 0.0
   sysZ3D1031: 3.86400000e-03
   sysZ3D1032: 1.93200000e-03
   sysZ3D1033: -1.93200000e-03
@@ -20334,15 +20334,15 @@ bins:
   sysZ3D1037: 0.0
   sysZ3D1038: 1.93200000e-03
   sysZ3D1039: -3.86400000e-03
-  sysZ3D1040: -0.0
+  sysZ3D1040: 0.0
   sysZ3D1041: 1.93200000e-03
   sysZ3D1042: -1.93200000e-03
   sysZ3D1043: 1.93200000e-03
   sysZ3D1044: 5.79600000e-03
-  sysZ3D1045: -0.0
-  sysZ3D1046: -0.0
+  sysZ3D1045: 0.0
+  sysZ3D1046: 0.0
   sysZ3D1047: -1.93200000e-03
-  sysZ3D1048: -0.0
+  sysZ3D1048: 0.0
   sysZ3D1049: 0.0
   sysZ3D1050: -3.86400000e-03
   sysZ3D1051: -1.93200000e-03
@@ -20350,7 +20350,7 @@ bins:
   sysZ3D1053: 3.86400000e-03
   sysZ3D1054: 0.0
   sysZ3D1055: 5.79600000e-03
-  sysZ3D1056: -0.0
+  sysZ3D1056: 0.0
   sysZ3D1057: -3.86400000e-03
   sysZ3D1058: -1.93200000e-03
   sysZ3D1059: 3.86400000e-03
@@ -20383,17 +20383,17 @@ bins:
   sysZ3D1086: 0.0
   sysZ3D1087: -1.93200000e-03
   sysZ3D1088: -1.93200000e-03
-  sysZ3D1089: -0.0
+  sysZ3D1089: 0.0
   sysZ3D1090: 0.0
   sysZ3D1091: -1.93200000e-03
-  sysZ3D1092: -0.0
+  sysZ3D1092: 0.0
   sysZ3D1093: 1.93200000e-03
   sysZ3D1094: 3.86400000e-03
   sysZ3D1095: -1.93200000e-03
   sysZ3D1096: 1.93200000e-03
   sysZ3D1097: -3.86400000e-03
   sysZ3D1098: 3.86400000e-03
-  sysZ3D1099: -0.0
+  sysZ3D1099: 0.0
   sysZ3D1100: -3.86400000e-03
   sysZ3D1101: -1.93200000e-03
   sysZ3D1102: 1.93200000e-03
@@ -20402,7 +20402,7 @@ bins:
   sysZ3D1105: -4.63680000e-02
   sysZ3D1106: -1.73880000e-02
   sysZ3D1107: -1.93200000e-03
-  sysZ3D1108: -0.0
+  sysZ3D1108: 0.0
   sysZ3D1109: -1.93200000e-03
   sysZ3D1110: 0.0
   sysZ3D1111: -3.86400000e-03
@@ -20422,7 +20422,7 @@ bins:
   sysZ3D1125: 5.79600000e-03
   sysZ3D1126: -3.86400000e-03
   sysZ3D1127: 3.86400000e-03
-  sysZ3D1128: -0.0
+  sysZ3D1128: 0.0
   sysZ3D1129: -1.93200000e-03
   sysZ3D1130: 0.0
   sysZ3D1131: -0.00966
@@ -20432,22 +20432,22 @@ bins:
   sysZ3D1135: 7.72800000e-03
   sysZ3D1136: 1.93200000e-03
   sysZ3D1137: 0.0
-  sysZ3D1138: -0.0
+  sysZ3D1138: 0.0
   sysZ3D1139: -1.93200000e-03
-  sysZ3D1140: -0.0
+  sysZ3D1140: 0.0
   sysZ3D1141: 0.0
-  sysZ3D1142: -0.0
-  sysZ3D1143: -0.0
+  sysZ3D1142: 0.0
+  sysZ3D1143: 0.0
   sysZ3D1144: -1.93200000e-03
-  sysZ3D1145: -0.0
+  sysZ3D1145: 0.0
   sysZ3D1146: 0.0
-  sysZ3D1147: -0.0
-  sysZ3D1148: -0.0
-  sysZ3D1149: -0.0
+  sysZ3D1147: 0.0
+  sysZ3D1148: 0.0
+  sysZ3D1149: 0.0
   sysZ3D1150: 0.0
-  sysZ3D1151: -0.0
-  sysZ3D1152: -0.0
-  sysZ3D1153: -0.0
+  sysZ3D1151: 0.0
+  sysZ3D1152: 0.0
+  sysZ3D1153: 0.0
   sysZ3D1154: 0.0
   sysZ3D1155: 0.0
   sysZ3D1156: 1.93200000e-03
@@ -20463,7 +20463,7 @@ bins:
   sysZ3D1166: -1.15920000e-02
   sysZ3D1167: 1.54560000e-02
   sysZ3D1168: -0.00966
-  sysZ3D1169: -0.0
+  sysZ3D1169: 0.0
   sysZ3D1170: 0.0
   sysZ3D1171: -3.86400000e-03
   sysZ3D1172: -7.72800000e-03
@@ -20472,7 +20472,7 @@ bins:
   sysZ3D1175: -1.93200000e-03
   sysZ3D1176: 0.025116
   sysZ3D1177: 1.54560000e-02
-  sysZ3D1178: -0.0
+  sysZ3D1178: 0.0
   sysZ3D1179: 1.35240000e-02
   sysZ3D1180: -3.86400000e-03
   sysZ3D1181: -3.86400000e-03
@@ -20502,44 +20502,44 @@ bins:
   sysZ3D1205: 0.0
   sysZ3D1206: 1.93200000e-03
   sysZ3D1207: 0.0
-  sysZ3D1208: -0.0
+  sysZ3D1208: 0.0
   sysZ3D1209: -1.93200000e-03
   sysZ3D1210: -1.93200000e-03
-  sysZ3D1211: -0.0
-  sysZ3D1212: -0.0
+  sysZ3D1211: 0.0
+  sysZ3D1212: 0.0
   sysZ3D1213: 0.0
-  sysZ3D1214: -0.0
+  sysZ3D1214: 0.0
   sysZ3D1215: -1.93200000e-03
-  sysZ3D1216: -0.0
+  sysZ3D1216: 0.0
   sysZ3D1217: 7.72800000e-03
   sysZ3D1218: -3.86400000e-03
   sysZ3D1219: 0.0
   sysZ3D1220: 0.0
-  sysZ3D1221: -0.0
+  sysZ3D1221: 0.0
   sysZ3D1222: 0.0
-  sysZ3D1223: -0.0
-  sysZ3D1224: -0.0
+  sysZ3D1223: 0.0
+  sysZ3D1224: 0.0
   sysZ3D1225: 1.93200000e-03
   sysZ3D1226: 3.86400000e-03
-  sysZ3D1227: -0.0
+  sysZ3D1227: 0.0
   sysZ3D1228: -3.86400000e-03
   sysZ3D1229: 0.0
   sysZ3D1230: 1.93200000e-03
   sysZ3D1231: 0.0
-  sysZ3D1232: -0.0
-  sysZ3D1233: -0.0
-  sysZ3D1234: -0.0
-  sysZ3D1235: -0.0
+  sysZ3D1232: 0.0
+  sysZ3D1233: 0.0
+  sysZ3D1234: 0.0
+  sysZ3D1235: 0.0
   sysZ3D1236: 0.0
   sysZ3D1237: 0.0
   sysZ3D1238: 1.93200000e-03
-  sysZ3D1239: -0.0
-  sysZ3D1240: -0.0
-  sysZ3D1241: -0.0
+  sysZ3D1239: 0.0
+  sysZ3D1240: 0.0
+  sysZ3D1241: 0.0
   sysZ3D1242: 0.0
   sysZ3D1243: 0.0
   sysZ3D1244: 1.93200000e-03
-  sysZ3D1245: -0.0
+  sysZ3D1245: 0.0
   sysZ3D1246: 1.93200000e-03
   sysZ3D1247: -1.93200000e-03
   sysZ3D1248: -5.79600000e-03
@@ -20547,15 +20547,15 @@ bins:
   sysZ3D1250: 0.0
   sysZ3D1251: -7.72800000e-03
   sysZ3D1252: -3.86400000e-03
-  sysZ3D1253: -0.0
+  sysZ3D1253: 0.0
   sysZ3D1254: -1.93200000e-03
   sysZ3D1255: -1.54560000e-02
   sysZ3D1256: -1.93200000e-03
-  sysZ3D1257: -0.0
-  sysZ3D1258: -0.0
+  sysZ3D1257: 0.0
+  sysZ3D1258: 0.0
   sysZ3D1259: -1.93200000e-03
   sysZ3D1260: 1.93200000e-03
-  sysZ3D1261: -0.0
+  sysZ3D1261: 0.0
   sysZ3D1262: 1.93200000e-03
   sysZ3D1263: 7.72800000e-03
   sysZ3D1264: 0.01932
@@ -20575,7 +20575,7 @@ bins:
 - stat: 0.16188
   sysZ3D1001: -0.00684
   sysZ3D1002: -1.14000000e-03
-  sysZ3D1003: -0.0
+  sysZ3D1003: 0.0
   sysZ3D1004: 0.0
   sysZ3D1005: 0.0
   sysZ3D1006: 0.0
@@ -20604,7 +20604,7 @@ bins:
   sysZ3D1029: -2.28000000e-03
   sysZ3D1030: 0.0
   sysZ3D1031: 1.14000000e-03
-  sysZ3D1032: -0.0
+  sysZ3D1032: 0.0
   sysZ3D1033: 0.0
   sysZ3D1034: 1.14000000e-03
   sysZ3D1035: 0.0
@@ -20612,7 +20612,7 @@ bins:
   sysZ3D1037: -0.00342
   sysZ3D1038: 0.0
   sysZ3D1039: 1.14000000e-03
-  sysZ3D1040: -0.0
+  sysZ3D1040: 0.0
   sysZ3D1041: -1.14000000e-03
   sysZ3D1042: 0.0
   sysZ3D1043: -1.14000000e-03
@@ -20624,16 +20624,16 @@ bins:
   sysZ3D1049: -2.28000000e-03
   sysZ3D1050: -1.14000000e-03
   sysZ3D1051: -2.28000000e-03
-  sysZ3D1052: -0.0
+  sysZ3D1052: 0.0
   sysZ3D1053: -0.00342
   sysZ3D1054: 1.14000000e-03
-  sysZ3D1055: -0.0
+  sysZ3D1055: 0.0
   sysZ3D1056: 1.14000000e-03
   sysZ3D1057: 0.0
-  sysZ3D1058: -0.0
+  sysZ3D1058: 0.0
   sysZ3D1059: -1.14000000e-03
   sysZ3D1060: -1.14000000e-03
-  sysZ3D1061: -0.0
+  sysZ3D1061: 0.0
   sysZ3D1062: 0.0
   sysZ3D1063: -1.14000000e-03
   sysZ3D1064: -2.28000000e-03
@@ -20642,26 +20642,26 @@ bins:
   sysZ3D1067: -1.14000000e-03
   sysZ3D1068: 1.14000000e-03
   sysZ3D1069: 0.00342
-  sysZ3D1070: -0.0
+  sysZ3D1070: 0.0
   sysZ3D1071: 0.00342
   sysZ3D1072: 1.14000000e-03
   sysZ3D1073: -2.28000000e-03
   sysZ3D1074: 2.28000000e-03
   sysZ3D1075: -2.28000000e-03
-  sysZ3D1076: -0.0
+  sysZ3D1076: 0.0
   sysZ3D1077: -1.14000000e-03
-  sysZ3D1078: -0.0
+  sysZ3D1078: 0.0
   sysZ3D1079: 0.0
   sysZ3D1080: -0.00342
-  sysZ3D1081: -0.0
+  sysZ3D1081: 0.0
   sysZ3D1082: -1.14000000e-03
   sysZ3D1083: -1.14000000e-03
-  sysZ3D1084: -0.0
+  sysZ3D1084: 0.0
   sysZ3D1085: -0.00342
   sysZ3D1086: -2.28000000e-03
   sysZ3D1087: 0.0
-  sysZ3D1088: -0.0
-  sysZ3D1089: -0.0
+  sysZ3D1088: 0.0
+  sysZ3D1089: 0.0
   sysZ3D1090: 2.28000000e-03
   sysZ3D1091: 1.14000000e-03
   sysZ3D1092: 1.14000000e-03
@@ -20675,7 +20675,7 @@ bins:
   sysZ3D1100: -1.14000000e-03
   sysZ3D1101: -1.14000000e-03
   sysZ3D1102: 0.0
-  sysZ3D1103: -0.0
+  sysZ3D1103: 0.0
   sysZ3D1104: -7.98000000e-03
   sysZ3D1105: -0.02394
   sysZ3D1106: -9.12000000e-03
@@ -20690,49 +20690,49 @@ bins:
   sysZ3D1115: -9.12000000e-03
   sysZ3D1116: 0.00342
   sysZ3D1117: 1.14000000e-03
-  sysZ3D1118: -0.0
-  sysZ3D1119: -0.0
+  sysZ3D1118: 0.0
+  sysZ3D1119: 0.0
   sysZ3D1120: 0.0
   sysZ3D1121: 0.0
   sysZ3D1122: 0.0
   sysZ3D1123: 2.28000000e-03
   sysZ3D1124: 4.56000000e-03
   sysZ3D1125: 0.0057
-  sysZ3D1126: -0.0
+  sysZ3D1126: 0.0
   sysZ3D1127: 1.14000000e-03
   sysZ3D1128: 4.56000000e-03
   sysZ3D1129: -1.25400000e-02
-  sysZ3D1130: -0.0
+  sysZ3D1130: 0.0
   sysZ3D1131: -2.28000000e-03
   sysZ3D1132: -0.00342
   sysZ3D1133: 0.0057
   sysZ3D1134: 2.28000000e-03
-  sysZ3D1135: -0.0
-  sysZ3D1136: -0.0
-  sysZ3D1137: -0.0
+  sysZ3D1135: 0.0
+  sysZ3D1136: 0.0
+  sysZ3D1137: 0.0
   sysZ3D1138: -1.14000000e-03
   sysZ3D1139: -1.14000000e-03
-  sysZ3D1140: -0.0
+  sysZ3D1140: 0.0
   sysZ3D1141: 0.0
-  sysZ3D1142: -0.0
-  sysZ3D1143: -0.0
-  sysZ3D1144: -0.0
+  sysZ3D1142: 0.0
+  sysZ3D1143: 0.0
+  sysZ3D1144: 0.0
   sysZ3D1145: -1.14000000e-03
   sysZ3D1146: 0.0
-  sysZ3D1147: -0.0
+  sysZ3D1147: 0.0
   sysZ3D1148: -1.14000000e-03
   sysZ3D1149: -1.14000000e-03
   sysZ3D1150: 0.0
-  sysZ3D1151: -0.0
+  sysZ3D1151: 0.0
   sysZ3D1152: -1.14000000e-03
-  sysZ3D1153: -0.0
+  sysZ3D1153: 0.0
   sysZ3D1154: 1.14000000e-03
   sysZ3D1155: -1.14000000e-03
   sysZ3D1156: -1.14000000e-03
   sysZ3D1157: 0.0
-  sysZ3D1158: -0.0
+  sysZ3D1158: 0.0
   sysZ3D1159: 1.14000000e-03
-  sysZ3D1160: -0.0
+  sysZ3D1160: 0.0
   sysZ3D1161: 2.28000000e-03
   sysZ3D1162: 2.28000000e-03
   sysZ3D1163: -2.28000000e-03
@@ -20750,11 +20750,11 @@ bins:
   sysZ3D1175: 0.0
   sysZ3D1176: 0.0114
   sysZ3D1177: 0.00684
-  sysZ3D1178: -0.0
+  sysZ3D1178: 0.0
   sysZ3D1179: 0.0057
   sysZ3D1180: -1.14000000e-03
-  sysZ3D1181: -0.0
-  sysZ3D1182: -0.0
+  sysZ3D1181: 0.0
+  sysZ3D1182: 0.0
   sysZ3D1183: 1.14000000e-03
   sysZ3D1184: -4.56000000e-03
   sysZ3D1185: 1.14000000e-03
@@ -20768,7 +20768,7 @@ bins:
   sysZ3D1193: -4.56000000e-03
   sysZ3D1194: -0.01482
   sysZ3D1195: -1.14000000e-03
-  sysZ3D1196: -0.0
+  sysZ3D1196: 0.0
   sysZ3D1197: 1.14000000e-03
   sysZ3D1198: 1.14000000e-03
   sysZ3D1199: -1.14000000e-03
@@ -20776,15 +20776,15 @@ bins:
   sysZ3D1201: -2.28000000e-03
   sysZ3D1202: 0.0
   sysZ3D1203: -2.28000000e-03
-  sysZ3D1204: -0.0
-  sysZ3D1205: -0.0
+  sysZ3D1204: 0.0
+  sysZ3D1205: 0.0
   sysZ3D1206: 1.14000000e-03
   sysZ3D1207: 0.0
-  sysZ3D1208: -0.0
+  sysZ3D1208: 0.0
   sysZ3D1209: -1.14000000e-03
   sysZ3D1210: -1.14000000e-03
-  sysZ3D1211: -0.0
-  sysZ3D1212: -0.0
+  sysZ3D1211: 0.0
+  sysZ3D1212: 0.0
   sysZ3D1213: 1.14000000e-03
   sysZ3D1214: 0.0057
   sysZ3D1215: 0.00342
@@ -20795,31 +20795,31 @@ bins:
   sysZ3D1220: 1.14000000e-03
   sysZ3D1221: 1.14000000e-03
   sysZ3D1222: 0.0
-  sysZ3D1223: -0.0
+  sysZ3D1223: 0.0
   sysZ3D1224: 0.0
   sysZ3D1225: 1.14000000e-03
   sysZ3D1226: 1.14000000e-03
   sysZ3D1227: 2.28000000e-03
   sysZ3D1228: 1.14000000e-03
-  sysZ3D1229: -0.0
+  sysZ3D1229: 0.0
   sysZ3D1230: -1.14000000e-03
   sysZ3D1231: -1.14000000e-03
   sysZ3D1232: 1.14000000e-03
   sysZ3D1233: 0.0
-  sysZ3D1234: -0.0
-  sysZ3D1235: -0.0
+  sysZ3D1234: 0.0
+  sysZ3D1235: 0.0
   sysZ3D1236: 0.0
   sysZ3D1237: 1.14000000e-03
   sysZ3D1238: 1.14000000e-03
-  sysZ3D1239: -0.0
+  sysZ3D1239: 0.0
   sysZ3D1240: 0.0
-  sysZ3D1241: -0.0
+  sysZ3D1241: 0.0
   sysZ3D1242: 0.0
   sysZ3D1243: 0.0
   sysZ3D1244: -1.14000000e-03
   sysZ3D1245: 0.00342
   sysZ3D1246: 1.14000000e-03
-  sysZ3D1247: -0.0
+  sysZ3D1247: 0.0
   sysZ3D1248: -2.28000000e-03
   sysZ3D1249: -0.00342
   sysZ3D1250: -1.14000000e-03
@@ -20830,7 +20830,7 @@ bins:
   sysZ3D1255: -0.01938
   sysZ3D1256: 1.14000000e-03
   sysZ3D1257: 1.14000000e-03
-  sysZ3D1258: -0.0
+  sysZ3D1258: 0.0
   sysZ3D1259: 1.14000000e-03
   sysZ3D1260: 1.14000000e-03
   sysZ3D1261: 0.0
@@ -20845,7 +20845,7 @@ bins:
   sysZ3D1270: 0.0
   sysZ3D1271: 7.98000000e-03
   sysZ3D1272: 0.0
-  sysZ3D1273: -0.0
+  sysZ3D1273: 0.0
   sysZ3D1274: -7.98000000e-03
   sysZ3D1275: 0.0114
   sys,uncor: 7.63800000e-02
@@ -20900,7 +20900,7 @@ bins:
   sysZ3D1047: 0.000696
   sysZ3D1048: -3.48000000e-04
   sysZ3D1049: 1.04400000e-03
-  sysZ3D1050: -0.0
+  sysZ3D1050: 0.0
   sysZ3D1051: 0.0
   sysZ3D1052: 0.001392
   sysZ3D1053: 0.00174
@@ -20913,7 +20913,7 @@ bins:
   sysZ3D1060: 0.001392
   sysZ3D1061: -1.39200000e-03
   sysZ3D1062: -1.39200000e-03
-  sysZ3D1063: -0.0
+  sysZ3D1063: 0.0
   sysZ3D1064: 1.04400000e-03
   sysZ3D1065: 0.000696
   sysZ3D1066: 0.0
@@ -20957,7 +20957,7 @@ bins:
   sysZ3D1104: -0.00174
   sysZ3D1105: -0.00522
   sysZ3D1106: -2.43600000e-03
-  sysZ3D1107: -0.0
+  sysZ3D1107: 0.0
   sysZ3D1108: 0.0
   sysZ3D1109: 0.0
   sysZ3D1110: 0.0
@@ -20968,7 +20968,7 @@ bins:
   sysZ3D1115: 0.00522
   sysZ3D1116: 1.04400000e-03
   sysZ3D1117: 0.000348
-  sysZ3D1118: -0.0
+  sysZ3D1118: 0.0
   sysZ3D1119: -3.48000000e-04
   sysZ3D1120: 0.000348
   sysZ3D1121: 0.0
@@ -20992,22 +20992,22 @@ bins:
   sysZ3D1139: 0.000696
   sysZ3D1140: -6.96000000e-04
   sysZ3D1141: -3.48000000e-04
-  sysZ3D1142: -0.0
-  sysZ3D1143: -0.0
+  sysZ3D1142: 0.0
+  sysZ3D1143: 0.0
   sysZ3D1144: -3.48000000e-04
   sysZ3D1145: -3.48000000e-04
-  sysZ3D1146: -0.0
+  sysZ3D1146: 0.0
   sysZ3D1147: 0.0
-  sysZ3D1148: -0.0
-  sysZ3D1149: -0.0
+  sysZ3D1148: 0.0
+  sysZ3D1149: 0.0
   sysZ3D1150: 0.0
   sysZ3D1151: -3.48000000e-04
   sysZ3D1152: -3.48000000e-04
-  sysZ3D1153: -0.0
+  sysZ3D1153: 0.0
   sysZ3D1154: -3.48000000e-04
-  sysZ3D1155: -0.0
+  sysZ3D1155: 0.0
   sysZ3D1156: -3.48000000e-04
-  sysZ3D1157: -0.0
+  sysZ3D1157: 0.0
   sysZ3D1158: 0.0
   sysZ3D1159: -0.00174
   sysZ3D1160: 0.000348
@@ -21030,9 +21030,9 @@ bins:
   sysZ3D1177: 3.82800000e-03
   sysZ3D1178: -3.48000000e-04
   sysZ3D1179: 0.000348
-  sysZ3D1180: -0.0
+  sysZ3D1180: 0.0
   sysZ3D1181: 0.000348
-  sysZ3D1182: -0.0
+  sysZ3D1182: 0.0
   sysZ3D1183: 0.000348
   sysZ3D1184: -6.96000000e-04
   sysZ3D1185: 0.000696
@@ -21061,18 +21061,18 @@ bins:
   sysZ3D1208: -3.48000000e-04
   sysZ3D1209: -3.48000000e-04
   sysZ3D1210: -6.96000000e-04
-  sysZ3D1211: -0.0
+  sysZ3D1211: 0.0
   sysZ3D1212: -3.48000000e-04
   sysZ3D1213: 0.000348
   sysZ3D1214: 2.08800000e-03
   sysZ3D1215: 1.04400000e-03
-  sysZ3D1216: -0.0
+  sysZ3D1216: 0.0
   sysZ3D1217: 0.002784
   sysZ3D1218: 0.000696
   sysZ3D1219: -6.96000000e-04
   sysZ3D1220: 0.000348
   sysZ3D1221: 0.000348
-  sysZ3D1222: -0.0
+  sysZ3D1222: 0.0
   sysZ3D1223: -3.48000000e-04
   sysZ3D1224: 0.000348
   sysZ3D1225: 0.000696
@@ -21083,15 +21083,15 @@ bins:
   sysZ3D1230: -3.48000000e-04
   sysZ3D1231: 0.000696
   sysZ3D1232: 0.000348
-  sysZ3D1233: -0.0
+  sysZ3D1233: 0.0
   sysZ3D1234: -3.48000000e-04
   sysZ3D1235: -3.48000000e-04
   sysZ3D1236: 0.0
   sysZ3D1237: 0.000348
   sysZ3D1238: 0.000348
-  sysZ3D1239: -0.0
-  sysZ3D1240: -0.0
-  sysZ3D1241: -0.0
+  sysZ3D1239: 0.0
+  sysZ3D1240: 0.0
+  sysZ3D1241: 0.0
   sysZ3D1242: 0.0
   sysZ3D1243: 0.0
   sysZ3D1244: 0.000696
@@ -21118,7 +21118,7 @@ bins:
   sysZ3D1265: 1.04400000e-03
   sysZ3D1266: -5.91600000e-03
   sysZ3D1267: -6.96000000e-04
-  sysZ3D1268: -0.0
+  sysZ3D1268: 0.0
   sysZ3D1269: -3.48000000e-04
   sysZ3D1270: 0.000696
   sysZ3D1271: 0.00174
@@ -21130,7 +21130,7 @@ bins:
   ATLAS_LUMI: 0.06264
 - stat: 0.17205
   sysZ3D1001: -0.00444
-  sysZ3D1002: -0.0
+  sysZ3D1002: 0.0
   sysZ3D1003: 0.00222
   sysZ3D1004: 0.0
   sysZ3D1005: 0.0
@@ -21148,7 +21148,7 @@ bins:
   sysZ3D1017: 0.0
   sysZ3D1018: 0.0
   sysZ3D1019: 0.0
-  sysZ3D1020: -0.0
+  sysZ3D1020: 0.0
   sysZ3D1021: 0.0
   sysZ3D1022: 0.0
   sysZ3D1023: 0.00222
@@ -21157,27 +21157,27 @@ bins:
   sysZ3D1026: -0.00222
   sysZ3D1027: 0.00222
   sysZ3D1028: 0.00111
-  sysZ3D1029: -0.0
-  sysZ3D1030: -0.0
+  sysZ3D1029: 0.0
+  sysZ3D1030: 0.0
   sysZ3D1031: -0.00111
   sysZ3D1032: 0.0
-  sysZ3D1033: -0.0
+  sysZ3D1033: 0.0
   sysZ3D1034: -0.00111
   sysZ3D1035: 0.0
-  sysZ3D1036: -0.0
-  sysZ3D1037: -0.0
+  sysZ3D1036: 0.0
+  sysZ3D1037: 0.0
   sysZ3D1038: 0.0
   sysZ3D1039: 0.0
   sysZ3D1040: -0.00111
-  sysZ3D1041: -0.0
-  sysZ3D1042: -0.0
+  sysZ3D1041: 0.0
+  sysZ3D1042: 0.0
   sysZ3D1043: 0.0
-  sysZ3D1044: -0.0
-  sysZ3D1045: -0.0
+  sysZ3D1044: 0.0
+  sysZ3D1045: 0.0
   sysZ3D1046: 0.00111
-  sysZ3D1047: -0.0
+  sysZ3D1047: 0.0
   sysZ3D1048: 0.0
-  sysZ3D1049: -0.0
+  sysZ3D1049: 0.0
   sysZ3D1050: 0.0
   sysZ3D1051: 0.0
   sysZ3D1052: 0.0
@@ -21189,55 +21189,55 @@ bins:
   sysZ3D1058: 0.00111
   sysZ3D1059: 0.00111
   sysZ3D1060: 0.0
-  sysZ3D1061: -0.0
+  sysZ3D1061: 0.0
   sysZ3D1062: -0.00111
-  sysZ3D1063: -0.0
-  sysZ3D1064: -0.0
+  sysZ3D1063: 0.0
+  sysZ3D1064: 0.0
   sysZ3D1065: -0.00111
-  sysZ3D1066: -0.0
-  sysZ3D1067: -0.0
+  sysZ3D1066: 0.0
+  sysZ3D1067: 0.0
   sysZ3D1068: 0.0
   sysZ3D1069: 0.00111
-  sysZ3D1070: -0.0
-  sysZ3D1071: -0.0
+  sysZ3D1070: 0.0
+  sysZ3D1071: 0.0
   sysZ3D1072: 0.0
   sysZ3D1073: 0.0
   sysZ3D1074: 0.0
   sysZ3D1075: 0.00111
-  sysZ3D1076: -0.0
-  sysZ3D1077: -0.0
+  sysZ3D1076: 0.0
+  sysZ3D1077: 0.0
   sysZ3D1078: 0.0
-  sysZ3D1079: -0.0
+  sysZ3D1079: 0.0
   sysZ3D1080: 0.0
   sysZ3D1081: 0.0
-  sysZ3D1082: -0.0
+  sysZ3D1082: 0.0
   sysZ3D1083: 0.0
   sysZ3D1084: 0.00111
   sysZ3D1085: 0.0
-  sysZ3D1086: -0.0
-  sysZ3D1087: -0.0
+  sysZ3D1086: 0.0
+  sysZ3D1087: 0.0
   sysZ3D1088: 0.0
   sysZ3D1089: 0.0
   sysZ3D1090: 0.0
-  sysZ3D1091: -0.0
-  sysZ3D1092: -0.0
+  sysZ3D1091: 0.0
+  sysZ3D1092: 0.0
   sysZ3D1093: -0.00111
-  sysZ3D1094: -0.0
+  sysZ3D1094: 0.0
   sysZ3D1095: 0.00111
-  sysZ3D1096: -0.0
+  sysZ3D1096: 0.0
   sysZ3D1097: 0.0
-  sysZ3D1098: -0.0
+  sysZ3D1098: 0.0
   sysZ3D1099: 0.00111
-  sysZ3D1100: -0.0
+  sysZ3D1100: 0.0
   sysZ3D1101: 0.0
-  sysZ3D1102: -0.0
-  sysZ3D1103: -0.0
+  sysZ3D1102: 0.0
+  sysZ3D1103: 0.0
   sysZ3D1104: -0.13431
   sysZ3D1105: -1.30980000e-01
   sysZ3D1106: -0.03663
   sysZ3D1107: -1.22100000e-02
   sysZ3D1108: -0.00111
-  sysZ3D1109: -0.0
+  sysZ3D1109: 0.0
   sysZ3D1110: 0.0
   sysZ3D1111: -0.00999
   sysZ3D1112: 0.00888
@@ -21271,13 +21271,13 @@ bins:
   sysZ3D1140: 0.00666
   sysZ3D1141: -0.00444
   sysZ3D1142: 0.0
-  sysZ3D1143: -0.0
+  sysZ3D1143: 0.0
   sysZ3D1144: 0.0
   sysZ3D1145: 0.00111
   sysZ3D1146: 0.0
   sysZ3D1147: 0.00222
   sysZ3D1148: -0.00111
-  sysZ3D1149: -0.0
+  sysZ3D1149: 0.0
   sysZ3D1150: 0.00222
   sysZ3D1151: -0.00222
   sysZ3D1152: -0.00222
@@ -21301,15 +21301,15 @@ bins:
   sysZ3D1170: 0.00222
   sysZ3D1171: -0.00333
   sysZ3D1172: 0.0
-  sysZ3D1173: -0.0
+  sysZ3D1173: 0.0
   sysZ3D1174: -0.00333
   sysZ3D1175: 0.0
   sysZ3D1176: -0.00111
   sysZ3D1177: 0.00111
   sysZ3D1178: 0.00222
-  sysZ3D1179: -0.0
+  sysZ3D1179: 0.0
   sysZ3D1180: 0.00111
-  sysZ3D1181: -0.0
+  sysZ3D1181: 0.0
   sysZ3D1182: -0.00111
   sysZ3D1183: 0.00111
   sysZ3D1184: -0.00111
@@ -21317,7 +21317,7 @@ bins:
   sysZ3D1186: 0.0
   sysZ3D1187: 0.00111
   sysZ3D1188: -0.00111
-  sysZ3D1189: -0.0
+  sysZ3D1189: 0.0
   sysZ3D1190: -0.00111
   sysZ3D1191: 0.00111
   sysZ3D1192: -0.00111
@@ -21328,7 +21328,7 @@ bins:
   sysZ3D1197: 0.0
   sysZ3D1198: 0.00444
   sysZ3D1199: 0.00111
-  sysZ3D1200: -0.0
+  sysZ3D1200: 0.0
   sysZ3D1201: -0.00111
   sysZ3D1202: 0.0
   sysZ3D1203: 0.00222
@@ -21338,11 +21338,11 @@ bins:
   sysZ3D1207: 0.00111
   sysZ3D1208: 0.0
   sysZ3D1209: 0.0
-  sysZ3D1210: -0.0
-  sysZ3D1211: -0.0
+  sysZ3D1210: 0.0
+  sysZ3D1211: 0.0
   sysZ3D1212: 0.0
   sysZ3D1213: 0.00111
-  sysZ3D1214: -0.0
+  sysZ3D1214: 0.0
   sysZ3D1215: -0.00222
   sysZ3D1216: -0.00111
   sysZ3D1217: -0.00111
@@ -21353,28 +21353,28 @@ bins:
   sysZ3D1222: -0.00222
   sysZ3D1223: -0.00222
   sysZ3D1224: -0.00111
-  sysZ3D1225: -0.0
+  sysZ3D1225: 0.0
   sysZ3D1226: 0.0
   sysZ3D1227: -0.00111
   sysZ3D1228: -0.00222
-  sysZ3D1229: -0.0
+  sysZ3D1229: 0.0
   sysZ3D1230: 0.0
   sysZ3D1231: 0.00111
   sysZ3D1232: -0.00111
-  sysZ3D1233: -0.0
-  sysZ3D1234: -0.0
+  sysZ3D1233: 0.0
+  sysZ3D1234: 0.0
   sysZ3D1235: -0.00111
   sysZ3D1236: 0.0
   sysZ3D1237: -0.00111
   sysZ3D1238: 0.0
-  sysZ3D1239: -0.0
-  sysZ3D1240: -0.0
-  sysZ3D1241: -0.0
+  sysZ3D1239: 0.0
+  sysZ3D1240: 0.0
+  sysZ3D1241: 0.0
   sysZ3D1242: 0.0
   sysZ3D1243: 0.0
   sysZ3D1244: 0.00222
-  sysZ3D1245: -0.0
-  sysZ3D1246: -0.0
+  sysZ3D1245: 0.0
+  sysZ3D1246: 0.0
   sysZ3D1247: -0.00111
   sysZ3D1248: -0.00111
   sysZ3D1249: -0.00111
@@ -21390,7 +21390,7 @@ bins:
   sysZ3D1259: 0.00333
   sysZ3D1260: 0.0
   sysZ3D1261: -0.00111
-  sysZ3D1262: -0.0
+  sysZ3D1262: 0.0
   sysZ3D1263: 0.00333
   sysZ3D1264: 1.22100000e-02
   sysZ3D1265: -7.77000000e-03
@@ -21408,7 +21408,7 @@ bins:
   ATLAS_LUMI: 1.99800000e-01
 - stat: 1.69708000e-01
   sysZ3D1001: -4.40800000e-03
-  sysZ3D1002: -0.0
+  sysZ3D1002: 0.0
   sysZ3D1003: 0.002204
   sysZ3D1004: 0.0
   sysZ3D1005: 0.0
@@ -21434,14 +21434,14 @@ bins:
   sysZ3D1025: -3.30600000e-03
   sysZ3D1026: 0.001102
   sysZ3D1027: -1.10200000e-03
-  sysZ3D1028: -0.0
+  sysZ3D1028: 0.0
   sysZ3D1029: 0.0
-  sysZ3D1030: -0.0
+  sysZ3D1030: 0.0
   sysZ3D1031: 0.0
   sysZ3D1032: 0.001102
-  sysZ3D1033: -0.0
+  sysZ3D1033: 0.0
   sysZ3D1034: 0.0
-  sysZ3D1035: -0.0
+  sysZ3D1035: 0.0
   sysZ3D1036: -1.10200000e-03
   sysZ3D1037: 0.001102
   sysZ3D1038: 0.0
@@ -21452,18 +21452,18 @@ bins:
   sysZ3D1043: 0.0
   sysZ3D1044: -1.10200000e-03
   sysZ3D1045: 0.0
-  sysZ3D1046: -0.0
+  sysZ3D1046: 0.0
   sysZ3D1047: 0.0
-  sysZ3D1048: -0.0
+  sysZ3D1048: 0.0
   sysZ3D1049: 0.001102
   sysZ3D1050: 0.001102
   sysZ3D1051: 0.0
-  sysZ3D1052: -0.0
+  sysZ3D1052: 0.0
   sysZ3D1053: 0.001102
   sysZ3D1054: 0.001102
   sysZ3D1055: -1.10200000e-03
   sysZ3D1056: -1.10200000e-03
-  sysZ3D1057: -0.0
+  sysZ3D1057: 0.0
   sysZ3D1058: 0.001102
   sysZ3D1059: 0.0
   sysZ3D1060: 0.001102
@@ -21475,39 +21475,39 @@ bins:
   sysZ3D1066: 0.0
   sysZ3D1067: 0.0
   sysZ3D1068: -1.10200000e-03
-  sysZ3D1069: -0.0
+  sysZ3D1069: 0.0
   sysZ3D1070: -1.10200000e-03
-  sysZ3D1071: -0.0
-  sysZ3D1072: -0.0
-  sysZ3D1073: -0.0
+  sysZ3D1071: 0.0
+  sysZ3D1072: 0.0
+  sysZ3D1073: 0.0
   sysZ3D1074: 0.001102
   sysZ3D1075: 0.001102
   sysZ3D1076: 0.0
-  sysZ3D1077: -0.0
+  sysZ3D1077: 0.0
   sysZ3D1078: -1.10200000e-03
   sysZ3D1079: 0.0
   sysZ3D1080: 0.001102
   sysZ3D1081: 0.001102
-  sysZ3D1082: -0.0
-  sysZ3D1083: -0.0
+  sysZ3D1082: 0.0
+  sysZ3D1083: 0.0
   sysZ3D1084: 0.0
   sysZ3D1085: 0.0
   sysZ3D1086: 0.0
   sysZ3D1087: 0.001102
   sysZ3D1088: -1.10200000e-03
   sysZ3D1089: 0.001102
-  sysZ3D1090: -0.0
+  sysZ3D1090: 0.0
   sysZ3D1091: 0.0
-  sysZ3D1092: -0.0
-  sysZ3D1093: -0.0
+  sysZ3D1092: 0.0
+  sysZ3D1093: 0.0
   sysZ3D1094: -1.10200000e-03
-  sysZ3D1095: -0.0
+  sysZ3D1095: 0.0
   sysZ3D1096: 0.0
-  sysZ3D1097: -0.0
+  sysZ3D1097: 0.0
   sysZ3D1098: 0.001102
   sysZ3D1099: -1.10200000e-03
   sysZ3D1100: 0.001102
-  sysZ3D1101: -0.0
+  sysZ3D1101: 0.0
   sysZ3D1102: 0.0
   sysZ3D1103: 0.0
   sysZ3D1104: -1.27832000e-01
@@ -21543,7 +21543,7 @@ bins:
   sysZ3D1134: -1.10200000e-03
   sysZ3D1135: 0.003306
   sysZ3D1136: -3.30600000e-03
-  sysZ3D1137: -0.0
+  sysZ3D1137: 0.0
   sysZ3D1138: 0.002204
   sysZ3D1139: -3.30600000e-03
   sysZ3D1140: 0.001102
@@ -21554,7 +21554,7 @@ bins:
   sysZ3D1145: -2.20400000e-03
   sysZ3D1146: 0.0
   sysZ3D1147: -2.20400000e-03
-  sysZ3D1148: -0.0
+  sysZ3D1148: 0.0
   sysZ3D1149: 0.009918
   sysZ3D1150: -4.40800000e-03
   sysZ3D1151: 0.0
@@ -21572,14 +21572,14 @@ bins:
   sysZ3D1163: 0.002204
   sysZ3D1164: -4.40800000e-03
   sysZ3D1165: 0.001102
-  sysZ3D1166: -0.0
+  sysZ3D1166: 0.0
   sysZ3D1167: 0.001102
   sysZ3D1168: -1.10200000e-03
   sysZ3D1169: -1.10200000e-03
   sysZ3D1170: 0.002204
   sysZ3D1171: -3.30600000e-03
-  sysZ3D1172: -0.0
-  sysZ3D1173: -0.0
+  sysZ3D1172: 0.0
+  sysZ3D1173: 0.0
   sysZ3D1174: -2.20400000e-03
   sysZ3D1175: 0.0
   sysZ3D1176: -3.30600000e-03
@@ -21590,15 +21590,15 @@ bins:
   sysZ3D1181: 0.0
   sysZ3D1182: -1.10200000e-03
   sysZ3D1183: 0.001102
-  sysZ3D1184: -0.0
+  sysZ3D1184: 0.0
   sysZ3D1185: 0.001102
-  sysZ3D1186: -0.0
+  sysZ3D1186: 0.0
   sysZ3D1187: 0.001102
   sysZ3D1188: 0.0
   sysZ3D1189: 0.0
   sysZ3D1190: -1.10200000e-03
   sysZ3D1191: 0.0
-  sysZ3D1192: -0.0
+  sysZ3D1192: 0.0
   sysZ3D1193: 0.002204
   sysZ3D1194: -6.61200000e-03
   sysZ3D1195: 0.003306
@@ -21615,9 +21615,9 @@ bins:
   sysZ3D1206: 0.001102
   sysZ3D1207: 0.0
   sysZ3D1208: 0.001102
-  sysZ3D1209: -0.0
+  sysZ3D1209: 0.0
   sysZ3D1210: 0.0
-  sysZ3D1211: -0.0
+  sysZ3D1211: 0.0
   sysZ3D1212: 0.0
   sysZ3D1213: 0.0
   sysZ3D1214: -1.10200000e-03
@@ -21635,7 +21635,7 @@ bins:
   sysZ3D1226: 0.0
   sysZ3D1227: 0.0
   sysZ3D1228: -1.10200000e-03
-  sysZ3D1229: -0.0
+  sysZ3D1229: 0.0
   sysZ3D1230: 0.0
   sysZ3D1231: 0.001102
   sysZ3D1232: -1.10200000e-03
@@ -21643,16 +21643,16 @@ bins:
   sysZ3D1234: 0.0
   sysZ3D1235: -1.10200000e-03
   sysZ3D1236: -1.10200000e-03
-  sysZ3D1237: -0.0
+  sysZ3D1237: 0.0
   sysZ3D1238: 0.0
-  sysZ3D1239: -0.0
-  sysZ3D1240: -0.0
+  sysZ3D1239: 0.0
+  sysZ3D1240: 0.0
   sysZ3D1241: 0.0
   sysZ3D1242: 0.0
   sysZ3D1243: 0.0
   sysZ3D1244: 0.004408
   sysZ3D1245: -2.20400000e-03
-  sysZ3D1246: -0.0
+  sysZ3D1246: 0.0
   sysZ3D1247: -1.10200000e-03
   sysZ3D1248: 0.001102
   sysZ3D1249: -2.20400000e-03
@@ -21711,19 +21711,19 @@ bins:
   sysZ3D1024: -2.16400000e-03
   sysZ3D1025: 0.001082
   sysZ3D1026: -2.16400000e-03
-  sysZ3D1027: -0.0
+  sysZ3D1027: 0.0
   sysZ3D1028: 0.001082
   sysZ3D1029: 0.0
   sysZ3D1030: 0.001082
   sysZ3D1031: -1.08200000e-03
-  sysZ3D1032: -0.0
+  sysZ3D1032: 0.0
   sysZ3D1033: 0.0
   sysZ3D1034: 0.0
   sysZ3D1035: 0.001082
   sysZ3D1036: 0.001082
-  sysZ3D1037: -0.0
-  sysZ3D1038: -0.0
-  sysZ3D1039: -0.0
+  sysZ3D1037: 0.0
+  sysZ3D1038: 0.0
+  sysZ3D1039: 0.0
   sysZ3D1040: 0.001082
   sysZ3D1041: -1.08200000e-03
   sysZ3D1042: 0.001082
@@ -21733,46 +21733,46 @@ bins:
   sysZ3D1046: 0.0
   sysZ3D1047: -1.08200000e-03
   sysZ3D1048: 0.0
-  sysZ3D1049: -0.0
-  sysZ3D1050: -0.0
-  sysZ3D1051: -0.0
-  sysZ3D1052: -0.0
-  sysZ3D1053: -0.0
+  sysZ3D1049: 0.0
+  sysZ3D1050: 0.0
+  sysZ3D1051: 0.0
+  sysZ3D1052: 0.0
+  sysZ3D1053: 0.0
   sysZ3D1054: 0.001082
   sysZ3D1055: 0.0
   sysZ3D1056: 0.0
-  sysZ3D1057: -0.0
-  sysZ3D1058: -0.0
+  sysZ3D1057: 0.0
+  sysZ3D1058: 0.0
   sysZ3D1059: 0.0
   sysZ3D1060: 0.001082
-  sysZ3D1061: -0.0
-  sysZ3D1062: -0.0
-  sysZ3D1063: -0.0
+  sysZ3D1061: 0.0
+  sysZ3D1062: 0.0
+  sysZ3D1063: 0.0
   sysZ3D1064: 0.001082
   sysZ3D1065: 0.0
   sysZ3D1066: 0.0
-  sysZ3D1067: -0.0
+  sysZ3D1067: 0.0
   sysZ3D1068: -1.08200000e-03
-  sysZ3D1069: -0.0
-  sysZ3D1070: -0.0
-  sysZ3D1071: -0.0
+  sysZ3D1069: 0.0
+  sysZ3D1070: 0.0
+  sysZ3D1071: 0.0
   sysZ3D1072: 0.0
   sysZ3D1073: 0.0
   sysZ3D1074: 0.0
   sysZ3D1075: 0.0
-  sysZ3D1076: -0.0
-  sysZ3D1077: -0.0
+  sysZ3D1076: 0.0
+  sysZ3D1077: 0.0
   sysZ3D1078: 0.001082
-  sysZ3D1079: -0.0
+  sysZ3D1079: 0.0
   sysZ3D1080: 0.0
   sysZ3D1081: 0.001082
-  sysZ3D1082: -0.0
+  sysZ3D1082: 0.0
   sysZ3D1083: 0.0
   sysZ3D1084: 0.0
   sysZ3D1085: 0.0
   sysZ3D1086: 0.001082
   sysZ3D1087: -1.08200000e-03
-  sysZ3D1088: -0.0
+  sysZ3D1088: 0.0
   sysZ3D1089: -1.08200000e-03
   sysZ3D1090: 0.001082
   sysZ3D1091: -2.16400000e-03
@@ -21786,8 +21786,8 @@ bins:
   sysZ3D1099: 0.001082
   sysZ3D1100: -1.08200000e-03
   sysZ3D1101: 0.001082
-  sysZ3D1102: -0.0
-  sysZ3D1103: -0.0
+  sysZ3D1102: 0.0
+  sysZ3D1103: 0.0
   sysZ3D1104: -1.17938000e-01
   sysZ3D1105: -1.23348000e-01
   sysZ3D1106: -3.35420000e-02
@@ -21799,7 +21799,7 @@ bins:
   sysZ3D1112: 6.49200000e-03
   sysZ3D1113: -1.08200000e-03
   sysZ3D1114: -9.73800000e-03
-  sysZ3D1115: -0.0
+  sysZ3D1115: 0.0
   sysZ3D1116: -4.32800000e-03
   sysZ3D1117: -3.24600000e-03
   sysZ3D1118: -2.16400000e-03
@@ -21814,7 +21814,7 @@ bins:
   sysZ3D1127: -3.24600000e-03
   sysZ3D1128: 0.0
   sysZ3D1129: 0.002164
-  sysZ3D1130: -0.0
+  sysZ3D1130: 0.0
   sysZ3D1131: -1.08200000e-03
   sysZ3D1132: 0.0
   sysZ3D1133: -7.57400000e-03
@@ -21836,13 +21836,13 @@ bins:
   sysZ3D1149: 0.002164
   sysZ3D1150: 6.49200000e-03
   sysZ3D1151: 0.004328
-  sysZ3D1152: -0.0
+  sysZ3D1152: 0.0
   sysZ3D1153: -2.16400000e-03
-  sysZ3D1154: -0.0
-  sysZ3D1155: -0.0
+  sysZ3D1154: 0.0
+  sysZ3D1155: 0.0
   sysZ3D1156: 0.002164
   sysZ3D1157: -3.24600000e-03
-  sysZ3D1158: -0.0
+  sysZ3D1158: 0.0
   sysZ3D1159: -9.73800000e-03
   sysZ3D1160: -4.32800000e-03
   sysZ3D1161: -1.08200000e-03
@@ -21852,18 +21852,18 @@ bins:
   sysZ3D1165: 0.002164
   sysZ3D1166: -6.49200000e-03
   sysZ3D1167: 0.001082
-  sysZ3D1168: -0.0
+  sysZ3D1168: 0.0
   sysZ3D1169: -1.08200000e-03
   sysZ3D1170: 0.002164
   sysZ3D1171: -2.16400000e-03
   sysZ3D1172: 0.0
-  sysZ3D1173: -0.0
+  sysZ3D1173: 0.0
   sysZ3D1174: -2.16400000e-03
   sysZ3D1175: 0.0
   sysZ3D1176: -1.08200000e-03
   sysZ3D1177: 0.001082
   sysZ3D1178: 0.002164
-  sysZ3D1179: -0.0
+  sysZ3D1179: 0.0
   sysZ3D1180: 0.001082
   sysZ3D1181: 0.0
   sysZ3D1182: -1.08200000e-03
@@ -21873,13 +21873,13 @@ bins:
   sysZ3D1186: 0.0
   sysZ3D1187: 0.001082
   sysZ3D1188: -1.08200000e-03
-  sysZ3D1189: -0.0
-  sysZ3D1190: -0.0
+  sysZ3D1189: 0.0
+  sysZ3D1190: 0.0
   sysZ3D1191: 0.001082
-  sysZ3D1192: -0.0
+  sysZ3D1192: 0.0
   sysZ3D1193: 0.002164
   sysZ3D1194: -0.00541
-  sysZ3D1195: -0.0
+  sysZ3D1195: 0.0
   sysZ3D1196: 0.0
   sysZ3D1197: 0.002164
   sysZ3D1198: 0.004328
@@ -21888,29 +21888,29 @@ bins:
   sysZ3D1201: -1.08200000e-03
   sysZ3D1202: 0.0
   sysZ3D1203: 0.001082
-  sysZ3D1204: -0.0
+  sysZ3D1204: 0.0
   sysZ3D1205: 0.0
   sysZ3D1206: 0.001082
   sysZ3D1207: 0.001082
-  sysZ3D1208: -0.0
+  sysZ3D1208: 0.0
   sysZ3D1209: 0.0
   sysZ3D1210: 0.0
-  sysZ3D1211: -0.0
+  sysZ3D1211: 0.0
   sysZ3D1212: 0.0
   sysZ3D1213: 0.0
-  sysZ3D1214: -0.0
+  sysZ3D1214: 0.0
   sysZ3D1215: -1.08200000e-03
   sysZ3D1216: 0.0
-  sysZ3D1217: -0.0
+  sysZ3D1217: 0.0
   sysZ3D1218: -1.08200000e-03
   sysZ3D1219: 0.001082
   sysZ3D1220: 0.001082
   sysZ3D1221: -1.08200000e-03
-  sysZ3D1222: -0.0
+  sysZ3D1222: 0.0
   sysZ3D1223: -2.16400000e-03
   sysZ3D1224: -1.08200000e-03
   sysZ3D1225: 0.0
-  sysZ3D1226: -0.0
+  sysZ3D1226: 0.0
   sysZ3D1227: -2.16400000e-03
   sysZ3D1228: -1.08200000e-03
   sysZ3D1229: 0.0
@@ -21923,9 +21923,9 @@ bins:
   sysZ3D1236: 0.0
   sysZ3D1237: 0.001082
   sysZ3D1238: 0.0
-  sysZ3D1239: -0.0
-  sysZ3D1240: -0.0
-  sysZ3D1241: -0.0
+  sysZ3D1239: 0.0
+  sysZ3D1240: 0.0
+  sysZ3D1241: 0.0
   sysZ3D1242: 0.0
   sysZ3D1243: 0.0
   sysZ3D1244: 3.24600000e-03
@@ -21937,7 +21937,7 @@ bins:
   sysZ3D1250: 0.001082
   sysZ3D1251: -3.24600000e-03
   sysZ3D1252: -4.32800000e-03
-  sysZ3D1253: -0.0
+  sysZ3D1253: 0.0
   sysZ3D1254: 0.001082
   sysZ3D1255: 0.002164
   sysZ3D1256: 0.001082
@@ -21953,10 +21953,10 @@ bins:
   sysZ3D1266: -9.73800000e-03
   sysZ3D1267: -3.24600000e-03
   sysZ3D1268: 0.001082
-  sysZ3D1269: -0.0
+  sysZ3D1269: 0.0
   sysZ3D1270: 0.002164
   sysZ3D1271: -2.16400000e-03
-  sysZ3D1272: -0.0
+  sysZ3D1272: 0.0
   sysZ3D1273: -2.16400000e-03
   sysZ3D1274: 3.24600000e-03
   sysZ3D1275: 0.008656
@@ -21985,82 +21985,82 @@ bins:
   sysZ3D1020: 0.0
   sysZ3D1021: -1.06600000e-03
   sysZ3D1022: 0.0
-  sysZ3D1023: -0.0
+  sysZ3D1023: 0.0
   sysZ3D1024: 0.001066
   sysZ3D1025: -2.13200000e-03
   sysZ3D1026: 0.002132
   sysZ3D1027: -1.06600000e-03
-  sysZ3D1028: -0.0
-  sysZ3D1029: -0.0
+  sysZ3D1028: 0.0
+  sysZ3D1029: 0.0
   sysZ3D1030: -1.06600000e-03
   sysZ3D1031: 0.001066
   sysZ3D1032: 0.0
   sysZ3D1033: 0.001066
-  sysZ3D1034: -0.0
+  sysZ3D1034: 0.0
   sysZ3D1035: 0.0
   sysZ3D1036: -1.06600000e-03
   sysZ3D1037: 0.001066
   sysZ3D1038: 0.001066
   sysZ3D1039: 0.001066
   sysZ3D1040: -1.06600000e-03
-  sysZ3D1041: -0.0
+  sysZ3D1041: 0.0
   sysZ3D1042: 0.0
   sysZ3D1043: 0.0
   sysZ3D1044: 0.001066
   sysZ3D1045: 0.0
   sysZ3D1046: -1.06600000e-03
   sysZ3D1047: 0.0
-  sysZ3D1048: -0.0
+  sysZ3D1048: 0.0
   sysZ3D1049: 0.001066
   sysZ3D1050: -2.13200000e-03
   sysZ3D1051: 0.0
-  sysZ3D1052: -0.0
+  sysZ3D1052: 0.0
   sysZ3D1053: 0.002132
   sysZ3D1054: 0.0
   sysZ3D1055: 0.0
   sysZ3D1056: 0.0
   sysZ3D1057: 0.002132
   sysZ3D1058: 0.0
-  sysZ3D1059: -0.0
+  sysZ3D1059: 0.0
   sysZ3D1060: -2.13200000e-03
-  sysZ3D1061: -0.0
+  sysZ3D1061: 0.0
   sysZ3D1062: 0.001066
-  sysZ3D1063: -0.0
+  sysZ3D1063: 0.0
   sysZ3D1064: -1.06600000e-03
   sysZ3D1065: 0.002132
-  sysZ3D1066: -0.0
+  sysZ3D1066: 0.0
   sysZ3D1067: 0.0
   sysZ3D1068: 0.0
   sysZ3D1069: 0.0
   sysZ3D1070: 0.0
-  sysZ3D1071: -0.0
+  sysZ3D1071: 0.0
   sysZ3D1072: 0.0
   sysZ3D1073: -1.06600000e-03
   sysZ3D1074: -1.06600000e-03
-  sysZ3D1075: -0.0
-  sysZ3D1076: -0.0
+  sysZ3D1075: 0.0
+  sysZ3D1076: 0.0
   sysZ3D1077: -1.06600000e-03
-  sysZ3D1078: -0.0
+  sysZ3D1078: 0.0
   sysZ3D1079: 0.0
   sysZ3D1080: -1.06600000e-03
-  sysZ3D1081: -0.0
+  sysZ3D1081: 0.0
   sysZ3D1082: 0.001066
-  sysZ3D1083: -0.0
-  sysZ3D1084: -0.0
+  sysZ3D1083: 0.0
+  sysZ3D1084: 0.0
   sysZ3D1085: 0.001066
-  sysZ3D1086: -0.0
+  sysZ3D1086: 0.0
   sysZ3D1087: 0.0
   sysZ3D1088: -1.06600000e-03
   sysZ3D1089: 0.0
-  sysZ3D1090: -0.0
-  sysZ3D1091: -0.0
+  sysZ3D1090: 0.0
+  sysZ3D1091: 0.0
   sysZ3D1092: 0.0
   sysZ3D1093: 0.0
-  sysZ3D1094: -0.0
-  sysZ3D1095: -0.0
+  sysZ3D1094: 0.0
+  sysZ3D1095: 0.0
   sysZ3D1096: -2.13200000e-03
-  sysZ3D1097: -0.0
-  sysZ3D1098: -0.0
+  sysZ3D1097: 0.0
+  sysZ3D1098: 0.0
   sysZ3D1099: 0.0
   sysZ3D1100: -1.06600000e-03
   sysZ3D1101: 0.001066
@@ -22070,7 +22070,7 @@ bins:
   sysZ3D1105: -1.09798000e-01
   sysZ3D1106: -3.41120000e-02
   sysZ3D1107: -9.59400000e-03
-  sysZ3D1108: -0.0
+  sysZ3D1108: 0.0
   sysZ3D1109: -1.06600000e-03
   sysZ3D1110: 0.0
   sysZ3D1111: -3.19800000e-03
@@ -22123,19 +22123,19 @@ bins:
   sysZ3D1158: 0.004264
   sysZ3D1159: 0.002132
   sysZ3D1160: 0.002132
-  sysZ3D1161: -0.0
+  sysZ3D1161: 0.0
   sysZ3D1162: 0.004264
   sysZ3D1163: 0.006396
   sysZ3D1164: 0.0
   sysZ3D1165: -0.00533
   sysZ3D1166: -4.26400000e-03
   sysZ3D1167: 0.0
-  sysZ3D1168: -0.0
+  sysZ3D1168: 0.0
   sysZ3D1169: -1.06600000e-03
   sysZ3D1170: 0.002132
   sysZ3D1171: -2.13200000e-03
-  sysZ3D1172: -0.0
-  sysZ3D1173: -0.0
+  sysZ3D1172: 0.0
+  sysZ3D1173: 0.0
   sysZ3D1174: -2.13200000e-03
   sysZ3D1175: 0.0
   sysZ3D1176: -1.06600000e-03
@@ -22143,16 +22143,16 @@ bins:
   sysZ3D1178: 0.001066
   sysZ3D1179: 0.0
   sysZ3D1180: 0.0
-  sysZ3D1181: -0.0
+  sysZ3D1181: 0.0
   sysZ3D1182: -1.06600000e-03
   sysZ3D1183: 0.001066
   sysZ3D1184: -1.06600000e-03
   sysZ3D1185: 0.0
-  sysZ3D1186: -0.0
+  sysZ3D1186: 0.0
   sysZ3D1187: 0.001066
   sysZ3D1188: -1.06600000e-03
-  sysZ3D1189: -0.0
-  sysZ3D1190: -0.0
+  sysZ3D1189: 0.0
+  sysZ3D1190: 0.0
   sysZ3D1191: 0.001066
   sysZ3D1192: 0.001066
   sysZ3D1193: 0.001066
@@ -22166,14 +22166,14 @@ bins:
   sysZ3D1201: 0.0
   sysZ3D1202: 0.0
   sysZ3D1203: 0.0
-  sysZ3D1204: -0.0
+  sysZ3D1204: 0.0
   sysZ3D1205: 0.001066
-  sysZ3D1206: -0.0
+  sysZ3D1206: 0.0
   sysZ3D1207: 0.001066
-  sysZ3D1208: -0.0
+  sysZ3D1208: 0.0
   sysZ3D1209: 0.0
   sysZ3D1210: 0.0
-  sysZ3D1211: -0.0
+  sysZ3D1211: 0.0
   sysZ3D1212: 0.0
   sysZ3D1213: 0.001066
   sysZ3D1214: 0.0
@@ -22182,16 +22182,16 @@ bins:
   sysZ3D1217: -1.06600000e-03
   sysZ3D1218: -1.06600000e-03
   sysZ3D1219: 0.001066
-  sysZ3D1220: -0.0
-  sysZ3D1221: -0.0
-  sysZ3D1222: -0.0
+  sysZ3D1220: 0.0
+  sysZ3D1221: 0.0
+  sysZ3D1222: 0.0
   sysZ3D1223: -3.19800000e-03
-  sysZ3D1224: -0.0
+  sysZ3D1224: 0.0
   sysZ3D1225: 0.001066
   sysZ3D1226: 0.001066
   sysZ3D1227: 0.0
   sysZ3D1228: -1.06600000e-03
-  sysZ3D1229: -0.0
+  sysZ3D1229: 0.0
   sysZ3D1230: 0.0
   sysZ3D1231: 0.001066
   sysZ3D1232: -1.06600000e-03
@@ -22201,8 +22201,8 @@ bins:
   sysZ3D1236: 0.001066
   sysZ3D1237: 0.0
   sysZ3D1238: 0.0
-  sysZ3D1239: -0.0
-  sysZ3D1240: -0.0
+  sysZ3D1239: 0.0
+  sysZ3D1240: 0.0
   sysZ3D1241: 0.0
   sysZ3D1242: 0.0
   sysZ3D1243: 0.0
@@ -22215,7 +22215,7 @@ bins:
   sysZ3D1250: 0.0
   sysZ3D1251: -3.19800000e-03
   sysZ3D1252: -3.19800000e-03
-  sysZ3D1253: -0.0
+  sysZ3D1253: 0.0
   sysZ3D1254: 0.001066
   sysZ3D1255: 0.004264
   sysZ3D1256: 0.002132
@@ -22234,7 +22234,7 @@ bins:
   sysZ3D1269: -1.06600000e-03
   sysZ3D1270: 0.002132
   sysZ3D1271: -1.06600000e-03
-  sysZ3D1272: -0.0
+  sysZ3D1272: 0.0
   sysZ3D1273: -1.06600000e-03
   sysZ3D1274: -1.27920000e-02
   sysZ3D1275: 0.009594
@@ -22262,14 +22262,14 @@ bins:
   sysZ3D1019: 0.0
   sysZ3D1020: 0.000998
   sysZ3D1021: 2.99400000e-03
-  sysZ3D1022: -0.0
+  sysZ3D1022: 0.0
   sysZ3D1023: 0.001996
   sysZ3D1024: -1.99600000e-03
   sysZ3D1025: 0.003992
   sysZ3D1026: -1.99600000e-03
   sysZ3D1027: 0.001996
   sysZ3D1028: 0.0
-  sysZ3D1029: -0.0
+  sysZ3D1029: 0.0
   sysZ3D1030: 0.000998
   sysZ3D1031: 0.000998
   sysZ3D1032: 0.001996
@@ -22280,10 +22280,10 @@ bins:
   sysZ3D1037: -1.99600000e-03
   sysZ3D1038: 0.000998
   sysZ3D1039: 0.0
-  sysZ3D1040: -0.0
+  sysZ3D1040: 0.0
   sysZ3D1041: 0.0
   sysZ3D1042: 0.0
-  sysZ3D1043: -0.0
+  sysZ3D1043: 0.0
   sysZ3D1044: 0.000998
   sysZ3D1045: 0.000998
   sysZ3D1046: 0.000998
@@ -22294,50 +22294,50 @@ bins:
   sysZ3D1051: -9.98000000e-04
   sysZ3D1052: -9.98000000e-04
   sysZ3D1053: 0.0
-  sysZ3D1054: -0.0
-  sysZ3D1055: -0.0
-  sysZ3D1056: -0.0
+  sysZ3D1054: 0.0
+  sysZ3D1055: 0.0
+  sysZ3D1056: 0.0
   sysZ3D1057: -1.99600000e-03
   sysZ3D1058: -9.98000000e-04
   sysZ3D1059: 0.0
   sysZ3D1060: 0.0
-  sysZ3D1061: -0.0
-  sysZ3D1062: -0.0
+  sysZ3D1061: 0.0
+  sysZ3D1062: 0.0
   sysZ3D1063: 0.000998
   sysZ3D1064: 0.000998
-  sysZ3D1065: -0.0
+  sysZ3D1065: 0.0
   sysZ3D1066: -9.98000000e-04
   sysZ3D1067: -9.98000000e-04
   sysZ3D1068: -9.98000000e-04
   sysZ3D1069: -2.99400000e-03
-  sysZ3D1070: -0.0
+  sysZ3D1070: 0.0
   sysZ3D1071: 0.0
   sysZ3D1072: 0.000998
   sysZ3D1073: 0.000998
-  sysZ3D1074: -0.0
+  sysZ3D1074: 0.0
   sysZ3D1075: 0.000998
   sysZ3D1076: 0.000998
   sysZ3D1077: 0.0
-  sysZ3D1078: -0.0
+  sysZ3D1078: 0.0
   sysZ3D1079: -1.99600000e-03
   sysZ3D1080: 0.000998
-  sysZ3D1081: -0.0
+  sysZ3D1081: 0.0
   sysZ3D1082: -9.98000000e-04
-  sysZ3D1083: -0.0
+  sysZ3D1083: 0.0
   sysZ3D1084: 0.0
   sysZ3D1085: -9.98000000e-04
   sysZ3D1086: -9.98000000e-04
   sysZ3D1087: -9.98000000e-04
-  sysZ3D1088: -0.0
+  sysZ3D1088: 0.0
   sysZ3D1089: 0.000998
   sysZ3D1090: 0.0
   sysZ3D1091: 0.000998
   sysZ3D1092: -9.98000000e-04
   sysZ3D1093: -9.98000000e-04
-  sysZ3D1094: -0.0
+  sysZ3D1094: 0.0
   sysZ3D1095: -9.98000000e-04
-  sysZ3D1096: -0.0
-  sysZ3D1097: -0.0
+  sysZ3D1096: 0.0
+  sysZ3D1097: 0.0
   sysZ3D1098: 0.0
   sysZ3D1099: -9.98000000e-04
   sysZ3D1100: 0.000998
@@ -22358,7 +22358,7 @@ bins:
   sysZ3D1115: -2.99400000e-03
   sysZ3D1116: -3.99200000e-03
   sysZ3D1117: -1.99600000e-03
-  sysZ3D1118: -0.0
+  sysZ3D1118: 0.0
   sysZ3D1119: 2.99400000e-03
   sysZ3D1120: 0.0
   sysZ3D1121: -0.00499
@@ -22366,7 +22366,7 @@ bins:
   sysZ3D1123: 0.0
   sysZ3D1124: 1.29740000e-02
   sysZ3D1125: -9.98000000e-04
-  sysZ3D1126: -0.0
+  sysZ3D1126: 0.0
   sysZ3D1127: 0.0
   sysZ3D1128: -9.98000000e-04
   sysZ3D1129: -9.98000000e-04
@@ -22383,7 +22383,7 @@ bins:
   sysZ3D1140: -5.98800000e-03
   sysZ3D1141: -9.98000000e-04
   sysZ3D1142: -2.99400000e-03
-  sysZ3D1143: -0.0
+  sysZ3D1143: 0.0
   sysZ3D1144: -2.99400000e-03
   sysZ3D1145: 2.99400000e-03
   sysZ3D1146: 0.0
@@ -22395,7 +22395,7 @@ bins:
   sysZ3D1152: 0.000998
   sysZ3D1153: -0.00499
   sysZ3D1154: 0.000998
-  sysZ3D1155: -0.0
+  sysZ3D1155: 0.0
   sysZ3D1156: -9.98000000e-04
   sysZ3D1157: -1.99600000e-03
   sysZ3D1158: -9.98000000e-04
@@ -22412,30 +22412,30 @@ bins:
   sysZ3D1169: -9.98000000e-04
   sysZ3D1170: 0.001996
   sysZ3D1171: -9.98000000e-04
-  sysZ3D1172: -0.0
-  sysZ3D1173: -0.0
+  sysZ3D1172: 0.0
+  sysZ3D1173: 0.0
   sysZ3D1174: -9.98000000e-04
   sysZ3D1175: 0.0
   sysZ3D1176: 0.001996
   sysZ3D1177: 0.001996
   sysZ3D1178: 0.001996
   sysZ3D1179: 0.0
-  sysZ3D1180: -0.0
-  sysZ3D1181: -0.0
+  sysZ3D1180: 0.0
+  sysZ3D1181: 0.0
   sysZ3D1182: -9.98000000e-04
   sysZ3D1183: 0.000998
   sysZ3D1184: -9.98000000e-04
-  sysZ3D1185: -0.0
+  sysZ3D1185: 0.0
   sysZ3D1186: 0.0
   sysZ3D1187: 0.000998
   sysZ3D1188: -9.98000000e-04
-  sysZ3D1189: -0.0
+  sysZ3D1189: 0.0
   sysZ3D1190: 0.0
   sysZ3D1191: 0.0
   sysZ3D1192: 0.0
   sysZ3D1193: 0.000998
   sysZ3D1194: -5.98800000e-03
-  sysZ3D1195: -0.0
+  sysZ3D1195: 0.0
   sysZ3D1196: 0.0
   sysZ3D1197: 0.000998
   sysZ3D1198: 2.99400000e-03
@@ -22444,12 +22444,12 @@ bins:
   sysZ3D1201: 0.0
   sysZ3D1202: 0.0
   sysZ3D1203: 0.0
-  sysZ3D1204: -0.0
+  sysZ3D1204: 0.0
   sysZ3D1205: 0.0
   sysZ3D1206: 0.0
   sysZ3D1207: 0.0
   sysZ3D1208: 0.0
-  sysZ3D1209: -0.0
+  sysZ3D1209: 0.0
   sysZ3D1210: 0.0
   sysZ3D1211: 0.0
   sysZ3D1212: 0.0
@@ -22460,27 +22460,27 @@ bins:
   sysZ3D1217: -9.98000000e-04
   sysZ3D1218: 0.0
   sysZ3D1219: 0.0
-  sysZ3D1220: -0.0
-  sysZ3D1221: -0.0
-  sysZ3D1222: -0.0
+  sysZ3D1220: 0.0
+  sysZ3D1221: 0.0
+  sysZ3D1222: 0.0
   sysZ3D1223: -1.99600000e-03
   sysZ3D1224: -9.98000000e-04
   sysZ3D1225: 0.0
-  sysZ3D1226: -0.0
-  sysZ3D1227: -0.0
+  sysZ3D1226: 0.0
+  sysZ3D1227: 0.0
   sysZ3D1228: 0.0
-  sysZ3D1229: -0.0
+  sysZ3D1229: 0.0
   sysZ3D1230: 0.0
   sysZ3D1231: 0.0
-  sysZ3D1232: -0.0
+  sysZ3D1232: 0.0
   sysZ3D1233: 0.0
-  sysZ3D1234: -0.0
+  sysZ3D1234: 0.0
   sysZ3D1235: -9.98000000e-04
-  sysZ3D1236: -0.0
+  sysZ3D1236: 0.0
   sysZ3D1237: 0.0
   sysZ3D1238: 0.0
-  sysZ3D1239: -0.0
-  sysZ3D1240: -0.0
+  sysZ3D1239: 0.0
+  sysZ3D1240: 0.0
   sysZ3D1241: 0.0
   sysZ3D1242: 0.0
   sysZ3D1243: 0.0
@@ -22500,9 +22500,9 @@ bins:
   sysZ3D1257: 0.003992
   sysZ3D1258: -1.99600000e-03
   sysZ3D1259: 2.99400000e-03
-  sysZ3D1260: -0.0
+  sysZ3D1260: 0.0
   sysZ3D1261: 0.0
-  sysZ3D1262: -0.0
+  sysZ3D1262: 0.0
   sysZ3D1263: 0.001996
   sysZ3D1264: 1.19760000e-02
   sysZ3D1265: -0.00499
@@ -22512,7 +22512,7 @@ bins:
   sysZ3D1269: -9.98000000e-04
   sysZ3D1270: 0.001996
   sysZ3D1271: 0.0
-  sysZ3D1272: -0.0
+  sysZ3D1272: 0.0
   sysZ3D1273: 0.0
   sysZ3D1274: 6.98600000e-03
   sysZ3D1275: 0.00998
@@ -22546,7 +22546,7 @@ bins:
   sysZ3D1025: 1.01420000e-02
   sysZ3D1026: -2.76600000e-03
   sysZ3D1027: 0.002766
-  sysZ3D1028: -0.0
+  sysZ3D1028: 0.0
   sysZ3D1029: 1.84400000e-03
   sysZ3D1030: -9.22000000e-04
   sysZ3D1031: -1.84400000e-03
@@ -22559,7 +22559,7 @@ bins:
   sysZ3D1038: 0.0
   sysZ3D1039: -9.22000000e-04
   sysZ3D1040: -9.22000000e-04
-  sysZ3D1041: -0.0
+  sysZ3D1041: 0.0
   sysZ3D1042: -9.22000000e-04
   sysZ3D1043: 9.22000000e-04
   sysZ3D1044: 9.22000000e-04
@@ -22569,8 +22569,8 @@ bins:
   sysZ3D1048: -9.22000000e-04
   sysZ3D1049: 0.0
   sysZ3D1050: 9.22000000e-04
-  sysZ3D1051: -0.0
-  sysZ3D1052: -0.0
+  sysZ3D1051: 0.0
+  sysZ3D1052: 0.0
   sysZ3D1053: 9.22000000e-04
   sysZ3D1054: 0.0
   sysZ3D1055: -9.22000000e-04
@@ -22580,7 +22580,7 @@ bins:
   sysZ3D1059: 0.0
   sysZ3D1060: -9.22000000e-04
   sysZ3D1061: 0.0
-  sysZ3D1062: -0.0
+  sysZ3D1062: 0.0
   sysZ3D1063: -9.22000000e-04
   sysZ3D1064: 9.22000000e-04
   sysZ3D1065: -9.22000000e-04
@@ -22597,36 +22597,36 @@ bins:
   sysZ3D1076: -9.22000000e-04
   sysZ3D1077: 0.0
   sysZ3D1078: 9.22000000e-04
-  sysZ3D1079: -0.0
+  sysZ3D1079: 0.0
   sysZ3D1080: -9.22000000e-04
   sysZ3D1081: 1.84400000e-03
-  sysZ3D1082: -0.0
-  sysZ3D1083: -0.0
+  sysZ3D1082: 0.0
+  sysZ3D1083: 0.0
   sysZ3D1084: -9.22000000e-04
   sysZ3D1085: -9.22000000e-04
   sysZ3D1086: -9.22000000e-04
   sysZ3D1087: 9.22000000e-04
   sysZ3D1088: -9.22000000e-04
   sysZ3D1089: 0.0
-  sysZ3D1090: -0.0
+  sysZ3D1090: 0.0
   sysZ3D1091: -9.22000000e-04
   sysZ3D1092: 9.22000000e-04
-  sysZ3D1093: -0.0
-  sysZ3D1094: -0.0
+  sysZ3D1093: 0.0
+  sysZ3D1094: 0.0
   sysZ3D1095: 1.84400000e-03
-  sysZ3D1096: -0.0
+  sysZ3D1096: 0.0
   sysZ3D1097: 0.0
   sysZ3D1098: -9.22000000e-04
   sysZ3D1099: -9.22000000e-04
   sysZ3D1100: -9.22000000e-04
   sysZ3D1101: -9.22000000e-04
-  sysZ3D1102: -0.0
+  sysZ3D1102: 0.0
   sysZ3D1103: 9.22000000e-04
   sysZ3D1104: -0.06454
   sysZ3D1105: -7.65260000e-02
   sysZ3D1106: -2.58160000e-02
   sysZ3D1107: -7.37600000e-03
-  sysZ3D1108: -0.0
+  sysZ3D1108: 0.0
   sysZ3D1109: -9.22000000e-04
   sysZ3D1110: 0.0
   sysZ3D1111: -3.68800000e-03
@@ -22634,7 +22634,7 @@ bins:
   sysZ3D1113: 9.22000000e-04
   sysZ3D1114: -1.19860000e-02
   sysZ3D1115: -5.53200000e-03
-  sysZ3D1116: -0.0
+  sysZ3D1116: 0.0
   sysZ3D1117: -0.00461
   sysZ3D1118: -2.76600000e-03
   sysZ3D1119: -9.22000000e-04
@@ -22645,7 +22645,7 @@ bins:
   sysZ3D1124: -2.76600000e-03
   sysZ3D1125: 0.0
   sysZ3D1126: 9.22000000e-04
-  sysZ3D1127: -0.0
+  sysZ3D1127: 0.0
   sysZ3D1128: -1.84400000e-03
   sysZ3D1129: 0.0
   sysZ3D1130: 3.68800000e-03
@@ -22682,7 +22682,7 @@ bins:
   sysZ3D1161: 1.84400000e-03
   sysZ3D1162: 0.00461
   sysZ3D1163: -0.00461
-  sysZ3D1164: -0.0
+  sysZ3D1164: 0.0
   sysZ3D1165: -3.68800000e-03
   sysZ3D1166: 1.84400000e-03
   sysZ3D1167: 9.22000000e-04
@@ -22691,38 +22691,38 @@ bins:
   sysZ3D1170: 1.84400000e-03
   sysZ3D1171: -9.22000000e-04
   sysZ3D1172: -9.22000000e-04
-  sysZ3D1173: -0.0
+  sysZ3D1173: 0.0
   sysZ3D1174: -9.22000000e-04
   sysZ3D1175: 0.0
   sysZ3D1176: 9.22000000e-04
   sysZ3D1177: 1.84400000e-03
   sysZ3D1178: 9.22000000e-04
   sysZ3D1179: 0.0
-  sysZ3D1180: -0.0
+  sysZ3D1180: 0.0
   sysZ3D1181: -9.22000000e-04
   sysZ3D1182: 0.0
   sysZ3D1183: 9.22000000e-04
   sysZ3D1184: -1.84400000e-03
-  sysZ3D1185: -0.0
+  sysZ3D1185: 0.0
   sysZ3D1186: 0.0
   sysZ3D1187: 9.22000000e-04
   sysZ3D1188: -9.22000000e-04
-  sysZ3D1189: -0.0
-  sysZ3D1190: -0.0
+  sysZ3D1189: 0.0
+  sysZ3D1190: 0.0
   sysZ3D1191: 0.0
   sysZ3D1192: 9.22000000e-04
   sysZ3D1193: 9.22000000e-04
   sysZ3D1194: -6.45400000e-03
-  sysZ3D1195: -0.0
+  sysZ3D1195: 0.0
   sysZ3D1196: 9.22000000e-04
   sysZ3D1197: 9.22000000e-04
   sysZ3D1198: 0.002766
   sysZ3D1199: 9.22000000e-04
-  sysZ3D1200: -0.0
-  sysZ3D1201: -0.0
+  sysZ3D1200: 0.0
+  sysZ3D1201: 0.0
   sysZ3D1202: 0.0
   sysZ3D1203: 0.002766
-  sysZ3D1204: -0.0
+  sysZ3D1204: 0.0
   sysZ3D1205: 0.0
   sysZ3D1206: 0.0
   sysZ3D1207: 9.22000000e-04
@@ -22731,7 +22731,7 @@ bins:
   sysZ3D1210: -9.22000000e-04
   sysZ3D1211: 0.0
   sysZ3D1212: 0.0
-  sysZ3D1213: -0.0
+  sysZ3D1213: 0.0
   sysZ3D1214: -9.22000000e-04
   sysZ3D1215: -1.84400000e-03
   sysZ3D1216: 0.0
@@ -22739,11 +22739,11 @@ bins:
   sysZ3D1218: -1.84400000e-03
   sysZ3D1219: 9.22000000e-04
   sysZ3D1220: 0.0
-  sysZ3D1221: -0.0
+  sysZ3D1221: 0.0
   sysZ3D1222: -9.22000000e-04
   sysZ3D1223: -9.22000000e-04
   sysZ3D1224: -9.22000000e-04
-  sysZ3D1225: -0.0
+  sysZ3D1225: 0.0
   sysZ3D1226: 9.22000000e-04
   sysZ3D1227: -9.22000000e-04
   sysZ3D1228: -1.84400000e-03
@@ -22751,13 +22751,13 @@ bins:
   sysZ3D1230: 0.0
   sysZ3D1231: 9.22000000e-04
   sysZ3D1232: 0.0
-  sysZ3D1233: -0.0
-  sysZ3D1234: -0.0
-  sysZ3D1235: -0.0
-  sysZ3D1236: -0.0
-  sysZ3D1237: -0.0
+  sysZ3D1233: 0.0
+  sysZ3D1234: 0.0
+  sysZ3D1235: 0.0
+  sysZ3D1236: 0.0
+  sysZ3D1237: 0.0
   sysZ3D1238: 0.0
-  sysZ3D1239: -0.0
+  sysZ3D1239: 0.0
   sysZ3D1240: 0.0
   sysZ3D1241: 0.0
   sysZ3D1242: 0.0
@@ -22765,12 +22765,12 @@ bins:
   sysZ3D1244: 1.84400000e-03
   sysZ3D1245: -9.22000000e-04
   sysZ3D1246: -9.22000000e-04
-  sysZ3D1247: -0.0
+  sysZ3D1247: 0.0
   sysZ3D1248: 9.22000000e-04
-  sysZ3D1249: -0.0
+  sysZ3D1249: 0.0
   sysZ3D1250: 9.22000000e-04
   sysZ3D1251: -9.22000000e-04
-  sysZ3D1252: -0.0
+  sysZ3D1252: 0.0
   sysZ3D1253: 9.22000000e-04
   sysZ3D1254: 9.22000000e-04
   sysZ3D1255: 1.84400000e-03
@@ -22780,7 +22780,7 @@ bins:
   sysZ3D1259: 9.22000000e-04
   sysZ3D1260: -9.22000000e-04
   sysZ3D1261: -9.22000000e-04
-  sysZ3D1262: -0.0
+  sysZ3D1262: 0.0
   sysZ3D1263: 1.84400000e-03
   sysZ3D1264: 0.00922
   sysZ3D1265: -0.00461
@@ -22790,7 +22790,7 @@ bins:
   sysZ3D1269: -9.22000000e-04
   sysZ3D1270: 9.22000000e-04
   sysZ3D1271: 0.0
-  sysZ3D1272: -0.0
+  sysZ3D1272: 0.0
   sysZ3D1273: -2.76600000e-03
   sysZ3D1274: -9.22000000e-04
   sysZ3D1275: 8.29800000e-03
@@ -22824,7 +22824,7 @@ bins:
   sysZ3D1025: -0.00428
   sysZ3D1026: 0.002568
   sysZ3D1027: -1.71200000e-03
-  sysZ3D1028: -0.0
+  sysZ3D1028: 0.0
   sysZ3D1029: -8.56000000e-04
   sysZ3D1030: -8.56000000e-04
   sysZ3D1031: 0.001712
@@ -22846,7 +22846,7 @@ bins:
   sysZ3D1047: -8.56000000e-04
   sysZ3D1048: 0.000856
   sysZ3D1049: 0.000856
-  sysZ3D1050: -0.0
+  sysZ3D1050: 0.0
   sysZ3D1051: 0.0
   sysZ3D1052: 0.0
   sysZ3D1053: -8.56000000e-04
@@ -22865,37 +22865,37 @@ bins:
   sysZ3D1066: 0.000856
   sysZ3D1067: 0.002568
   sysZ3D1068: -1.71200000e-03
-  sysZ3D1069: -0.0
+  sysZ3D1069: 0.0
   sysZ3D1070: 0.000856
-  sysZ3D1071: -0.0
+  sysZ3D1071: 0.0
   sysZ3D1072: -8.56000000e-04
   sysZ3D1073: -1.71200000e-03
   sysZ3D1074: -8.56000000e-04
   sysZ3D1075: -8.56000000e-04
   sysZ3D1076: 0.000856
-  sysZ3D1077: -0.0
-  sysZ3D1078: -0.0
+  sysZ3D1077: 0.0
+  sysZ3D1078: 0.0
   sysZ3D1079: 0.001712
   sysZ3D1080: -8.56000000e-04
   sysZ3D1081: -1.71200000e-03
   sysZ3D1082: 0.0
-  sysZ3D1083: -0.0
+  sysZ3D1083: 0.0
   sysZ3D1084: 0.0
   sysZ3D1085: 0.001712
   sysZ3D1086: 0.000856
   sysZ3D1087: 0.000856
   sysZ3D1088: 0.000856
   sysZ3D1089: -8.56000000e-04
-  sysZ3D1090: -0.0
+  sysZ3D1090: 0.0
   sysZ3D1091: 0.000856
   sysZ3D1092: 0.000856
   sysZ3D1093: -8.56000000e-04
-  sysZ3D1094: -0.0
+  sysZ3D1094: 0.0
   sysZ3D1095: -8.56000000e-04
   sysZ3D1096: -8.56000000e-04
   sysZ3D1097: -8.56000000e-04
   sysZ3D1098: 0.000856
-  sysZ3D1099: -0.0
+  sysZ3D1099: 0.0
   sysZ3D1100: 0.0
   sysZ3D1101: -8.56000000e-04
   sysZ3D1102: 0.000856
@@ -22904,13 +22904,13 @@ bins:
   sysZ3D1105: -6.33440000e-02
   sysZ3D1106: -2.39680000e-02
   sysZ3D1107: -5.13600000e-03
-  sysZ3D1108: -0.0
+  sysZ3D1108: 0.0
   sysZ3D1109: -1.71200000e-03
   sysZ3D1110: 0.0
   sysZ3D1111: 0.0
   sysZ3D1112: 0.001712
   sysZ3D1113: 0.000856
-  sysZ3D1114: -0.0
+  sysZ3D1114: 0.0
   sysZ3D1115: 0.003424
   sysZ3D1116: -8.56000000e-04
   sysZ3D1117: 0.000856
@@ -22941,20 +22941,20 @@ bins:
   sysZ3D1142: 0.001712
   sysZ3D1143: 0.002568
   sysZ3D1144: -1.71200000e-03
-  sysZ3D1145: -0.0
-  sysZ3D1146: -0.0
+  sysZ3D1145: 0.0
+  sysZ3D1146: 0.0
   sysZ3D1147: -8.56000000e-04
   sysZ3D1148: -8.56000000e-04
   sysZ3D1149: -8.56000000e-04
-  sysZ3D1150: -0.0
+  sysZ3D1150: 0.0
   sysZ3D1151: 0.001712
   sysZ3D1152: 0.000856
-  sysZ3D1153: -0.0
+  sysZ3D1153: 0.0
   sysZ3D1154: -3.42400000e-03
   sysZ3D1155: 0.00856
   sysZ3D1156: 0.001712
   sysZ3D1157: -3.42400000e-03
-  sysZ3D1158: -0.0
+  sysZ3D1158: 0.0
   sysZ3D1159: 0.002568
   sysZ3D1160: 0.0
   sysZ3D1161: -5.13600000e-03
@@ -22964,34 +22964,34 @@ bins:
   sysZ3D1165: -8.56000000e-04
   sysZ3D1166: 7.70400000e-03
   sysZ3D1167: -1.71200000e-03
-  sysZ3D1168: -0.0
+  sysZ3D1168: 0.0
   sysZ3D1169: -8.56000000e-04
   sysZ3D1170: 0.002568
   sysZ3D1171: -8.56000000e-04
-  sysZ3D1172: -0.0
-  sysZ3D1173: -0.0
+  sysZ3D1172: 0.0
+  sysZ3D1173: 0.0
   sysZ3D1174: -8.56000000e-04
   sysZ3D1175: 0.0
   sysZ3D1176: 0.001712
   sysZ3D1177: 0.002568
   sysZ3D1178: 0.000856
   sysZ3D1179: 0.001712
-  sysZ3D1180: -0.0
-  sysZ3D1181: -0.0
-  sysZ3D1182: -0.0
+  sysZ3D1180: 0.0
+  sysZ3D1181: 0.0
+  sysZ3D1182: 0.0
   sysZ3D1183: 0.000856
   sysZ3D1184: -8.56000000e-04
   sysZ3D1185: -8.56000000e-04
-  sysZ3D1186: -0.0
+  sysZ3D1186: 0.0
   sysZ3D1187: 0.000856
   sysZ3D1188: -8.56000000e-04
-  sysZ3D1189: -0.0
+  sysZ3D1189: 0.0
   sysZ3D1190: 0.0
-  sysZ3D1191: -0.0
+  sysZ3D1191: 0.0
   sysZ3D1192: 0.000856
   sysZ3D1193: 0.000856
   sysZ3D1194: -0.00428
-  sysZ3D1195: -0.0
+  sysZ3D1195: 0.0
   sysZ3D1196: 0.0
   sysZ3D1197: 0.000856
   sysZ3D1198: 0.001712
@@ -22999,16 +22999,16 @@ bins:
   sysZ3D1200: -8.56000000e-04
   sysZ3D1201: 0.0
   sysZ3D1202: 0.0
-  sysZ3D1203: -0.0
-  sysZ3D1204: -0.0
+  sysZ3D1203: 0.0
+  sysZ3D1204: 0.0
   sysZ3D1205: 0.0
-  sysZ3D1206: -0.0
+  sysZ3D1206: 0.0
   sysZ3D1207: 0.0
-  sysZ3D1208: -0.0
-  sysZ3D1209: -0.0
+  sysZ3D1208: 0.0
+  sysZ3D1209: 0.0
   sysZ3D1210: 0.0
-  sysZ3D1211: -0.0
-  sysZ3D1212: -0.0
+  sysZ3D1211: 0.0
+  sysZ3D1212: 0.0
   sysZ3D1213: 0.000856
   sysZ3D1214: 0.000856
   sysZ3D1215: -8.56000000e-04
@@ -23017,27 +23017,27 @@ bins:
   sysZ3D1218: -1.71200000e-03
   sysZ3D1219: 0.0
   sysZ3D1220: 0.0
-  sysZ3D1221: -0.0
-  sysZ3D1222: -0.0
+  sysZ3D1221: 0.0
+  sysZ3D1222: 0.0
   sysZ3D1223: -8.56000000e-04
   sysZ3D1224: -8.56000000e-04
   sysZ3D1225: 0.000856
-  sysZ3D1226: -0.0
+  sysZ3D1226: 0.0
   sysZ3D1227: 0.0
   sysZ3D1228: 0.000856
   sysZ3D1229: -8.56000000e-04
-  sysZ3D1230: -0.0
+  sysZ3D1230: 0.0
   sysZ3D1231: 0.0
-  sysZ3D1232: -0.0
+  sysZ3D1232: 0.0
   sysZ3D1233: 0.0
   sysZ3D1234: 0.0
   sysZ3D1235: -8.56000000e-04
   sysZ3D1236: 0.0
   sysZ3D1237: 0.0
-  sysZ3D1238: -0.0
-  sysZ3D1239: -0.0
-  sysZ3D1240: -0.0
-  sysZ3D1241: -0.0
+  sysZ3D1238: 0.0
+  sysZ3D1239: 0.0
+  sysZ3D1240: 0.0
+  sysZ3D1241: 0.0
   sysZ3D1242: 0.0
   sysZ3D1243: 0.0
   sysZ3D1244: 0.0
@@ -23068,7 +23068,7 @@ bins:
   sysZ3D1269: -8.56000000e-04
   sysZ3D1270: 0.000856
   sysZ3D1271: 0.000856
-  sysZ3D1272: -0.0
+  sysZ3D1272: 0.0
   sysZ3D1273: -8.56000000e-04
   sysZ3D1274: 0.005136
   sysZ3D1275: 0.009416
@@ -23096,7 +23096,7 @@ bins:
   sysZ3D1019: 0.0
   sysZ3D1020: 7.12000000e-04
   sysZ3D1021: -2.13600000e-03
-  sysZ3D1022: -0.0
+  sysZ3D1022: 0.0
   sysZ3D1023: -4.98400000e-03
   sysZ3D1024: 4.27200000e-03
   sysZ3D1025: -1.13920000e-02
@@ -23112,9 +23112,9 @@ bins:
   sysZ3D1035: 7.12000000e-04
   sysZ3D1036: 1.42400000e-03
   sysZ3D1037: 7.12000000e-04
-  sysZ3D1038: -0.0
+  sysZ3D1038: 0.0
   sysZ3D1039: 1.42400000e-03
-  sysZ3D1040: -0.0
+  sysZ3D1040: 0.0
   sysZ3D1041: 1.42400000e-03
   sysZ3D1042: 1.42400000e-03
   sysZ3D1043: 1.42400000e-03
@@ -23131,7 +23131,7 @@ bins:
   sysZ3D1054: 7.12000000e-04
   sysZ3D1055: 7.12000000e-04
   sysZ3D1056: 1.42400000e-03
-  sysZ3D1057: -0.0
+  sysZ3D1057: 0.0
   sysZ3D1058: -1.42400000e-03
   sysZ3D1059: 1.42400000e-03
   sysZ3D1060: 7.12000000e-04
@@ -23143,23 +23143,23 @@ bins:
   sysZ3D1066: -7.12000000e-04
   sysZ3D1067: -1.42400000e-03
   sysZ3D1068: 7.12000000e-04
-  sysZ3D1069: -0.0
+  sysZ3D1069: 0.0
   sysZ3D1070: 7.12000000e-04
   sysZ3D1071: 7.12000000e-04
   sysZ3D1072: 1.42400000e-03
-  sysZ3D1073: -0.0
+  sysZ3D1073: 0.0
   sysZ3D1074: 7.12000000e-04
   sysZ3D1075: 0.0
   sysZ3D1076: -7.12000000e-04
   sysZ3D1077: 1.42400000e-03
   sysZ3D1078: -1.42400000e-03
-  sysZ3D1079: -0.0
+  sysZ3D1079: 0.0
   sysZ3D1080: 2.13600000e-03
-  sysZ3D1081: -0.0
+  sysZ3D1081: 0.0
   sysZ3D1082: -7.12000000e-04
   sysZ3D1083: -1.42400000e-03
   sysZ3D1084: -1.42400000e-03
-  sysZ3D1085: -0.0
+  sysZ3D1085: 0.0
   sysZ3D1086: -7.12000000e-04
   sysZ3D1087: -7.12000000e-04
   sysZ3D1088: 0.0
@@ -23172,7 +23172,7 @@ bins:
   sysZ3D1095: -7.12000000e-04
   sysZ3D1096: 7.12000000e-04
   sysZ3D1097: 7.12000000e-04
-  sysZ3D1098: -0.0
+  sysZ3D1098: 0.0
   sysZ3D1099: 7.12000000e-04
   sysZ3D1100: 0.0
   sysZ3D1101: -1.42400000e-03
@@ -23182,7 +23182,7 @@ bins:
   sysZ3D1105: -4.48560000e-02
   sysZ3D1106: -1.63760000e-02
   sysZ3D1107: -2.84800000e-03
-  sysZ3D1108: -0.0
+  sysZ3D1108: 0.0
   sysZ3D1109: -2.84800000e-03
   sysZ3D1110: 0.0
   sysZ3D1111: 1.42400000e-03
@@ -23195,13 +23195,13 @@ bins:
   sysZ3D1118: -2.13600000e-03
   sysZ3D1119: -7.12000000e-04
   sysZ3D1120: 7.12000000e-04
-  sysZ3D1121: -0.0
+  sysZ3D1121: 0.0
   sysZ3D1122: -1.42400000e-03
   sysZ3D1123: -7.12000000e-04
   sysZ3D1124: -7.12000000e-04
   sysZ3D1125: 7.12000000e-04
   sysZ3D1126: 0.0
-  sysZ3D1127: -0.0
+  sysZ3D1127: 0.0
   sysZ3D1128: -2.84800000e-03
   sysZ3D1129: -2.13600000e-03
   sysZ3D1130: 1.42400000e-03
@@ -23216,22 +23216,22 @@ bins:
   sysZ3D1139: -2.13600000e-03
   sysZ3D1140: 2.84800000e-03
   sysZ3D1141: -2.84800000e-03
-  sysZ3D1142: -0.0
+  sysZ3D1142: 0.0
   sysZ3D1143: -4.27200000e-03
   sysZ3D1144: -2.84800000e-03
   sysZ3D1145: 4.27200000e-03
-  sysZ3D1146: -0.0
+  sysZ3D1146: 0.0
   sysZ3D1147: 0.0
-  sysZ3D1148: -0.0
-  sysZ3D1149: -0.0
+  sysZ3D1148: 0.0
+  sysZ3D1149: 0.0
   sysZ3D1150: 7.12000000e-04
   sysZ3D1151: 7.12000000e-04
   sysZ3D1152: -7.12000000e-04
-  sysZ3D1153: -0.0
+  sysZ3D1153: 0.0
   sysZ3D1154: 2.13600000e-03
   sysZ3D1155: 7.12000000e-04
-  sysZ3D1156: -0.0
-  sysZ3D1157: -0.0
+  sysZ3D1156: 0.0
+  sysZ3D1157: 0.0
   sysZ3D1158: -1.42400000e-03
   sysZ3D1159: -2.13600000e-03
   sysZ3D1160: 2.84800000e-03
@@ -23248,19 +23248,19 @@ bins:
   sysZ3D1171: -7.12000000e-04
   sysZ3D1172: -7.12000000e-04
   sysZ3D1173: 0.0
-  sysZ3D1174: -0.0
-  sysZ3D1175: -0.0
+  sysZ3D1174: 0.0
+  sysZ3D1175: 0.0
   sysZ3D1176: 2.13600000e-03
   sysZ3D1177: 2.84800000e-03
   sysZ3D1178: 0.0
   sysZ3D1179: 1.42400000e-03
   sysZ3D1180: -7.12000000e-04
-  sysZ3D1181: -0.0
+  sysZ3D1181: 0.0
   sysZ3D1182: 0.0
   sysZ3D1183: 1.42400000e-03
   sysZ3D1184: -1.42400000e-03
   sysZ3D1185: -7.12000000e-04
-  sysZ3D1186: -0.0
+  sysZ3D1186: 0.0
   sysZ3D1187: 7.12000000e-04
   sysZ3D1188: -7.12000000e-04
   sysZ3D1189: -7.12000000e-04
@@ -23270,7 +23270,7 @@ bins:
   sysZ3D1193: 0.0
   sysZ3D1194: -2.84800000e-03
   sysZ3D1195: 0.0
-  sysZ3D1196: -0.0
+  sysZ3D1196: 0.0
   sysZ3D1197: 7.12000000e-04
   sysZ3D1198: 0.0
   sysZ3D1199: 7.12000000e-04
@@ -23278,14 +23278,14 @@ bins:
   sysZ3D1201: -7.12000000e-04
   sysZ3D1202: 0.0
   sysZ3D1203: 7.12000000e-04
-  sysZ3D1204: -0.0
+  sysZ3D1204: 0.0
   sysZ3D1205: 0.0
   sysZ3D1206: 7.12000000e-04
   sysZ3D1207: 0.0
-  sysZ3D1208: -0.0
-  sysZ3D1209: -0.0
-  sysZ3D1210: -0.0
-  sysZ3D1211: -0.0
+  sysZ3D1208: 0.0
+  sysZ3D1209: 0.0
+  sysZ3D1210: 0.0
+  sysZ3D1211: 0.0
   sysZ3D1212: 0.0
   sysZ3D1213: 7.12000000e-04
   sysZ3D1214: 7.12000000e-04
@@ -23297,31 +23297,31 @@ bins:
   sysZ3D1220: 0.0
   sysZ3D1221: -7.12000000e-04
   sysZ3D1222: 0.0
-  sysZ3D1223: -0.0
+  sysZ3D1223: 0.0
   sysZ3D1224: -7.12000000e-04
   sysZ3D1225: 0.0
   sysZ3D1226: 0.0
   sysZ3D1227: 0.0
   sysZ3D1228: -1.42400000e-03
-  sysZ3D1229: -0.0
-  sysZ3D1230: -0.0
-  sysZ3D1231: -0.0
+  sysZ3D1229: 0.0
+  sysZ3D1230: 0.0
+  sysZ3D1231: 0.0
   sysZ3D1232: 0.0
-  sysZ3D1233: -0.0
+  sysZ3D1233: 0.0
   sysZ3D1234: 0.0
   sysZ3D1235: 0.0
-  sysZ3D1236: -0.0
+  sysZ3D1236: 0.0
   sysZ3D1237: 0.0
   sysZ3D1238: 0.0
-  sysZ3D1239: -0.0
-  sysZ3D1240: -0.0
-  sysZ3D1241: -0.0
+  sysZ3D1239: 0.0
+  sysZ3D1240: 0.0
+  sysZ3D1241: 0.0
   sysZ3D1242: 0.0
   sysZ3D1243: 0.0
   sysZ3D1244: -7.12000000e-04
   sysZ3D1245: 0.0
   sysZ3D1246: -7.12000000e-04
-  sysZ3D1247: -0.0
+  sysZ3D1247: 0.0
   sysZ3D1248: 7.12000000e-04
   sysZ3D1249: -7.12000000e-04
   sysZ3D1250: -7.12000000e-04
@@ -23335,7 +23335,7 @@ bins:
   sysZ3D1258: -1.42400000e-03
   sysZ3D1259: 2.13600000e-03
   sysZ3D1260: 0.0
-  sysZ3D1261: -0.0
+  sysZ3D1261: 0.0
   sysZ3D1262: 7.12000000e-04
   sysZ3D1263: 2.13600000e-03
   sysZ3D1264: 0.006408
@@ -23343,18 +23343,18 @@ bins:
   sysZ3D1266: -6.40800000e-03
   sysZ3D1267: -2.84800000e-03
   sysZ3D1268: 7.12000000e-04
-  sysZ3D1269: -0.0
+  sysZ3D1269: 0.0
   sysZ3D1270: 7.12000000e-04
   sysZ3D1271: 1.42400000e-03
-  sysZ3D1272: -0.0
-  sysZ3D1273: -0.0
-  sysZ3D1274: -0.0
+  sysZ3D1272: 0.0
+  sysZ3D1273: 0.0
+  sysZ3D1274: 0.0
   sysZ3D1275: 0.006408
   sys,uncor: 0.062656
   ATLAS_LUMI: 1.28160000e-01
 - stat: 0.110396
   sysZ3D1001: -3.43200000e-03
-  sysZ3D1002: -0.0
+  sysZ3D1002: 0.0
   sysZ3D1003: 5.72000000e-04
   sysZ3D1004: 0.0
   sysZ3D1005: 0.0
@@ -23372,7 +23372,7 @@ bins:
   sysZ3D1017: 0.0
   sysZ3D1018: 0.0
   sysZ3D1019: 0.0
-  sysZ3D1020: -0.0
+  sysZ3D1020: 0.0
   sysZ3D1021: 0.0
   sysZ3D1022: 0.0
   sysZ3D1023: 5.72000000e-04
@@ -23385,11 +23385,11 @@ bins:
   sysZ3D1030: 5.72000000e-04
   sysZ3D1031: -1.14400000e-03
   sysZ3D1032: -1.14400000e-03
-  sysZ3D1033: -0.0
-  sysZ3D1034: -0.0
+  sysZ3D1033: 0.0
+  sysZ3D1034: 0.0
   sysZ3D1035: 0.0
   sysZ3D1036: -1.71600000e-03
-  sysZ3D1037: -0.0
+  sysZ3D1037: 0.0
   sysZ3D1038: -1.71600000e-03
   sysZ3D1039: -1.14400000e-03
   sysZ3D1040: -1.14400000e-03
@@ -23410,13 +23410,13 @@ bins:
   sysZ3D1055: 5.72000000e-04
   sysZ3D1056: -5.72000000e-04
   sysZ3D1057: 0.0
-  sysZ3D1058: -0.0
+  sysZ3D1058: 0.0
   sysZ3D1059: 1.71600000e-03
   sysZ3D1060: 0.0
   sysZ3D1061: 1.14400000e-03
   sysZ3D1062: 1.71600000e-03
   sysZ3D1063: -5.72000000e-04
-  sysZ3D1064: -0.0
+  sysZ3D1064: 0.0
   sysZ3D1065: 1.71600000e-03
   sysZ3D1066: -5.72000000e-04
   sysZ3D1067: -5.72000000e-04
@@ -23431,18 +23431,18 @@ bins:
   sysZ3D1076: 5.72000000e-04
   sysZ3D1077: 5.72000000e-04
   sysZ3D1078: 1.14400000e-03
-  sysZ3D1079: -0.0
+  sysZ3D1079: 0.0
   sysZ3D1080: 5.72000000e-04
   sysZ3D1081: 5.72000000e-04
-  sysZ3D1082: -0.0
+  sysZ3D1082: 0.0
   sysZ3D1083: 5.72000000e-04
   sysZ3D1084: 1.71600000e-03
   sysZ3D1085: -1.14400000e-03
   sysZ3D1086: -5.72000000e-04
   sysZ3D1087: 5.72000000e-04
-  sysZ3D1088: -0.0
+  sysZ3D1088: 0.0
   sysZ3D1089: -5.72000000e-04
-  sysZ3D1090: -0.0
+  sysZ3D1090: 0.0
   sysZ3D1091: -1.14400000e-03
   sysZ3D1092: -5.72000000e-04
   sysZ3D1093: 1.71600000e-03
@@ -23460,8 +23460,8 @@ bins:
   sysZ3D1105: -3.03160000e-02
   sysZ3D1106: -9.15200000e-03
   sysZ3D1107: -1.14400000e-03
-  sysZ3D1108: -0.0
-  sysZ3D1109: -0.0
+  sysZ3D1108: 0.0
+  sysZ3D1109: 0.0
   sysZ3D1110: 0.0
   sysZ3D1111: -5.72000000e-04
   sysZ3D1112: 5.72000000e-04
@@ -23470,24 +23470,24 @@ bins:
   sysZ3D1115: -0.00286
   sysZ3D1116: -2.28800000e-03
   sysZ3D1117: 0.0
-  sysZ3D1118: -0.0
-  sysZ3D1119: -0.0
-  sysZ3D1120: -0.0
-  sysZ3D1121: -0.0
+  sysZ3D1118: 0.0
+  sysZ3D1119: 0.0
+  sysZ3D1120: 0.0
+  sysZ3D1121: 0.0
   sysZ3D1122: -5.72000000e-04
   sysZ3D1123: -1.71600000e-03
   sysZ3D1124: 5.72000000e-04
   sysZ3D1125: 0.00286
   sysZ3D1126: -5.72000000e-04
   sysZ3D1127: 1.71600000e-03
-  sysZ3D1128: -0.0
+  sysZ3D1128: 0.0
   sysZ3D1129: 1.14400000e-03
   sysZ3D1130: -8.00800000e-03
   sysZ3D1131: 0.00572
   sysZ3D1132: 4.00400000e-03
   sysZ3D1133: 0.00572
   sysZ3D1134: 0.005148
-  sysZ3D1135: -0.0
+  sysZ3D1135: 0.0
   sysZ3D1136: 1.14400000e-03
   sysZ3D1137: -1.71600000e-03
   sysZ3D1138: -5.72000000e-04
@@ -23505,7 +23505,7 @@ bins:
   sysZ3D1150: 0.0
   sysZ3D1151: 5.72000000e-04
   sysZ3D1152: 0.0
-  sysZ3D1153: -0.0
+  sysZ3D1153: 0.0
   sysZ3D1154: -5.72000000e-04
   sysZ3D1155: 1.14400000e-03
   sysZ3D1156: 0.0
@@ -23521,7 +23521,7 @@ bins:
   sysZ3D1166: -1.14400000e-03
   sysZ3D1167: -1.71600000e-03
   sysZ3D1168: -1.14400000e-03
-  sysZ3D1169: -0.0
+  sysZ3D1169: 0.0
   sysZ3D1170: 1.14400000e-03
   sysZ3D1171: -5.72000000e-04
   sysZ3D1172: -5.72000000e-04
@@ -23530,10 +23530,10 @@ bins:
   sysZ3D1175: 0.0
   sysZ3D1176: 1.71600000e-03
   sysZ3D1177: 1.14400000e-03
-  sysZ3D1178: -0.0
+  sysZ3D1178: 0.0
   sysZ3D1179: 1.14400000e-03
   sysZ3D1180: -5.72000000e-04
-  sysZ3D1181: -0.0
+  sysZ3D1181: 0.0
   sysZ3D1182: 0.0
   sysZ3D1183: 5.72000000e-04
   sysZ3D1184: -5.72000000e-04
@@ -23560,12 +23560,12 @@ bins:
   sysZ3D1205: 0.0
   sysZ3D1206: 0.0
   sysZ3D1207: 0.0
-  sysZ3D1208: -0.0
-  sysZ3D1209: -0.0
+  sysZ3D1208: 0.0
+  sysZ3D1209: 0.0
   sysZ3D1210: 0.0
-  sysZ3D1211: -0.0
-  sysZ3D1212: -0.0
-  sysZ3D1213: -0.0
+  sysZ3D1211: 0.0
+  sysZ3D1212: 0.0
+  sysZ3D1213: 0.0
   sysZ3D1214: -5.72000000e-04
   sysZ3D1215: -1.14400000e-03
   sysZ3D1216: 0.0
@@ -23574,32 +23574,32 @@ bins:
   sysZ3D1219: -5.72000000e-04
   sysZ3D1220: 0.0
   sysZ3D1221: -5.72000000e-04
-  sysZ3D1222: -0.0
-  sysZ3D1223: -0.0
+  sysZ3D1222: 0.0
+  sysZ3D1223: 0.0
   sysZ3D1224: 5.72000000e-04
   sysZ3D1225: 5.72000000e-04
-  sysZ3D1226: -0.0
+  sysZ3D1226: 0.0
   sysZ3D1227: 5.72000000e-04
   sysZ3D1228: -1.14400000e-03
-  sysZ3D1229: -0.0
-  sysZ3D1230: -0.0
-  sysZ3D1231: -0.0
+  sysZ3D1229: 0.0
+  sysZ3D1230: 0.0
+  sysZ3D1231: 0.0
   sysZ3D1232: 0.0
-  sysZ3D1233: -0.0
-  sysZ3D1234: -0.0
-  sysZ3D1235: -0.0
+  sysZ3D1233: 0.0
+  sysZ3D1234: 0.0
+  sysZ3D1235: 0.0
   sysZ3D1236: 0.0
   sysZ3D1237: 0.0
   sysZ3D1238: -5.72000000e-04
-  sysZ3D1239: -0.0
-  sysZ3D1240: -0.0
-  sysZ3D1241: -0.0
+  sysZ3D1239: 0.0
+  sysZ3D1240: 0.0
+  sysZ3D1241: 0.0
   sysZ3D1242: 0.0
   sysZ3D1243: 0.0
-  sysZ3D1244: -0.0
+  sysZ3D1244: 0.0
   sysZ3D1245: -5.72000000e-04
   sysZ3D1246: 0.0
-  sysZ3D1247: -0.0
+  sysZ3D1247: 0.0
   sysZ3D1248: -5.72000000e-04
   sysZ3D1249: 0.0
   sysZ3D1250: -5.72000000e-04
@@ -23613,18 +23613,18 @@ bins:
   sysZ3D1258: -5.72000000e-04
   sysZ3D1259: 0.0
   sysZ3D1260: -5.72000000e-04
-  sysZ3D1261: -0.0
+  sysZ3D1261: 0.0
   sysZ3D1262: 5.72000000e-04
   sysZ3D1263: 1.14400000e-03
   sysZ3D1264: 6.29200000e-03
-  sysZ3D1265: -0.0
+  sysZ3D1265: 0.0
   sysZ3D1266: -0.00572
   sysZ3D1267: -1.71600000e-03
   sysZ3D1268: 5.72000000e-04
   sysZ3D1269: -5.72000000e-04
   sysZ3D1270: 5.72000000e-04
   sysZ3D1271: 1.71600000e-03
-  sysZ3D1272: -0.0
+  sysZ3D1272: 0.0
   sysZ3D1273: -2.28800000e-03
   sysZ3D1274: -5.72000000e-04
   sysZ3D1275: 6.86400000e-03
@@ -23632,7 +23632,7 @@ bins:
   ATLAS_LUMI: 1.02960000e-01
 - stat: 0.088102
   sysZ3D1001: -2.43600000e-03
-  sysZ3D1002: -0.0
+  sysZ3D1002: 0.0
   sysZ3D1003: 4.06000000e-04
   sysZ3D1004: 0.0
   sysZ3D1005: 0.0
@@ -23650,7 +23650,7 @@ bins:
   sysZ3D1017: 0.0
   sysZ3D1018: 0.0
   sysZ3D1019: 0.0
-  sysZ3D1020: -0.0
+  sysZ3D1020: 0.0
   sysZ3D1021: 8.12000000e-04
   sysZ3D1022: 1.21800000e-03
   sysZ3D1023: 2.84200000e-03
@@ -23661,16 +23661,16 @@ bins:
   sysZ3D1028: 8.12000000e-04
   sysZ3D1029: 8.12000000e-04
   sysZ3D1030: 4.06000000e-04
-  sysZ3D1031: -0.0
+  sysZ3D1031: 0.0
   sysZ3D1032: 4.06000000e-04
   sysZ3D1033: 4.06000000e-04
-  sysZ3D1034: -0.0
+  sysZ3D1034: 0.0
   sysZ3D1035: 1.21800000e-03
   sysZ3D1036: 4.06000000e-04
   sysZ3D1037: 0.0
   sysZ3D1038: 1.21800000e-03
   sysZ3D1039: 4.06000000e-04
-  sysZ3D1040: -0.0
+  sysZ3D1040: 0.0
   sysZ3D1041: 4.06000000e-04
   sysZ3D1042: 0.0
   sysZ3D1043: -8.12000000e-04
@@ -23679,7 +23679,7 @@ bins:
   sysZ3D1046: 8.12000000e-04
   sysZ3D1047: 4.06000000e-04
   sysZ3D1048: -4.06000000e-04
-  sysZ3D1049: -0.0
+  sysZ3D1049: 0.0
   sysZ3D1050: 1.21800000e-03
   sysZ3D1051: 0.0
   sysZ3D1052: -4.06000000e-04
@@ -23695,14 +23695,14 @@ bins:
   sysZ3D1062: -1.21800000e-03
   sysZ3D1063: 0.0
   sysZ3D1064: 4.06000000e-04
-  sysZ3D1065: -0.0
+  sysZ3D1065: 0.0
   sysZ3D1066: -4.06000000e-04
-  sysZ3D1067: -0.0
+  sysZ3D1067: 0.0
   sysZ3D1068: 1.62400000e-03
   sysZ3D1069: -1.21800000e-03
   sysZ3D1070: 0.0
   sysZ3D1071: 4.06000000e-04
-  sysZ3D1072: -0.0
+  sysZ3D1072: 0.0
   sysZ3D1073: -4.06000000e-04
   sysZ3D1074: 4.06000000e-04
   sysZ3D1075: 8.12000000e-04
@@ -23712,7 +23712,7 @@ bins:
   sysZ3D1079: 8.12000000e-04
   sysZ3D1080: -4.06000000e-04
   sysZ3D1081: 1.21800000e-03
-  sysZ3D1082: -0.0
+  sysZ3D1082: 0.0
   sysZ3D1083: -1.21800000e-03
   sysZ3D1084: -1.21800000e-03
   sysZ3D1085: 0.0
@@ -23720,15 +23720,15 @@ bins:
   sysZ3D1087: 8.12000000e-04
   sysZ3D1088: 8.12000000e-04
   sysZ3D1089: -4.06000000e-04
-  sysZ3D1090: -0.0
+  sysZ3D1090: 0.0
   sysZ3D1091: 1.21800000e-03
   sysZ3D1092: -1.21800000e-03
-  sysZ3D1093: -0.0
-  sysZ3D1094: -0.0
+  sysZ3D1093: 0.0
+  sysZ3D1094: 0.0
   sysZ3D1095: 4.06000000e-04
   sysZ3D1096: 1.62400000e-03
   sysZ3D1097: 8.12000000e-04
-  sysZ3D1098: -0.0
+  sysZ3D1098: 0.0
   sysZ3D1099: 4.06000000e-04
   sysZ3D1100: -8.12000000e-04
   sysZ3D1101: 4.06000000e-04
@@ -23738,8 +23738,8 @@ bins:
   sysZ3D1105: -1.90820000e-02
   sysZ3D1106: -5.68400000e-03
   sysZ3D1107: -8.12000000e-04
-  sysZ3D1108: -0.0
-  sysZ3D1109: -0.0
+  sysZ3D1108: 0.0
+  sysZ3D1109: 0.0
   sysZ3D1110: 0.0
   sysZ3D1111: 4.06000000e-04
   sysZ3D1112: 0.0
@@ -23771,12 +23771,12 @@ bins:
   sysZ3D1138: 1.21800000e-03
   sysZ3D1139: 0.0
   sysZ3D1140: -4.06000000e-04
-  sysZ3D1141: -0.0
+  sysZ3D1141: 0.0
   sysZ3D1142: -4.06000000e-04
-  sysZ3D1143: -0.0
+  sysZ3D1143: 0.0
   sysZ3D1144: -1.21800000e-03
   sysZ3D1145: -4.06000000e-04
-  sysZ3D1146: -0.0
+  sysZ3D1146: 0.0
   sysZ3D1147: -4.06000000e-04
   sysZ3D1148: -4.06000000e-04
   sysZ3D1149: -8.12000000e-04
@@ -23785,17 +23785,17 @@ bins:
   sysZ3D1152: -8.12000000e-04
   sysZ3D1153: 0.0
   sysZ3D1154: 4.06000000e-04
-  sysZ3D1155: -0.0
+  sysZ3D1155: 0.0
   sysZ3D1156: 0.0
   sysZ3D1157: 4.06000000e-04
-  sysZ3D1158: -0.0
+  sysZ3D1158: 0.0
   sysZ3D1159: 2.84200000e-03
   sysZ3D1160: -8.12000000e-04
   sysZ3D1161: -1.21800000e-03
   sysZ3D1162: 1.21800000e-03
   sysZ3D1163: 8.12000000e-04
   sysZ3D1164: -4.46600000e-03
-  sysZ3D1165: -0.0
+  sysZ3D1165: 0.0
   sysZ3D1166: -3.65400000e-03
   sysZ3D1167: -2.84200000e-03
   sysZ3D1168: -8.12000000e-04
@@ -23810,8 +23810,8 @@ bins:
   sysZ3D1177: 8.12000000e-04
   sysZ3D1178: 4.06000000e-04
   sysZ3D1179: 8.12000000e-04
-  sysZ3D1180: -0.0
-  sysZ3D1181: -0.0
+  sysZ3D1180: 0.0
+  sysZ3D1181: 0.0
   sysZ3D1182: 0.0
   sysZ3D1183: 4.06000000e-04
   sysZ3D1184: -8.12000000e-04
@@ -23829,8 +23829,8 @@ bins:
   sysZ3D1196: 0.0
   sysZ3D1197: 4.06000000e-04
   sysZ3D1198: 4.06000000e-04
-  sysZ3D1199: -0.0
-  sysZ3D1200: -0.0
+  sysZ3D1199: 0.0
+  sysZ3D1200: 0.0
   sysZ3D1201: -4.06000000e-04
   sysZ3D1202: 0.0
   sysZ3D1203: 4.06000000e-04
@@ -23840,36 +23840,36 @@ bins:
   sysZ3D1207: 0.0
   sysZ3D1208: 0.0
   sysZ3D1209: -4.06000000e-04
-  sysZ3D1210: -0.0
-  sysZ3D1211: -0.0
+  sysZ3D1210: 0.0
+  sysZ3D1211: 0.0
   sysZ3D1212: 4.06000000e-04
   sysZ3D1213: 4.06000000e-04
   sysZ3D1214: 4.06000000e-04
   sysZ3D1215: 0.0
-  sysZ3D1216: -0.0
+  sysZ3D1216: 0.0
   sysZ3D1217: 0.0
   sysZ3D1218: 8.12000000e-04
   sysZ3D1219: 8.12000000e-04
-  sysZ3D1220: -0.0
+  sysZ3D1220: 0.0
   sysZ3D1221: -4.06000000e-04
-  sysZ3D1222: -0.0
+  sysZ3D1222: 0.0
   sysZ3D1223: -4.06000000e-04
   sysZ3D1224: 0.0
   sysZ3D1225: 4.06000000e-04
   sysZ3D1226: 0.0
   sysZ3D1227: 8.12000000e-04
   sysZ3D1228: -1.21800000e-03
-  sysZ3D1229: -0.0
+  sysZ3D1229: 0.0
   sysZ3D1230: 4.06000000e-04
-  sysZ3D1231: -0.0
-  sysZ3D1232: -0.0
-  sysZ3D1233: -0.0
-  sysZ3D1234: -0.0
+  sysZ3D1231: 0.0
+  sysZ3D1232: 0.0
+  sysZ3D1233: 0.0
+  sysZ3D1234: 0.0
   sysZ3D1235: -4.06000000e-04
   sysZ3D1236: 0.0
   sysZ3D1237: 0.0
-  sysZ3D1238: -0.0
-  sysZ3D1239: -0.0
+  sysZ3D1238: 0.0
+  sysZ3D1239: 0.0
   sysZ3D1240: 4.06000000e-04
   sysZ3D1241: 0.0
   sysZ3D1242: 0.0
@@ -23884,7 +23884,7 @@ bins:
   sysZ3D1251: -4.06000000e-04
   sysZ3D1252: -4.06000000e-04
   sysZ3D1253: 4.06000000e-04
-  sysZ3D1254: -0.0
+  sysZ3D1254: 0.0
   sysZ3D1255: -4.06000000e-04
   sysZ3D1256: 4.06000000e-04
   sysZ3D1257: 0.00203
@@ -23899,7 +23899,7 @@ bins:
   sysZ3D1266: -4.46600000e-03
   sysZ3D1267: -8.12000000e-04
   sysZ3D1268: 4.06000000e-04
-  sysZ3D1269: -0.0
+  sysZ3D1269: 0.0
   sysZ3D1270: 4.06000000e-04
   sysZ3D1271: 1.62400000e-03
   sysZ3D1272: 0.0
@@ -23940,20 +23940,20 @@ bins:
   sysZ3D1029: 0.000246
   sysZ3D1030: -2.46000000e-04
   sysZ3D1031: 0.0
-  sysZ3D1032: -0.0
+  sysZ3D1032: 0.0
   sysZ3D1033: 7.38000000e-04
   sysZ3D1034: -4.92000000e-04
-  sysZ3D1035: -0.0
+  sysZ3D1035: 0.0
   sysZ3D1036: -4.92000000e-04
-  sysZ3D1037: -0.0
-  sysZ3D1038: -0.0
+  sysZ3D1037: 0.0
+  sysZ3D1038: 0.0
   sysZ3D1039: 0.0
   sysZ3D1040: -4.92000000e-04
   sysZ3D1041: -4.92000000e-04
   sysZ3D1042: 0.000492
   sysZ3D1043: 0.000246
   sysZ3D1044: 0.000492
-  sysZ3D1045: -0.0
+  sysZ3D1045: 0.0
   sysZ3D1046: 0.000984
   sysZ3D1047: -4.92000000e-04
   sysZ3D1048: -2.46000000e-04
@@ -23961,7 +23961,7 @@ bins:
   sysZ3D1050: -2.46000000e-04
   sysZ3D1051: 0.000984
   sysZ3D1052: -2.46000000e-04
-  sysZ3D1053: -0.0
+  sysZ3D1053: 0.0
   sysZ3D1054: 0.000246
   sysZ3D1055: 0.000492
   sysZ3D1056: 1.23000000e-03
@@ -23970,7 +23970,7 @@ bins:
   sysZ3D1059: 7.38000000e-04
   sysZ3D1060: -7.38000000e-04
   sysZ3D1061: 0.0
-  sysZ3D1062: -0.0
+  sysZ3D1062: 0.0
   sysZ3D1063: 0.000492
   sysZ3D1064: 0.000246
   sysZ3D1065: -4.92000000e-04
@@ -23983,7 +23983,7 @@ bins:
   sysZ3D1072: 0.000246
   sysZ3D1073: -4.92000000e-04
   sysZ3D1074: -7.38000000e-04
-  sysZ3D1075: -0.0
+  sysZ3D1075: 0.0
   sysZ3D1076: -2.46000000e-04
   sysZ3D1077: 7.38000000e-04
   sysZ3D1078: 0.0
@@ -24002,11 +24002,11 @@ bins:
   sysZ3D1091: -1.23000000e-03
   sysZ3D1092: -4.92000000e-04
   sysZ3D1093: -2.46000000e-04
-  sysZ3D1094: -0.0
+  sysZ3D1094: 0.0
   sysZ3D1095: 7.38000000e-04
   sysZ3D1096: -7.38000000e-04
   sysZ3D1097: 7.38000000e-04
-  sysZ3D1098: -0.0
+  sysZ3D1098: 0.0
   sysZ3D1099: -2.46000000e-04
   sysZ3D1100: 7.38000000e-04
   sysZ3D1101: -7.38000000e-04
@@ -24016,7 +24016,7 @@ bins:
   sysZ3D1105: -9.34800000e-03
   sysZ3D1106: -3.44400000e-03
   sysZ3D1107: -2.46000000e-04
-  sysZ3D1108: -0.0
+  sysZ3D1108: 0.0
   sysZ3D1109: -7.38000000e-04
   sysZ3D1110: 0.0
   sysZ3D1111: 0.000246
@@ -24026,9 +24026,9 @@ bins:
   sysZ3D1115: -2.46000000e-04
   sysZ3D1116: -4.92000000e-04
   sysZ3D1117: -2.46000000e-04
-  sysZ3D1118: -0.0
-  sysZ3D1119: -0.0
-  sysZ3D1120: -0.0
+  sysZ3D1118: 0.0
+  sysZ3D1119: 0.0
+  sysZ3D1120: 0.0
   sysZ3D1121: -2.46000000e-04
   sysZ3D1122: -2.46000000e-04
   sysZ3D1123: -4.92000000e-04
@@ -24045,12 +24045,12 @@ bins:
   sysZ3D1134: 0.000492
   sysZ3D1135: 0.000246
   sysZ3D1136: 0.000492
-  sysZ3D1137: -0.0
+  sysZ3D1137: 0.0
   sysZ3D1138: 0.0
   sysZ3D1139: 0.000246
-  sysZ3D1140: -0.0
-  sysZ3D1141: -0.0
-  sysZ3D1142: -0.0
+  sysZ3D1140: 0.0
+  sysZ3D1141: 0.0
+  sysZ3D1142: 0.0
   sysZ3D1143: 0.0
   sysZ3D1144: 0.0
   sysZ3D1145: 0.000246
@@ -24061,7 +24061,7 @@ bins:
   sysZ3D1150: 0.0
   sysZ3D1151: 0.0
   sysZ3D1152: 0.0
-  sysZ3D1153: -0.0
+  sysZ3D1153: 0.0
   sysZ3D1154: -2.46000000e-04
   sysZ3D1155: 0.000246
   sysZ3D1156: 0.0
@@ -24086,11 +24086,11 @@ bins:
   sysZ3D1175: 0.000246
   sysZ3D1176: 0.000984
   sysZ3D1177: 0.000246
-  sysZ3D1178: -0.0
+  sysZ3D1178: 0.0
   sysZ3D1179: 0.000492
   sysZ3D1180: -4.92000000e-04
   sysZ3D1181: -2.46000000e-04
-  sysZ3D1182: -0.0
+  sysZ3D1182: 0.0
   sysZ3D1183: 0.000246
   sysZ3D1184: -4.92000000e-04
   sysZ3D1185: -2.46000000e-04
@@ -24116,58 +24116,58 @@ bins:
   sysZ3D1205: 0.000246
   sysZ3D1206: 0.000246
   sysZ3D1207: 0.0
-  sysZ3D1208: -0.0
-  sysZ3D1209: -0.0
-  sysZ3D1210: -0.0
-  sysZ3D1211: -0.0
-  sysZ3D1212: -0.0
-  sysZ3D1213: -0.0
+  sysZ3D1208: 0.0
+  sysZ3D1209: 0.0
+  sysZ3D1210: 0.0
+  sysZ3D1211: 0.0
+  sysZ3D1212: 0.0
+  sysZ3D1213: 0.0
   sysZ3D1214: 0.000492
-  sysZ3D1215: -0.0
-  sysZ3D1216: -0.0
+  sysZ3D1215: 0.0
+  sysZ3D1216: 0.0
   sysZ3D1217: 0.000246
   sysZ3D1218: 0.000246
   sysZ3D1219: -2.46000000e-04
   sysZ3D1220: 0.0
   sysZ3D1221: -2.46000000e-04
-  sysZ3D1222: -0.0
+  sysZ3D1222: 0.0
   sysZ3D1223: -2.46000000e-04
   sysZ3D1224: 0.0
   sysZ3D1225: 0.0
   sysZ3D1226: 0.0
   sysZ3D1227: 0.000246
-  sysZ3D1228: -0.0
+  sysZ3D1228: 0.0
   sysZ3D1229: -2.46000000e-04
   sysZ3D1230: 0.0
   sysZ3D1231: -2.46000000e-04
   sysZ3D1232: 0.0
-  sysZ3D1233: -0.0
-  sysZ3D1234: -0.0
-  sysZ3D1235: -0.0
+  sysZ3D1233: 0.0
+  sysZ3D1234: 0.0
+  sysZ3D1235: 0.0
   sysZ3D1236: 0.0
   sysZ3D1237: 0.0
   sysZ3D1238: 0.0
-  sysZ3D1239: -0.0
-  sysZ3D1240: -0.0
+  sysZ3D1239: 0.0
+  sysZ3D1240: 0.0
   sysZ3D1241: 0.0
   sysZ3D1242: 0.0
   sysZ3D1243: 0.0
   sysZ3D1244: 0.000246
   sysZ3D1245: 0.000492
   sysZ3D1246: 0.000246
-  sysZ3D1247: -0.0
+  sysZ3D1247: 0.0
   sysZ3D1248: -2.46000000e-04
   sysZ3D1249: -4.92000000e-04
-  sysZ3D1250: -0.0
+  sysZ3D1250: 0.0
   sysZ3D1251: -1.23000000e-03
   sysZ3D1252: -4.92000000e-04
-  sysZ3D1253: -0.0
-  sysZ3D1254: -0.0
+  sysZ3D1253: 0.0
+  sysZ3D1254: 0.0
   sysZ3D1255: 0.000246
   sysZ3D1256: -4.92000000e-04
   sysZ3D1257: 7.38000000e-04
   sysZ3D1258: -2.46000000e-04
-  sysZ3D1259: -0.0
+  sysZ3D1259: 0.0
   sysZ3D1260: -1.23000000e-03
   sysZ3D1261: 0.000246
   sysZ3D1262: 0.000492
@@ -24177,10 +24177,10 @@ bins:
   sysZ3D1266: -2.95200000e-03
   sysZ3D1267: -7.38000000e-04
   sysZ3D1268: 0.000246
-  sysZ3D1269: -0.0
+  sysZ3D1269: 0.0
   sysZ3D1270: 0.000246
   sysZ3D1271: 1.23000000e-03
-  sysZ3D1272: -0.0
+  sysZ3D1272: 0.0
   sysZ3D1273: -4.92000000e-04
   sysZ3D1274: -2.95200000e-03
   sysZ3D1275: 0.003198
@@ -24242,7 +24242,7 @@ bins:
   sysZ3D1053: -4.92000000e-04
   sysZ3D1054: 2.46000000e-04
   sysZ3D1055: -2.46000000e-04
-  sysZ3D1056: -0.0
+  sysZ3D1056: 0.0
   sysZ3D1057: 4.92000000e-04
   sysZ3D1058: 0.000164
   sysZ3D1059: -3.28000000e-04
@@ -24251,7 +24251,7 @@ bins:
   sysZ3D1062: 0.000164
   sysZ3D1063: -1.64000000e-04
   sysZ3D1064: -8.2e-05
-  sysZ3D1065: -0.0
+  sysZ3D1065: 0.0
   sysZ3D1066: -1.64000000e-04
   sysZ3D1067: 2.46000000e-04
   sysZ3D1068: -4.92000000e-04
@@ -24274,7 +24274,7 @@ bins:
   sysZ3D1085: -1.64000000e-04
   sysZ3D1086: 0.000164
   sysZ3D1087: -7.38000000e-04
-  sysZ3D1088: -0.0
+  sysZ3D1088: 0.0
   sysZ3D1089: -6.56000000e-04
   sysZ3D1090: -1.64000000e-04
   sysZ3D1091: 0.0
@@ -24293,9 +24293,9 @@ bins:
   sysZ3D1104: -5.74000000e-04
   sysZ3D1105: -2.37800000e-03
   sysZ3D1106: -7.38000000e-04
-  sysZ3D1107: -0.0
+  sysZ3D1107: 0.0
   sysZ3D1108: 0.0
-  sysZ3D1109: -0.0
+  sysZ3D1109: 0.0
   sysZ3D1110: 0.0
   sysZ3D1111: 8.2e-05
   sysZ3D1112: 0.0
@@ -24303,7 +24303,7 @@ bins:
   sysZ3D1114: -3.28000000e-04
   sysZ3D1115: 0.000328
   sysZ3D1116: 8.2e-05
-  sysZ3D1117: -0.0
+  sysZ3D1117: 0.0
   sysZ3D1118: -8.2e-05
   sysZ3D1119: -8.2e-05
   sysZ3D1120: 0.0
@@ -24319,35 +24319,35 @@ bins:
   sysZ3D1130: 7.38000000e-04
   sysZ3D1131: 0.000328
   sysZ3D1132: -3.28000000e-04
-  sysZ3D1133: -0.0
+  sysZ3D1133: 0.0
   sysZ3D1134: 1.23000000e-03
   sysZ3D1135: 8.2e-05
   sysZ3D1136: 8.2e-05
-  sysZ3D1137: -0.0
+  sysZ3D1137: 0.0
   sysZ3D1138: 2.46000000e-04
   sysZ3D1139: 2.46000000e-04
   sysZ3D1140: -8.2e-05
   sysZ3D1141: -1.64000000e-04
   sysZ3D1142: 8.2e-05
   sysZ3D1143: 0.0
-  sysZ3D1144: -0.0
+  sysZ3D1144: 0.0
   sysZ3D1145: -8.2e-05
-  sysZ3D1146: -0.0
+  sysZ3D1146: 0.0
   sysZ3D1147: 0.0
-  sysZ3D1148: -0.0
+  sysZ3D1148: 0.0
   sysZ3D1149: -8.2e-05
   sysZ3D1150: 0.0
-  sysZ3D1151: -0.0
+  sysZ3D1151: 0.0
   sysZ3D1152: 0.0
-  sysZ3D1153: -0.0
+  sysZ3D1153: 0.0
   sysZ3D1154: -8.2e-05
   sysZ3D1155: 0.0
-  sysZ3D1156: -0.0
+  sysZ3D1156: 0.0
   sysZ3D1157: 0.0
-  sysZ3D1158: -0.0
+  sysZ3D1158: 0.0
   sysZ3D1159: -8.2e-05
   sysZ3D1160: 8.2e-05
-  sysZ3D1161: -0.0
+  sysZ3D1161: 0.0
   sysZ3D1162: -8.2e-05
   sysZ3D1163: 9.84000000e-04
   sysZ3D1164: -3.52600000e-03
@@ -24355,24 +24355,24 @@ bins:
   sysZ3D1166: 0.000902
   sysZ3D1167: -3.03400000e-03
   sysZ3D1168: -2.46000000e-04
-  sysZ3D1169: -0.0
+  sysZ3D1169: 0.0
   sysZ3D1170: -8.2e-05
   sysZ3D1171: -1.64000000e-04
   sysZ3D1172: -8.2e-05
-  sysZ3D1173: -0.0
+  sysZ3D1173: 0.0
   sysZ3D1174: -1.64000000e-04
   sysZ3D1175: -8.2e-05
   sysZ3D1176: 0.000164
   sysZ3D1177: 0.00041
   sysZ3D1178: -3.28000000e-04
   sysZ3D1179: 2.46000000e-04
-  sysZ3D1180: -0.0
+  sysZ3D1180: 0.0
   sysZ3D1181: 0.0
-  sysZ3D1182: -0.0
+  sysZ3D1182: 0.0
   sysZ3D1183: 0.000164
   sysZ3D1184: -2.46000000e-04
-  sysZ3D1185: -0.0
-  sysZ3D1186: -0.0
+  sysZ3D1185: 0.0
+  sysZ3D1186: 0.0
   sysZ3D1187: 8.2e-05
   sysZ3D1188: -8.2e-05
   sysZ3D1189: -1.64000000e-04
@@ -24384,7 +24384,7 @@ bins:
   sysZ3D1195: 8.2e-05
   sysZ3D1196: 0.0
   sysZ3D1197: 8.2e-05
-  sysZ3D1198: -0.0
+  sysZ3D1198: 0.0
   sysZ3D1199: -8.2e-05
   sysZ3D1200: -1.64000000e-04
   sysZ3D1201: -8.2e-05
@@ -24394,47 +24394,47 @@ bins:
   sysZ3D1205: 0.0
   sysZ3D1206: 8.2e-05
   sysZ3D1207: 0.0
-  sysZ3D1208: -0.0
-  sysZ3D1209: -0.0
-  sysZ3D1210: -0.0
-  sysZ3D1211: -0.0
-  sysZ3D1212: -0.0
-  sysZ3D1213: -0.0
+  sysZ3D1208: 0.0
+  sysZ3D1209: 0.0
+  sysZ3D1210: 0.0
+  sysZ3D1211: 0.0
+  sysZ3D1212: 0.0
+  sysZ3D1213: 0.0
   sysZ3D1214: 0.000164
   sysZ3D1215: 0.000902
-  sysZ3D1216: -0.0
+  sysZ3D1216: 0.0
   sysZ3D1217: 2.46000000e-04
   sysZ3D1218: 8.2e-05
   sysZ3D1219: -1.64000000e-04
   sysZ3D1220: 8.2e-05
   sysZ3D1221: 8.2e-05
-  sysZ3D1222: -0.0
+  sysZ3D1222: 0.0
   sysZ3D1223: 0.0
   sysZ3D1224: 8.2e-05
   sysZ3D1225: 8.2e-05
   sysZ3D1226: 0.0
   sysZ3D1227: 0.000164
   sysZ3D1228: 2.46000000e-04
-  sysZ3D1229: -0.0
+  sysZ3D1229: 0.0
   sysZ3D1230: -2.46000000e-04
   sysZ3D1231: -2.46000000e-04
   sysZ3D1232: 8.2e-05
   sysZ3D1233: 0.0
   sysZ3D1234: -8.2e-05
-  sysZ3D1235: -0.0
+  sysZ3D1235: 0.0
   sysZ3D1236: 8.2e-05
   sysZ3D1237: 0.0
-  sysZ3D1238: -0.0
-  sysZ3D1239: -0.0
-  sysZ3D1240: -0.0
-  sysZ3D1241: -0.0
+  sysZ3D1238: 0.0
+  sysZ3D1239: 0.0
+  sysZ3D1240: 0.0
+  sysZ3D1241: 0.0
   sysZ3D1242: 0.0
   sysZ3D1243: 0.0
-  sysZ3D1244: -0.0
+  sysZ3D1244: 0.0
   sysZ3D1245: 0.000164
   sysZ3D1246: 0.0
-  sysZ3D1247: -0.0
-  sysZ3D1248: -0.0
+  sysZ3D1247: 0.0
+  sysZ3D1248: 0.0
   sysZ3D1249: -2.46000000e-04
   sysZ3D1250: -8.2e-05
   sysZ3D1251: -1.06600000e-03
@@ -24446,7 +24446,7 @@ bins:
   sysZ3D1257: -3.28000000e-04
   sysZ3D1258: -8.2e-05
   sysZ3D1259: 8.2e-05
-  sysZ3D1260: -0.0
+  sysZ3D1260: 0.0
   sysZ3D1261: -8.2e-05
   sysZ3D1262: 0.000164
   sysZ3D1263: 4.92000000e-04
@@ -24459,7 +24459,7 @@ bins:
   sysZ3D1270: 8.2e-05
   sysZ3D1271: 4.92000000e-04
   sysZ3D1272: 0.0
-  sysZ3D1273: -0.0
+  sysZ3D1273: 0.0
   sysZ3D1274: -1.64000000e-04
   sysZ3D1275: 0.001394
   sys,uncor: 0.010742

--- a/nnpdf_data/nnpdf_data/commondata/CMS_1JET_8TEV/uncertainties.yaml
+++ b/nnpdf_data/nnpdf_data/commondata/CMS_1JET_8TEV/uncertainties.yaml
@@ -1403,186 +1403,186 @@ definitions:
     treatment: MULT
     type: CORR
 bins:
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
-  art_sys_4: -0.0
+  art_sys_3: 0.0
+  art_sys_4: 0.0
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
-  art_sys_28: -0.0
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_28: 0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
-  art_sys_39: -0.0
+  art_sys_39: 0.0
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
-  art_sys_45: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
+  art_sys_45: 0.0
   art_sys_46: 0.0
-  art_sys_47: -0.0
-  art_sys_48: -0.0
+  art_sys_47: 0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 0.0
   art_sys_54: 0.0
   art_sys_55: 0.0
-  art_sys_56: -0.0
+  art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
-  art_sys_62: -0.0
-  art_sys_63: -0.0
+  art_sys_62: 0.0
+  art_sys_63: 0.0
   art_sys_64: 0.0
   art_sys_65: 0.0
   art_sys_66: 0.0
   art_sys_67: 0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
-  art_sys_71: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
+  art_sys_71: 0.0
   art_sys_72: 0.0
-  art_sys_73: -0.0
+  art_sys_73: 0.0
   art_sys_74: 0.0
-  art_sys_75: -0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_75: 0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 0.0
-  art_sys_88: -0.0
-  art_sys_89: -0.0
+  art_sys_88: 0.0
+  art_sys_89: 0.0
   art_sys_90: 0.0
   art_sys_91: 0.0
-  art_sys_92: -0.0
+  art_sys_92: 0.0
   art_sys_93: 0.0
   art_sys_94: 0.0
-  art_sys_95: -0.0
-  art_sys_96: -0.0
-  art_sys_97: -0.0
+  art_sys_95: 0.0
+  art_sys_96: 0.0
+  art_sys_97: 0.0
   art_sys_98: 0.0
   art_sys_99: 0.0
-  art_sys_100: -0.0
+  art_sys_100: 0.0
   art_sys_101: 0.0
-  art_sys_102: -0.0
+  art_sys_102: 0.0
   art_sys_103: 0.0
-  art_sys_104: -0.0
+  art_sys_104: 0.0
   art_sys_105: 0.0
   art_sys_106: 0.0
-  art_sys_107: -0.0
-  art_sys_108: -0.0
-  art_sys_109: -0.0
-  art_sys_110: -0.0
-  art_sys_111: -0.0
-  art_sys_112: -0.0
+  art_sys_107: 0.0
+  art_sys_108: 0.0
+  art_sys_109: 0.0
+  art_sys_110: 0.0
+  art_sys_111: 0.0
+  art_sys_112: 0.0
   art_sys_113: 0.0
-  art_sys_114: -0.0
+  art_sys_114: 0.0
   art_sys_115: 0.0
-  art_sys_116: -0.0
+  art_sys_116: 0.0
   art_sys_117: 0.0
   art_sys_118: 0.0
   art_sys_119: 0.0
   art_sys_120: 0.0
   art_sys_121: 0.0
   art_sys_122: 0.0
-  art_sys_123: -0.0
+  art_sys_123: 0.0
   art_sys_124: 0.0
   art_sys_125: 0.0
   art_sys_126: 0.0
-  art_sys_127: -0.0
-  art_sys_128: -0.0
+  art_sys_127: 0.0
+  art_sys_128: 0.0
   art_sys_129: 0.0
   art_sys_130: 0.0
   art_sys_131: 0.0
-  art_sys_132: -0.0
-  art_sys_133: -0.0
+  art_sys_132: 0.0
+  art_sys_133: 0.0
   art_sys_134: 0.0
   art_sys_135: 0.0
   art_sys_136: 0.0
   art_sys_137: 0.0
-  art_sys_138: -0.0
+  art_sys_138: 0.0
   art_sys_139: 0.0
   art_sys_140: 0.0
   art_sys_141: 0.0
-  art_sys_142: -0.0
+  art_sys_142: 0.0
   art_sys_143: 0.0
-  art_sys_144: -0.0
-  art_sys_145: -0.0
+  art_sys_144: 0.0
+  art_sys_145: 0.0
   art_sys_146: 0.0
-  art_sys_147: -0.0
+  art_sys_147: 0.0
   art_sys_148: 0.0
   art_sys_149: 0.0
-  art_sys_150: -0.0
-  art_sys_151: -0.0
-  art_sys_152: -0.0
+  art_sys_150: 0.0
+  art_sys_151: 0.0
+  art_sys_152: 0.0
   art_sys_153: 0.0
   art_sys_154: 0.0
   art_sys_155: 0.0
-  art_sys_156: -0.0
-  art_sys_157: -0.0
+  art_sys_156: 0.0
+  art_sys_157: 0.0
   art_sys_158: 0.0
-  art_sys_159: -0.0
-  art_sys_160: -0.0
-  art_sys_161: -0.0
+  art_sys_159: 0.0
+  art_sys_160: 0.0
+  art_sys_161: 0.0
   art_sys_162: 0.0
   art_sys_163: 0.0
-  art_sys_164: -0.0
+  art_sys_164: 0.0
   art_sys_165: 0.0
-  art_sys_166: -0.0
+  art_sys_166: 0.0
   art_sys_167: 0.0
-  art_sys_168: -0.0
+  art_sys_168: 0.0
   art_sys_169: 0.0
   art_sys_170: 0.0
-  art_sys_171: -0.0
+  art_sys_171: 0.0
   art_sys_172: 0.0
-  art_sys_173: -0.0
-  art_sys_174: -0.0
-  art_sys_175: -0.0
-  art_sys_176: -0.0
+  art_sys_173: 0.0
+  art_sys_174: 0.0
+  art_sys_175: 0.0
+  art_sys_176: 0.0
   art_sys_177: 0.0
   art_sys_178: 0.0
   art_sys_179: 0.0
-  art_sys_180: -0.0
+  art_sys_180: 0.0
   art_sys_181: 0.0
   art_sys_182: 0.0
   art_sys_183: 0.0
@@ -1639,8 +1639,8 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 9.79122475e+02
   Unfolding-: -9.64789970e+02
@@ -1694,186 +1694,186 @@ bins:
   RelativeStatFSR-: -2.65151356e+05
   luminosity_uncertainty: 975.9256
   uncorrelated_uncertainty: 375.356
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
-  art_sys_4: -0.0
+  art_sys_3: 0.0
+  art_sys_4: 0.0
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
-  art_sys_28: -0.0
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_28: 0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
-  art_sys_39: -0.0
+  art_sys_39: 0.0
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
-  art_sys_45: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
+  art_sys_45: 0.0
   art_sys_46: 0.0
-  art_sys_47: -0.0
-  art_sys_48: -0.0
+  art_sys_47: 0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 0.0
   art_sys_54: 0.0
   art_sys_55: 0.0
-  art_sys_56: -0.0
+  art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
-  art_sys_62: -0.0
-  art_sys_63: -0.0
+  art_sys_62: 0.0
+  art_sys_63: 0.0
   art_sys_64: 0.0
   art_sys_65: 0.0
   art_sys_66: 0.0
   art_sys_67: 0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
-  art_sys_71: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
+  art_sys_71: 0.0
   art_sys_72: 0.0
-  art_sys_73: -0.0
+  art_sys_73: 0.0
   art_sys_74: 0.0
-  art_sys_75: -0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_75: 0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 0.0
-  art_sys_88: -0.0
-  art_sys_89: -0.0
+  art_sys_88: 0.0
+  art_sys_89: 0.0
   art_sys_90: 0.0
   art_sys_91: 0.0
-  art_sys_92: -0.0
+  art_sys_92: 0.0
   art_sys_93: 0.0
   art_sys_94: 0.0
-  art_sys_95: -0.0
-  art_sys_96: -0.0
-  art_sys_97: -0.0
+  art_sys_95: 0.0
+  art_sys_96: 0.0
+  art_sys_97: 0.0
   art_sys_98: 0.0
   art_sys_99: 0.0
-  art_sys_100: -0.0
+  art_sys_100: 0.0
   art_sys_101: 0.0
-  art_sys_102: -0.0
+  art_sys_102: 0.0
   art_sys_103: 0.0
-  art_sys_104: -0.0
+  art_sys_104: 0.0
   art_sys_105: 0.0
   art_sys_106: 0.0
-  art_sys_107: -0.0
-  art_sys_108: -0.0
-  art_sys_109: -0.0
-  art_sys_110: -0.0
-  art_sys_111: -0.0
-  art_sys_112: -0.0
+  art_sys_107: 0.0
+  art_sys_108: 0.0
+  art_sys_109: 0.0
+  art_sys_110: 0.0
+  art_sys_111: 0.0
+  art_sys_112: 0.0
   art_sys_113: 0.0
-  art_sys_114: -0.0
+  art_sys_114: 0.0
   art_sys_115: 0.0
-  art_sys_116: -0.0
+  art_sys_116: 0.0
   art_sys_117: 0.0
   art_sys_118: 0.0
   art_sys_119: 0.0
   art_sys_120: 0.0
   art_sys_121: 0.0
   art_sys_122: 0.0
-  art_sys_123: -0.0
+  art_sys_123: 0.0
   art_sys_124: 0.0
   art_sys_125: 0.0
   art_sys_126: 0.0
-  art_sys_127: -0.0
-  art_sys_128: -0.0
+  art_sys_127: 0.0
+  art_sys_128: 0.0
   art_sys_129: 0.0
   art_sys_130: 0.0
   art_sys_131: 0.0
-  art_sys_132: -0.0
-  art_sys_133: -0.0
+  art_sys_132: 0.0
+  art_sys_133: 0.0
   art_sys_134: 0.0
   art_sys_135: 0.0
   art_sys_136: 0.0
   art_sys_137: 0.0
-  art_sys_138: -0.0
+  art_sys_138: 0.0
   art_sys_139: 0.0
   art_sys_140: 0.0
   art_sys_141: 0.0
-  art_sys_142: -0.0
+  art_sys_142: 0.0
   art_sys_143: 0.0
-  art_sys_144: -0.0
-  art_sys_145: -0.0
+  art_sys_144: 0.0
+  art_sys_145: 0.0
   art_sys_146: 0.0
-  art_sys_147: -0.0
+  art_sys_147: 0.0
   art_sys_148: 0.0
   art_sys_149: 0.0
-  art_sys_150: -0.0
-  art_sys_151: -0.0
-  art_sys_152: -0.0
+  art_sys_150: 0.0
+  art_sys_151: 0.0
+  art_sys_152: 0.0
   art_sys_153: 0.0
   art_sys_154: 0.0
   art_sys_155: 0.0
-  art_sys_156: -0.0
-  art_sys_157: -0.0
+  art_sys_156: 0.0
+  art_sys_157: 0.0
   art_sys_158: 0.0
-  art_sys_159: -0.0
-  art_sys_160: -0.0
-  art_sys_161: -0.0
+  art_sys_159: 0.0
+  art_sys_160: 0.0
+  art_sys_161: 0.0
   art_sys_162: 0.0
   art_sys_163: 0.0
-  art_sys_164: -0.0
+  art_sys_164: 0.0
   art_sys_165: 0.0
-  art_sys_166: -0.0
+  art_sys_166: 0.0
   art_sys_167: 0.0
-  art_sys_168: -0.0
+  art_sys_168: 0.0
   art_sys_169: 0.0
   art_sys_170: 0.0
-  art_sys_171: -0.0
+  art_sys_171: 0.0
   art_sys_172: 0.0
-  art_sys_173: -0.0
-  art_sys_174: -0.0
-  art_sys_175: -0.0
-  art_sys_176: -0.0
+  art_sys_173: 0.0
+  art_sys_174: 0.0
+  art_sys_175: 0.0
+  art_sys_176: 0.0
   art_sys_177: 0.0
   art_sys_178: 0.0
   art_sys_179: 0.0
-  art_sys_180: -0.0
+  art_sys_180: 0.0
   art_sys_181: 0.0
   art_sys_182: 0.0
   art_sys_183: 0.0
@@ -1930,8 +1930,8 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 9.79122475e+02
   Unfolding-: -9.64789970e+02
@@ -1985,186 +1985,186 @@ bins:
   RelativeStatFSR-: -2.65151356e+05
   luminosity_uncertainty: 975.9256
   uncorrelated_uncertainty: 375.356
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
-  art_sys_4: -0.0
+  art_sys_3: 0.0
+  art_sys_4: 0.0
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
-  art_sys_28: -0.0
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_28: 0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
-  art_sys_39: -0.0
+  art_sys_39: 0.0
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
-  art_sys_45: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
+  art_sys_45: 0.0
   art_sys_46: 0.0
-  art_sys_47: -0.0
-  art_sys_48: -0.0
+  art_sys_47: 0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 0.0
   art_sys_54: 0.0
   art_sys_55: 0.0
-  art_sys_56: -0.0
+  art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
-  art_sys_62: -0.0
-  art_sys_63: -0.0
+  art_sys_62: 0.0
+  art_sys_63: 0.0
   art_sys_64: 0.0
   art_sys_65: 0.0
   art_sys_66: 0.0
   art_sys_67: 0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
-  art_sys_71: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
+  art_sys_71: 0.0
   art_sys_72: 0.0
-  art_sys_73: -0.0
+  art_sys_73: 0.0
   art_sys_74: 0.0
-  art_sys_75: -0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_75: 0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 0.0
-  art_sys_88: -0.0
-  art_sys_89: -0.0
+  art_sys_88: 0.0
+  art_sys_89: 0.0
   art_sys_90: 0.0
   art_sys_91: 0.0
-  art_sys_92: -0.0
+  art_sys_92: 0.0
   art_sys_93: 0.0
   art_sys_94: 0.0
-  art_sys_95: -0.0
-  art_sys_96: -0.0
-  art_sys_97: -0.0
+  art_sys_95: 0.0
+  art_sys_96: 0.0
+  art_sys_97: 0.0
   art_sys_98: 0.0
   art_sys_99: 0.0
-  art_sys_100: -0.0
+  art_sys_100: 0.0
   art_sys_101: 0.0
-  art_sys_102: -0.0
+  art_sys_102: 0.0
   art_sys_103: 0.0
-  art_sys_104: -0.0
+  art_sys_104: 0.0
   art_sys_105: 0.0
   art_sys_106: 0.0
-  art_sys_107: -0.0
-  art_sys_108: -0.0
-  art_sys_109: -0.0
-  art_sys_110: -0.0
-  art_sys_111: -0.0
-  art_sys_112: -0.0
+  art_sys_107: 0.0
+  art_sys_108: 0.0
+  art_sys_109: 0.0
+  art_sys_110: 0.0
+  art_sys_111: 0.0
+  art_sys_112: 0.0
   art_sys_113: 0.0
-  art_sys_114: -0.0
+  art_sys_114: 0.0
   art_sys_115: 0.0
-  art_sys_116: -0.0
+  art_sys_116: 0.0
   art_sys_117: 0.0
   art_sys_118: 0.0
   art_sys_119: 0.0
   art_sys_120: 0.0
   art_sys_121: 0.0
   art_sys_122: 0.0
-  art_sys_123: -0.0
+  art_sys_123: 0.0
   art_sys_124: 0.0
   art_sys_125: 0.0
   art_sys_126: 0.0
-  art_sys_127: -0.0
-  art_sys_128: -0.0
+  art_sys_127: 0.0
+  art_sys_128: 0.0
   art_sys_129: 0.0
   art_sys_130: 0.0
   art_sys_131: 0.0
-  art_sys_132: -0.0
-  art_sys_133: -0.0
+  art_sys_132: 0.0
+  art_sys_133: 0.0
   art_sys_134: 0.0
   art_sys_135: 0.0
   art_sys_136: 0.0
   art_sys_137: 0.0
-  art_sys_138: -0.0
+  art_sys_138: 0.0
   art_sys_139: 0.0
   art_sys_140: 0.0
   art_sys_141: 0.0
-  art_sys_142: -0.0
+  art_sys_142: 0.0
   art_sys_143: 0.0
-  art_sys_144: -0.0
-  art_sys_145: -0.0
+  art_sys_144: 0.0
+  art_sys_145: 0.0
   art_sys_146: 0.0
-  art_sys_147: -0.0
+  art_sys_147: 0.0
   art_sys_148: 0.0
   art_sys_149: 0.0
-  art_sys_150: -0.0
-  art_sys_151: -0.0
-  art_sys_152: -0.0
+  art_sys_150: 0.0
+  art_sys_151: 0.0
+  art_sys_152: 0.0
   art_sys_153: 0.0
   art_sys_154: 0.0
   art_sys_155: 0.0
-  art_sys_156: -0.0
-  art_sys_157: -0.0
+  art_sys_156: 0.0
+  art_sys_157: 0.0
   art_sys_158: 0.0
-  art_sys_159: -0.0
-  art_sys_160: -0.0
-  art_sys_161: -0.0
+  art_sys_159: 0.0
+  art_sys_160: 0.0
+  art_sys_161: 0.0
   art_sys_162: 0.0
   art_sys_163: 0.0
-  art_sys_164: -0.0
+  art_sys_164: 0.0
   art_sys_165: 0.0
-  art_sys_166: -0.0
+  art_sys_166: 0.0
   art_sys_167: 0.0
-  art_sys_168: -0.0
+  art_sys_168: 0.0
   art_sys_169: 0.0
   art_sys_170: 0.0
-  art_sys_171: -0.0
+  art_sys_171: 0.0
   art_sys_172: 0.0
-  art_sys_173: -0.0
-  art_sys_174: -0.0
-  art_sys_175: -0.0
-  art_sys_176: -0.0
+  art_sys_173: 0.0
+  art_sys_174: 0.0
+  art_sys_175: 0.0
+  art_sys_176: 0.0
   art_sys_177: 0.0
   art_sys_178: 0.0
   art_sys_179: 0.0
-  art_sys_180: -0.0
+  art_sys_180: 0.0
   art_sys_181: 0.0
   art_sys_182: 0.0
   art_sys_183: 0.0
@@ -2221,8 +2221,8 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 9.79122475e+02
   Unfolding-: -9.64789970e+02
@@ -2276,186 +2276,186 @@ bins:
   RelativeStatFSR-: -2.65151356e+05
   luminosity_uncertainty: 975.9256
   uncorrelated_uncertainty: 375.356
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
-  art_sys_4: -0.0
+  art_sys_3: 0.0
+  art_sys_4: 0.0
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
-  art_sys_28: -0.0
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_28: 0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
-  art_sys_39: -0.0
+  art_sys_39: 0.0
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
-  art_sys_45: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
+  art_sys_45: 0.0
   art_sys_46: 0.0
-  art_sys_47: -0.0
-  art_sys_48: -0.0
+  art_sys_47: 0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 0.0
   art_sys_54: 0.0
   art_sys_55: 0.0
-  art_sys_56: -0.0
+  art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
-  art_sys_62: -0.0
-  art_sys_63: -0.0
+  art_sys_62: 0.0
+  art_sys_63: 0.0
   art_sys_64: 0.0
   art_sys_65: 0.0
   art_sys_66: 0.0
   art_sys_67: 0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
-  art_sys_71: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
+  art_sys_71: 0.0
   art_sys_72: 0.0
-  art_sys_73: -0.0
+  art_sys_73: 0.0
   art_sys_74: 0.0
-  art_sys_75: -0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_75: 0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 0.0
-  art_sys_88: -0.0
-  art_sys_89: -0.0
+  art_sys_88: 0.0
+  art_sys_89: 0.0
   art_sys_90: 0.0
   art_sys_91: 0.0
-  art_sys_92: -0.0
+  art_sys_92: 0.0
   art_sys_93: 0.0
   art_sys_94: 0.0
-  art_sys_95: -0.0
-  art_sys_96: -0.0
-  art_sys_97: -0.0
+  art_sys_95: 0.0
+  art_sys_96: 0.0
+  art_sys_97: 0.0
   art_sys_98: 0.0
   art_sys_99: 0.0
-  art_sys_100: -0.0
+  art_sys_100: 0.0
   art_sys_101: 0.0
-  art_sys_102: -0.0
+  art_sys_102: 0.0
   art_sys_103: 0.0
-  art_sys_104: -0.0
+  art_sys_104: 0.0
   art_sys_105: 0.0
   art_sys_106: 0.0
-  art_sys_107: -0.0
-  art_sys_108: -0.0
-  art_sys_109: -0.0
-  art_sys_110: -0.0
-  art_sys_111: -0.0
-  art_sys_112: -0.0
+  art_sys_107: 0.0
+  art_sys_108: 0.0
+  art_sys_109: 0.0
+  art_sys_110: 0.0
+  art_sys_111: 0.0
+  art_sys_112: 0.0
   art_sys_113: 0.0
-  art_sys_114: -0.0
+  art_sys_114: 0.0
   art_sys_115: 0.0
-  art_sys_116: -0.0
+  art_sys_116: 0.0
   art_sys_117: 0.0
   art_sys_118: 0.0
   art_sys_119: 0.0
   art_sys_120: 0.0
   art_sys_121: 0.0
   art_sys_122: 0.0
-  art_sys_123: -0.0
+  art_sys_123: 0.0
   art_sys_124: 0.0
   art_sys_125: 0.0
   art_sys_126: 0.0
-  art_sys_127: -0.0
-  art_sys_128: -0.0
+  art_sys_127: 0.0
+  art_sys_128: 0.0
   art_sys_129: 0.0
   art_sys_130: 0.0
   art_sys_131: 0.0
-  art_sys_132: -0.0
-  art_sys_133: -0.0
+  art_sys_132: 0.0
+  art_sys_133: 0.0
   art_sys_134: 0.0
   art_sys_135: 0.0
   art_sys_136: 0.0
   art_sys_137: 0.0
-  art_sys_138: -0.0
+  art_sys_138: 0.0
   art_sys_139: 0.0
   art_sys_140: 0.0
   art_sys_141: 0.0
-  art_sys_142: -0.0
+  art_sys_142: 0.0
   art_sys_143: 0.0
-  art_sys_144: -0.0
-  art_sys_145: -0.0
+  art_sys_144: 0.0
+  art_sys_145: 0.0
   art_sys_146: 0.0
-  art_sys_147: -0.0
+  art_sys_147: 0.0
   art_sys_148: 0.0
   art_sys_149: 0.0
-  art_sys_150: -0.0
-  art_sys_151: -0.0
-  art_sys_152: -0.0
+  art_sys_150: 0.0
+  art_sys_151: 0.0
+  art_sys_152: 0.0
   art_sys_153: 0.0
   art_sys_154: 0.0
   art_sys_155: 0.0
-  art_sys_156: -0.0
-  art_sys_157: -0.0
+  art_sys_156: 0.0
+  art_sys_157: 0.0
   art_sys_158: 0.0
-  art_sys_159: -0.0
-  art_sys_160: -0.0
-  art_sys_161: -0.0
+  art_sys_159: 0.0
+  art_sys_160: 0.0
+  art_sys_161: 0.0
   art_sys_162: 0.0
   art_sys_163: 0.0
-  art_sys_164: -0.0
+  art_sys_164: 0.0
   art_sys_165: 0.0
-  art_sys_166: -0.0
+  art_sys_166: 0.0
   art_sys_167: 0.0
-  art_sys_168: -0.0
+  art_sys_168: 0.0
   art_sys_169: 0.0
   art_sys_170: 0.0
-  art_sys_171: -0.0
+  art_sys_171: 0.0
   art_sys_172: 0.0
-  art_sys_173: -0.0
-  art_sys_174: -0.0
-  art_sys_175: -0.0
-  art_sys_176: -0.0
+  art_sys_173: 0.0
+  art_sys_174: 0.0
+  art_sys_175: 0.0
+  art_sys_176: 0.0
   art_sys_177: 0.0
   art_sys_178: 0.0
   art_sys_179: 0.0
-  art_sys_180: -0.0
+  art_sys_180: 0.0
   art_sys_181: 0.0
   art_sys_182: 0.0
   art_sys_183: 0.0
@@ -2512,8 +2512,8 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 9.79122475e+02
   Unfolding-: -9.64789970e+02
@@ -2567,186 +2567,186 @@ bins:
   RelativeStatFSR-: -2.65151356e+05
   luminosity_uncertainty: 975.9256
   uncorrelated_uncertainty: 375.356
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
-  art_sys_4: -0.0
+  art_sys_3: 0.0
+  art_sys_4: 0.0
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
-  art_sys_28: -0.0
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_28: 0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
-  art_sys_39: -0.0
+  art_sys_39: 0.0
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
-  art_sys_45: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
+  art_sys_45: 0.0
   art_sys_46: 0.0
-  art_sys_47: -0.0
-  art_sys_48: -0.0
+  art_sys_47: 0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 0.0
   art_sys_54: 0.0
   art_sys_55: 0.0
-  art_sys_56: -0.0
+  art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
-  art_sys_62: -0.0
-  art_sys_63: -0.0
+  art_sys_62: 0.0
+  art_sys_63: 0.0
   art_sys_64: 0.0
   art_sys_65: 0.0
   art_sys_66: 0.0
   art_sys_67: 0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
-  art_sys_71: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
+  art_sys_71: 0.0
   art_sys_72: 0.0
-  art_sys_73: -0.0
+  art_sys_73: 0.0
   art_sys_74: 0.0
-  art_sys_75: -0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_75: 0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 0.0
-  art_sys_88: -0.0
-  art_sys_89: -0.0
+  art_sys_88: 0.0
+  art_sys_89: 0.0
   art_sys_90: 0.0
   art_sys_91: 0.0
-  art_sys_92: -0.0
+  art_sys_92: 0.0
   art_sys_93: 0.0
   art_sys_94: 0.0
-  art_sys_95: -0.0
-  art_sys_96: -0.0
-  art_sys_97: -0.0
+  art_sys_95: 0.0
+  art_sys_96: 0.0
+  art_sys_97: 0.0
   art_sys_98: 0.0
   art_sys_99: 0.0
-  art_sys_100: -0.0
+  art_sys_100: 0.0
   art_sys_101: 0.0
-  art_sys_102: -0.0
+  art_sys_102: 0.0
   art_sys_103: 0.0
-  art_sys_104: -0.0
+  art_sys_104: 0.0
   art_sys_105: 0.0
   art_sys_106: 0.0
-  art_sys_107: -0.0
-  art_sys_108: -0.0
-  art_sys_109: -0.0
-  art_sys_110: -0.0
-  art_sys_111: -0.0
-  art_sys_112: -0.0
+  art_sys_107: 0.0
+  art_sys_108: 0.0
+  art_sys_109: 0.0
+  art_sys_110: 0.0
+  art_sys_111: 0.0
+  art_sys_112: 0.0
   art_sys_113: 0.0
-  art_sys_114: -0.0
+  art_sys_114: 0.0
   art_sys_115: 0.0
-  art_sys_116: -0.0
+  art_sys_116: 0.0
   art_sys_117: 0.0
   art_sys_118: 0.0
   art_sys_119: 0.0
   art_sys_120: 0.0
   art_sys_121: 0.0
   art_sys_122: 0.0
-  art_sys_123: -0.0
+  art_sys_123: 0.0
   art_sys_124: 0.0
   art_sys_125: 0.0
   art_sys_126: 0.0
-  art_sys_127: -0.0
-  art_sys_128: -0.0
+  art_sys_127: 0.0
+  art_sys_128: 0.0
   art_sys_129: 0.0
   art_sys_130: 0.0
   art_sys_131: 0.0
-  art_sys_132: -0.0
-  art_sys_133: -0.0
+  art_sys_132: 0.0
+  art_sys_133: 0.0
   art_sys_134: 0.0
   art_sys_135: 0.0
   art_sys_136: 0.0
   art_sys_137: 0.0
-  art_sys_138: -0.0
+  art_sys_138: 0.0
   art_sys_139: 0.0
   art_sys_140: 0.0
   art_sys_141: 0.0
-  art_sys_142: -0.0
+  art_sys_142: 0.0
   art_sys_143: 0.0
-  art_sys_144: -0.0
-  art_sys_145: -0.0
+  art_sys_144: 0.0
+  art_sys_145: 0.0
   art_sys_146: 0.0
-  art_sys_147: -0.0
+  art_sys_147: 0.0
   art_sys_148: 0.0
   art_sys_149: 0.0
-  art_sys_150: -0.0
-  art_sys_151: -0.0
-  art_sys_152: -0.0
+  art_sys_150: 0.0
+  art_sys_151: 0.0
+  art_sys_152: 0.0
   art_sys_153: 0.0
   art_sys_154: 0.0
   art_sys_155: 0.0
-  art_sys_156: -0.0
-  art_sys_157: -0.0
+  art_sys_156: 0.0
+  art_sys_157: 0.0
   art_sys_158: 0.0
-  art_sys_159: -0.0
-  art_sys_160: -0.0
-  art_sys_161: -0.0
+  art_sys_159: 0.0
+  art_sys_160: 0.0
+  art_sys_161: 0.0
   art_sys_162: 0.0
   art_sys_163: 0.0
-  art_sys_164: -0.0
+  art_sys_164: 0.0
   art_sys_165: 0.0
-  art_sys_166: -0.0
+  art_sys_166: 0.0
   art_sys_167: 0.0
-  art_sys_168: -0.0
+  art_sys_168: 0.0
   art_sys_169: 0.0
   art_sys_170: 0.0
-  art_sys_171: -0.0
+  art_sys_171: 0.0
   art_sys_172: 0.0
-  art_sys_173: -0.0
-  art_sys_174: -0.0
-  art_sys_175: -0.0
-  art_sys_176: -0.0
+  art_sys_173: 0.0
+  art_sys_174: 0.0
+  art_sys_175: 0.0
+  art_sys_176: 0.0
   art_sys_177: 0.0
   art_sys_178: 0.0
   art_sys_179: 0.0
-  art_sys_180: -0.0
+  art_sys_180: 0.0
   art_sys_181: 0.0
   art_sys_182: 0.0
   art_sys_183: 0.0
@@ -2803,8 +2803,8 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 9.79122475e+02
   Unfolding-: -9.64789970e+02
@@ -2858,186 +2858,186 @@ bins:
   RelativeStatFSR-: -2.65151356e+05
   luminosity_uncertainty: 975.9256
   uncorrelated_uncertainty: 375.356
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
-  art_sys_4: -0.0
+  art_sys_3: 0.0
+  art_sys_4: 0.0
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
-  art_sys_28: -0.0
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_28: 0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
-  art_sys_39: -0.0
+  art_sys_39: 0.0
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
-  art_sys_45: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
+  art_sys_45: 0.0
   art_sys_46: 0.0
-  art_sys_47: -0.0
-  art_sys_48: -0.0
+  art_sys_47: 0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 0.0
   art_sys_54: 0.0
   art_sys_55: 0.0
-  art_sys_56: -0.0
+  art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
-  art_sys_62: -0.0
-  art_sys_63: -0.0
+  art_sys_62: 0.0
+  art_sys_63: 0.0
   art_sys_64: 0.0
   art_sys_65: 0.0
   art_sys_66: 0.0
   art_sys_67: 0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
-  art_sys_71: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
+  art_sys_71: 0.0
   art_sys_72: 0.0
-  art_sys_73: -0.0
+  art_sys_73: 0.0
   art_sys_74: 0.0
-  art_sys_75: -0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_75: 0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 0.0
-  art_sys_88: -0.0
-  art_sys_89: -0.0
+  art_sys_88: 0.0
+  art_sys_89: 0.0
   art_sys_90: 0.0
   art_sys_91: 0.0
-  art_sys_92: -0.0
+  art_sys_92: 0.0
   art_sys_93: 0.0
   art_sys_94: 0.0
-  art_sys_95: -0.0
-  art_sys_96: -0.0
-  art_sys_97: -0.0
+  art_sys_95: 0.0
+  art_sys_96: 0.0
+  art_sys_97: 0.0
   art_sys_98: 0.0
   art_sys_99: 0.0
-  art_sys_100: -0.0
+  art_sys_100: 0.0
   art_sys_101: 0.0
-  art_sys_102: -0.0
+  art_sys_102: 0.0
   art_sys_103: 0.0
-  art_sys_104: -0.0
+  art_sys_104: 0.0
   art_sys_105: 0.0
   art_sys_106: 0.0
-  art_sys_107: -0.0
-  art_sys_108: -0.0
-  art_sys_109: -0.0
-  art_sys_110: -0.0
-  art_sys_111: -0.0
-  art_sys_112: -0.0
+  art_sys_107: 0.0
+  art_sys_108: 0.0
+  art_sys_109: 0.0
+  art_sys_110: 0.0
+  art_sys_111: 0.0
+  art_sys_112: 0.0
   art_sys_113: 0.0
-  art_sys_114: -0.0
+  art_sys_114: 0.0
   art_sys_115: 0.0
-  art_sys_116: -0.0
+  art_sys_116: 0.0
   art_sys_117: 0.0
   art_sys_118: 0.0
   art_sys_119: 0.0
   art_sys_120: 0.0
   art_sys_121: 0.0
   art_sys_122: 0.0
-  art_sys_123: -0.0
+  art_sys_123: 0.0
   art_sys_124: 0.0
   art_sys_125: 0.0
   art_sys_126: 0.0
-  art_sys_127: -0.0
-  art_sys_128: -0.0
+  art_sys_127: 0.0
+  art_sys_128: 0.0
   art_sys_129: 0.0
   art_sys_130: 0.0
   art_sys_131: 0.0
-  art_sys_132: -0.0
-  art_sys_133: -0.0
+  art_sys_132: 0.0
+  art_sys_133: 0.0
   art_sys_134: 0.0
   art_sys_135: 0.0
   art_sys_136: 0.0
   art_sys_137: 0.0
-  art_sys_138: -0.0
+  art_sys_138: 0.0
   art_sys_139: 0.0
   art_sys_140: 0.0
   art_sys_141: 0.0
-  art_sys_142: -0.0
+  art_sys_142: 0.0
   art_sys_143: 0.0
-  art_sys_144: -0.0
-  art_sys_145: -0.0
+  art_sys_144: 0.0
+  art_sys_145: 0.0
   art_sys_146: 0.0
-  art_sys_147: -0.0
+  art_sys_147: 0.0
   art_sys_148: 0.0
   art_sys_149: 0.0
-  art_sys_150: -0.0
-  art_sys_151: -0.0
-  art_sys_152: -0.0
+  art_sys_150: 0.0
+  art_sys_151: 0.0
+  art_sys_152: 0.0
   art_sys_153: 0.0
   art_sys_154: 0.0
   art_sys_155: 0.0
-  art_sys_156: -0.0
-  art_sys_157: -0.0
+  art_sys_156: 0.0
+  art_sys_157: 0.0
   art_sys_158: 0.0
-  art_sys_159: -0.0
-  art_sys_160: -0.0
-  art_sys_161: -0.0
+  art_sys_159: 0.0
+  art_sys_160: 0.0
+  art_sys_161: 0.0
   art_sys_162: 0.0
   art_sys_163: 0.0
-  art_sys_164: -0.0
+  art_sys_164: 0.0
   art_sys_165: 0.0
-  art_sys_166: -0.0
+  art_sys_166: 0.0
   art_sys_167: 0.0
-  art_sys_168: -0.0
+  art_sys_168: 0.0
   art_sys_169: 0.0
   art_sys_170: 0.0
-  art_sys_171: -0.0
+  art_sys_171: 0.0
   art_sys_172: 0.0
-  art_sys_173: -0.0
-  art_sys_174: -0.0
-  art_sys_175: -0.0
-  art_sys_176: -0.0
+  art_sys_173: 0.0
+  art_sys_174: 0.0
+  art_sys_175: 0.0
+  art_sys_176: 0.0
   art_sys_177: 0.0
   art_sys_178: 0.0
   art_sys_179: 0.0
-  art_sys_180: -0.0
+  art_sys_180: 0.0
   art_sys_181: 0.0
   art_sys_182: 0.0
   art_sys_183: 0.0
@@ -3094,8 +3094,8 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 9.79122475e+02
   Unfolding-: -9.64789970e+02
@@ -3149,186 +3149,186 @@ bins:
   RelativeStatFSR-: -2.65151356e+05
   luminosity_uncertainty: 975.9256
   uncorrelated_uncertainty: 375.356
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
-  art_sys_4: -0.0
+  art_sys_3: 0.0
+  art_sys_4: 0.0
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
-  art_sys_28: -0.0
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_28: 0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
-  art_sys_39: -0.0
+  art_sys_39: 0.0
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
-  art_sys_45: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
+  art_sys_45: 0.0
   art_sys_46: 0.0
-  art_sys_47: -0.0
-  art_sys_48: -0.0
+  art_sys_47: 0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 0.0
   art_sys_54: 0.0
   art_sys_55: 0.0
-  art_sys_56: -0.0
+  art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
-  art_sys_62: -0.0
-  art_sys_63: -0.0
+  art_sys_62: 0.0
+  art_sys_63: 0.0
   art_sys_64: 0.0
   art_sys_65: 0.0
   art_sys_66: 0.0
   art_sys_67: 0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
-  art_sys_71: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
+  art_sys_71: 0.0
   art_sys_72: 0.0
-  art_sys_73: -0.0
+  art_sys_73: 0.0
   art_sys_74: 0.0
-  art_sys_75: -0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_75: 0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 0.0
-  art_sys_88: -0.0
-  art_sys_89: -0.0
+  art_sys_88: 0.0
+  art_sys_89: 0.0
   art_sys_90: 0.0
   art_sys_91: 0.0
-  art_sys_92: -0.0
+  art_sys_92: 0.0
   art_sys_93: 0.0
   art_sys_94: 0.0
-  art_sys_95: -0.0
-  art_sys_96: -0.0
-  art_sys_97: -0.0
+  art_sys_95: 0.0
+  art_sys_96: 0.0
+  art_sys_97: 0.0
   art_sys_98: 0.0
   art_sys_99: 0.0
-  art_sys_100: -0.0
+  art_sys_100: 0.0
   art_sys_101: 0.0
-  art_sys_102: -0.0
+  art_sys_102: 0.0
   art_sys_103: 0.0
-  art_sys_104: -0.0
+  art_sys_104: 0.0
   art_sys_105: 0.0
   art_sys_106: 0.0
-  art_sys_107: -0.0
-  art_sys_108: -0.0
-  art_sys_109: -0.0
-  art_sys_110: -0.0
-  art_sys_111: -0.0
-  art_sys_112: -0.0
+  art_sys_107: 0.0
+  art_sys_108: 0.0
+  art_sys_109: 0.0
+  art_sys_110: 0.0
+  art_sys_111: 0.0
+  art_sys_112: 0.0
   art_sys_113: 0.0
-  art_sys_114: -0.0
+  art_sys_114: 0.0
   art_sys_115: 0.0
-  art_sys_116: -0.0
+  art_sys_116: 0.0
   art_sys_117: 0.0
   art_sys_118: 0.0
   art_sys_119: 0.0
   art_sys_120: 0.0
   art_sys_121: 0.0
   art_sys_122: 0.0
-  art_sys_123: -0.0
+  art_sys_123: 0.0
   art_sys_124: 0.0
   art_sys_125: 0.0
   art_sys_126: 0.0
-  art_sys_127: -0.0
-  art_sys_128: -0.0
+  art_sys_127: 0.0
+  art_sys_128: 0.0
   art_sys_129: 0.0
   art_sys_130: 0.0
   art_sys_131: 0.0
-  art_sys_132: -0.0
-  art_sys_133: -0.0
+  art_sys_132: 0.0
+  art_sys_133: 0.0
   art_sys_134: 0.0
   art_sys_135: 0.0
   art_sys_136: 0.0
   art_sys_137: 0.0
-  art_sys_138: -0.0
+  art_sys_138: 0.0
   art_sys_139: 0.0
   art_sys_140: 0.0
   art_sys_141: 0.0
-  art_sys_142: -0.0
+  art_sys_142: 0.0
   art_sys_143: 0.0
-  art_sys_144: -0.0
-  art_sys_145: -0.0
+  art_sys_144: 0.0
+  art_sys_145: 0.0
   art_sys_146: 0.0
-  art_sys_147: -0.0
+  art_sys_147: 0.0
   art_sys_148: 0.0
   art_sys_149: 0.0
-  art_sys_150: -0.0
-  art_sys_151: -0.0
-  art_sys_152: -0.0
+  art_sys_150: 0.0
+  art_sys_151: 0.0
+  art_sys_152: 0.0
   art_sys_153: 0.0
   art_sys_154: 0.0
   art_sys_155: 0.0
-  art_sys_156: -0.0
-  art_sys_157: -0.0
+  art_sys_156: 0.0
+  art_sys_157: 0.0
   art_sys_158: 0.0
-  art_sys_159: -0.0
-  art_sys_160: -0.0
-  art_sys_161: -0.0
+  art_sys_159: 0.0
+  art_sys_160: 0.0
+  art_sys_161: 0.0
   art_sys_162: 0.0
   art_sys_163: 0.0
-  art_sys_164: -0.0
+  art_sys_164: 0.0
   art_sys_165: 0.0
-  art_sys_166: -0.0
+  art_sys_166: 0.0
   art_sys_167: 0.0
-  art_sys_168: -0.0
+  art_sys_168: 0.0
   art_sys_169: 0.0
   art_sys_170: 0.0
-  art_sys_171: -0.0
+  art_sys_171: 0.0
   art_sys_172: 0.0
-  art_sys_173: -0.0
-  art_sys_174: -0.0
-  art_sys_175: -0.0
-  art_sys_176: -0.0
+  art_sys_173: 0.0
+  art_sys_174: 0.0
+  art_sys_175: 0.0
+  art_sys_176: 0.0
   art_sys_177: 0.0
   art_sys_178: 0.0
   art_sys_179: 0.0
-  art_sys_180: -0.0
+  art_sys_180: 0.0
   art_sys_181: 0.0
   art_sys_182: 0.0
   art_sys_183: 0.0
@@ -3385,8 +3385,8 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 9.79122475e+02
   Unfolding-: -9.64789970e+02
@@ -3440,186 +3440,186 @@ bins:
   RelativeStatFSR-: -2.65151356e+05
   luminosity_uncertainty: 975.9256
   uncorrelated_uncertainty: 375.356
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
-  art_sys_4: -0.0
+  art_sys_3: 0.0
+  art_sys_4: 0.0
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
-  art_sys_28: -0.0
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_28: 0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
-  art_sys_39: -0.0
+  art_sys_39: 0.0
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
-  art_sys_45: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
+  art_sys_45: 0.0
   art_sys_46: 0.0
-  art_sys_47: -0.0
-  art_sys_48: -0.0
+  art_sys_47: 0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 0.0
   art_sys_54: 0.0
   art_sys_55: 0.0
-  art_sys_56: -0.0
+  art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
-  art_sys_62: -0.0
-  art_sys_63: -0.0
+  art_sys_62: 0.0
+  art_sys_63: 0.0
   art_sys_64: 0.0
   art_sys_65: 0.0
   art_sys_66: 0.0
   art_sys_67: 0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
-  art_sys_71: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
+  art_sys_71: 0.0
   art_sys_72: 0.0
-  art_sys_73: -0.0
+  art_sys_73: 0.0
   art_sys_74: 0.0
-  art_sys_75: -0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_75: 0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 0.0
-  art_sys_88: -0.0
-  art_sys_89: -0.0
+  art_sys_88: 0.0
+  art_sys_89: 0.0
   art_sys_90: 0.0
   art_sys_91: 0.0
-  art_sys_92: -0.0
+  art_sys_92: 0.0
   art_sys_93: 0.0
   art_sys_94: 0.0
-  art_sys_95: -0.0
-  art_sys_96: -0.0
-  art_sys_97: -0.0
+  art_sys_95: 0.0
+  art_sys_96: 0.0
+  art_sys_97: 0.0
   art_sys_98: 0.0
   art_sys_99: 0.0
-  art_sys_100: -0.0
+  art_sys_100: 0.0
   art_sys_101: 0.0
-  art_sys_102: -0.0
+  art_sys_102: 0.0
   art_sys_103: 0.0
-  art_sys_104: -0.0
+  art_sys_104: 0.0
   art_sys_105: 0.0
   art_sys_106: 0.0
-  art_sys_107: -0.0
-  art_sys_108: -0.0
-  art_sys_109: -0.0
-  art_sys_110: -0.0
-  art_sys_111: -0.0
-  art_sys_112: -0.0
+  art_sys_107: 0.0
+  art_sys_108: 0.0
+  art_sys_109: 0.0
+  art_sys_110: 0.0
+  art_sys_111: 0.0
+  art_sys_112: 0.0
   art_sys_113: 0.0
-  art_sys_114: -0.0
+  art_sys_114: 0.0
   art_sys_115: 0.0
-  art_sys_116: -0.0
+  art_sys_116: 0.0
   art_sys_117: 0.0
   art_sys_118: 0.0
   art_sys_119: 0.0
   art_sys_120: 0.0
   art_sys_121: 0.0
   art_sys_122: 0.0
-  art_sys_123: -0.0
+  art_sys_123: 0.0
   art_sys_124: 0.0
   art_sys_125: 0.0
   art_sys_126: 0.0
-  art_sys_127: -0.0
-  art_sys_128: -0.0
+  art_sys_127: 0.0
+  art_sys_128: 0.0
   art_sys_129: 0.0
   art_sys_130: 0.0
   art_sys_131: 0.0
-  art_sys_132: -0.0
-  art_sys_133: -0.0
+  art_sys_132: 0.0
+  art_sys_133: 0.0
   art_sys_134: 0.0
   art_sys_135: 0.0
   art_sys_136: 0.0
   art_sys_137: 0.0
-  art_sys_138: -0.0
+  art_sys_138: 0.0
   art_sys_139: 0.0
   art_sys_140: 0.0
   art_sys_141: 0.0
-  art_sys_142: -0.0
+  art_sys_142: 0.0
   art_sys_143: 0.0
-  art_sys_144: -0.0
-  art_sys_145: -0.0
+  art_sys_144: 0.0
+  art_sys_145: 0.0
   art_sys_146: 0.0
-  art_sys_147: -0.0
+  art_sys_147: 0.0
   art_sys_148: 0.0
   art_sys_149: 0.0
-  art_sys_150: -0.0
-  art_sys_151: -0.0
-  art_sys_152: -0.0
+  art_sys_150: 0.0
+  art_sys_151: 0.0
+  art_sys_152: 0.0
   art_sys_153: 0.0
   art_sys_154: 0.0
   art_sys_155: 0.0
-  art_sys_156: -0.0
-  art_sys_157: -0.0
+  art_sys_156: 0.0
+  art_sys_157: 0.0
   art_sys_158: 0.0
-  art_sys_159: -0.0
-  art_sys_160: -0.0
-  art_sys_161: -0.0
+  art_sys_159: 0.0
+  art_sys_160: 0.0
+  art_sys_161: 0.0
   art_sys_162: 0.0
   art_sys_163: 0.0
-  art_sys_164: -0.0
+  art_sys_164: 0.0
   art_sys_165: 0.0
-  art_sys_166: -0.0
+  art_sys_166: 0.0
   art_sys_167: 0.0
-  art_sys_168: -0.0
+  art_sys_168: 0.0
   art_sys_169: 0.0
   art_sys_170: 0.0
-  art_sys_171: -0.0
+  art_sys_171: 0.0
   art_sys_172: 0.0
-  art_sys_173: -0.0
-  art_sys_174: -0.0
-  art_sys_175: -0.0
-  art_sys_176: -0.0
+  art_sys_173: 0.0
+  art_sys_174: 0.0
+  art_sys_175: 0.0
+  art_sys_176: 0.0
   art_sys_177: 0.0
   art_sys_178: 0.0
   art_sys_179: 0.0
-  art_sys_180: -0.0
+  art_sys_180: 0.0
   art_sys_181: 0.0
   art_sys_182: 0.0
   art_sys_183: 0.0
@@ -3676,8 +3676,8 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 9.79122475e+02
   Unfolding-: -9.64789970e+02
@@ -3731,186 +3731,186 @@ bins:
   RelativeStatFSR-: -2.65151356e+05
   luminosity_uncertainty: 975.9256
   uncorrelated_uncertainty: 375.356
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
-  art_sys_4: -0.0
+  art_sys_3: 0.0
+  art_sys_4: 0.0
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
-  art_sys_28: -0.0
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_28: 0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
-  art_sys_39: -0.0
+  art_sys_39: 0.0
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
-  art_sys_45: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
+  art_sys_45: 0.0
   art_sys_46: 0.0
-  art_sys_47: -0.0
-  art_sys_48: -0.0
+  art_sys_47: 0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 0.0
   art_sys_54: 0.0
   art_sys_55: 0.0
-  art_sys_56: -0.0
+  art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
-  art_sys_62: -0.0
-  art_sys_63: -0.0
+  art_sys_62: 0.0
+  art_sys_63: 0.0
   art_sys_64: 0.0
   art_sys_65: 0.0
   art_sys_66: 0.0
   art_sys_67: 0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
-  art_sys_71: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
+  art_sys_71: 0.0
   art_sys_72: 0.0
-  art_sys_73: -0.0
+  art_sys_73: 0.0
   art_sys_74: 0.0
-  art_sys_75: -0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_75: 0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 0.0
-  art_sys_88: -0.0
-  art_sys_89: -0.0
+  art_sys_88: 0.0
+  art_sys_89: 0.0
   art_sys_90: 0.0
   art_sys_91: 0.0
-  art_sys_92: -0.0
+  art_sys_92: 0.0
   art_sys_93: 0.0
   art_sys_94: 0.0
-  art_sys_95: -0.0
-  art_sys_96: -0.0
-  art_sys_97: -0.0
+  art_sys_95: 0.0
+  art_sys_96: 0.0
+  art_sys_97: 0.0
   art_sys_98: 0.0
   art_sys_99: 0.0
-  art_sys_100: -0.0
+  art_sys_100: 0.0
   art_sys_101: 0.0
-  art_sys_102: -0.0
+  art_sys_102: 0.0
   art_sys_103: 0.0
-  art_sys_104: -0.0
+  art_sys_104: 0.0
   art_sys_105: 0.0
   art_sys_106: 0.0
-  art_sys_107: -0.0
-  art_sys_108: -0.0
-  art_sys_109: -0.0
-  art_sys_110: -0.0
-  art_sys_111: -0.0
-  art_sys_112: -0.0
+  art_sys_107: 0.0
+  art_sys_108: 0.0
+  art_sys_109: 0.0
+  art_sys_110: 0.0
+  art_sys_111: 0.0
+  art_sys_112: 0.0
   art_sys_113: 0.0
-  art_sys_114: -0.0
+  art_sys_114: 0.0
   art_sys_115: 0.0
-  art_sys_116: -0.0
+  art_sys_116: 0.0
   art_sys_117: 0.0
   art_sys_118: 0.0
   art_sys_119: 0.0
   art_sys_120: 0.0
   art_sys_121: 0.0
   art_sys_122: 0.0
-  art_sys_123: -0.0
+  art_sys_123: 0.0
   art_sys_124: 0.0
   art_sys_125: 0.0
   art_sys_126: 0.0
-  art_sys_127: -0.0
-  art_sys_128: -0.0
+  art_sys_127: 0.0
+  art_sys_128: 0.0
   art_sys_129: 0.0
   art_sys_130: 0.0
   art_sys_131: 0.0
-  art_sys_132: -0.0
-  art_sys_133: -0.0
+  art_sys_132: 0.0
+  art_sys_133: 0.0
   art_sys_134: 0.0
   art_sys_135: 0.0
   art_sys_136: 0.0
   art_sys_137: 0.0
-  art_sys_138: -0.0
+  art_sys_138: 0.0
   art_sys_139: 0.0
   art_sys_140: 0.0
   art_sys_141: 0.0
-  art_sys_142: -0.0
+  art_sys_142: 0.0
   art_sys_143: 0.0
-  art_sys_144: -0.0
-  art_sys_145: -0.0
+  art_sys_144: 0.0
+  art_sys_145: 0.0
   art_sys_146: 0.0
-  art_sys_147: -0.0
+  art_sys_147: 0.0
   art_sys_148: 0.0
   art_sys_149: 0.0
-  art_sys_150: -0.0
-  art_sys_151: -0.0
-  art_sys_152: -0.0
+  art_sys_150: 0.0
+  art_sys_151: 0.0
+  art_sys_152: 0.0
   art_sys_153: 0.0
   art_sys_154: 0.0
   art_sys_155: 0.0
-  art_sys_156: -0.0
-  art_sys_157: -0.0
+  art_sys_156: 0.0
+  art_sys_157: 0.0
   art_sys_158: 0.0
-  art_sys_159: -0.0
-  art_sys_160: -0.0
-  art_sys_161: -0.0
+  art_sys_159: 0.0
+  art_sys_160: 0.0
+  art_sys_161: 0.0
   art_sys_162: 0.0
   art_sys_163: 0.0
-  art_sys_164: -0.0
+  art_sys_164: 0.0
   art_sys_165: 0.0
-  art_sys_166: -0.0
+  art_sys_166: 0.0
   art_sys_167: 0.0
-  art_sys_168: -0.0
+  art_sys_168: 0.0
   art_sys_169: 0.0
   art_sys_170: 0.0
-  art_sys_171: -0.0
+  art_sys_171: 0.0
   art_sys_172: 0.0
-  art_sys_173: -0.0
-  art_sys_174: -0.0
-  art_sys_175: -0.0
-  art_sys_176: -0.0
+  art_sys_173: 0.0
+  art_sys_174: 0.0
+  art_sys_175: 0.0
+  art_sys_176: 0.0
   art_sys_177: 0.0
   art_sys_178: 0.0
   art_sys_179: 0.0
-  art_sys_180: -0.0
+  art_sys_180: 0.0
   art_sys_181: 0.0
   art_sys_182: 0.0
   art_sys_183: 0.0
@@ -3967,8 +3967,8 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 9.79122475e+02
   Unfolding-: -9.64789970e+02
@@ -4549,9 +4549,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
-  art_sys_239: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
+  art_sys_239: 0.0
   Unfolding+: 4.56908961e+02
   Unfolding-: -4.55432897e+02
   AbsoluteStat+: -2.00744730e-01
@@ -5131,9 +5131,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
-  art_sys_239: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
+  art_sys_239: 0.0
   Unfolding+: 7.51887649e+01
   Unfolding-: -7.70246126e+01
   AbsoluteStat+: 5.29696074e-01
@@ -5713,9 +5713,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
-  art_sys_239: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
+  art_sys_239: 0.0
   Unfolding+: 1.31890621e+01
   Unfolding-: -1.38755682e+01
   AbsoluteStat+: 2.60697783e-01
@@ -6295,9 +6295,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
-  art_sys_239: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
+  art_sys_239: 0.0
   Unfolding+: 2.72961786e+00
   Unfolding-: -2.93800804e+00
   AbsoluteStat+: 1.06337694e-01
@@ -6877,9 +6877,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
-  art_sys_239: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
+  art_sys_239: 0.0
   Unfolding+: 6.67981265e-01
   Unfolding-: -7.34165760e-01
   AbsoluteStat+: 4.53648694e-02
@@ -7459,9 +7459,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
-  art_sys_239: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
+  art_sys_239: 0.0
   Unfolding+: 1.69480662e-01
   Unfolding-: -1.89563239e-01
   AbsoluteStat+: 1.86985070e-02
@@ -8041,9 +8041,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
-  art_sys_239: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
+  art_sys_239: 0.0
   Unfolding+: 4.66520965e-02
   Unfolding-: -5.28602033e-02
   AbsoluteStat+: 8.02945575e-03
@@ -8623,9 +8623,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
-  art_sys_239: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
+  art_sys_239: 0.0
   Unfolding+: 1.32559539e-02
   Unfolding-: -1.51512450e-02
   AbsoluteStat+: 3.45015810e-03
@@ -9205,9 +9205,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
-  art_sys_239: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
+  art_sys_239: 0.0
   Unfolding+: 3.87139968e-03
   Unfolding-: -4.43015840e-03
   AbsoluteStat+: 1.48515144e-03
@@ -9787,9 +9787,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
-  art_sys_239: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
+  art_sys_239: 0.0
   Unfolding+: 1.19428160e-03
   Unfolding-: -1.35556386e-03
   AbsoluteStat+: 6.58273662e-04
@@ -10369,9 +10369,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
-  art_sys_239: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
+  art_sys_239: 0.0
   Unfolding+: 3.74756909e-04
   Unfolding-: -4.17286888e-04
   AbsoluteStat+: 2.86229835e-04
@@ -10951,9 +10951,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
-  art_sys_239: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
+  art_sys_239: 0.0
   Unfolding+: 1.20791088e-04
   Unfolding-: -1.30494996e-04
   AbsoluteStat+: 1.22116913e-04
@@ -11533,8 +11533,8 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 4.09042354e-05
   Unfolding-: -4.25986770e-05
@@ -11826,7 +11826,7 @@ bins:
   art_sys_236: 0.0
   art_sys_237: 0.0
   art_sys_238: 0.0
-  art_sys_239: -0.0
+  art_sys_239: 0.0
   Unfolding+: 2.40400249e-05
   Unfolding-: -2.45898995e-05
   AbsoluteStat+: 3.31531158e-05
@@ -12115,8 +12115,8 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 1.40463572e-05
   Unfolding-: -1.41403612e-05
@@ -12408,7 +12408,7 @@ bins:
   art_sys_236: 0.0
   art_sys_237: 0.0
   art_sys_238: 0.0
-  art_sys_239: -0.0
+  art_sys_239: 0.0
   Unfolding+: 8.34944913e-06
   Unfolding-: -8.30070869e-06
   AbsoluteStat+: 1.30136972e-05
@@ -12697,8 +12697,8 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 5.03267941e-06
   Unfolding-: -4.96440182e-06
@@ -12988,9 +12988,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
-  art_sys_239: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
+  art_sys_239: 0.0
   Unfolding+: 3.01610585e-06
   Unfolding-: -2.96688369e-06
   AbsoluteStat+: 4.98713245e-06
@@ -13570,9 +13570,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
-  art_sys_239: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
+  art_sys_239: 0.0
   Unfolding+: 1.05937554e-06
   Unfolding-: -1.05201566e-06
   AbsoluteStat+: 1.76592326e-06
@@ -14152,9 +14152,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
-  art_sys_239: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
+  art_sys_239: 0.0
   Unfolding+: 2.92134254e-07
   Unfolding-: -3.00029774e-07
   AbsoluteStat+: 4.69095788e-07
@@ -14789,186 +14789,186 @@ bins:
   RelativeStatFSR-: -1.86220636e-09
   luminosity_uncertainty: 1.87956340e-08
   uncorrelated_uncertainty: 7.22909000e-09
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
-  art_sys_4: -0.0
+  art_sys_3: 0.0
+  art_sys_4: 0.0
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
-  art_sys_28: -0.0
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_28: 0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
-  art_sys_39: -0.0
+  art_sys_39: 0.0
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
-  art_sys_45: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
+  art_sys_45: 0.0
   art_sys_46: 0.0
-  art_sys_47: -0.0
-  art_sys_48: -0.0
+  art_sys_47: 0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 0.0
   art_sys_54: 0.0
   art_sys_55: 0.0
-  art_sys_56: -0.0
+  art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
-  art_sys_62: -0.0
-  art_sys_63: -0.0
+  art_sys_62: 0.0
+  art_sys_63: 0.0
   art_sys_64: 0.0
   art_sys_65: 0.0
   art_sys_66: 0.0
   art_sys_67: 0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
-  art_sys_71: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
+  art_sys_71: 0.0
   art_sys_72: 0.0
-  art_sys_73: -0.0
+  art_sys_73: 0.0
   art_sys_74: 0.0
-  art_sys_75: -0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_75: 0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 0.0
-  art_sys_88: -0.0
-  art_sys_89: -0.0
+  art_sys_88: 0.0
+  art_sys_89: 0.0
   art_sys_90: 0.0
   art_sys_91: 0.0
-  art_sys_92: -0.0
+  art_sys_92: 0.0
   art_sys_93: 0.0
   art_sys_94: 0.0
-  art_sys_95: -0.0
-  art_sys_96: -0.0
-  art_sys_97: -0.0
+  art_sys_95: 0.0
+  art_sys_96: 0.0
+  art_sys_97: 0.0
   art_sys_98: 0.0
   art_sys_99: 0.0
-  art_sys_100: -0.0
+  art_sys_100: 0.0
   art_sys_101: 0.0
-  art_sys_102: -0.0
+  art_sys_102: 0.0
   art_sys_103: 0.0
-  art_sys_104: -0.0
+  art_sys_104: 0.0
   art_sys_105: 0.0
   art_sys_106: 0.0
-  art_sys_107: -0.0
-  art_sys_108: -0.0
-  art_sys_109: -0.0
-  art_sys_110: -0.0
-  art_sys_111: -0.0
-  art_sys_112: -0.0
+  art_sys_107: 0.0
+  art_sys_108: 0.0
+  art_sys_109: 0.0
+  art_sys_110: 0.0
+  art_sys_111: 0.0
+  art_sys_112: 0.0
   art_sys_113: 0.0
-  art_sys_114: -0.0
+  art_sys_114: 0.0
   art_sys_115: 0.0
-  art_sys_116: -0.0
+  art_sys_116: 0.0
   art_sys_117: 0.0
   art_sys_118: 0.0
   art_sys_119: 0.0
   art_sys_120: 0.0
   art_sys_121: 0.0
   art_sys_122: 0.0
-  art_sys_123: -0.0
+  art_sys_123: 0.0
   art_sys_124: 0.0
   art_sys_125: 0.0
   art_sys_126: 0.0
-  art_sys_127: -0.0
-  art_sys_128: -0.0
+  art_sys_127: 0.0
+  art_sys_128: 0.0
   art_sys_129: 0.0
   art_sys_130: 0.0
   art_sys_131: 0.0
-  art_sys_132: -0.0
-  art_sys_133: -0.0
+  art_sys_132: 0.0
+  art_sys_133: 0.0
   art_sys_134: 0.0
   art_sys_135: 0.0
   art_sys_136: 0.0
   art_sys_137: 0.0
-  art_sys_138: -0.0
+  art_sys_138: 0.0
   art_sys_139: 0.0
   art_sys_140: 0.0
   art_sys_141: 0.0
-  art_sys_142: -0.0
+  art_sys_142: 0.0
   art_sys_143: 0.0
-  art_sys_144: -0.0
-  art_sys_145: -0.0
+  art_sys_144: 0.0
+  art_sys_145: 0.0
   art_sys_146: 0.0
-  art_sys_147: -0.0
+  art_sys_147: 0.0
   art_sys_148: 0.0
   art_sys_149: 0.0
-  art_sys_150: -0.0
-  art_sys_151: -0.0
-  art_sys_152: -0.0
+  art_sys_150: 0.0
+  art_sys_151: 0.0
+  art_sys_152: 0.0
   art_sys_153: 0.0
   art_sys_154: 0.0
   art_sys_155: 0.0
-  art_sys_156: -0.0
-  art_sys_157: -0.0
+  art_sys_156: 0.0
+  art_sys_157: 0.0
   art_sys_158: 0.0
-  art_sys_159: -0.0
-  art_sys_160: -0.0
-  art_sys_161: -0.0
+  art_sys_159: 0.0
+  art_sys_160: 0.0
+  art_sys_161: 0.0
   art_sys_162: 0.0
   art_sys_163: 0.0
-  art_sys_164: -0.0
+  art_sys_164: 0.0
   art_sys_165: 0.0
-  art_sys_166: -0.0
+  art_sys_166: 0.0
   art_sys_167: 0.0
-  art_sys_168: -0.0
+  art_sys_168: 0.0
   art_sys_169: 0.0
   art_sys_170: 0.0
-  art_sys_171: -0.0
+  art_sys_171: 0.0
   art_sys_172: 0.0
-  art_sys_173: -0.0
-  art_sys_174: -0.0
-  art_sys_175: -0.0
-  art_sys_176: -0.0
+  art_sys_173: 0.0
+  art_sys_174: 0.0
+  art_sys_175: 0.0
+  art_sys_176: 0.0
   art_sys_177: 0.0
   art_sys_178: 0.0
   art_sys_179: 0.0
-  art_sys_180: -0.0
+  art_sys_180: 0.0
   art_sys_181: 0.0
   art_sys_182: 0.0
   art_sys_183: 0.0
@@ -15025,8 +15025,8 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 9.60715394e+02
   Unfolding-: -1.00493880e+03
@@ -15080,186 +15080,186 @@ bins:
   RelativeStatFSR-: -2.53903354e+05
   luminosity_uncertainty: 9.34525800e+02
   uncorrelated_uncertainty: 3.59433000e+02
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
-  art_sys_4: -0.0
+  art_sys_3: 0.0
+  art_sys_4: 0.0
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
-  art_sys_28: -0.0
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_28: 0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
-  art_sys_39: -0.0
+  art_sys_39: 0.0
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
-  art_sys_45: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
+  art_sys_45: 0.0
   art_sys_46: 0.0
-  art_sys_47: -0.0
-  art_sys_48: -0.0
+  art_sys_47: 0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 0.0
   art_sys_54: 0.0
   art_sys_55: 0.0
-  art_sys_56: -0.0
+  art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
-  art_sys_62: -0.0
-  art_sys_63: -0.0
+  art_sys_62: 0.0
+  art_sys_63: 0.0
   art_sys_64: 0.0
   art_sys_65: 0.0
   art_sys_66: 0.0
   art_sys_67: 0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
-  art_sys_71: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
+  art_sys_71: 0.0
   art_sys_72: 0.0
-  art_sys_73: -0.0
+  art_sys_73: 0.0
   art_sys_74: 0.0
-  art_sys_75: -0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_75: 0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 0.0
-  art_sys_88: -0.0
-  art_sys_89: -0.0
+  art_sys_88: 0.0
+  art_sys_89: 0.0
   art_sys_90: 0.0
   art_sys_91: 0.0
-  art_sys_92: -0.0
+  art_sys_92: 0.0
   art_sys_93: 0.0
   art_sys_94: 0.0
-  art_sys_95: -0.0
-  art_sys_96: -0.0
-  art_sys_97: -0.0
+  art_sys_95: 0.0
+  art_sys_96: 0.0
+  art_sys_97: 0.0
   art_sys_98: 0.0
   art_sys_99: 0.0
-  art_sys_100: -0.0
+  art_sys_100: 0.0
   art_sys_101: 0.0
-  art_sys_102: -0.0
+  art_sys_102: 0.0
   art_sys_103: 0.0
-  art_sys_104: -0.0
+  art_sys_104: 0.0
   art_sys_105: 0.0
   art_sys_106: 0.0
-  art_sys_107: -0.0
-  art_sys_108: -0.0
-  art_sys_109: -0.0
-  art_sys_110: -0.0
-  art_sys_111: -0.0
-  art_sys_112: -0.0
+  art_sys_107: 0.0
+  art_sys_108: 0.0
+  art_sys_109: 0.0
+  art_sys_110: 0.0
+  art_sys_111: 0.0
+  art_sys_112: 0.0
   art_sys_113: 0.0
-  art_sys_114: -0.0
+  art_sys_114: 0.0
   art_sys_115: 0.0
-  art_sys_116: -0.0
+  art_sys_116: 0.0
   art_sys_117: 0.0
   art_sys_118: 0.0
   art_sys_119: 0.0
   art_sys_120: 0.0
   art_sys_121: 0.0
   art_sys_122: 0.0
-  art_sys_123: -0.0
+  art_sys_123: 0.0
   art_sys_124: 0.0
   art_sys_125: 0.0
   art_sys_126: 0.0
-  art_sys_127: -0.0
-  art_sys_128: -0.0
+  art_sys_127: 0.0
+  art_sys_128: 0.0
   art_sys_129: 0.0
   art_sys_130: 0.0
   art_sys_131: 0.0
-  art_sys_132: -0.0
-  art_sys_133: -0.0
+  art_sys_132: 0.0
+  art_sys_133: 0.0
   art_sys_134: 0.0
   art_sys_135: 0.0
   art_sys_136: 0.0
   art_sys_137: 0.0
-  art_sys_138: -0.0
+  art_sys_138: 0.0
   art_sys_139: 0.0
   art_sys_140: 0.0
   art_sys_141: 0.0
-  art_sys_142: -0.0
+  art_sys_142: 0.0
   art_sys_143: 0.0
-  art_sys_144: -0.0
-  art_sys_145: -0.0
+  art_sys_144: 0.0
+  art_sys_145: 0.0
   art_sys_146: 0.0
-  art_sys_147: -0.0
+  art_sys_147: 0.0
   art_sys_148: 0.0
   art_sys_149: 0.0
-  art_sys_150: -0.0
-  art_sys_151: -0.0
-  art_sys_152: -0.0
+  art_sys_150: 0.0
+  art_sys_151: 0.0
+  art_sys_152: 0.0
   art_sys_153: 0.0
   art_sys_154: 0.0
   art_sys_155: 0.0
-  art_sys_156: -0.0
-  art_sys_157: -0.0
+  art_sys_156: 0.0
+  art_sys_157: 0.0
   art_sys_158: 0.0
-  art_sys_159: -0.0
-  art_sys_160: -0.0
-  art_sys_161: -0.0
+  art_sys_159: 0.0
+  art_sys_160: 0.0
+  art_sys_161: 0.0
   art_sys_162: 0.0
   art_sys_163: 0.0
-  art_sys_164: -0.0
+  art_sys_164: 0.0
   art_sys_165: 0.0
-  art_sys_166: -0.0
+  art_sys_166: 0.0
   art_sys_167: 0.0
-  art_sys_168: -0.0
+  art_sys_168: 0.0
   art_sys_169: 0.0
   art_sys_170: 0.0
-  art_sys_171: -0.0
+  art_sys_171: 0.0
   art_sys_172: 0.0
-  art_sys_173: -0.0
-  art_sys_174: -0.0
-  art_sys_175: -0.0
-  art_sys_176: -0.0
+  art_sys_173: 0.0
+  art_sys_174: 0.0
+  art_sys_175: 0.0
+  art_sys_176: 0.0
   art_sys_177: 0.0
   art_sys_178: 0.0
   art_sys_179: 0.0
-  art_sys_180: -0.0
+  art_sys_180: 0.0
   art_sys_181: 0.0
   art_sys_182: 0.0
   art_sys_183: 0.0
@@ -15316,8 +15316,8 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 9.60715394e+02
   Unfolding-: -1.00493880e+03
@@ -15371,186 +15371,186 @@ bins:
   RelativeStatFSR-: -2.53903354e+05
   luminosity_uncertainty: 9.34525800e+02
   uncorrelated_uncertainty: 3.59433000e+02
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
-  art_sys_4: -0.0
+  art_sys_3: 0.0
+  art_sys_4: 0.0
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
-  art_sys_28: -0.0
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_28: 0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
-  art_sys_39: -0.0
+  art_sys_39: 0.0
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
-  art_sys_45: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
+  art_sys_45: 0.0
   art_sys_46: 0.0
-  art_sys_47: -0.0
-  art_sys_48: -0.0
+  art_sys_47: 0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 0.0
   art_sys_54: 0.0
   art_sys_55: 0.0
-  art_sys_56: -0.0
+  art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
-  art_sys_62: -0.0
-  art_sys_63: -0.0
+  art_sys_62: 0.0
+  art_sys_63: 0.0
   art_sys_64: 0.0
   art_sys_65: 0.0
   art_sys_66: 0.0
   art_sys_67: 0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
-  art_sys_71: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
+  art_sys_71: 0.0
   art_sys_72: 0.0
-  art_sys_73: -0.0
+  art_sys_73: 0.0
   art_sys_74: 0.0
-  art_sys_75: -0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_75: 0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 0.0
-  art_sys_88: -0.0
-  art_sys_89: -0.0
+  art_sys_88: 0.0
+  art_sys_89: 0.0
   art_sys_90: 0.0
   art_sys_91: 0.0
-  art_sys_92: -0.0
+  art_sys_92: 0.0
   art_sys_93: 0.0
   art_sys_94: 0.0
-  art_sys_95: -0.0
-  art_sys_96: -0.0
-  art_sys_97: -0.0
+  art_sys_95: 0.0
+  art_sys_96: 0.0
+  art_sys_97: 0.0
   art_sys_98: 0.0
   art_sys_99: 0.0
-  art_sys_100: -0.0
+  art_sys_100: 0.0
   art_sys_101: 0.0
-  art_sys_102: -0.0
+  art_sys_102: 0.0
   art_sys_103: 0.0
-  art_sys_104: -0.0
+  art_sys_104: 0.0
   art_sys_105: 0.0
   art_sys_106: 0.0
-  art_sys_107: -0.0
-  art_sys_108: -0.0
-  art_sys_109: -0.0
-  art_sys_110: -0.0
-  art_sys_111: -0.0
-  art_sys_112: -0.0
+  art_sys_107: 0.0
+  art_sys_108: 0.0
+  art_sys_109: 0.0
+  art_sys_110: 0.0
+  art_sys_111: 0.0
+  art_sys_112: 0.0
   art_sys_113: 0.0
-  art_sys_114: -0.0
+  art_sys_114: 0.0
   art_sys_115: 0.0
-  art_sys_116: -0.0
+  art_sys_116: 0.0
   art_sys_117: 0.0
   art_sys_118: 0.0
   art_sys_119: 0.0
   art_sys_120: 0.0
   art_sys_121: 0.0
   art_sys_122: 0.0
-  art_sys_123: -0.0
+  art_sys_123: 0.0
   art_sys_124: 0.0
   art_sys_125: 0.0
   art_sys_126: 0.0
-  art_sys_127: -0.0
-  art_sys_128: -0.0
+  art_sys_127: 0.0
+  art_sys_128: 0.0
   art_sys_129: 0.0
   art_sys_130: 0.0
   art_sys_131: 0.0
-  art_sys_132: -0.0
-  art_sys_133: -0.0
+  art_sys_132: 0.0
+  art_sys_133: 0.0
   art_sys_134: 0.0
   art_sys_135: 0.0
   art_sys_136: 0.0
   art_sys_137: 0.0
-  art_sys_138: -0.0
+  art_sys_138: 0.0
   art_sys_139: 0.0
   art_sys_140: 0.0
   art_sys_141: 0.0
-  art_sys_142: -0.0
+  art_sys_142: 0.0
   art_sys_143: 0.0
-  art_sys_144: -0.0
-  art_sys_145: -0.0
+  art_sys_144: 0.0
+  art_sys_145: 0.0
   art_sys_146: 0.0
-  art_sys_147: -0.0
+  art_sys_147: 0.0
   art_sys_148: 0.0
   art_sys_149: 0.0
-  art_sys_150: -0.0
-  art_sys_151: -0.0
-  art_sys_152: -0.0
+  art_sys_150: 0.0
+  art_sys_151: 0.0
+  art_sys_152: 0.0
   art_sys_153: 0.0
   art_sys_154: 0.0
   art_sys_155: 0.0
-  art_sys_156: -0.0
-  art_sys_157: -0.0
+  art_sys_156: 0.0
+  art_sys_157: 0.0
   art_sys_158: 0.0
-  art_sys_159: -0.0
-  art_sys_160: -0.0
-  art_sys_161: -0.0
+  art_sys_159: 0.0
+  art_sys_160: 0.0
+  art_sys_161: 0.0
   art_sys_162: 0.0
   art_sys_163: 0.0
-  art_sys_164: -0.0
+  art_sys_164: 0.0
   art_sys_165: 0.0
-  art_sys_166: -0.0
+  art_sys_166: 0.0
   art_sys_167: 0.0
-  art_sys_168: -0.0
+  art_sys_168: 0.0
   art_sys_169: 0.0
   art_sys_170: 0.0
-  art_sys_171: -0.0
+  art_sys_171: 0.0
   art_sys_172: 0.0
-  art_sys_173: -0.0
-  art_sys_174: -0.0
-  art_sys_175: -0.0
-  art_sys_176: -0.0
+  art_sys_173: 0.0
+  art_sys_174: 0.0
+  art_sys_175: 0.0
+  art_sys_176: 0.0
   art_sys_177: 0.0
   art_sys_178: 0.0
   art_sys_179: 0.0
-  art_sys_180: -0.0
+  art_sys_180: 0.0
   art_sys_181: 0.0
   art_sys_182: 0.0
   art_sys_183: 0.0
@@ -15607,8 +15607,8 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 9.60715394e+02
   Unfolding-: -1.00493880e+03
@@ -15662,186 +15662,186 @@ bins:
   RelativeStatFSR-: -2.53903354e+05
   luminosity_uncertainty: 9.34525800e+02
   uncorrelated_uncertainty: 3.59433000e+02
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
-  art_sys_4: -0.0
+  art_sys_3: 0.0
+  art_sys_4: 0.0
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
-  art_sys_28: -0.0
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_28: 0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
-  art_sys_39: -0.0
+  art_sys_39: 0.0
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
-  art_sys_45: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
+  art_sys_45: 0.0
   art_sys_46: 0.0
-  art_sys_47: -0.0
-  art_sys_48: -0.0
+  art_sys_47: 0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 0.0
   art_sys_54: 0.0
   art_sys_55: 0.0
-  art_sys_56: -0.0
+  art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
-  art_sys_62: -0.0
-  art_sys_63: -0.0
+  art_sys_62: 0.0
+  art_sys_63: 0.0
   art_sys_64: 0.0
   art_sys_65: 0.0
   art_sys_66: 0.0
   art_sys_67: 0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
-  art_sys_71: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
+  art_sys_71: 0.0
   art_sys_72: 0.0
-  art_sys_73: -0.0
+  art_sys_73: 0.0
   art_sys_74: 0.0
-  art_sys_75: -0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_75: 0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 0.0
-  art_sys_88: -0.0
-  art_sys_89: -0.0
+  art_sys_88: 0.0
+  art_sys_89: 0.0
   art_sys_90: 0.0
   art_sys_91: 0.0
-  art_sys_92: -0.0
+  art_sys_92: 0.0
   art_sys_93: 0.0
   art_sys_94: 0.0
-  art_sys_95: -0.0
-  art_sys_96: -0.0
-  art_sys_97: -0.0
+  art_sys_95: 0.0
+  art_sys_96: 0.0
+  art_sys_97: 0.0
   art_sys_98: 0.0
   art_sys_99: 0.0
-  art_sys_100: -0.0
+  art_sys_100: 0.0
   art_sys_101: 0.0
-  art_sys_102: -0.0
+  art_sys_102: 0.0
   art_sys_103: 0.0
-  art_sys_104: -0.0
+  art_sys_104: 0.0
   art_sys_105: 0.0
   art_sys_106: 0.0
-  art_sys_107: -0.0
-  art_sys_108: -0.0
-  art_sys_109: -0.0
-  art_sys_110: -0.0
-  art_sys_111: -0.0
-  art_sys_112: -0.0
+  art_sys_107: 0.0
+  art_sys_108: 0.0
+  art_sys_109: 0.0
+  art_sys_110: 0.0
+  art_sys_111: 0.0
+  art_sys_112: 0.0
   art_sys_113: 0.0
-  art_sys_114: -0.0
+  art_sys_114: 0.0
   art_sys_115: 0.0
-  art_sys_116: -0.0
+  art_sys_116: 0.0
   art_sys_117: 0.0
   art_sys_118: 0.0
   art_sys_119: 0.0
   art_sys_120: 0.0
   art_sys_121: 0.0
   art_sys_122: 0.0
-  art_sys_123: -0.0
+  art_sys_123: 0.0
   art_sys_124: 0.0
   art_sys_125: 0.0
   art_sys_126: 0.0
-  art_sys_127: -0.0
-  art_sys_128: -0.0
+  art_sys_127: 0.0
+  art_sys_128: 0.0
   art_sys_129: 0.0
   art_sys_130: 0.0
   art_sys_131: 0.0
-  art_sys_132: -0.0
-  art_sys_133: -0.0
+  art_sys_132: 0.0
+  art_sys_133: 0.0
   art_sys_134: 0.0
   art_sys_135: 0.0
   art_sys_136: 0.0
   art_sys_137: 0.0
-  art_sys_138: -0.0
+  art_sys_138: 0.0
   art_sys_139: 0.0
   art_sys_140: 0.0
   art_sys_141: 0.0
-  art_sys_142: -0.0
+  art_sys_142: 0.0
   art_sys_143: 0.0
-  art_sys_144: -0.0
-  art_sys_145: -0.0
+  art_sys_144: 0.0
+  art_sys_145: 0.0
   art_sys_146: 0.0
-  art_sys_147: -0.0
+  art_sys_147: 0.0
   art_sys_148: 0.0
   art_sys_149: 0.0
-  art_sys_150: -0.0
-  art_sys_151: -0.0
-  art_sys_152: -0.0
+  art_sys_150: 0.0
+  art_sys_151: 0.0
+  art_sys_152: 0.0
   art_sys_153: 0.0
   art_sys_154: 0.0
   art_sys_155: 0.0
-  art_sys_156: -0.0
-  art_sys_157: -0.0
+  art_sys_156: 0.0
+  art_sys_157: 0.0
   art_sys_158: 0.0
-  art_sys_159: -0.0
-  art_sys_160: -0.0
-  art_sys_161: -0.0
+  art_sys_159: 0.0
+  art_sys_160: 0.0
+  art_sys_161: 0.0
   art_sys_162: 0.0
   art_sys_163: 0.0
-  art_sys_164: -0.0
+  art_sys_164: 0.0
   art_sys_165: 0.0
-  art_sys_166: -0.0
+  art_sys_166: 0.0
   art_sys_167: 0.0
-  art_sys_168: -0.0
+  art_sys_168: 0.0
   art_sys_169: 0.0
   art_sys_170: 0.0
-  art_sys_171: -0.0
+  art_sys_171: 0.0
   art_sys_172: 0.0
-  art_sys_173: -0.0
-  art_sys_174: -0.0
-  art_sys_175: -0.0
-  art_sys_176: -0.0
+  art_sys_173: 0.0
+  art_sys_174: 0.0
+  art_sys_175: 0.0
+  art_sys_176: 0.0
   art_sys_177: 0.0
   art_sys_178: 0.0
   art_sys_179: 0.0
-  art_sys_180: -0.0
+  art_sys_180: 0.0
   art_sys_181: 0.0
   art_sys_182: 0.0
   art_sys_183: 0.0
@@ -15898,8 +15898,8 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 9.60715394e+02
   Unfolding-: -1.00493880e+03
@@ -15953,186 +15953,186 @@ bins:
   RelativeStatFSR-: -2.53903354e+05
   luminosity_uncertainty: 9.34525800e+02
   uncorrelated_uncertainty: 3.59433000e+02
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
-  art_sys_4: -0.0
+  art_sys_3: 0.0
+  art_sys_4: 0.0
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
-  art_sys_28: -0.0
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_28: 0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
-  art_sys_39: -0.0
+  art_sys_39: 0.0
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
-  art_sys_45: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
+  art_sys_45: 0.0
   art_sys_46: 0.0
-  art_sys_47: -0.0
-  art_sys_48: -0.0
+  art_sys_47: 0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 0.0
   art_sys_54: 0.0
   art_sys_55: 0.0
-  art_sys_56: -0.0
+  art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
-  art_sys_62: -0.0
-  art_sys_63: -0.0
+  art_sys_62: 0.0
+  art_sys_63: 0.0
   art_sys_64: 0.0
   art_sys_65: 0.0
   art_sys_66: 0.0
   art_sys_67: 0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
-  art_sys_71: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
+  art_sys_71: 0.0
   art_sys_72: 0.0
-  art_sys_73: -0.0
+  art_sys_73: 0.0
   art_sys_74: 0.0
-  art_sys_75: -0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_75: 0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 0.0
-  art_sys_88: -0.0
-  art_sys_89: -0.0
+  art_sys_88: 0.0
+  art_sys_89: 0.0
   art_sys_90: 0.0
   art_sys_91: 0.0
-  art_sys_92: -0.0
+  art_sys_92: 0.0
   art_sys_93: 0.0
   art_sys_94: 0.0
-  art_sys_95: -0.0
-  art_sys_96: -0.0
-  art_sys_97: -0.0
+  art_sys_95: 0.0
+  art_sys_96: 0.0
+  art_sys_97: 0.0
   art_sys_98: 0.0
   art_sys_99: 0.0
-  art_sys_100: -0.0
+  art_sys_100: 0.0
   art_sys_101: 0.0
-  art_sys_102: -0.0
+  art_sys_102: 0.0
   art_sys_103: 0.0
-  art_sys_104: -0.0
+  art_sys_104: 0.0
   art_sys_105: 0.0
   art_sys_106: 0.0
-  art_sys_107: -0.0
-  art_sys_108: -0.0
-  art_sys_109: -0.0
-  art_sys_110: -0.0
-  art_sys_111: -0.0
-  art_sys_112: -0.0
+  art_sys_107: 0.0
+  art_sys_108: 0.0
+  art_sys_109: 0.0
+  art_sys_110: 0.0
+  art_sys_111: 0.0
+  art_sys_112: 0.0
   art_sys_113: 0.0
-  art_sys_114: -0.0
+  art_sys_114: 0.0
   art_sys_115: 0.0
-  art_sys_116: -0.0
+  art_sys_116: 0.0
   art_sys_117: 0.0
   art_sys_118: 0.0
   art_sys_119: 0.0
   art_sys_120: 0.0
   art_sys_121: 0.0
   art_sys_122: 0.0
-  art_sys_123: -0.0
+  art_sys_123: 0.0
   art_sys_124: 0.0
   art_sys_125: 0.0
   art_sys_126: 0.0
-  art_sys_127: -0.0
-  art_sys_128: -0.0
+  art_sys_127: 0.0
+  art_sys_128: 0.0
   art_sys_129: 0.0
   art_sys_130: 0.0
   art_sys_131: 0.0
-  art_sys_132: -0.0
-  art_sys_133: -0.0
+  art_sys_132: 0.0
+  art_sys_133: 0.0
   art_sys_134: 0.0
   art_sys_135: 0.0
   art_sys_136: 0.0
   art_sys_137: 0.0
-  art_sys_138: -0.0
+  art_sys_138: 0.0
   art_sys_139: 0.0
   art_sys_140: 0.0
   art_sys_141: 0.0
-  art_sys_142: -0.0
+  art_sys_142: 0.0
   art_sys_143: 0.0
-  art_sys_144: -0.0
-  art_sys_145: -0.0
+  art_sys_144: 0.0
+  art_sys_145: 0.0
   art_sys_146: 0.0
-  art_sys_147: -0.0
+  art_sys_147: 0.0
   art_sys_148: 0.0
   art_sys_149: 0.0
-  art_sys_150: -0.0
-  art_sys_151: -0.0
-  art_sys_152: -0.0
+  art_sys_150: 0.0
+  art_sys_151: 0.0
+  art_sys_152: 0.0
   art_sys_153: 0.0
   art_sys_154: 0.0
   art_sys_155: 0.0
-  art_sys_156: -0.0
-  art_sys_157: -0.0
+  art_sys_156: 0.0
+  art_sys_157: 0.0
   art_sys_158: 0.0
-  art_sys_159: -0.0
-  art_sys_160: -0.0
-  art_sys_161: -0.0
+  art_sys_159: 0.0
+  art_sys_160: 0.0
+  art_sys_161: 0.0
   art_sys_162: 0.0
   art_sys_163: 0.0
-  art_sys_164: -0.0
+  art_sys_164: 0.0
   art_sys_165: 0.0
-  art_sys_166: -0.0
+  art_sys_166: 0.0
   art_sys_167: 0.0
-  art_sys_168: -0.0
+  art_sys_168: 0.0
   art_sys_169: 0.0
   art_sys_170: 0.0
-  art_sys_171: -0.0
+  art_sys_171: 0.0
   art_sys_172: 0.0
-  art_sys_173: -0.0
-  art_sys_174: -0.0
-  art_sys_175: -0.0
-  art_sys_176: -0.0
+  art_sys_173: 0.0
+  art_sys_174: 0.0
+  art_sys_175: 0.0
+  art_sys_176: 0.0
   art_sys_177: 0.0
   art_sys_178: 0.0
   art_sys_179: 0.0
-  art_sys_180: -0.0
+  art_sys_180: 0.0
   art_sys_181: 0.0
   art_sys_182: 0.0
   art_sys_183: 0.0
@@ -16189,8 +16189,8 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 9.60715394e+02
   Unfolding-: -1.00493880e+03
@@ -16244,186 +16244,186 @@ bins:
   RelativeStatFSR-: -2.53903354e+05
   luminosity_uncertainty: 9.34525800e+02
   uncorrelated_uncertainty: 3.59433000e+02
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
-  art_sys_4: -0.0
+  art_sys_3: 0.0
+  art_sys_4: 0.0
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
-  art_sys_28: -0.0
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_28: 0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
-  art_sys_39: -0.0
+  art_sys_39: 0.0
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
-  art_sys_45: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
+  art_sys_45: 0.0
   art_sys_46: 0.0
-  art_sys_47: -0.0
-  art_sys_48: -0.0
+  art_sys_47: 0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 0.0
   art_sys_54: 0.0
   art_sys_55: 0.0
-  art_sys_56: -0.0
+  art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
-  art_sys_62: -0.0
-  art_sys_63: -0.0
+  art_sys_62: 0.0
+  art_sys_63: 0.0
   art_sys_64: 0.0
   art_sys_65: 0.0
   art_sys_66: 0.0
   art_sys_67: 0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
-  art_sys_71: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
+  art_sys_71: 0.0
   art_sys_72: 0.0
-  art_sys_73: -0.0
+  art_sys_73: 0.0
   art_sys_74: 0.0
-  art_sys_75: -0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_75: 0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 0.0
-  art_sys_88: -0.0
-  art_sys_89: -0.0
+  art_sys_88: 0.0
+  art_sys_89: 0.0
   art_sys_90: 0.0
   art_sys_91: 0.0
-  art_sys_92: -0.0
+  art_sys_92: 0.0
   art_sys_93: 0.0
   art_sys_94: 0.0
-  art_sys_95: -0.0
-  art_sys_96: -0.0
-  art_sys_97: -0.0
+  art_sys_95: 0.0
+  art_sys_96: 0.0
+  art_sys_97: 0.0
   art_sys_98: 0.0
   art_sys_99: 0.0
-  art_sys_100: -0.0
+  art_sys_100: 0.0
   art_sys_101: 0.0
-  art_sys_102: -0.0
+  art_sys_102: 0.0
   art_sys_103: 0.0
-  art_sys_104: -0.0
+  art_sys_104: 0.0
   art_sys_105: 0.0
   art_sys_106: 0.0
-  art_sys_107: -0.0
-  art_sys_108: -0.0
-  art_sys_109: -0.0
-  art_sys_110: -0.0
-  art_sys_111: -0.0
-  art_sys_112: -0.0
+  art_sys_107: 0.0
+  art_sys_108: 0.0
+  art_sys_109: 0.0
+  art_sys_110: 0.0
+  art_sys_111: 0.0
+  art_sys_112: 0.0
   art_sys_113: 0.0
-  art_sys_114: -0.0
+  art_sys_114: 0.0
   art_sys_115: 0.0
-  art_sys_116: -0.0
+  art_sys_116: 0.0
   art_sys_117: 0.0
   art_sys_118: 0.0
   art_sys_119: 0.0
   art_sys_120: 0.0
   art_sys_121: 0.0
   art_sys_122: 0.0
-  art_sys_123: -0.0
+  art_sys_123: 0.0
   art_sys_124: 0.0
   art_sys_125: 0.0
   art_sys_126: 0.0
-  art_sys_127: -0.0
-  art_sys_128: -0.0
+  art_sys_127: 0.0
+  art_sys_128: 0.0
   art_sys_129: 0.0
   art_sys_130: 0.0
   art_sys_131: 0.0
-  art_sys_132: -0.0
-  art_sys_133: -0.0
+  art_sys_132: 0.0
+  art_sys_133: 0.0
   art_sys_134: 0.0
   art_sys_135: 0.0
   art_sys_136: 0.0
   art_sys_137: 0.0
-  art_sys_138: -0.0
+  art_sys_138: 0.0
   art_sys_139: 0.0
   art_sys_140: 0.0
   art_sys_141: 0.0
-  art_sys_142: -0.0
+  art_sys_142: 0.0
   art_sys_143: 0.0
-  art_sys_144: -0.0
-  art_sys_145: -0.0
+  art_sys_144: 0.0
+  art_sys_145: 0.0
   art_sys_146: 0.0
-  art_sys_147: -0.0
+  art_sys_147: 0.0
   art_sys_148: 0.0
   art_sys_149: 0.0
-  art_sys_150: -0.0
-  art_sys_151: -0.0
-  art_sys_152: -0.0
+  art_sys_150: 0.0
+  art_sys_151: 0.0
+  art_sys_152: 0.0
   art_sys_153: 0.0
   art_sys_154: 0.0
   art_sys_155: 0.0
-  art_sys_156: -0.0
-  art_sys_157: -0.0
+  art_sys_156: 0.0
+  art_sys_157: 0.0
   art_sys_158: 0.0
-  art_sys_159: -0.0
-  art_sys_160: -0.0
-  art_sys_161: -0.0
+  art_sys_159: 0.0
+  art_sys_160: 0.0
+  art_sys_161: 0.0
   art_sys_162: 0.0
   art_sys_163: 0.0
-  art_sys_164: -0.0
+  art_sys_164: 0.0
   art_sys_165: 0.0
-  art_sys_166: -0.0
+  art_sys_166: 0.0
   art_sys_167: 0.0
-  art_sys_168: -0.0
+  art_sys_168: 0.0
   art_sys_169: 0.0
   art_sys_170: 0.0
-  art_sys_171: -0.0
+  art_sys_171: 0.0
   art_sys_172: 0.0
-  art_sys_173: -0.0
-  art_sys_174: -0.0
-  art_sys_175: -0.0
-  art_sys_176: -0.0
+  art_sys_173: 0.0
+  art_sys_174: 0.0
+  art_sys_175: 0.0
+  art_sys_176: 0.0
   art_sys_177: 0.0
   art_sys_178: 0.0
   art_sys_179: 0.0
-  art_sys_180: -0.0
+  art_sys_180: 0.0
   art_sys_181: 0.0
   art_sys_182: 0.0
   art_sys_183: 0.0
@@ -16480,8 +16480,8 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 9.60715394e+02
   Unfolding-: -1.00493880e+03
@@ -16535,186 +16535,186 @@ bins:
   RelativeStatFSR-: -2.53903354e+05
   luminosity_uncertainty: 9.34525800e+02
   uncorrelated_uncertainty: 3.59433000e+02
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
-  art_sys_4: -0.0
+  art_sys_3: 0.0
+  art_sys_4: 0.0
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
-  art_sys_28: -0.0
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_28: 0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
-  art_sys_39: -0.0
+  art_sys_39: 0.0
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
-  art_sys_45: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
+  art_sys_45: 0.0
   art_sys_46: 0.0
-  art_sys_47: -0.0
-  art_sys_48: -0.0
+  art_sys_47: 0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 0.0
   art_sys_54: 0.0
   art_sys_55: 0.0
-  art_sys_56: -0.0
+  art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
-  art_sys_62: -0.0
-  art_sys_63: -0.0
+  art_sys_62: 0.0
+  art_sys_63: 0.0
   art_sys_64: 0.0
   art_sys_65: 0.0
   art_sys_66: 0.0
   art_sys_67: 0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
-  art_sys_71: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
+  art_sys_71: 0.0
   art_sys_72: 0.0
-  art_sys_73: -0.0
+  art_sys_73: 0.0
   art_sys_74: 0.0
-  art_sys_75: -0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_75: 0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 0.0
-  art_sys_88: -0.0
-  art_sys_89: -0.0
+  art_sys_88: 0.0
+  art_sys_89: 0.0
   art_sys_90: 0.0
   art_sys_91: 0.0
-  art_sys_92: -0.0
+  art_sys_92: 0.0
   art_sys_93: 0.0
   art_sys_94: 0.0
-  art_sys_95: -0.0
-  art_sys_96: -0.0
-  art_sys_97: -0.0
+  art_sys_95: 0.0
+  art_sys_96: 0.0
+  art_sys_97: 0.0
   art_sys_98: 0.0
   art_sys_99: 0.0
-  art_sys_100: -0.0
+  art_sys_100: 0.0
   art_sys_101: 0.0
-  art_sys_102: -0.0
+  art_sys_102: 0.0
   art_sys_103: 0.0
-  art_sys_104: -0.0
+  art_sys_104: 0.0
   art_sys_105: 0.0
   art_sys_106: 0.0
-  art_sys_107: -0.0
-  art_sys_108: -0.0
-  art_sys_109: -0.0
-  art_sys_110: -0.0
-  art_sys_111: -0.0
-  art_sys_112: -0.0
+  art_sys_107: 0.0
+  art_sys_108: 0.0
+  art_sys_109: 0.0
+  art_sys_110: 0.0
+  art_sys_111: 0.0
+  art_sys_112: 0.0
   art_sys_113: 0.0
-  art_sys_114: -0.0
+  art_sys_114: 0.0
   art_sys_115: 0.0
-  art_sys_116: -0.0
+  art_sys_116: 0.0
   art_sys_117: 0.0
   art_sys_118: 0.0
   art_sys_119: 0.0
   art_sys_120: 0.0
   art_sys_121: 0.0
   art_sys_122: 0.0
-  art_sys_123: -0.0
+  art_sys_123: 0.0
   art_sys_124: 0.0
   art_sys_125: 0.0
   art_sys_126: 0.0
-  art_sys_127: -0.0
-  art_sys_128: -0.0
+  art_sys_127: 0.0
+  art_sys_128: 0.0
   art_sys_129: 0.0
   art_sys_130: 0.0
   art_sys_131: 0.0
-  art_sys_132: -0.0
-  art_sys_133: -0.0
+  art_sys_132: 0.0
+  art_sys_133: 0.0
   art_sys_134: 0.0
   art_sys_135: 0.0
   art_sys_136: 0.0
   art_sys_137: 0.0
-  art_sys_138: -0.0
+  art_sys_138: 0.0
   art_sys_139: 0.0
   art_sys_140: 0.0
   art_sys_141: 0.0
-  art_sys_142: -0.0
+  art_sys_142: 0.0
   art_sys_143: 0.0
-  art_sys_144: -0.0
-  art_sys_145: -0.0
+  art_sys_144: 0.0
+  art_sys_145: 0.0
   art_sys_146: 0.0
-  art_sys_147: -0.0
+  art_sys_147: 0.0
   art_sys_148: 0.0
   art_sys_149: 0.0
-  art_sys_150: -0.0
-  art_sys_151: -0.0
-  art_sys_152: -0.0
+  art_sys_150: 0.0
+  art_sys_151: 0.0
+  art_sys_152: 0.0
   art_sys_153: 0.0
   art_sys_154: 0.0
   art_sys_155: 0.0
-  art_sys_156: -0.0
-  art_sys_157: -0.0
+  art_sys_156: 0.0
+  art_sys_157: 0.0
   art_sys_158: 0.0
-  art_sys_159: -0.0
-  art_sys_160: -0.0
-  art_sys_161: -0.0
+  art_sys_159: 0.0
+  art_sys_160: 0.0
+  art_sys_161: 0.0
   art_sys_162: 0.0
   art_sys_163: 0.0
-  art_sys_164: -0.0
+  art_sys_164: 0.0
   art_sys_165: 0.0
-  art_sys_166: -0.0
+  art_sys_166: 0.0
   art_sys_167: 0.0
-  art_sys_168: -0.0
+  art_sys_168: 0.0
   art_sys_169: 0.0
   art_sys_170: 0.0
-  art_sys_171: -0.0
+  art_sys_171: 0.0
   art_sys_172: 0.0
-  art_sys_173: -0.0
-  art_sys_174: -0.0
-  art_sys_175: -0.0
-  art_sys_176: -0.0
+  art_sys_173: 0.0
+  art_sys_174: 0.0
+  art_sys_175: 0.0
+  art_sys_176: 0.0
   art_sys_177: 0.0
   art_sys_178: 0.0
   art_sys_179: 0.0
-  art_sys_180: -0.0
+  art_sys_180: 0.0
   art_sys_181: 0.0
   art_sys_182: 0.0
   art_sys_183: 0.0
@@ -16771,8 +16771,8 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 9.60715394e+02
   Unfolding-: -1.00493880e+03
@@ -16826,186 +16826,186 @@ bins:
   RelativeStatFSR-: -2.53903354e+05
   luminosity_uncertainty: 9.34525800e+02
   uncorrelated_uncertainty: 3.59433000e+02
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
-  art_sys_4: -0.0
+  art_sys_3: 0.0
+  art_sys_4: 0.0
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
-  art_sys_28: -0.0
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_28: 0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
-  art_sys_39: -0.0
+  art_sys_39: 0.0
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
-  art_sys_45: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
+  art_sys_45: 0.0
   art_sys_46: 0.0
-  art_sys_47: -0.0
-  art_sys_48: -0.0
+  art_sys_47: 0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 0.0
   art_sys_54: 0.0
   art_sys_55: 0.0
-  art_sys_56: -0.0
+  art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
-  art_sys_62: -0.0
-  art_sys_63: -0.0
+  art_sys_62: 0.0
+  art_sys_63: 0.0
   art_sys_64: 0.0
   art_sys_65: 0.0
   art_sys_66: 0.0
   art_sys_67: 0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
-  art_sys_71: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
+  art_sys_71: 0.0
   art_sys_72: 0.0
-  art_sys_73: -0.0
+  art_sys_73: 0.0
   art_sys_74: 0.0
-  art_sys_75: -0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_75: 0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 0.0
-  art_sys_88: -0.0
-  art_sys_89: -0.0
+  art_sys_88: 0.0
+  art_sys_89: 0.0
   art_sys_90: 0.0
   art_sys_91: 0.0
-  art_sys_92: -0.0
+  art_sys_92: 0.0
   art_sys_93: 0.0
   art_sys_94: 0.0
-  art_sys_95: -0.0
-  art_sys_96: -0.0
-  art_sys_97: -0.0
+  art_sys_95: 0.0
+  art_sys_96: 0.0
+  art_sys_97: 0.0
   art_sys_98: 0.0
   art_sys_99: 0.0
-  art_sys_100: -0.0
+  art_sys_100: 0.0
   art_sys_101: 0.0
-  art_sys_102: -0.0
+  art_sys_102: 0.0
   art_sys_103: 0.0
-  art_sys_104: -0.0
+  art_sys_104: 0.0
   art_sys_105: 0.0
   art_sys_106: 0.0
-  art_sys_107: -0.0
-  art_sys_108: -0.0
-  art_sys_109: -0.0
-  art_sys_110: -0.0
-  art_sys_111: -0.0
-  art_sys_112: -0.0
+  art_sys_107: 0.0
+  art_sys_108: 0.0
+  art_sys_109: 0.0
+  art_sys_110: 0.0
+  art_sys_111: 0.0
+  art_sys_112: 0.0
   art_sys_113: 0.0
-  art_sys_114: -0.0
+  art_sys_114: 0.0
   art_sys_115: 0.0
-  art_sys_116: -0.0
+  art_sys_116: 0.0
   art_sys_117: 0.0
   art_sys_118: 0.0
   art_sys_119: 0.0
   art_sys_120: 0.0
   art_sys_121: 0.0
   art_sys_122: 0.0
-  art_sys_123: -0.0
+  art_sys_123: 0.0
   art_sys_124: 0.0
   art_sys_125: 0.0
   art_sys_126: 0.0
-  art_sys_127: -0.0
-  art_sys_128: -0.0
+  art_sys_127: 0.0
+  art_sys_128: 0.0
   art_sys_129: 0.0
   art_sys_130: 0.0
   art_sys_131: 0.0
-  art_sys_132: -0.0
-  art_sys_133: -0.0
+  art_sys_132: 0.0
+  art_sys_133: 0.0
   art_sys_134: 0.0
   art_sys_135: 0.0
   art_sys_136: 0.0
   art_sys_137: 0.0
-  art_sys_138: -0.0
+  art_sys_138: 0.0
   art_sys_139: 0.0
   art_sys_140: 0.0
   art_sys_141: 0.0
-  art_sys_142: -0.0
+  art_sys_142: 0.0
   art_sys_143: 0.0
-  art_sys_144: -0.0
-  art_sys_145: -0.0
+  art_sys_144: 0.0
+  art_sys_145: 0.0
   art_sys_146: 0.0
-  art_sys_147: -0.0
+  art_sys_147: 0.0
   art_sys_148: 0.0
   art_sys_149: 0.0
-  art_sys_150: -0.0
-  art_sys_151: -0.0
-  art_sys_152: -0.0
+  art_sys_150: 0.0
+  art_sys_151: 0.0
+  art_sys_152: 0.0
   art_sys_153: 0.0
   art_sys_154: 0.0
   art_sys_155: 0.0
-  art_sys_156: -0.0
-  art_sys_157: -0.0
+  art_sys_156: 0.0
+  art_sys_157: 0.0
   art_sys_158: 0.0
-  art_sys_159: -0.0
-  art_sys_160: -0.0
-  art_sys_161: -0.0
+  art_sys_159: 0.0
+  art_sys_160: 0.0
+  art_sys_161: 0.0
   art_sys_162: 0.0
   art_sys_163: 0.0
-  art_sys_164: -0.0
+  art_sys_164: 0.0
   art_sys_165: 0.0
-  art_sys_166: -0.0
+  art_sys_166: 0.0
   art_sys_167: 0.0
-  art_sys_168: -0.0
+  art_sys_168: 0.0
   art_sys_169: 0.0
   art_sys_170: 0.0
-  art_sys_171: -0.0
+  art_sys_171: 0.0
   art_sys_172: 0.0
-  art_sys_173: -0.0
-  art_sys_174: -0.0
-  art_sys_175: -0.0
-  art_sys_176: -0.0
+  art_sys_173: 0.0
+  art_sys_174: 0.0
+  art_sys_175: 0.0
+  art_sys_176: 0.0
   art_sys_177: 0.0
   art_sys_178: 0.0
   art_sys_179: 0.0
-  art_sys_180: -0.0
+  art_sys_180: 0.0
   art_sys_181: 0.0
   art_sys_182: 0.0
   art_sys_183: 0.0
@@ -17062,8 +17062,8 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 9.60715394e+02
   Unfolding-: -1.00493880e+03
@@ -17117,186 +17117,186 @@ bins:
   RelativeStatFSR-: -2.53903354e+05
   luminosity_uncertainty: 9.34525800e+02
   uncorrelated_uncertainty: 3.59433000e+02
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
-  art_sys_4: -0.0
+  art_sys_3: 0.0
+  art_sys_4: 0.0
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
-  art_sys_28: -0.0
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_28: 0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
-  art_sys_39: -0.0
+  art_sys_39: 0.0
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
-  art_sys_45: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
+  art_sys_45: 0.0
   art_sys_46: 0.0
-  art_sys_47: -0.0
-  art_sys_48: -0.0
+  art_sys_47: 0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 0.0
   art_sys_54: 0.0
   art_sys_55: 0.0
-  art_sys_56: -0.0
+  art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
-  art_sys_62: -0.0
-  art_sys_63: -0.0
+  art_sys_62: 0.0
+  art_sys_63: 0.0
   art_sys_64: 0.0
   art_sys_65: 0.0
   art_sys_66: 0.0
   art_sys_67: 0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
-  art_sys_71: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
+  art_sys_71: 0.0
   art_sys_72: 0.0
-  art_sys_73: -0.0
+  art_sys_73: 0.0
   art_sys_74: 0.0
-  art_sys_75: -0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_75: 0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 0.0
-  art_sys_88: -0.0
-  art_sys_89: -0.0
+  art_sys_88: 0.0
+  art_sys_89: 0.0
   art_sys_90: 0.0
   art_sys_91: 0.0
-  art_sys_92: -0.0
+  art_sys_92: 0.0
   art_sys_93: 0.0
   art_sys_94: 0.0
-  art_sys_95: -0.0
-  art_sys_96: -0.0
-  art_sys_97: -0.0
+  art_sys_95: 0.0
+  art_sys_96: 0.0
+  art_sys_97: 0.0
   art_sys_98: 0.0
   art_sys_99: 0.0
-  art_sys_100: -0.0
+  art_sys_100: 0.0
   art_sys_101: 0.0
-  art_sys_102: -0.0
+  art_sys_102: 0.0
   art_sys_103: 0.0
-  art_sys_104: -0.0
+  art_sys_104: 0.0
   art_sys_105: 0.0
   art_sys_106: 0.0
-  art_sys_107: -0.0
-  art_sys_108: -0.0
-  art_sys_109: -0.0
-  art_sys_110: -0.0
-  art_sys_111: -0.0
-  art_sys_112: -0.0
+  art_sys_107: 0.0
+  art_sys_108: 0.0
+  art_sys_109: 0.0
+  art_sys_110: 0.0
+  art_sys_111: 0.0
+  art_sys_112: 0.0
   art_sys_113: 0.0
-  art_sys_114: -0.0
+  art_sys_114: 0.0
   art_sys_115: 0.0
-  art_sys_116: -0.0
+  art_sys_116: 0.0
   art_sys_117: 0.0
   art_sys_118: 0.0
   art_sys_119: 0.0
   art_sys_120: 0.0
   art_sys_121: 0.0
   art_sys_122: 0.0
-  art_sys_123: -0.0
+  art_sys_123: 0.0
   art_sys_124: 0.0
   art_sys_125: 0.0
   art_sys_126: 0.0
-  art_sys_127: -0.0
-  art_sys_128: -0.0
+  art_sys_127: 0.0
+  art_sys_128: 0.0
   art_sys_129: 0.0
   art_sys_130: 0.0
   art_sys_131: 0.0
-  art_sys_132: -0.0
-  art_sys_133: -0.0
+  art_sys_132: 0.0
+  art_sys_133: 0.0
   art_sys_134: 0.0
   art_sys_135: 0.0
   art_sys_136: 0.0
   art_sys_137: 0.0
-  art_sys_138: -0.0
+  art_sys_138: 0.0
   art_sys_139: 0.0
   art_sys_140: 0.0
   art_sys_141: 0.0
-  art_sys_142: -0.0
+  art_sys_142: 0.0
   art_sys_143: 0.0
-  art_sys_144: -0.0
-  art_sys_145: -0.0
+  art_sys_144: 0.0
+  art_sys_145: 0.0
   art_sys_146: 0.0
-  art_sys_147: -0.0
+  art_sys_147: 0.0
   art_sys_148: 0.0
   art_sys_149: 0.0
-  art_sys_150: -0.0
-  art_sys_151: -0.0
-  art_sys_152: -0.0
+  art_sys_150: 0.0
+  art_sys_151: 0.0
+  art_sys_152: 0.0
   art_sys_153: 0.0
   art_sys_154: 0.0
   art_sys_155: 0.0
-  art_sys_156: -0.0
-  art_sys_157: -0.0
+  art_sys_156: 0.0
+  art_sys_157: 0.0
   art_sys_158: 0.0
-  art_sys_159: -0.0
-  art_sys_160: -0.0
-  art_sys_161: -0.0
+  art_sys_159: 0.0
+  art_sys_160: 0.0
+  art_sys_161: 0.0
   art_sys_162: 0.0
   art_sys_163: 0.0
-  art_sys_164: -0.0
+  art_sys_164: 0.0
   art_sys_165: 0.0
-  art_sys_166: -0.0
+  art_sys_166: 0.0
   art_sys_167: 0.0
-  art_sys_168: -0.0
+  art_sys_168: 0.0
   art_sys_169: 0.0
   art_sys_170: 0.0
-  art_sys_171: -0.0
+  art_sys_171: 0.0
   art_sys_172: 0.0
-  art_sys_173: -0.0
-  art_sys_174: -0.0
-  art_sys_175: -0.0
-  art_sys_176: -0.0
+  art_sys_173: 0.0
+  art_sys_174: 0.0
+  art_sys_175: 0.0
+  art_sys_176: 0.0
   art_sys_177: 0.0
   art_sys_178: 0.0
   art_sys_179: 0.0
-  art_sys_180: -0.0
+  art_sys_180: 0.0
   art_sys_181: 0.0
   art_sys_182: 0.0
   art_sys_183: 0.0
@@ -17353,8 +17353,8 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 9.60715394e+02
   Unfolding-: -1.00493880e+03
@@ -17410,7 +17410,7 @@ bins:
   uncorrelated_uncertainty: 3.59433000e+02
 - art_sys_1: -2.30114783e+02
   art_sys_2: -1.22253263e-15
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 3.70300778e-23
   art_sys_5: 0.0
   art_sys_6: 0.0
@@ -17418,44 +17418,44 @@ bins:
   art_sys_8: 0.0
   art_sys_9: -1.03931105e-16
   art_sys_10: 8.26252881e-24
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 1.71049626e+01
   art_sys_14: 0.0
   art_sys_15: -1.30915941e-17
   art_sys_16: 7.95700377e-24
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 2.60546159e+00
   art_sys_20: 0.0
   art_sys_21: -3.96303417e-24
   art_sys_22: -8.59560359e-21
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: -4.22559009e-02
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 5.22397179e-20
   art_sys_28: -2.97222846e-25
   art_sys_29: -1.48247833e-02
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: -1.59715465e-20
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: 5.63369828e-27
   art_sys_35: 8.59232927e-03
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 7.87485050e-21
   art_sys_39: 1.63213811e-26
   art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: -1.64569667e-03
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 6.11843521e-26
   art_sys_46: 0.0
   art_sys_47: 4.70841963e-22
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 4.98612036e-06
   art_sys_50: 2.04955135e-17
   art_sys_51: -1.46953685e-22
@@ -17645,7 +17645,7 @@ bins:
   art_sys_235: 0.0
   art_sys_236: 0.0
   art_sys_237: 0.0
-  art_sys_238: -0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 9.60715394e+02
   Unfolding-: -1.00493880e+03
@@ -17701,7 +17701,7 @@ bins:
   uncorrelated_uncertainty: 3.59433000e+02
 - art_sys_1: -1.16855503e+02
   art_sys_2: -2.38830904e-17
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -1.62892925e-22
   art_sys_5: 0.0
   art_sys_6: 0.0
@@ -17709,44 +17709,44 @@ bins:
   art_sys_8: 0.0
   art_sys_9: -3.45683927e-17
   art_sys_10: -4.07999854e-23
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: -3.03338079e+01
   art_sys_14: 0.0
   art_sys_15: -8.02743396e-19
   art_sys_16: -3.45968919e-23
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: -7.69466219e+00
   art_sys_20: 0.0
   art_sys_21: 1.78323720e-23
   art_sys_22: -4.08021879e-20
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 1.43335780e-01
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 3.61918939e-20
   art_sys_28: 3.55222815e-25
   art_sys_29: 5.09411189e-02
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: -7.46304820e-21
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: 8.20805240e-27
   art_sys_35: -3.29568334e-02
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 3.39840784e-21
   art_sys_39: 3.83885184e-26
   art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 6.83247670e-03
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -3.69260952e-25
   art_sys_46: 0.0
   art_sys_47: -1.61145422e-22
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: -2.94756994e-05
   art_sys_50: 1.14744175e-17
   art_sys_51: -1.44973528e-22
@@ -17935,9 +17935,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
+  art_sys_237: 0.0
   art_sys_238: 0.0
-  art_sys_239: -0.0
+  art_sys_239: 0.0
   Unfolding+: 4.38205820e+02
   Unfolding-: -4.63088170e+02
   AbsoluteStat+: 0.0
@@ -17992,7 +17992,7 @@ bins:
   uncorrelated_uncertainty: 177.722
 - art_sys_1: -1.10868380e+01
   art_sys_2: 8.45914714e-16
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 6.23078149e-22
   art_sys_5: 0.0
   art_sys_6: 0.0
@@ -18000,44 +18000,44 @@ bins:
   art_sys_8: 0.0
   art_sys_9: 1.80628281e-17
   art_sys_10: 1.50251866e-22
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 2.81430208e+01
   art_sys_14: 0.0
   art_sys_15: 4.34955390e-20
   art_sys_16: 1.30652529e-22
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 1.18005223e+01
   art_sys_20: 0.0
   art_sys_21: -6.80491459e-23
   art_sys_22: 6.48149241e-20
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: -4.78281847e-01
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 2.56800925e-22
   art_sys_28: -1.14380905e-24
   art_sys_29: -1.31187661e-01
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 6.53124599e-21
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: -1.45370588e-25
   art_sys_35: 1.01370950e-01
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: -7.74941224e-21
   art_sys_39: -1.89296748e-24
   art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: -2.22256904e-02
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 1.38483530e-24
   art_sys_46: 0.0
   art_sys_47: 1.06693855e-23
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 8.54896383e-05
   art_sys_50: -1.45903730e-17
   art_sys_51: 1.68026209e-22
@@ -18227,7 +18227,7 @@ bins:
   art_sys_235: 0.0
   art_sys_236: 0.0
   art_sys_237: 0.0
-  art_sys_238: -0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 1.81426468e+02
   Unfolding-: -1.93972220e+02
@@ -18283,7 +18283,7 @@ bins:
   uncorrelated_uncertainty: 81.0154
 - art_sys_1: 1.38300030e+01
   art_sys_2: -3.27717578e-17
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -2.13546142e-21
   art_sys_5: 0.0
   art_sys_6: 0.0
@@ -18291,44 +18291,44 @@ bins:
   art_sys_8: 0.0
   art_sys_9: 3.83705019e-17
   art_sys_10: -5.39216513e-22
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 5.05245959e+01
   art_sys_14: 0.0
   art_sys_15: 3.78860990e-18
   art_sys_16: -4.52369119e-22
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: -1.18890768e+01
   art_sys_20: 0.0
   art_sys_21: 2.30314449e-22
   art_sys_22: -1.76289456e-19
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 4.55413650e-01
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: -4.77539126e-20
   art_sys_28: 6.28877111e-25
   art_sys_29: 2.82448384e-01
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: -3.76308313e-21
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: 2.77268617e-25
   art_sys_35: -1.97899849e-01
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 2.09802500e-20
   art_sys_39: 1.05009403e-23
   art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 5.24979136e-02
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -5.08519110e-24
   art_sys_46: 0.0
   art_sys_47: -1.12141256e-21
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: -2.99902824e-04
   art_sys_50: 7.72230999e-18
   art_sys_51: -2.69401322e-22
@@ -18517,9 +18517,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
+  art_sys_237: 0.0
   art_sys_238: 0.0
-  art_sys_239: -0.0
+  art_sys_239: 0.0
   Unfolding+: 7.23343296e+01
   Unfolding-: -7.82733588e+01
   AbsoluteStat+: 0.0
@@ -18574,7 +18574,7 @@ bins:
   uncorrelated_uncertainty: 35.8934
 - art_sys_1: 1.29952067e+00
   art_sys_2: -8.19800144e-16
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 1.05977734e-20
   art_sys_5: 0.0
   art_sys_6: 0.0
@@ -18582,44 +18582,44 @@ bins:
   art_sys_8: 0.0
   art_sys_9: 3.69543865e-17
   art_sys_10: 2.67757700e-21
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 2.48796212e+00
   art_sys_14: 0.0
   art_sys_15: 2.57483323e-19
   art_sys_16: 2.15982019e-21
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: -3.01983922e+00
   art_sys_20: 0.0
   art_sys_21: -1.14930565e-21
   art_sys_22: 1.36348463e-19
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: -4.63153544e+00
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 3.02840864e-20
   art_sys_28: 5.85839641e-24
   art_sys_29: -8.83091587e-01
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 8.95939807e-20
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: -3.96502937e-24
   art_sys_35: 1.06656367e+00
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: -1.52799879e-19
   art_sys_39: -2.04959248e-23
   art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: -2.71044122e-01
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 2.74826636e-23
   art_sys_46: 0.0
   art_sys_47: 3.73898889e-21
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 1.60629334e-03
   art_sys_50: 2.64214505e-18
   art_sys_51: 8.14983778e-22
@@ -18809,7 +18809,7 @@ bins:
   art_sys_235: 0.0
   art_sys_236: 0.0
   art_sys_237: 0.0
-  art_sys_238: -0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 2.84732577e+01
   Unfolding-: -3.11564853e+01
@@ -18865,7 +18865,7 @@ bins:
   uncorrelated_uncertainty: 1.56804000e+01
 - art_sys_1: -5.47294573e-01
   art_sys_2: 9.92609629e-16
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -5.05790344e-20
   art_sys_5: 0.0
   art_sys_6: 0.0
@@ -18873,44 +18873,44 @@ bins:
   art_sys_8: 0.0
   art_sys_9: -1.60671384e-17
   art_sys_10: -1.21242678e-20
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: -2.58247733e+00
   art_sys_14: 0.0
   art_sys_15: 1.49666847e-17
   art_sys_16: -1.06271189e-20
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 6.79556819e-01
   art_sys_20: 0.0
   art_sys_21: 5.61346097e-21
   art_sys_22: -5.41875642e-19
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: -2.73763425e+00
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: -2.04810401e-19
   art_sys_28: 1.11324931e-22
   art_sys_29: 2.21566859e+00
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: -2.93661083e-19
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: 1.00838966e-23
   art_sys_35: -1.26807733e+00
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 5.06957514e-19
   art_sys_39: 1.12528436e-22
   art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 5.56702667e-01
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -1.11730078e-22
   art_sys_46: 0.0
   art_sys_47: -1.30654840e-20
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: -3.73157574e-03
   art_sys_50: -4.73380388e-19
   art_sys_51: -1.85051463e-21
@@ -19099,9 +19099,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
+  art_sys_237: 0.0
   art_sys_238: 0.0
-  art_sys_239: -0.0
+  art_sys_239: 0.0
   Unfolding+: 1.21895785e+01
   Unfolding-: -1.34820941e+01
   AbsoluteStat+: 4.82906965e-01
@@ -19156,7 +19156,7 @@ bins:
   uncorrelated_uncertainty: 7.43046
 - art_sys_1: -1.48475353e-01
   art_sys_2: 8.80843396e-16
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 1.19587230e-19
   art_sys_5: 0.0
   art_sys_6: 0.0
@@ -19164,44 +19164,44 @@ bins:
   art_sys_8: 0.0
   art_sys_9: -8.06769419e-18
   art_sys_10: 3.12904641e-20
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: -3.09605307e-01
   art_sys_14: 0.0
   art_sys_15: -2.96449469e-17
   art_sys_16: 2.42700339e-20
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 3.73471351e-01
   art_sys_20: 0.0
   art_sys_21: -1.30437498e-20
   art_sys_22: 1.22030812e-18
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 4.12275208e-01
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 6.25453042e-19
   art_sys_28: 4.31184132e-22
   art_sys_29: 3.13582620e+00
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 9.61266835e-19
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: -3.99963781e-23
   art_sys_35: 7.61332956e-01
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: -1.65118063e-18
   art_sys_39: -4.77228678e-22
   art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: -6.46028916e-01
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 3.14521237e-22
   art_sys_46: 0.0
   art_sys_47: 3.87693654e-20
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 1.61879527e-02
   art_sys_50: -3.12777351e-19
   art_sys_51: 7.47503415e-21
@@ -19391,7 +19391,7 @@ bins:
   art_sys_235: 0.0
   art_sys_236: 0.0
   art_sys_237: 0.0
-  art_sys_238: -0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 5.68054776e+00
   Unfolding-: -6.33994531e+00
@@ -19447,7 +19447,7 @@ bins:
   uncorrelated_uncertainty: 3.82184000e+00
 - art_sys_1: 9.86779758e-03
   art_sys_2: -5.99158737e-16
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -4.98292682e-19
   art_sys_5: 0.0
   art_sys_6: 0.0
@@ -19455,44 +19455,44 @@ bins:
   art_sys_8: 0.0
   art_sys_9: 6.02248741e-18
   art_sys_10: -1.18012630e-19
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 1.54657118e-01
   art_sys_14: 0.0
   art_sys_15: 8.16364501e-17
   art_sys_16: -1.03592747e-19
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: -1.27783178e-02
   art_sys_20: 0.0
   art_sys_21: 5.48008074e-20
   art_sys_22: -3.33091544e-18
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 6.58143998e-01
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: -1.82210168e-18
   art_sys_28: 1.30506297e-21
   art_sys_29: 7.35546721e-01
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: -2.81634414e-18
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: 1.76241003e-22
   art_sys_35: 1.96312639e+00
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 4.90254324e-18
   art_sys_39: 1.16647156e-21
   art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 7.52009988e-01
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -1.14615327e-21
   art_sys_46: 0.0
   art_sys_47: -1.17225655e-19
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: -1.22387258e-02
   art_sys_50: 4.56334607e-21
   art_sys_51: -2.24229253e-20
@@ -19681,9 +19681,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
+  art_sys_237: 0.0
   art_sys_238: 0.0
-  art_sys_239: -0.0
+  art_sys_239: 0.0
   Unfolding+: 2.65172069e+00
   Unfolding-: -2.98457848e+00
   AbsoluteStat+: 1.59465346e-01
@@ -19738,7 +19738,7 @@ bins:
   uncorrelated_uncertainty: 1.96959
 - art_sys_1: 5.67305623e-03
   art_sys_2: 1.95827160e-15
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 2.32885468e-18
   art_sys_5: 0.0
   art_sys_6: 0.0
@@ -19746,44 +19746,44 @@ bins:
   art_sys_8: 0.0
   art_sys_9: -2.18820829e-16
   art_sys_10: 6.02744545e-19
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 2.68773801e-02
   art_sys_14: 0.0
   art_sys_15: -4.63170519e-16
   art_sys_16: 4.81895022e-19
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: -1.78411342e-02
   art_sys_20: 0.0
   art_sys_21: -2.54077336e-19
   art_sys_22: 1.77305312e-17
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 1.75259929e-02
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 9.74821836e-18
   art_sys_28: 3.14304636e-21
   art_sys_29: -1.34345944e-01
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 1.43852417e-17
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: -6.52546807e-22
   art_sys_35: 1.11377876e-01
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: -2.51064307e-17
   art_sys_39: -5.63494147e-21
   art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 1.54332737e-01
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 6.13891245e-21
   art_sys_46: 0.0
   art_sys_47: 5.81970823e-19
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 1.86275580e-01
   art_sys_50: 1.42629014e-20
   art_sys_51: 1.10783631e-19
@@ -19973,7 +19973,7 @@ bins:
   art_sys_235: 0.0
   art_sys_236: 0.0
   art_sys_237: 0.0
-  art_sys_238: -0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 1.23868986e+00
   Unfolding-: -1.40528467e+00
@@ -20029,7 +20029,7 @@ bins:
   uncorrelated_uncertainty: 1.01552
 - art_sys_1: 1.04046512e-03
   art_sys_2: -8.33281474e-15
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -7.44412180e-18
   art_sys_5: 0.0
   art_sys_6: 0.0
@@ -20037,44 +20037,44 @@ bins:
   art_sys_8: 0.0
   art_sys_9: 5.86120270e-16
   art_sys_10: -1.78587166e-18
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 1.77953259e-04
   art_sys_14: 0.0
   art_sys_15: 1.27642613e-15
   art_sys_16: -1.48710755e-18
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: -2.30380582e-03
   art_sys_20: 0.0
   art_sys_21: 7.97155874e-19
   art_sys_22: -4.87002239e-17
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: -3.41186608e-02
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: -2.60909805e-17
   art_sys_28: 3.12742700e-21
   art_sys_29: -5.23935428e-02
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: -3.88768882e-17
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: 4.18387575e-21
   art_sys_35: -1.18339460e-01
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 6.88898030e-17
   art_sys_39: 2.14246945e-20
   art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: -5.01272356e-02
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -1.84993093e-20
   art_sys_46: 0.0
   art_sys_47: -1.78803418e-18
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 1.30876649e-01
   art_sys_50: 1.96117131e-21
   art_sys_51: -3.25369610e-19
@@ -20263,9 +20263,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
+  art_sys_237: 0.0
   art_sys_238: 0.0
-  art_sys_239: -0.0
+  art_sys_239: 0.0
   Unfolding+: 6.28479333e-01
   Unfolding-: -7.17286195e-01
   AbsoluteStat+: 5.62175567e-02
@@ -20320,7 +20320,7 @@ bins:
   uncorrelated_uncertainty: 5.68289000e-01
 - art_sys_1: 6.25260902e-05
   art_sys_2: 1.32366035e-14
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 1.98352008e-17
   art_sys_5: 0.0
   art_sys_6: 0.0
@@ -20328,44 +20328,44 @@ bins:
   art_sys_8: 0.0
   art_sys_9: -7.88100896e-16
   art_sys_10: 4.80095192e-18
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: -1.60894948e-03
   art_sys_14: 0.0
   art_sys_15: -2.14538281e-15
   art_sys_16: 4.02750158e-18
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 6.72756584e-04
   art_sys_20: 0.0
   art_sys_21: -2.15297815e-18
   art_sys_22: 8.44258714e-17
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: -5.44724727e-03
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 4.43525959e-17
   art_sys_28: -2.69924664e-20
   art_sys_29: 7.90026173e-03
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 6.19719981e-17
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: -8.46167174e-21
   art_sys_35: -1.72286726e-02
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: -1.15142603e-16
   art_sys_39: -1.92788107e-20
   art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: -1.88381027e-02
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 5.05377600e-20
   art_sys_46: 0.0
   art_sys_47: 3.12659354e-18
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: -1.99107516e-03
   art_sys_50: -5.13456989e-22
   art_sys_51: 6.27636978e-19
@@ -20555,7 +20555,7 @@ bins:
   art_sys_235: 0.0
   art_sys_236: 0.0
   art_sys_237: 0.0
-  art_sys_238: -0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 3.13382246e-01
   Unfolding-: -3.59825627e-01
@@ -20611,7 +20611,7 @@ bins:
   uncorrelated_uncertainty: 0.312766
 - art_sys_1: -1.55800211e-05
   art_sys_2: -3.88028521e-14
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -6.06425062e-17
   art_sys_5: 0.0
   art_sys_6: 0.0
@@ -20619,44 +20619,44 @@ bins:
   art_sys_8: 0.0
   art_sys_9: 2.89744948e-15
   art_sys_10: -1.52407648e-17
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: -3.55604768e-04
   art_sys_14: 0.0
   art_sys_15: 7.06352725e-15
   art_sys_16: -1.18154472e-17
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 2.23323412e-04
   art_sys_20: 0.0
   art_sys_21: 6.51245353e-18
   art_sys_22: -2.80165054e-16
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 1.46059140e-03
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: -1.50564237e-16
   art_sys_28: -1.04270642e-19
   art_sys_29: 4.95002921e-03
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: -1.95170062e-16
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: 4.85397359e-20
   art_sys_35: 6.61681903e-03
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 3.69567532e-16
   art_sys_39: -1.46345264e-19
   art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 2.03289127e-03
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -1.81698631e-19
   art_sys_46: 0.0
   art_sys_47: -9.29202568e-18
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: -1.56411332e-02
   art_sys_50: -1.80902808e-22
   art_sys_51: -2.03628053e-18
@@ -20845,9 +20845,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
+  art_sys_237: 0.0
   art_sys_238: 0.0
-  art_sys_239: -0.0
+  art_sys_239: 0.0
   Unfolding+: 1.58496934e-01
   Unfolding-: -1.82653543e-01
   AbsoluteStat+: 2.06933400e-02
@@ -20902,7 +20902,7 @@ bins:
   uncorrelated_uncertainty: 0.174299
 - art_sys_1: -4.01159843e-06
   art_sys_2: 4.13902161e-14
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 2.39224709e-16
   art_sys_5: 0.0
   art_sys_6: 0.0
@@ -20910,44 +20910,44 @@ bins:
   art_sys_8: 0.0
   art_sys_9: 2.27512075e-16
   art_sys_10: 5.07657056e-17
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: -5.17594766e-05
   art_sys_14: 0.0
   art_sys_15: -1.06381685e-14
   art_sys_16: 4.29605301e-17
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 2.61466724e-05
   art_sys_20: 0.0
   art_sys_21: -2.39636845e-17
   art_sys_22: 4.58681436e-16
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 5.02693029e-04
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 1.96216504e-16
   art_sys_28: -3.63562970e-19
   art_sys_29: 5.82487091e-04
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 2.44295339e-16
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: -1.74113068e-19
   art_sys_35: 1.96147319e-03
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: -5.57895889e-16
   art_sys_39: -7.31903973e-19
   art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 1.36753960e-03
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 5.63578403e-19
   art_sys_46: 0.0
   art_sys_47: 2.41944073e-17
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: -1.20479416e-03
   art_sys_50: -2.09192253e-23
   art_sys_51: 4.84196458e-18
@@ -21137,7 +21137,7 @@ bins:
   art_sys_235: 0.0
   art_sys_236: 0.0
   art_sys_237: 0.0
-  art_sys_238: -0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 8.25756216e-02
   Unfolding-: -9.54647838e-02
@@ -21193,7 +21193,7 @@ bins:
   uncorrelated_uncertainty: 1.00154000e-01
 - art_sys_1: -5.07350415e-07
   art_sys_2: -2.60780887e-14
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -5.90381042e-16
   art_sys_5: 0.0
   art_sys_6: 0.0
@@ -21201,44 +21201,44 @@ bins:
   art_sys_8: 0.0
   art_sys_9: 1.84732418e-15
   art_sys_10: -1.36579132e-16
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: -5.53841394e-06
   art_sys_14: 0.0
   art_sys_15: 1.42527234e-14
   art_sys_16: -1.06618400e-16
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: -1.54160714e-06
   art_sys_20: 0.0
   art_sys_21: 6.51060050e-17
   art_sys_22: -7.06809132e-16
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 3.86106380e-05
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: -4.22976228e-16
   art_sys_28: -7.92207296e-19
   art_sys_29: -1.41268021e-04
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: -1.05081395e-16
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: 5.31783773e-19
   art_sys_35: 3.10602343e-05
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 5.45218853e-16
   art_sys_39: -5.68629826e-19
   art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 1.15803797e-04
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -1.67981814e-18
   art_sys_46: 0.0
   art_sys_47: 1.60310310e-18
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 1.30149254e-03
   art_sys_50: 1.47626230e-24
   art_sys_51: -6.37756176e-18
@@ -21427,9 +21427,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
+  art_sys_237: 0.0
   art_sys_238: 0.0
-  art_sys_239: -0.0
+  art_sys_239: 0.0
   Unfolding+: 4.34104264e-02
   Unfolding-: -5.02625448e-02
   AbsoluteStat+: 8.16920218e-03
@@ -21484,7 +21484,7 @@ bins:
   uncorrelated_uncertainty: 5.80261000e-02
 - art_sys_1: -2.79278704e-08
   art_sys_2: -1.35522851e-13
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 1.74035574e-15
   art_sys_5: 0.0
   art_sys_6: 0.0
@@ -21492,44 +21492,44 @@ bins:
   art_sys_8: 0.0
   art_sys_9: 3.55977444e-14
   art_sys_10: 3.76763260e-16
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: -4.10270950e-07
   art_sys_14: 0.0
   art_sys_15: -1.37745229e-14
   art_sys_16: 2.82337783e-16
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: -9.68138409e-07
   art_sys_20: 0.0
   art_sys_21: -1.85524990e-16
   art_sys_22: 1.11025796e-15
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: -1.11414178e-05
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 2.17061889e-17
   art_sys_28: 2.19529496e-18
   art_sys_29: -5.95711075e-05
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: -4.47245988e-16
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: -2.65240988e-18
   art_sys_35: -8.36840280e-05
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: -3.61890988e-16
   art_sys_39: 2.30034674e-18
   art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: -4.75168139e-05
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 5.16660988e-18
   art_sys_46: 0.0
   art_sys_47: 4.58641617e-17
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 2.59402519e-04
   art_sys_50: 8.23358015e-25
   art_sys_51: 1.98481343e-17
@@ -21719,7 +21719,7 @@ bins:
   art_sys_235: 0.0
   art_sys_236: 0.0
   art_sys_237: 0.0
-  art_sys_238: -0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 2.27422153e-02
   Unfolding-: -2.63246341e-02
@@ -21775,7 +21775,7 @@ bins:
   uncorrelated_uncertainty: 3.34189000e-02
 - art_sys_1: 3.51032666e-10
   art_sys_2: 1.49919816e-13
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -7.21767514e-15
   art_sys_5: 0.0
   art_sys_6: 0.0
@@ -21783,44 +21783,44 @@ bins:
   art_sys_8: 0.0
   art_sys_9: 3.01769857e-14
   art_sys_10: -1.46637671e-15
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: -3.85795824e-08
   art_sys_14: 0.0
   art_sys_15: 2.42255416e-14
   art_sys_16: -1.25380181e-15
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: -1.84063241e-07
   art_sys_20: 0.0
   art_sys_21: 7.66999577e-16
   art_sys_22: -1.97465091e-15
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: -3.86401432e-06
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: -1.92739903e-15
   art_sys_28: 2.65395014e-17
   art_sys_29: -1.21875230e-05
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 1.60928218e-15
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: 7.09760658e-18
   art_sys_35: -2.30503909e-05
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: -8.06252346e-16
   art_sys_39: -3.36904105e-18
   art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: -1.54587071e-05
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -1.89310372e-17
   art_sys_46: 0.0
   art_sys_47: 3.21963064e-16
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: -2.90627656e-05
   art_sys_50: 1.62951442e-25
   art_sys_51: -1.09701611e-17
@@ -22009,9 +22009,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
+  art_sys_237: 0.0
   art_sys_238: 0.0
-  art_sys_239: -0.0
+  art_sys_239: 0.0
   Unfolding+: 1.20550805e-02
   Unfolding-: -1.39256015e-02
   AbsoluteStat+: 3.21624921e-03
@@ -22066,7 +22066,7 @@ bins:
   uncorrelated_uncertainty: 1.94795000e-02
 - art_sys_1: 2.66562795e-10
   art_sys_2: 1.43737084e-14
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 6.79670525e-15
   art_sys_5: 0.0
   art_sys_6: 0.0
@@ -22074,44 +22074,44 @@ bins:
   art_sys_8: 0.0
   art_sys_9: -1.09891177e-14
   art_sys_10: 1.54643653e-15
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: -5.31346452e-09
   art_sys_14: 0.0
   art_sys_15: -2.73564889e-14
   art_sys_16: 5.05230777e-16
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: -2.38294428e-08
   art_sys_20: 0.0
   art_sys_21: -7.44127948e-16
   art_sys_22: 2.53043407e-15
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: -6.71789689e-07
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: -7.49054539e-16
   art_sys_28: 1.07341935e-16
   art_sys_29: -1.80287584e-06
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: -1.17616351e-15
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: -2.59647474e-17
   art_sys_35: -3.63678586e-06
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 5.65817400e-16
   art_sys_39: 4.18549358e-17
   art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: -1.99825287e-06
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 4.03068932e-17
   art_sys_46: 0.0
   art_sys_47: -4.01902256e-16
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: -1.93477493e-05
   art_sys_50: 2.12048542e-26
   art_sys_51: 2.18822199e-17
@@ -22301,7 +22301,7 @@ bins:
   art_sys_235: 0.0
   art_sys_236: 0.0
   art_sys_237: 0.0
-  art_sys_238: -0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 6.45097447e-03
   Unfolding-: -7.41655847e-03
@@ -22357,7 +22357,7 @@ bins:
   uncorrelated_uncertainty: 1.14367000e-02
 - art_sys_1: 1.84169019e-11
   art_sys_2: -3.23446728e-14
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -6.72549508e-14
   art_sys_5: 0.0
   art_sys_6: 0.0
@@ -22365,44 +22365,44 @@ bins:
   art_sys_8: 0.0
   art_sys_9: 3.50849270e-14
   art_sys_10: -1.05489025e-14
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: -4.52659684e-10
   art_sys_14: 0.0
   art_sys_15: -1.59225831e-14
   art_sys_16: -9.68877977e-15
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: -1.56536859e-09
   art_sys_20: 0.0
   art_sys_21: 6.38668540e-15
   art_sys_22: 1.16575189e-15
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: -4.97487637e-08
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 2.70993910e-17
   art_sys_28: 5.21177430e-16
   art_sys_29: -1.40638580e-07
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 1.00484865e-17
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: 1.03075719e-16
   art_sys_35: -2.40485602e-07
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 2.35182926e-16
   art_sys_39: 1.46780086e-16
   art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: -3.29250718e-09
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -1.57454214e-16
   art_sys_46: 0.0
   art_sys_47: 2.91722612e-16
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: -1.78673663e-06
   art_sys_50: 1.38085578e-27
   art_sys_51: -1.06358127e-16
@@ -22591,9 +22591,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
+  art_sys_237: 0.0
   art_sys_238: 0.0
-  art_sys_239: -0.0
+  art_sys_239: 0.0
   Unfolding+: 3.59086027e-03
   Unfolding-: -4.10074964e-03
   AbsoluteStat+: 1.33446457e-03
@@ -22648,7 +22648,7 @@ bins:
   uncorrelated_uncertainty: 6.95364000e-03
 - art_sys_1: 4.76819712e-13
   art_sys_2: 3.13725140e-14
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -1.96383952e-14
   art_sys_5: 0.0
   art_sys_6: 0.0
@@ -22656,44 +22656,44 @@ bins:
   art_sys_8: 0.0
   art_sys_9: -8.01259010e-14
   art_sys_10: -2.62526230e-15
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: -3.81846546e-11
   art_sys_14: 0.0
   art_sys_15: 8.04136818e-15
   art_sys_16: -1.41114907e-14
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: -1.37435402e-10
   art_sys_20: 0.0
   art_sys_21: 1.97406022e-15
   art_sys_22: -2.46839236e-15
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: -3.62784507e-09
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: -1.15280485e-15
   art_sys_28: 2.15450326e-15
   art_sys_29: -1.45766719e-08
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: -1.02178011e-15
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: -1.71644404e-16
   art_sys_35: -1.47673737e-08
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: -9.96040389e-16
   art_sys_39: 1.04375023e-16
   art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 2.49468354e-08
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 2.49851553e-16
   art_sys_46: 0.0
   art_sys_47: -1.46665732e-15
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 4.99845581e-08
   art_sys_50: 1.18210524e-28
   art_sys_51: 2.32681343e-16
@@ -22939,7 +22939,7 @@ bins:
   uncorrelated_uncertainty: 4.13665000e-03
 - art_sys_1: -1.40644714e-13
   art_sys_2: 4.69895423e-14
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -5.04744543e-14
   art_sys_5: 0.0
   art_sys_6: 0.0
@@ -22947,44 +22947,44 @@ bins:
   art_sys_8: 0.0
   art_sys_9: -1.82319706e-14
   art_sys_10: 1.86839189e-14
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: -8.96264410e-13
   art_sys_14: 0.0
   art_sys_15: -3.91182299e-15
   art_sys_16: 1.22070870e-14
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: -1.55579318e-11
   art_sys_20: 0.0
   art_sys_21: 2.65562437e-15
   art_sys_22: -1.83575333e-15
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: -2.33346837e-10
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: -4.26833200e-16
   art_sys_28: 1.96888410e-15
   art_sys_29: -1.63280322e-09
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 4.97380328e-16
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: 3.11493526e-16
   art_sys_35: -1.02209831e-09
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 4.98863028e-16
   art_sys_39: 3.39662006e-16
   art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 3.51619695e-09
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -1.48163528e-16
   art_sys_46: 0.0
   art_sys_47: 2.03268161e-15
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 2.55552477e-08
   art_sys_50: 1.34784049e-29
   art_sys_51: -2.70653136e-16
@@ -23173,9 +23173,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
-  art_sys_239: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
+  art_sys_239: 0.0
   Unfolding+: 1.07289370e-03
   Unfolding-: -1.19968708e-03
   AbsoluteStat+: 5.42509375e-04
@@ -23230,7 +23230,7 @@ bins:
   uncorrelated_uncertainty: 2.44963000e-03
 - art_sys_1: -2.44942889e-14
   art_sys_2: 5.10175158e-14
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 1.65680587e-14
   art_sys_5: 0.0
   art_sys_6: 0.0
@@ -23238,44 +23238,44 @@ bins:
   art_sys_8: 0.0
   art_sys_9: 2.81660612e-14
   art_sys_10: 6.50267982e-15
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 3.38720262e-13
   art_sys_14: 0.0
   art_sys_15: 2.12940716e-15
   art_sys_16: -1.24801108e-14
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: -1.84461428e-12
   art_sys_20: 0.0
   art_sys_21: -4.14193603e-15
   art_sys_22: -2.64457891e-15
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: -2.69171659e-11
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: -1.76185799e-15
   art_sys_28: 1.96871611e-15
   art_sys_29: -1.36339122e-10
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 6.67880132e-16
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: 1.05225586e-15
   art_sys_35: -1.89819955e-10
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: -1.41112082e-15
   art_sys_39: -1.60719132e-15
   art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: -8.71482329e-11
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 1.05121249e-17
   art_sys_46: 0.0
   art_sys_47: -3.09534183e-15
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: -7.52180847e-09
   art_sys_50: 1.59901887e-30
   art_sys_51: 5.74466171e-16
@@ -23521,7 +23521,7 @@ bins:
   uncorrelated_uncertainty: 1.46384000e-03
 - art_sys_1: -2.40470508e-15
   art_sys_2: 3.29455998e-14
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -1.68656285e-14
   art_sys_5: 0.0
   art_sys_6: 0.0
@@ -23529,44 +23529,44 @@ bins:
   art_sys_8: 0.0
   art_sys_9: 5.89352460e-14
   art_sys_10: 1.44454306e-14
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 6.40076687e-14
   art_sys_14: 0.0
   art_sys_15: 6.80854563e-15
   art_sys_16: 8.12324580e-15
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: -2.05538946e-13
   art_sys_20: 0.0
   art_sys_21: 7.81026682e-16
   art_sys_22: 3.00632790e-15
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: -4.66158910e-12
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 6.34539799e-16
   art_sys_28: -9.25091710e-16
   art_sys_29: -4.02978104e-12
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: -6.71413320e-16
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: -5.91577375e-16
   art_sys_35: -2.89364483e-11
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 3.81625566e-15
   art_sys_39: 9.44533938e-16
   art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: -7.04253291e-11
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -1.85562474e-16
   art_sys_46: 0.0
   art_sys_47: 6.02660608e-15
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: -3.20236087e-09
   art_sys_50: 1.73558002e-31
   art_sys_51: -9.75044312e-16
@@ -23755,9 +23755,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
-  art_sys_239: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
+  art_sys_239: 0.0
   Unfolding+: 3.34179492e-04
   Unfolding-: -3.62491406e-04
   AbsoluteStat+: 2.21982715e-04
@@ -23812,7 +23812,7 @@ bins:
   uncorrelated_uncertainty: 8.74216000e-04
 - art_sys_1: -1.72685773e-16
   art_sys_2: 4.86503206e-14
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -1.70350376e-14
   art_sys_5: 0.0
   art_sys_6: 0.0
@@ -23820,44 +23820,44 @@ bins:
   art_sys_8: 0.0
   art_sys_9: 4.89270264e-15
   art_sys_10: -6.53890071e-15
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 7.24560386e-15
   art_sys_14: 0.0
   art_sys_15: -1.13640171e-14
   art_sys_16: 5.78548073e-16
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: -1.78684731e-14
   art_sys_20: 0.0
   art_sys_21: 1.88340595e-15
   art_sys_22: -5.49966757e-15
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: -5.11476579e-13
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: -2.80049459e-15
   art_sys_28: -3.12873165e-16
   art_sys_29: 1.46347879e-12
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 2.95302392e-15
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: -2.25960390e-16
   art_sys_35: -1.05153403e-12
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: -4.75139353e-15
   art_sys_39: 2.30158431e-16
   art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: -7.04828103e-12
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 5.12086045e-16
   art_sys_46: 0.0
   art_sys_47: -9.55981700e-15
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: -4.81022244e-10
   art_sys_50: 1.53965688e-32
   art_sys_51: 1.49869602e-15
@@ -24103,7 +24103,7 @@ bins:
   uncorrelated_uncertainty: 5.08882000e-04
 - art_sys_1: -1.03774000e-17
   art_sys_2: -4.24155948e-15
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -8.81356494e-15
   art_sys_5: 0.0
   art_sys_6: 0.0
@@ -24111,44 +24111,44 @@ bins:
   art_sys_8: 0.0
   art_sys_9: 3.03301865e-14
   art_sys_10: 6.60027673e-15
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 6.67817965e-16
   art_sys_14: 0.0
   art_sys_15: -9.15119803e-15
   art_sys_16: -3.13147554e-14
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: -1.12660823e-15
   art_sys_20: 0.0
   art_sys_21: 3.67209432e-15
   art_sys_22: 1.34760065e-14
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: -1.88515760e-14
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 2.85485426e-15
   art_sys_28: 5.03798208e-16
   art_sys_29: 3.75752230e-13
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: -2.23815802e-17
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: 2.59105589e-16
   art_sys_35: 4.84528447e-13
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 5.59884198e-15
   art_sys_39: 4.22480566e-16
   art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 3.82553310e-13
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 7.95425262e-17
   art_sys_46: 0.0
   art_sys_47: 1.17475292e-14
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: -2.20535508e-11
   art_sys_50: 9.68017470e-34
   art_sys_51: -1.92333970e-15
@@ -24337,9 +24337,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
-  art_sys_239: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
+  art_sys_239: 0.0
   Unfolding+: 1.05404841e-04
   Unfolding-: -1.10383245e-04
   AbsoluteStat+: 8.78302143e-05
@@ -24394,7 +24394,7 @@ bins:
   uncorrelated_uncertainty: 3.03471000e-04
 - art_sys_1: -5.81616300e-19
   art_sys_2: 1.99213345e-14
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 5.65141165e-14
   art_sys_5: 0.0
   art_sys_6: 0.0
@@ -24402,44 +24402,44 @@ bins:
   art_sys_8: 0.0
   art_sys_9: -1.72814737e-14
   art_sys_10: -2.16688172e-14
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 5.50202164e-17
   art_sys_14: 0.0
   art_sys_15: 4.42678972e-15
   art_sys_16: 7.50280163e-15
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: -4.00719425e-17
   art_sys_20: 0.0
   art_sys_21: 1.58233806e-15
   art_sys_22: -2.53461704e-14
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 4.07530615e-15
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: -1.15061562e-15
   art_sys_28: 7.19109314e-16
   art_sys_29: 5.43926034e-14
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: -3.22736189e-15
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: -7.64720228e-16
   art_sys_35: 1.24253770e-13
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: -9.77702438e-16
   art_sys_39: -6.54266470e-17
   art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 2.12998392e-13
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 8.74737376e-17
   art_sys_46: 0.0
   art_sys_47: -6.87311314e-15
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 5.46455676e-12
   art_sys_50: 3.43652162e-35
   art_sys_51: 1.61755226e-15
@@ -24685,7 +24685,7 @@ bins:
   uncorrelated_uncertainty: 1.76874000e-04
 - art_sys_1: -3.31485043e-20
   art_sys_2: 4.77367241e-14
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -7.51602857e-14
   art_sys_5: 0.0
   art_sys_6: 0.0
@@ -24693,44 +24693,44 @@ bins:
   art_sys_8: 0.0
   art_sys_9: -2.92327605e-14
   art_sys_10: -4.55592790e-14
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 4.25850607e-18
   art_sys_14: 0.0
   art_sys_15: -1.29151261e-14
   art_sys_16: -4.29268608e-15
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 8.70347860e-19
   art_sys_20: 0.0
   art_sys_21: -2.46619057e-15
   art_sys_22: 4.24663799e-14
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 9.29308083e-16
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: -8.58167895e-15
   art_sys_28: 2.00512360e-16
   art_sys_29: 5.81596334e-15
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 1.20027894e-14
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: 4.32995352e-16
   art_sys_35: 1.74778628e-14
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: -1.50136582e-14
   art_sys_39: -6.68546547e-16
   art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 3.46667439e-14
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 5.03157323e-17
   art_sys_46: 0.0
   art_sys_47: -1.74393390e-14
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 1.40762252e-12
   art_sys_50: -7.92695388e-37
   art_sys_51: 1.37010911e-15
@@ -24919,9 +24919,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
-  art_sys_239: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
+  art_sys_239: 0.0
   Unfolding+: 3.40103707e-05
   Unfolding-: -3.44957157e-05
   AbsoluteStat+: 3.36481729e-05
@@ -24976,7 +24976,7 @@ bins:
   uncorrelated_uncertainty: 1.02445000e-04
 - art_sys_1: -2.07360648e-21
   art_sys_2: 1.52351678e-14
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 3.50129848e-14
   art_sys_5: 0.0
   art_sys_6: 0.0
@@ -24984,44 +24984,44 @@ bins:
   art_sys_8: 0.0
   art_sys_9: 1.80118027e-15
   art_sys_10: -1.08967472e-14
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 3.20507614e-19
   art_sys_14: 0.0
   art_sys_15: 1.82371449e-14
   art_sys_16: -2.54413602e-14
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 2.55796041e-19
   art_sys_20: 0.0
   art_sys_21: 5.25572457e-15
   art_sys_22: -5.94098639e-14
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 1.11160223e-16
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 2.90677022e-14
   art_sys_28: 1.33940207e-15
   art_sys_29: 5.12601756e-16
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: -3.13867263e-14
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: -4.11793853e-16
   art_sys_35: 1.78944666e-15
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 5.71012719e-14
   art_sys_39: -9.24246482e-16
   art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 3.70207262e-15
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 1.14481775e-16
   art_sys_46: 0.0
   art_sys_47: 8.87728840e-14
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 1.78915522e-13
   art_sys_50: -2.24698697e-37
   art_sys_51: -1.11887379e-14
@@ -25267,7 +25267,7 @@ bins:
   uncorrelated_uncertainty: 5.94397000e-05
 - art_sys_1: -1.12489355e-22
   art_sys_2: 4.45725351e-15
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -3.26303626e-14
   art_sys_5: 0.0
   art_sys_6: 0.0
@@ -25275,44 +25275,44 @@ bins:
   art_sys_8: 0.0
   art_sys_9: 2.39563169e-14
   art_sys_10: 2.45771507e-14
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 2.11580575e-20
   art_sys_14: 0.0
   art_sys_15: 4.06238380e-15
   art_sys_16: -3.22010153e-15
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 2.82332336e-20
   art_sys_20: 0.0
   art_sys_21: -5.15624384e-15
   art_sys_22: 6.64867226e-14
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 9.75789715e-18
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: -6.47891743e-14
   art_sys_28: -1.06688388e-15
   art_sys_29: 4.02943960e-17
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 5.96745811e-14
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: 6.89672384e-17
   art_sys_35: 1.48413920e-16
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: -1.21361422e-13
   art_sys_39: -7.80798203e-16
   art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 3.04767719e-16
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -1.69401514e-16
   art_sys_46: 0.0
   art_sys_47: -1.96314745e-13
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 1.52166445e-14
   art_sys_50: -2.38818503e-38
   art_sys_51: 2.57939732e-14
@@ -25501,9 +25501,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
-  art_sys_239: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
+  art_sys_239: 0.0
   Unfolding+: 1.13509834e-05
   Unfolding-: -1.13031394e-05
   AbsoluteStat+: 1.25614359e-05
@@ -25558,7 +25558,7 @@ bins:
   uncorrelated_uncertainty: 3.38308000e-05
 - art_sys_1: -4.53731186e-24
   art_sys_2: -1.30759607e-14
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -7.00469828e-14
   art_sys_5: 0.0
   art_sys_6: 0.0
@@ -25566,44 +25566,44 @@ bins:
   art_sys_8: 0.0
   art_sys_9: 7.63307234e-15
   art_sys_10: 2.88692789e-14
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 1.05725815e-21
   art_sys_14: 0.0
   art_sys_15: 1.71021961e-14
   art_sys_16: 1.51682991e-14
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 3.04681657e-21
   art_sys_20: 0.0
   art_sys_21: -7.28757532e-15
   art_sys_22: -4.51923185e-14
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 7.24121425e-19
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 9.60623787e-14
   art_sys_28: 2.59648377e-15
   art_sys_29: 3.14358216e-18
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: -9.16300447e-14
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: -5.84718027e-16
   art_sys_35: 1.12030282e-17
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 2.02137899e-13
   art_sys_39: -6.29338197e-16
   art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 2.25194584e-17
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 1.89709104e-18
   art_sys_46: 0.0
   art_sys_47: 3.51891892e-13
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 1.04198711e-15
   art_sys_50: -2.65309693e-39
   art_sys_51: -4.93772094e-14
@@ -25849,7 +25849,7 @@ bins:
   uncorrelated_uncertainty: 1.90764000e-05
 - art_sys_1: -8.10606026e-26
   art_sys_2: 3.97765636e-15
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -1.38051656e-14
   art_sys_5: 0.0
   art_sys_6: 0.0
@@ -25857,44 +25857,44 @@ bins:
   art_sys_8: 0.0
   art_sys_9: -8.05653003e-16
   art_sys_10: 2.67553702e-14
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 1.46799097e-23
   art_sys_14: 0.0
   art_sys_15: -8.17251384e-15
   art_sys_16: 6.13498320e-15
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 3.84986226e-22
   art_sys_20: 0.0
   art_sys_21: -1.87030084e-15
   art_sys_22: 3.07041934e-14
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 5.77868369e-20
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: -7.93036299e-14
   art_sys_28: -4.53274109e-16
   art_sys_29: 2.59627848e-19
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 6.67156487e-14
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: -5.46874826e-16
   art_sys_35: 9.18605772e-19
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: -1.51839245e-13
   art_sys_39: -9.86054881e-16
   art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 1.92392281e-18
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -2.76967918e-16
   art_sys_46: 0.0
   art_sys_47: -2.61458959e-13
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 1.07511785e-16
   art_sys_50: -3.19539201e-40
   art_sys_51: 3.78655904e-14
@@ -26083,9 +26083,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
-  art_sys_239: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
+  art_sys_239: 0.0
   Unfolding+: 3.88779280e-06
   Unfolding-: -3.88009877e-06
   AbsoluteStat+: 4.55024868e-06
@@ -26140,7 +26140,7 @@ bins:
   uncorrelated_uncertainty: 1.08810000e-05
 - art_sys_1: 3.45845938e-27
   art_sys_2: 1.10257854e-14
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 2.19551162e-14
   art_sys_5: 0.0
   art_sys_6: 0.0
@@ -26148,44 +26148,44 @@ bins:
   art_sys_8: 0.0
   art_sys_9: -3.79558325e-15
   art_sys_10: 3.37471254e-14
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: -5.64548878e-24
   art_sys_14: 0.0
   art_sys_15: 1.04257264e-14
   art_sys_16: -5.61260770e-15
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 4.29973547e-23
   art_sys_20: 0.0
   art_sys_21: 8.26698178e-16
   art_sys_22: -5.23691073e-14
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 4.87860419e-21
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: -8.96400688e-15
   art_sys_28: -6.77697222e-16
   art_sys_29: 1.62458361e-20
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: -2.80680732e-14
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: -8.15247703e-16
   art_sys_35: 6.90829894e-20
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 4.29831359e-14
   art_sys_39: 1.91011658e-16
   art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 1.60488798e-19
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 2.79053049e-16
   art_sys_46: 0.0
   art_sys_47: 9.43036799e-14
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 1.67274544e-17
   art_sys_50: -3.59800686e-41
   art_sys_51: -1.25900220e-14
@@ -26431,7 +26431,7 @@ bins:
   uncorrelated_uncertainty: 5.95922000e-06
 - art_sys_1: -2.73963393e-28
   art_sys_2: -1.56273790e-14
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 6.10304937e-14
   art_sys_5: 0.0
   art_sys_6: 0.0
@@ -26439,44 +26439,44 @@ bins:
   art_sys_8: 0.0
   art_sys_9: 2.67167686e-15
   art_sys_10: 4.31531744e-14
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: -9.40195404e-25
   art_sys_14: 0.0
   art_sys_15: 2.18474567e-14
   art_sys_16: -7.75730660e-15
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 3.82134416e-24
   art_sys_20: 0.0
   art_sys_21: 6.48206707e-15
   art_sys_22: -3.30003876e-14
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 3.87583470e-22
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 3.86210334e-14
   art_sys_28: 2.18475863e-17
   art_sys_29: -1.34793103e-24
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: -2.23497188e-14
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: 1.88957278e-15
   art_sys_35: 2.97903274e-21
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 4.56053294e-14
   art_sys_39: 3.24780686e-16
   art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: 7.73945229e-21
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -1.68412931e-16
   art_sys_46: 0.0
   art_sys_47: 5.37736206e-14
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 2.22514264e-18
   art_sys_50: -3.24693119e-42
   art_sys_51: -5.80519517e-15
@@ -26666,8 +26666,8 @@ bins:
   art_sys_235: 0.0
   art_sys_236: 0.0
   art_sys_237: 0.0
-  art_sys_238: -0.0
-  art_sys_239: -0.0
+  art_sys_238: 0.0
+  art_sys_239: 0.0
   Unfolding+: 1.21656198e-06
   Unfolding-: -1.24125715e-06
   AbsoluteStat+: 1.43838524e-06
@@ -26722,7 +26722,7 @@ bins:
   uncorrelated_uncertainty: 3.06353000e-06
 - art_sys_1: -1.33919756e-28
   art_sys_2: 1.20508559e-14
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -1.83942506e-14
   art_sys_5: 0.0
   art_sys_6: 0.0
@@ -26730,44 +26730,44 @@ bins:
   art_sys_8: 0.0
   art_sys_9: -1.75123286e-15
   art_sys_10: -2.07413821e-14
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: -1.07716143e-25
   art_sys_14: 0.0
   art_sys_15: -1.81377466e-14
   art_sys_16: 7.79161994e-15
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 2.26955421e-25
   art_sys_20: 0.0
   art_sys_21: -2.09572851e-15
   art_sys_22: -8.45767075e-14
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 1.60884049e-23
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 9.79917668e-14
   art_sys_28: 2.50571265e-16
   art_sys_29: -2.43359680e-22
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: -8.04235640e-14
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: 8.98542652e-16
   art_sys_35: -4.17446253e-22
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 1.70886263e-13
   art_sys_39: -7.31204218e-18
   art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: -1.03573016e-21
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 1.59962170e-16
   art_sys_46: 0.0
   art_sys_47: 2.85946791e-13
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 1.82116329e-19
   art_sys_50: -1.93918311e-43
   art_sys_51: -4.05170335e-14
@@ -26956,9 +26956,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
+  art_sys_237: 0.0
   art_sys_238: 0.0
-  art_sys_239: -0.0
+  art_sys_239: 0.0
   Unfolding+: 6.92804932e-07
   Unfolding-: -7.18939787e-07
   AbsoluteStat+: 8.12724597e-07
@@ -27013,7 +27013,7 @@ bins:
   uncorrelated_uncertainty: 1.63541000e-06
 - art_sys_1: -1.78692266e-29
   art_sys_2: 1.04666726e-14
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 8.18184474e-14
   art_sys_5: 0.0
   art_sys_6: 0.0
@@ -27021,44 +27021,44 @@ bins:
   art_sys_8: 0.0
   art_sys_9: 1.09856927e-15
   art_sys_10: -4.88949736e-14
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: -8.74606783e-27
   art_sys_14: 0.0
   art_sys_15: 5.67283070e-15
   art_sys_16: 7.10320576e-15
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: -1.73766005e-27
   art_sys_20: 0.0
   art_sys_21: 6.21408673e-15
   art_sys_22: 5.37674627e-15
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: -2.07100625e-24
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 6.79934985e-14
   art_sys_28: -2.56947843e-16
   art_sys_29: -4.62429891e-23
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: -2.64965193e-14
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: 5.52981651e-16
   art_sys_35: -1.23872245e-22
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 7.27032463e-14
   art_sys_39: -5.73965391e-16
   art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: -3.18836892e-22
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -1.57438618e-16
   art_sys_46: 0.0
   art_sys_47: 9.77644877e-14
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: -1.76052766e-21
   art_sys_50: 1.50551264e-45
   art_sys_51: -1.42206269e-14
@@ -27248,7 +27248,7 @@ bins:
   art_sys_235: 0.0
   art_sys_236: 0.0
   art_sys_237: 0.0
-  art_sys_238: -0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 3.54730655e-07
   Unfolding-: -3.75259561e-07
@@ -27304,7 +27304,7 @@ bins:
   uncorrelated_uncertainty: 7.80437000e-07
 - art_sys_1: -4.10643620e-31
   art_sys_2: 4.33526383e-15
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 9.20188388e-15
   art_sys_5: 0.0
   art_sys_6: 0.0
@@ -27312,44 +27312,44 @@ bins:
   art_sys_8: 0.0
   art_sys_9: 8.24843423e-17
   art_sys_10: -1.29384173e-14
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: -1.55879646e-28
   art_sys_14: 0.0
   art_sys_15: -1.41249207e-14
   art_sys_16: 4.28556976e-15
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: -5.53385931e-28
   art_sys_20: 0.0
   art_sys_21: -1.43567448e-16
   art_sys_22: 3.18687627e-14
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: -1.42815778e-25
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: -3.80622794e-14
   art_sys_28: -6.62508017e-16
   art_sys_29: -1.55068644e-24
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 3.32597597e-14
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: 3.99350220e-16
   art_sys_35: -4.85437340e-24
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: -6.76470142e-14
   art_sys_39: -3.84763644e-16
   art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: -1.22409168e-23
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 4.70740182e-16
   art_sys_46: 0.0
   art_sys_47: -1.07251428e-13
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: -7.23637866e-22
   art_sys_50: 4.64953792e-46
   art_sys_51: 1.41315573e-14
@@ -27538,9 +27538,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
-  art_sys_239: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
+  art_sys_239: 0.0
   Unfolding+: 1.21316697e-07
   Unfolding-: -1.32607058e-07
   AbsoluteStat+: 1.36005945e-07
@@ -27595,7 +27595,7 @@ bins:
   uncorrelated_uncertainty: 2.37958000e-07
 - art_sys_1: -7.73113125e-35
   art_sys_2: 1.69651499e-15
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -1.60174204e-14
   art_sys_5: 0.0
   art_sys_6: 0.0
@@ -27603,44 +27603,44 @@ bins:
   art_sys_8: 0.0
   art_sys_9: -9.28458620e-15
   art_sys_10: -4.25148111e-15
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: -2.65041875e-32
   art_sys_14: 0.0
   art_sys_15: -4.58893507e-15
   art_sys_16: -1.17312071e-15
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: -2.75521701e-31
   art_sys_20: 0.0
   art_sys_21: 9.20968980e-16
   art_sys_22: -5.09363339e-14
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: -6.78034752e-29
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 2.27666359e-14
   art_sys_28: 7.64553801e-16
   art_sys_29: -5.31792209e-28
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: 2.94452178e-14
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: 2.16375428e-16
   art_sys_35: -1.84214528e-27
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: -7.54537606e-14
   art_sys_39: 7.64842911e-16
   art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: -4.17701990e-27
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 1.45258916e-17
   art_sys_46: 0.0
   art_sys_47: -2.06344669e-13
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: -4.96479948e-25
   art_sys_50: 2.38185209e-49
   art_sys_51: 3.21825346e-14
@@ -27829,9 +27829,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
-  art_sys_239: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
+  art_sys_239: 0.0
   Unfolding+: 1.97610846e-08
   Unfolding-: -2.28760774e-08
   AbsoluteStat+: 2.07338211e-08
@@ -27886,7 +27886,7 @@ bins:
   uncorrelated_uncertainty: 3.16243000e-08
 - art_sys_1: -1.31170418e-38
   art_sys_2: -4.51877614e-15
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -5.77900002e-14
   art_sys_5: 0.0
   art_sys_6: 0.0
@@ -27894,44 +27894,44 @@ bins:
   art_sys_8: 0.0
   art_sys_9: 3.38489671e-15
   art_sys_10: 9.45036412e-15
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: -5.09717781e-36
   art_sys_14: 0.0
   art_sys_15: 2.11552532e-14
   art_sys_16: -5.34239360e-15
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: -1.05673022e-34
   art_sys_20: 0.0
   art_sys_21: 5.10688693e-16
   art_sys_22: -1.34595954e-14
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: -2.72250845e-32
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 1.55185448e-14
   art_sys_28: 2.06207037e-16
   art_sys_29: -1.85504436e-31
-  art_sys_30: -0.0
+  art_sys_30: 0.0
   art_sys_31: -1.44473476e-14
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: 3.09688433e-16
   art_sys_35: -6.69603715e-31
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 2.84455916e-14
   art_sys_39: -7.32922781e-17
   art_sys_40: 0.0
   art_sys_41: 0.0
   art_sys_42: -1.26206691e-30
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 1.55832704e-16
   art_sys_46: 0.0
   art_sys_47: 3.84549776e-14
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: -3.07623325e-28
   art_sys_50: 8.99234638e-53
   art_sys_51: -5.17010829e-15
@@ -28120,7 +28120,7 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
+  art_sys_237: 0.0
   art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 9.34226651e-10
@@ -28175,186 +28175,186 @@ bins:
   RelativeStatFSR-: -9.39187146e-11
   luminosity_uncertainty: 3.03992000e-09
   uncorrelated_uncertainty: 1.16920000e-09
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
-  art_sys_4: -0.0
+  art_sys_3: 0.0
+  art_sys_4: 0.0
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
-  art_sys_28: -0.0
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_28: 0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
-  art_sys_39: -0.0
+  art_sys_39: 0.0
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
-  art_sys_45: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
+  art_sys_45: 0.0
   art_sys_46: 0.0
-  art_sys_47: -0.0
-  art_sys_48: -0.0
+  art_sys_47: 0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 0.0
   art_sys_54: 0.0
   art_sys_55: 0.0
-  art_sys_56: -0.0
+  art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
-  art_sys_62: -0.0
-  art_sys_63: -0.0
+  art_sys_62: 0.0
+  art_sys_63: 0.0
   art_sys_64: 0.0
   art_sys_65: 0.0
   art_sys_66: 0.0
   art_sys_67: 0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
-  art_sys_71: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
+  art_sys_71: 0.0
   art_sys_72: 0.0
-  art_sys_73: -0.0
+  art_sys_73: 0.0
   art_sys_74: 0.0
-  art_sys_75: -0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_75: 0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 0.0
-  art_sys_88: -0.0
-  art_sys_89: -0.0
+  art_sys_88: 0.0
+  art_sys_89: 0.0
   art_sys_90: 0.0
   art_sys_91: 0.0
-  art_sys_92: -0.0
+  art_sys_92: 0.0
   art_sys_93: 0.0
   art_sys_94: 0.0
-  art_sys_95: -0.0
-  art_sys_96: -0.0
-  art_sys_97: -0.0
+  art_sys_95: 0.0
+  art_sys_96: 0.0
+  art_sys_97: 0.0
   art_sys_98: 0.0
   art_sys_99: 0.0
-  art_sys_100: -0.0
+  art_sys_100: 0.0
   art_sys_101: 0.0
-  art_sys_102: -0.0
+  art_sys_102: 0.0
   art_sys_103: 0.0
-  art_sys_104: -0.0
+  art_sys_104: 0.0
   art_sys_105: 0.0
   art_sys_106: 0.0
-  art_sys_107: -0.0
-  art_sys_108: -0.0
-  art_sys_109: -0.0
-  art_sys_110: -0.0
-  art_sys_111: -0.0
-  art_sys_112: -0.0
+  art_sys_107: 0.0
+  art_sys_108: 0.0
+  art_sys_109: 0.0
+  art_sys_110: 0.0
+  art_sys_111: 0.0
+  art_sys_112: 0.0
   art_sys_113: 0.0
-  art_sys_114: -0.0
+  art_sys_114: 0.0
   art_sys_115: 0.0
-  art_sys_116: -0.0
+  art_sys_116: 0.0
   art_sys_117: 0.0
   art_sys_118: 0.0
   art_sys_119: 0.0
   art_sys_120: 0.0
   art_sys_121: 0.0
   art_sys_122: 0.0
-  art_sys_123: -0.0
+  art_sys_123: 0.0
   art_sys_124: 0.0
   art_sys_125: 0.0
   art_sys_126: 0.0
-  art_sys_127: -0.0
-  art_sys_128: -0.0
+  art_sys_127: 0.0
+  art_sys_128: 0.0
   art_sys_129: 0.0
   art_sys_130: 0.0
   art_sys_131: 0.0
-  art_sys_132: -0.0
-  art_sys_133: -0.0
+  art_sys_132: 0.0
+  art_sys_133: 0.0
   art_sys_134: 0.0
   art_sys_135: 0.0
   art_sys_136: 0.0
   art_sys_137: 0.0
-  art_sys_138: -0.0
+  art_sys_138: 0.0
   art_sys_139: 0.0
   art_sys_140: 0.0
   art_sys_141: 0.0
-  art_sys_142: -0.0
+  art_sys_142: 0.0
   art_sys_143: 0.0
-  art_sys_144: -0.0
-  art_sys_145: -0.0
+  art_sys_144: 0.0
+  art_sys_145: 0.0
   art_sys_146: 0.0
-  art_sys_147: -0.0
+  art_sys_147: 0.0
   art_sys_148: 0.0
   art_sys_149: 0.0
-  art_sys_150: -0.0
-  art_sys_151: -0.0
-  art_sys_152: -0.0
+  art_sys_150: 0.0
+  art_sys_151: 0.0
+  art_sys_152: 0.0
   art_sys_153: 0.0
   art_sys_154: 0.0
   art_sys_155: 0.0
-  art_sys_156: -0.0
-  art_sys_157: -0.0
+  art_sys_156: 0.0
+  art_sys_157: 0.0
   art_sys_158: 0.0
-  art_sys_159: -0.0
-  art_sys_160: -0.0
-  art_sys_161: -0.0
+  art_sys_159: 0.0
+  art_sys_160: 0.0
+  art_sys_161: 0.0
   art_sys_162: 0.0
   art_sys_163: 0.0
-  art_sys_164: -0.0
+  art_sys_164: 0.0
   art_sys_165: 0.0
-  art_sys_166: -0.0
+  art_sys_166: 0.0
   art_sys_167: 0.0
-  art_sys_168: -0.0
+  art_sys_168: 0.0
   art_sys_169: 0.0
   art_sys_170: 0.0
-  art_sys_171: -0.0
+  art_sys_171: 0.0
   art_sys_172: 0.0
-  art_sys_173: -0.0
-  art_sys_174: -0.0
-  art_sys_175: -0.0
-  art_sys_176: -0.0
+  art_sys_173: 0.0
+  art_sys_174: 0.0
+  art_sys_175: 0.0
+  art_sys_176: 0.0
   art_sys_177: 0.0
   art_sys_178: 0.0
   art_sys_179: 0.0
-  art_sys_180: -0.0
+  art_sys_180: 0.0
   art_sys_181: 0.0
   art_sys_182: 0.0
   art_sys_183: 0.0
@@ -28411,8 +28411,8 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 1.03044542e+03
   Unfolding-: -1.11582985e+03
@@ -28466,186 +28466,186 @@ bins:
   RelativeStatFSR-: -2.33057500e+05
   luminosity_uncertainty: 8.57799800e+02
   uncorrelated_uncertainty: 329.923
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
-  art_sys_4: -0.0
+  art_sys_3: 0.0
+  art_sys_4: 0.0
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
-  art_sys_28: -0.0
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_28: 0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
-  art_sys_39: -0.0
+  art_sys_39: 0.0
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
-  art_sys_45: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
+  art_sys_45: 0.0
   art_sys_46: 0.0
-  art_sys_47: -0.0
-  art_sys_48: -0.0
+  art_sys_47: 0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 0.0
   art_sys_54: 0.0
   art_sys_55: 0.0
-  art_sys_56: -0.0
+  art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
-  art_sys_62: -0.0
-  art_sys_63: -0.0
+  art_sys_62: 0.0
+  art_sys_63: 0.0
   art_sys_64: 0.0
   art_sys_65: 0.0
   art_sys_66: 0.0
   art_sys_67: 0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
-  art_sys_71: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
+  art_sys_71: 0.0
   art_sys_72: 0.0
-  art_sys_73: -0.0
+  art_sys_73: 0.0
   art_sys_74: 0.0
-  art_sys_75: -0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_75: 0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 0.0
-  art_sys_88: -0.0
-  art_sys_89: -0.0
+  art_sys_88: 0.0
+  art_sys_89: 0.0
   art_sys_90: 0.0
   art_sys_91: 0.0
-  art_sys_92: -0.0
+  art_sys_92: 0.0
   art_sys_93: 0.0
   art_sys_94: 0.0
-  art_sys_95: -0.0
-  art_sys_96: -0.0
-  art_sys_97: -0.0
+  art_sys_95: 0.0
+  art_sys_96: 0.0
+  art_sys_97: 0.0
   art_sys_98: 0.0
   art_sys_99: 0.0
-  art_sys_100: -0.0
+  art_sys_100: 0.0
   art_sys_101: 0.0
-  art_sys_102: -0.0
+  art_sys_102: 0.0
   art_sys_103: 0.0
-  art_sys_104: -0.0
+  art_sys_104: 0.0
   art_sys_105: 0.0
   art_sys_106: 0.0
-  art_sys_107: -0.0
-  art_sys_108: -0.0
-  art_sys_109: -0.0
-  art_sys_110: -0.0
-  art_sys_111: -0.0
-  art_sys_112: -0.0
+  art_sys_107: 0.0
+  art_sys_108: 0.0
+  art_sys_109: 0.0
+  art_sys_110: 0.0
+  art_sys_111: 0.0
+  art_sys_112: 0.0
   art_sys_113: 0.0
-  art_sys_114: -0.0
+  art_sys_114: 0.0
   art_sys_115: 0.0
-  art_sys_116: -0.0
+  art_sys_116: 0.0
   art_sys_117: 0.0
   art_sys_118: 0.0
   art_sys_119: 0.0
   art_sys_120: 0.0
   art_sys_121: 0.0
   art_sys_122: 0.0
-  art_sys_123: -0.0
+  art_sys_123: 0.0
   art_sys_124: 0.0
   art_sys_125: 0.0
   art_sys_126: 0.0
-  art_sys_127: -0.0
-  art_sys_128: -0.0
+  art_sys_127: 0.0
+  art_sys_128: 0.0
   art_sys_129: 0.0
   art_sys_130: 0.0
   art_sys_131: 0.0
-  art_sys_132: -0.0
-  art_sys_133: -0.0
+  art_sys_132: 0.0
+  art_sys_133: 0.0
   art_sys_134: 0.0
   art_sys_135: 0.0
   art_sys_136: 0.0
   art_sys_137: 0.0
-  art_sys_138: -0.0
+  art_sys_138: 0.0
   art_sys_139: 0.0
   art_sys_140: 0.0
   art_sys_141: 0.0
-  art_sys_142: -0.0
+  art_sys_142: 0.0
   art_sys_143: 0.0
-  art_sys_144: -0.0
-  art_sys_145: -0.0
+  art_sys_144: 0.0
+  art_sys_145: 0.0
   art_sys_146: 0.0
-  art_sys_147: -0.0
+  art_sys_147: 0.0
   art_sys_148: 0.0
   art_sys_149: 0.0
-  art_sys_150: -0.0
-  art_sys_151: -0.0
-  art_sys_152: -0.0
+  art_sys_150: 0.0
+  art_sys_151: 0.0
+  art_sys_152: 0.0
   art_sys_153: 0.0
   art_sys_154: 0.0
   art_sys_155: 0.0
-  art_sys_156: -0.0
-  art_sys_157: -0.0
+  art_sys_156: 0.0
+  art_sys_157: 0.0
   art_sys_158: 0.0
-  art_sys_159: -0.0
-  art_sys_160: -0.0
-  art_sys_161: -0.0
+  art_sys_159: 0.0
+  art_sys_160: 0.0
+  art_sys_161: 0.0
   art_sys_162: 0.0
   art_sys_163: 0.0
-  art_sys_164: -0.0
+  art_sys_164: 0.0
   art_sys_165: 0.0
-  art_sys_166: -0.0
+  art_sys_166: 0.0
   art_sys_167: 0.0
-  art_sys_168: -0.0
+  art_sys_168: 0.0
   art_sys_169: 0.0
   art_sys_170: 0.0
-  art_sys_171: -0.0
+  art_sys_171: 0.0
   art_sys_172: 0.0
-  art_sys_173: -0.0
-  art_sys_174: -0.0
-  art_sys_175: -0.0
-  art_sys_176: -0.0
+  art_sys_173: 0.0
+  art_sys_174: 0.0
+  art_sys_175: 0.0
+  art_sys_176: 0.0
   art_sys_177: 0.0
   art_sys_178: 0.0
   art_sys_179: 0.0
-  art_sys_180: -0.0
+  art_sys_180: 0.0
   art_sys_181: 0.0
   art_sys_182: 0.0
   art_sys_183: 0.0
@@ -28702,8 +28702,8 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 1.03044542e+03
   Unfolding-: -1.11582985e+03
@@ -28757,186 +28757,186 @@ bins:
   RelativeStatFSR-: -2.33057500e+05
   luminosity_uncertainty: 8.57799800e+02
   uncorrelated_uncertainty: 329.923
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
-  art_sys_4: -0.0
+  art_sys_3: 0.0
+  art_sys_4: 0.0
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
-  art_sys_28: -0.0
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_28: 0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
-  art_sys_39: -0.0
+  art_sys_39: 0.0
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
-  art_sys_45: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
+  art_sys_45: 0.0
   art_sys_46: 0.0
-  art_sys_47: -0.0
-  art_sys_48: -0.0
+  art_sys_47: 0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 0.0
   art_sys_54: 0.0
   art_sys_55: 0.0
-  art_sys_56: -0.0
+  art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
-  art_sys_62: -0.0
-  art_sys_63: -0.0
+  art_sys_62: 0.0
+  art_sys_63: 0.0
   art_sys_64: 0.0
   art_sys_65: 0.0
   art_sys_66: 0.0
   art_sys_67: 0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
-  art_sys_71: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
+  art_sys_71: 0.0
   art_sys_72: 0.0
-  art_sys_73: -0.0
+  art_sys_73: 0.0
   art_sys_74: 0.0
-  art_sys_75: -0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_75: 0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 0.0
-  art_sys_88: -0.0
-  art_sys_89: -0.0
+  art_sys_88: 0.0
+  art_sys_89: 0.0
   art_sys_90: 0.0
   art_sys_91: 0.0
-  art_sys_92: -0.0
+  art_sys_92: 0.0
   art_sys_93: 0.0
   art_sys_94: 0.0
-  art_sys_95: -0.0
-  art_sys_96: -0.0
-  art_sys_97: -0.0
+  art_sys_95: 0.0
+  art_sys_96: 0.0
+  art_sys_97: 0.0
   art_sys_98: 0.0
   art_sys_99: 0.0
-  art_sys_100: -0.0
+  art_sys_100: 0.0
   art_sys_101: 0.0
-  art_sys_102: -0.0
+  art_sys_102: 0.0
   art_sys_103: 0.0
-  art_sys_104: -0.0
+  art_sys_104: 0.0
   art_sys_105: 0.0
   art_sys_106: 0.0
-  art_sys_107: -0.0
-  art_sys_108: -0.0
-  art_sys_109: -0.0
-  art_sys_110: -0.0
-  art_sys_111: -0.0
-  art_sys_112: -0.0
+  art_sys_107: 0.0
+  art_sys_108: 0.0
+  art_sys_109: 0.0
+  art_sys_110: 0.0
+  art_sys_111: 0.0
+  art_sys_112: 0.0
   art_sys_113: 0.0
-  art_sys_114: -0.0
+  art_sys_114: 0.0
   art_sys_115: 0.0
-  art_sys_116: -0.0
+  art_sys_116: 0.0
   art_sys_117: 0.0
   art_sys_118: 0.0
   art_sys_119: 0.0
   art_sys_120: 0.0
   art_sys_121: 0.0
   art_sys_122: 0.0
-  art_sys_123: -0.0
+  art_sys_123: 0.0
   art_sys_124: 0.0
   art_sys_125: 0.0
   art_sys_126: 0.0
-  art_sys_127: -0.0
-  art_sys_128: -0.0
+  art_sys_127: 0.0
+  art_sys_128: 0.0
   art_sys_129: 0.0
   art_sys_130: 0.0
   art_sys_131: 0.0
-  art_sys_132: -0.0
-  art_sys_133: -0.0
+  art_sys_132: 0.0
+  art_sys_133: 0.0
   art_sys_134: 0.0
   art_sys_135: 0.0
   art_sys_136: 0.0
   art_sys_137: 0.0
-  art_sys_138: -0.0
+  art_sys_138: 0.0
   art_sys_139: 0.0
   art_sys_140: 0.0
   art_sys_141: 0.0
-  art_sys_142: -0.0
+  art_sys_142: 0.0
   art_sys_143: 0.0
-  art_sys_144: -0.0
-  art_sys_145: -0.0
+  art_sys_144: 0.0
+  art_sys_145: 0.0
   art_sys_146: 0.0
-  art_sys_147: -0.0
+  art_sys_147: 0.0
   art_sys_148: 0.0
   art_sys_149: 0.0
-  art_sys_150: -0.0
-  art_sys_151: -0.0
-  art_sys_152: -0.0
+  art_sys_150: 0.0
+  art_sys_151: 0.0
+  art_sys_152: 0.0
   art_sys_153: 0.0
   art_sys_154: 0.0
   art_sys_155: 0.0
-  art_sys_156: -0.0
-  art_sys_157: -0.0
+  art_sys_156: 0.0
+  art_sys_157: 0.0
   art_sys_158: 0.0
-  art_sys_159: -0.0
-  art_sys_160: -0.0
-  art_sys_161: -0.0
+  art_sys_159: 0.0
+  art_sys_160: 0.0
+  art_sys_161: 0.0
   art_sys_162: 0.0
   art_sys_163: 0.0
-  art_sys_164: -0.0
+  art_sys_164: 0.0
   art_sys_165: 0.0
-  art_sys_166: -0.0
+  art_sys_166: 0.0
   art_sys_167: 0.0
-  art_sys_168: -0.0
+  art_sys_168: 0.0
   art_sys_169: 0.0
   art_sys_170: 0.0
-  art_sys_171: -0.0
+  art_sys_171: 0.0
   art_sys_172: 0.0
-  art_sys_173: -0.0
-  art_sys_174: -0.0
-  art_sys_175: -0.0
-  art_sys_176: -0.0
+  art_sys_173: 0.0
+  art_sys_174: 0.0
+  art_sys_175: 0.0
+  art_sys_176: 0.0
   art_sys_177: 0.0
   art_sys_178: 0.0
   art_sys_179: 0.0
-  art_sys_180: -0.0
+  art_sys_180: 0.0
   art_sys_181: 0.0
   art_sys_182: 0.0
   art_sys_183: 0.0
@@ -28993,8 +28993,8 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 1.03044542e+03
   Unfolding-: -1.11582985e+03
@@ -29048,186 +29048,186 @@ bins:
   RelativeStatFSR-: -2.33057500e+05
   luminosity_uncertainty: 8.57799800e+02
   uncorrelated_uncertainty: 329.923
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
-  art_sys_4: -0.0
+  art_sys_3: 0.0
+  art_sys_4: 0.0
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
-  art_sys_28: -0.0
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_28: 0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
-  art_sys_39: -0.0
+  art_sys_39: 0.0
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
-  art_sys_45: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
+  art_sys_45: 0.0
   art_sys_46: 0.0
-  art_sys_47: -0.0
-  art_sys_48: -0.0
+  art_sys_47: 0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 0.0
   art_sys_54: 0.0
   art_sys_55: 0.0
-  art_sys_56: -0.0
+  art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
-  art_sys_62: -0.0
-  art_sys_63: -0.0
+  art_sys_62: 0.0
+  art_sys_63: 0.0
   art_sys_64: 0.0
   art_sys_65: 0.0
   art_sys_66: 0.0
   art_sys_67: 0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
-  art_sys_71: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
+  art_sys_71: 0.0
   art_sys_72: 0.0
-  art_sys_73: -0.0
+  art_sys_73: 0.0
   art_sys_74: 0.0
-  art_sys_75: -0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_75: 0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 0.0
-  art_sys_88: -0.0
-  art_sys_89: -0.0
+  art_sys_88: 0.0
+  art_sys_89: 0.0
   art_sys_90: 0.0
   art_sys_91: 0.0
-  art_sys_92: -0.0
+  art_sys_92: 0.0
   art_sys_93: 0.0
   art_sys_94: 0.0
-  art_sys_95: -0.0
-  art_sys_96: -0.0
-  art_sys_97: -0.0
+  art_sys_95: 0.0
+  art_sys_96: 0.0
+  art_sys_97: 0.0
   art_sys_98: 0.0
   art_sys_99: 0.0
-  art_sys_100: -0.0
+  art_sys_100: 0.0
   art_sys_101: 0.0
-  art_sys_102: -0.0
+  art_sys_102: 0.0
   art_sys_103: 0.0
-  art_sys_104: -0.0
+  art_sys_104: 0.0
   art_sys_105: 0.0
   art_sys_106: 0.0
-  art_sys_107: -0.0
-  art_sys_108: -0.0
-  art_sys_109: -0.0
-  art_sys_110: -0.0
-  art_sys_111: -0.0
-  art_sys_112: -0.0
+  art_sys_107: 0.0
+  art_sys_108: 0.0
+  art_sys_109: 0.0
+  art_sys_110: 0.0
+  art_sys_111: 0.0
+  art_sys_112: 0.0
   art_sys_113: 0.0
-  art_sys_114: -0.0
+  art_sys_114: 0.0
   art_sys_115: 0.0
-  art_sys_116: -0.0
+  art_sys_116: 0.0
   art_sys_117: 0.0
   art_sys_118: 0.0
   art_sys_119: 0.0
   art_sys_120: 0.0
   art_sys_121: 0.0
   art_sys_122: 0.0
-  art_sys_123: -0.0
+  art_sys_123: 0.0
   art_sys_124: 0.0
   art_sys_125: 0.0
   art_sys_126: 0.0
-  art_sys_127: -0.0
-  art_sys_128: -0.0
+  art_sys_127: 0.0
+  art_sys_128: 0.0
   art_sys_129: 0.0
   art_sys_130: 0.0
   art_sys_131: 0.0
-  art_sys_132: -0.0
-  art_sys_133: -0.0
+  art_sys_132: 0.0
+  art_sys_133: 0.0
   art_sys_134: 0.0
   art_sys_135: 0.0
   art_sys_136: 0.0
   art_sys_137: 0.0
-  art_sys_138: -0.0
+  art_sys_138: 0.0
   art_sys_139: 0.0
   art_sys_140: 0.0
   art_sys_141: 0.0
-  art_sys_142: -0.0
+  art_sys_142: 0.0
   art_sys_143: 0.0
-  art_sys_144: -0.0
-  art_sys_145: -0.0
+  art_sys_144: 0.0
+  art_sys_145: 0.0
   art_sys_146: 0.0
-  art_sys_147: -0.0
+  art_sys_147: 0.0
   art_sys_148: 0.0
   art_sys_149: 0.0
-  art_sys_150: -0.0
-  art_sys_151: -0.0
-  art_sys_152: -0.0
+  art_sys_150: 0.0
+  art_sys_151: 0.0
+  art_sys_152: 0.0
   art_sys_153: 0.0
   art_sys_154: 0.0
   art_sys_155: 0.0
-  art_sys_156: -0.0
-  art_sys_157: -0.0
+  art_sys_156: 0.0
+  art_sys_157: 0.0
   art_sys_158: 0.0
-  art_sys_159: -0.0
-  art_sys_160: -0.0
-  art_sys_161: -0.0
+  art_sys_159: 0.0
+  art_sys_160: 0.0
+  art_sys_161: 0.0
   art_sys_162: 0.0
   art_sys_163: 0.0
-  art_sys_164: -0.0
+  art_sys_164: 0.0
   art_sys_165: 0.0
-  art_sys_166: -0.0
+  art_sys_166: 0.0
   art_sys_167: 0.0
-  art_sys_168: -0.0
+  art_sys_168: 0.0
   art_sys_169: 0.0
   art_sys_170: 0.0
-  art_sys_171: -0.0
+  art_sys_171: 0.0
   art_sys_172: 0.0
-  art_sys_173: -0.0
-  art_sys_174: -0.0
-  art_sys_175: -0.0
-  art_sys_176: -0.0
+  art_sys_173: 0.0
+  art_sys_174: 0.0
+  art_sys_175: 0.0
+  art_sys_176: 0.0
   art_sys_177: 0.0
   art_sys_178: 0.0
   art_sys_179: 0.0
-  art_sys_180: -0.0
+  art_sys_180: 0.0
   art_sys_181: 0.0
   art_sys_182: 0.0
   art_sys_183: 0.0
@@ -29284,8 +29284,8 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 1.03044542e+03
   Unfolding-: -1.11582985e+03
@@ -29339,186 +29339,186 @@ bins:
   RelativeStatFSR-: -2.33057500e+05
   luminosity_uncertainty: 8.57799800e+02
   uncorrelated_uncertainty: 329.923
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
-  art_sys_4: -0.0
+  art_sys_3: 0.0
+  art_sys_4: 0.0
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
-  art_sys_28: -0.0
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_28: 0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
-  art_sys_39: -0.0
+  art_sys_39: 0.0
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
-  art_sys_45: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
+  art_sys_45: 0.0
   art_sys_46: 0.0
-  art_sys_47: -0.0
-  art_sys_48: -0.0
+  art_sys_47: 0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 0.0
   art_sys_54: 0.0
   art_sys_55: 0.0
-  art_sys_56: -0.0
+  art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
-  art_sys_62: -0.0
-  art_sys_63: -0.0
+  art_sys_62: 0.0
+  art_sys_63: 0.0
   art_sys_64: 0.0
   art_sys_65: 0.0
   art_sys_66: 0.0
   art_sys_67: 0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
-  art_sys_71: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
+  art_sys_71: 0.0
   art_sys_72: 0.0
-  art_sys_73: -0.0
+  art_sys_73: 0.0
   art_sys_74: 0.0
-  art_sys_75: -0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_75: 0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 0.0
-  art_sys_88: -0.0
-  art_sys_89: -0.0
+  art_sys_88: 0.0
+  art_sys_89: 0.0
   art_sys_90: 0.0
   art_sys_91: 0.0
-  art_sys_92: -0.0
+  art_sys_92: 0.0
   art_sys_93: 0.0
   art_sys_94: 0.0
-  art_sys_95: -0.0
-  art_sys_96: -0.0
-  art_sys_97: -0.0
+  art_sys_95: 0.0
+  art_sys_96: 0.0
+  art_sys_97: 0.0
   art_sys_98: 0.0
   art_sys_99: 0.0
-  art_sys_100: -0.0
+  art_sys_100: 0.0
   art_sys_101: 0.0
-  art_sys_102: -0.0
+  art_sys_102: 0.0
   art_sys_103: 0.0
-  art_sys_104: -0.0
+  art_sys_104: 0.0
   art_sys_105: 0.0
   art_sys_106: 0.0
-  art_sys_107: -0.0
-  art_sys_108: -0.0
-  art_sys_109: -0.0
-  art_sys_110: -0.0
-  art_sys_111: -0.0
-  art_sys_112: -0.0
+  art_sys_107: 0.0
+  art_sys_108: 0.0
+  art_sys_109: 0.0
+  art_sys_110: 0.0
+  art_sys_111: 0.0
+  art_sys_112: 0.0
   art_sys_113: 0.0
-  art_sys_114: -0.0
+  art_sys_114: 0.0
   art_sys_115: 0.0
-  art_sys_116: -0.0
+  art_sys_116: 0.0
   art_sys_117: 0.0
   art_sys_118: 0.0
   art_sys_119: 0.0
   art_sys_120: 0.0
   art_sys_121: 0.0
   art_sys_122: 0.0
-  art_sys_123: -0.0
+  art_sys_123: 0.0
   art_sys_124: 0.0
   art_sys_125: 0.0
   art_sys_126: 0.0
-  art_sys_127: -0.0
-  art_sys_128: -0.0
+  art_sys_127: 0.0
+  art_sys_128: 0.0
   art_sys_129: 0.0
   art_sys_130: 0.0
   art_sys_131: 0.0
-  art_sys_132: -0.0
-  art_sys_133: -0.0
+  art_sys_132: 0.0
+  art_sys_133: 0.0
   art_sys_134: 0.0
   art_sys_135: 0.0
   art_sys_136: 0.0
   art_sys_137: 0.0
-  art_sys_138: -0.0
+  art_sys_138: 0.0
   art_sys_139: 0.0
   art_sys_140: 0.0
   art_sys_141: 0.0
-  art_sys_142: -0.0
+  art_sys_142: 0.0
   art_sys_143: 0.0
-  art_sys_144: -0.0
-  art_sys_145: -0.0
+  art_sys_144: 0.0
+  art_sys_145: 0.0
   art_sys_146: 0.0
-  art_sys_147: -0.0
+  art_sys_147: 0.0
   art_sys_148: 0.0
   art_sys_149: 0.0
-  art_sys_150: -0.0
-  art_sys_151: -0.0
-  art_sys_152: -0.0
+  art_sys_150: 0.0
+  art_sys_151: 0.0
+  art_sys_152: 0.0
   art_sys_153: 0.0
   art_sys_154: 0.0
   art_sys_155: 0.0
-  art_sys_156: -0.0
-  art_sys_157: -0.0
+  art_sys_156: 0.0
+  art_sys_157: 0.0
   art_sys_158: 0.0
-  art_sys_159: -0.0
-  art_sys_160: -0.0
-  art_sys_161: -0.0
+  art_sys_159: 0.0
+  art_sys_160: 0.0
+  art_sys_161: 0.0
   art_sys_162: 0.0
   art_sys_163: 0.0
-  art_sys_164: -0.0
+  art_sys_164: 0.0
   art_sys_165: 0.0
-  art_sys_166: -0.0
+  art_sys_166: 0.0
   art_sys_167: 0.0
-  art_sys_168: -0.0
+  art_sys_168: 0.0
   art_sys_169: 0.0
   art_sys_170: 0.0
-  art_sys_171: -0.0
+  art_sys_171: 0.0
   art_sys_172: 0.0
-  art_sys_173: -0.0
-  art_sys_174: -0.0
-  art_sys_175: -0.0
-  art_sys_176: -0.0
+  art_sys_173: 0.0
+  art_sys_174: 0.0
+  art_sys_175: 0.0
+  art_sys_176: 0.0
   art_sys_177: 0.0
   art_sys_178: 0.0
   art_sys_179: 0.0
-  art_sys_180: -0.0
+  art_sys_180: 0.0
   art_sys_181: 0.0
   art_sys_182: 0.0
   art_sys_183: 0.0
@@ -29575,8 +29575,8 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 1.03044542e+03
   Unfolding-: -1.11582985e+03
@@ -29630,186 +29630,186 @@ bins:
   RelativeStatFSR-: -2.33057500e+05
   luminosity_uncertainty: 8.57799800e+02
   uncorrelated_uncertainty: 329.923
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
-  art_sys_4: -0.0
+  art_sys_3: 0.0
+  art_sys_4: 0.0
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
-  art_sys_28: -0.0
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_28: 0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
-  art_sys_39: -0.0
+  art_sys_39: 0.0
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
-  art_sys_45: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
+  art_sys_45: 0.0
   art_sys_46: 0.0
-  art_sys_47: -0.0
-  art_sys_48: -0.0
+  art_sys_47: 0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 0.0
   art_sys_54: 0.0
   art_sys_55: 0.0
-  art_sys_56: -0.0
+  art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
-  art_sys_62: -0.0
-  art_sys_63: -0.0
+  art_sys_62: 0.0
+  art_sys_63: 0.0
   art_sys_64: 0.0
   art_sys_65: 0.0
   art_sys_66: 0.0
   art_sys_67: 0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
-  art_sys_71: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
+  art_sys_71: 0.0
   art_sys_72: 0.0
-  art_sys_73: -0.0
+  art_sys_73: 0.0
   art_sys_74: 0.0
-  art_sys_75: -0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_75: 0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 0.0
-  art_sys_88: -0.0
-  art_sys_89: -0.0
+  art_sys_88: 0.0
+  art_sys_89: 0.0
   art_sys_90: 0.0
   art_sys_91: 0.0
-  art_sys_92: -0.0
+  art_sys_92: 0.0
   art_sys_93: 0.0
   art_sys_94: 0.0
-  art_sys_95: -0.0
-  art_sys_96: -0.0
-  art_sys_97: -0.0
+  art_sys_95: 0.0
+  art_sys_96: 0.0
+  art_sys_97: 0.0
   art_sys_98: 0.0
   art_sys_99: 0.0
-  art_sys_100: -0.0
+  art_sys_100: 0.0
   art_sys_101: 0.0
-  art_sys_102: -0.0
+  art_sys_102: 0.0
   art_sys_103: 0.0
-  art_sys_104: -0.0
+  art_sys_104: 0.0
   art_sys_105: 0.0
   art_sys_106: 0.0
-  art_sys_107: -0.0
-  art_sys_108: -0.0
-  art_sys_109: -0.0
-  art_sys_110: -0.0
-  art_sys_111: -0.0
-  art_sys_112: -0.0
+  art_sys_107: 0.0
+  art_sys_108: 0.0
+  art_sys_109: 0.0
+  art_sys_110: 0.0
+  art_sys_111: 0.0
+  art_sys_112: 0.0
   art_sys_113: 0.0
-  art_sys_114: -0.0
+  art_sys_114: 0.0
   art_sys_115: 0.0
-  art_sys_116: -0.0
+  art_sys_116: 0.0
   art_sys_117: 0.0
   art_sys_118: 0.0
   art_sys_119: 0.0
   art_sys_120: 0.0
   art_sys_121: 0.0
   art_sys_122: 0.0
-  art_sys_123: -0.0
+  art_sys_123: 0.0
   art_sys_124: 0.0
   art_sys_125: 0.0
   art_sys_126: 0.0
-  art_sys_127: -0.0
-  art_sys_128: -0.0
+  art_sys_127: 0.0
+  art_sys_128: 0.0
   art_sys_129: 0.0
   art_sys_130: 0.0
   art_sys_131: 0.0
-  art_sys_132: -0.0
-  art_sys_133: -0.0
+  art_sys_132: 0.0
+  art_sys_133: 0.0
   art_sys_134: 0.0
   art_sys_135: 0.0
   art_sys_136: 0.0
   art_sys_137: 0.0
-  art_sys_138: -0.0
+  art_sys_138: 0.0
   art_sys_139: 0.0
   art_sys_140: 0.0
   art_sys_141: 0.0
-  art_sys_142: -0.0
+  art_sys_142: 0.0
   art_sys_143: 0.0
-  art_sys_144: -0.0
-  art_sys_145: -0.0
+  art_sys_144: 0.0
+  art_sys_145: 0.0
   art_sys_146: 0.0
-  art_sys_147: -0.0
+  art_sys_147: 0.0
   art_sys_148: 0.0
   art_sys_149: 0.0
-  art_sys_150: -0.0
-  art_sys_151: -0.0
-  art_sys_152: -0.0
+  art_sys_150: 0.0
+  art_sys_151: 0.0
+  art_sys_152: 0.0
   art_sys_153: 0.0
   art_sys_154: 0.0
   art_sys_155: 0.0
-  art_sys_156: -0.0
-  art_sys_157: -0.0
+  art_sys_156: 0.0
+  art_sys_157: 0.0
   art_sys_158: 0.0
-  art_sys_159: -0.0
-  art_sys_160: -0.0
-  art_sys_161: -0.0
+  art_sys_159: 0.0
+  art_sys_160: 0.0
+  art_sys_161: 0.0
   art_sys_162: 0.0
   art_sys_163: 0.0
-  art_sys_164: -0.0
+  art_sys_164: 0.0
   art_sys_165: 0.0
-  art_sys_166: -0.0
+  art_sys_166: 0.0
   art_sys_167: 0.0
-  art_sys_168: -0.0
+  art_sys_168: 0.0
   art_sys_169: 0.0
   art_sys_170: 0.0
-  art_sys_171: -0.0
+  art_sys_171: 0.0
   art_sys_172: 0.0
-  art_sys_173: -0.0
-  art_sys_174: -0.0
-  art_sys_175: -0.0
-  art_sys_176: -0.0
+  art_sys_173: 0.0
+  art_sys_174: 0.0
+  art_sys_175: 0.0
+  art_sys_176: 0.0
   art_sys_177: 0.0
   art_sys_178: 0.0
   art_sys_179: 0.0
-  art_sys_180: -0.0
+  art_sys_180: 0.0
   art_sys_181: 0.0
   art_sys_182: 0.0
   art_sys_183: 0.0
@@ -29866,8 +29866,8 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 1.03044542e+03
   Unfolding-: -1.11582985e+03
@@ -29921,186 +29921,186 @@ bins:
   RelativeStatFSR-: -2.33057500e+05
   luminosity_uncertainty: 8.57799800e+02
   uncorrelated_uncertainty: 329.923
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
-  art_sys_4: -0.0
+  art_sys_3: 0.0
+  art_sys_4: 0.0
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
-  art_sys_28: -0.0
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_28: 0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
-  art_sys_39: -0.0
+  art_sys_39: 0.0
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
-  art_sys_45: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
+  art_sys_45: 0.0
   art_sys_46: 0.0
-  art_sys_47: -0.0
-  art_sys_48: -0.0
+  art_sys_47: 0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 0.0
   art_sys_54: 0.0
   art_sys_55: 0.0
-  art_sys_56: -0.0
+  art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
-  art_sys_62: -0.0
-  art_sys_63: -0.0
+  art_sys_62: 0.0
+  art_sys_63: 0.0
   art_sys_64: 0.0
   art_sys_65: 0.0
   art_sys_66: 0.0
   art_sys_67: 0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
-  art_sys_71: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
+  art_sys_71: 0.0
   art_sys_72: 0.0
-  art_sys_73: -0.0
+  art_sys_73: 0.0
   art_sys_74: 0.0
-  art_sys_75: -0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_75: 0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 0.0
-  art_sys_88: -0.0
-  art_sys_89: -0.0
+  art_sys_88: 0.0
+  art_sys_89: 0.0
   art_sys_90: 0.0
   art_sys_91: 0.0
-  art_sys_92: -0.0
+  art_sys_92: 0.0
   art_sys_93: 0.0
   art_sys_94: 0.0
-  art_sys_95: -0.0
-  art_sys_96: -0.0
-  art_sys_97: -0.0
+  art_sys_95: 0.0
+  art_sys_96: 0.0
+  art_sys_97: 0.0
   art_sys_98: 0.0
   art_sys_99: 0.0
-  art_sys_100: -0.0
+  art_sys_100: 0.0
   art_sys_101: 0.0
-  art_sys_102: -0.0
+  art_sys_102: 0.0
   art_sys_103: 0.0
-  art_sys_104: -0.0
+  art_sys_104: 0.0
   art_sys_105: 0.0
   art_sys_106: 0.0
-  art_sys_107: -0.0
-  art_sys_108: -0.0
-  art_sys_109: -0.0
-  art_sys_110: -0.0
-  art_sys_111: -0.0
-  art_sys_112: -0.0
+  art_sys_107: 0.0
+  art_sys_108: 0.0
+  art_sys_109: 0.0
+  art_sys_110: 0.0
+  art_sys_111: 0.0
+  art_sys_112: 0.0
   art_sys_113: 0.0
-  art_sys_114: -0.0
+  art_sys_114: 0.0
   art_sys_115: 0.0
-  art_sys_116: -0.0
+  art_sys_116: 0.0
   art_sys_117: 0.0
   art_sys_118: 0.0
   art_sys_119: 0.0
   art_sys_120: 0.0
   art_sys_121: 0.0
   art_sys_122: 0.0
-  art_sys_123: -0.0
+  art_sys_123: 0.0
   art_sys_124: 0.0
   art_sys_125: 0.0
   art_sys_126: 0.0
-  art_sys_127: -0.0
-  art_sys_128: -0.0
+  art_sys_127: 0.0
+  art_sys_128: 0.0
   art_sys_129: 0.0
   art_sys_130: 0.0
   art_sys_131: 0.0
-  art_sys_132: -0.0
-  art_sys_133: -0.0
+  art_sys_132: 0.0
+  art_sys_133: 0.0
   art_sys_134: 0.0
   art_sys_135: 0.0
   art_sys_136: 0.0
   art_sys_137: 0.0
-  art_sys_138: -0.0
+  art_sys_138: 0.0
   art_sys_139: 0.0
   art_sys_140: 0.0
   art_sys_141: 0.0
-  art_sys_142: -0.0
+  art_sys_142: 0.0
   art_sys_143: 0.0
-  art_sys_144: -0.0
-  art_sys_145: -0.0
+  art_sys_144: 0.0
+  art_sys_145: 0.0
   art_sys_146: 0.0
-  art_sys_147: -0.0
+  art_sys_147: 0.0
   art_sys_148: 0.0
   art_sys_149: 0.0
-  art_sys_150: -0.0
-  art_sys_151: -0.0
-  art_sys_152: -0.0
+  art_sys_150: 0.0
+  art_sys_151: 0.0
+  art_sys_152: 0.0
   art_sys_153: 0.0
   art_sys_154: 0.0
   art_sys_155: 0.0
-  art_sys_156: -0.0
-  art_sys_157: -0.0
+  art_sys_156: 0.0
+  art_sys_157: 0.0
   art_sys_158: 0.0
-  art_sys_159: -0.0
-  art_sys_160: -0.0
-  art_sys_161: -0.0
+  art_sys_159: 0.0
+  art_sys_160: 0.0
+  art_sys_161: 0.0
   art_sys_162: 0.0
   art_sys_163: 0.0
-  art_sys_164: -0.0
+  art_sys_164: 0.0
   art_sys_165: 0.0
-  art_sys_166: -0.0
+  art_sys_166: 0.0
   art_sys_167: 0.0
-  art_sys_168: -0.0
+  art_sys_168: 0.0
   art_sys_169: 0.0
   art_sys_170: 0.0
-  art_sys_171: -0.0
+  art_sys_171: 0.0
   art_sys_172: 0.0
-  art_sys_173: -0.0
-  art_sys_174: -0.0
-  art_sys_175: -0.0
-  art_sys_176: -0.0
+  art_sys_173: 0.0
+  art_sys_174: 0.0
+  art_sys_175: 0.0
+  art_sys_176: 0.0
   art_sys_177: 0.0
   art_sys_178: 0.0
   art_sys_179: 0.0
-  art_sys_180: -0.0
+  art_sys_180: 0.0
   art_sys_181: 0.0
   art_sys_182: 0.0
   art_sys_183: 0.0
@@ -30157,8 +30157,8 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 1.03044542e+03
   Unfolding-: -1.11582985e+03
@@ -30212,186 +30212,186 @@ bins:
   RelativeStatFSR-: -2.33057500e+05
   luminosity_uncertainty: 8.57799800e+02
   uncorrelated_uncertainty: 329.923
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
-  art_sys_4: -0.0
+  art_sys_3: 0.0
+  art_sys_4: 0.0
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
-  art_sys_28: -0.0
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_28: 0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
-  art_sys_39: -0.0
+  art_sys_39: 0.0
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
-  art_sys_45: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
+  art_sys_45: 0.0
   art_sys_46: 0.0
-  art_sys_47: -0.0
-  art_sys_48: -0.0
+  art_sys_47: 0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 0.0
   art_sys_54: 0.0
   art_sys_55: 0.0
-  art_sys_56: -0.0
+  art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
-  art_sys_62: -0.0
-  art_sys_63: -0.0
+  art_sys_62: 0.0
+  art_sys_63: 0.0
   art_sys_64: 0.0
   art_sys_65: 0.0
   art_sys_66: 0.0
   art_sys_67: 0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
-  art_sys_71: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
+  art_sys_71: 0.0
   art_sys_72: 0.0
-  art_sys_73: -0.0
+  art_sys_73: 0.0
   art_sys_74: 0.0
-  art_sys_75: -0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_75: 0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 0.0
-  art_sys_88: -0.0
-  art_sys_89: -0.0
+  art_sys_88: 0.0
+  art_sys_89: 0.0
   art_sys_90: 0.0
   art_sys_91: 0.0
-  art_sys_92: -0.0
+  art_sys_92: 0.0
   art_sys_93: 0.0
   art_sys_94: 0.0
-  art_sys_95: -0.0
-  art_sys_96: -0.0
-  art_sys_97: -0.0
+  art_sys_95: 0.0
+  art_sys_96: 0.0
+  art_sys_97: 0.0
   art_sys_98: 0.0
   art_sys_99: 0.0
-  art_sys_100: -0.0
+  art_sys_100: 0.0
   art_sys_101: 0.0
-  art_sys_102: -0.0
+  art_sys_102: 0.0
   art_sys_103: 0.0
-  art_sys_104: -0.0
+  art_sys_104: 0.0
   art_sys_105: 0.0
   art_sys_106: 0.0
-  art_sys_107: -0.0
-  art_sys_108: -0.0
-  art_sys_109: -0.0
-  art_sys_110: -0.0
-  art_sys_111: -0.0
-  art_sys_112: -0.0
+  art_sys_107: 0.0
+  art_sys_108: 0.0
+  art_sys_109: 0.0
+  art_sys_110: 0.0
+  art_sys_111: 0.0
+  art_sys_112: 0.0
   art_sys_113: 0.0
-  art_sys_114: -0.0
+  art_sys_114: 0.0
   art_sys_115: 0.0
-  art_sys_116: -0.0
+  art_sys_116: 0.0
   art_sys_117: 0.0
   art_sys_118: 0.0
   art_sys_119: 0.0
   art_sys_120: 0.0
   art_sys_121: 0.0
   art_sys_122: 0.0
-  art_sys_123: -0.0
+  art_sys_123: 0.0
   art_sys_124: 0.0
   art_sys_125: 0.0
   art_sys_126: 0.0
-  art_sys_127: -0.0
-  art_sys_128: -0.0
+  art_sys_127: 0.0
+  art_sys_128: 0.0
   art_sys_129: 0.0
   art_sys_130: 0.0
   art_sys_131: 0.0
-  art_sys_132: -0.0
-  art_sys_133: -0.0
+  art_sys_132: 0.0
+  art_sys_133: 0.0
   art_sys_134: 0.0
   art_sys_135: 0.0
   art_sys_136: 0.0
   art_sys_137: 0.0
-  art_sys_138: -0.0
+  art_sys_138: 0.0
   art_sys_139: 0.0
   art_sys_140: 0.0
   art_sys_141: 0.0
-  art_sys_142: -0.0
+  art_sys_142: 0.0
   art_sys_143: 0.0
-  art_sys_144: -0.0
-  art_sys_145: -0.0
+  art_sys_144: 0.0
+  art_sys_145: 0.0
   art_sys_146: 0.0
-  art_sys_147: -0.0
+  art_sys_147: 0.0
   art_sys_148: 0.0
   art_sys_149: 0.0
-  art_sys_150: -0.0
-  art_sys_151: -0.0
-  art_sys_152: -0.0
+  art_sys_150: 0.0
+  art_sys_151: 0.0
+  art_sys_152: 0.0
   art_sys_153: 0.0
   art_sys_154: 0.0
   art_sys_155: 0.0
-  art_sys_156: -0.0
-  art_sys_157: -0.0
+  art_sys_156: 0.0
+  art_sys_157: 0.0
   art_sys_158: 0.0
-  art_sys_159: -0.0
-  art_sys_160: -0.0
-  art_sys_161: -0.0
+  art_sys_159: 0.0
+  art_sys_160: 0.0
+  art_sys_161: 0.0
   art_sys_162: 0.0
   art_sys_163: 0.0
-  art_sys_164: -0.0
+  art_sys_164: 0.0
   art_sys_165: 0.0
-  art_sys_166: -0.0
+  art_sys_166: 0.0
   art_sys_167: 0.0
-  art_sys_168: -0.0
+  art_sys_168: 0.0
   art_sys_169: 0.0
   art_sys_170: 0.0
-  art_sys_171: -0.0
+  art_sys_171: 0.0
   art_sys_172: 0.0
-  art_sys_173: -0.0
-  art_sys_174: -0.0
-  art_sys_175: -0.0
-  art_sys_176: -0.0
+  art_sys_173: 0.0
+  art_sys_174: 0.0
+  art_sys_175: 0.0
+  art_sys_176: 0.0
   art_sys_177: 0.0
   art_sys_178: 0.0
   art_sys_179: 0.0
-  art_sys_180: -0.0
+  art_sys_180: 0.0
   art_sys_181: 0.0
   art_sys_182: 0.0
   art_sys_183: 0.0
@@ -30448,8 +30448,8 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 1.03044542e+03
   Unfolding-: -1.11582985e+03
@@ -30503,186 +30503,186 @@ bins:
   RelativeStatFSR-: -2.33057500e+05
   luminosity_uncertainty: 8.57799800e+02
   uncorrelated_uncertainty: 329.923
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
-  art_sys_4: -0.0
+  art_sys_3: 0.0
+  art_sys_4: 0.0
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
-  art_sys_28: -0.0
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_28: 0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
-  art_sys_39: -0.0
+  art_sys_39: 0.0
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
-  art_sys_45: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
+  art_sys_45: 0.0
   art_sys_46: 0.0
-  art_sys_47: -0.0
-  art_sys_48: -0.0
+  art_sys_47: 0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 0.0
   art_sys_54: 0.0
   art_sys_55: 0.0
-  art_sys_56: -0.0
+  art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
-  art_sys_62: -0.0
-  art_sys_63: -0.0
+  art_sys_62: 0.0
+  art_sys_63: 0.0
   art_sys_64: 0.0
   art_sys_65: 0.0
   art_sys_66: 0.0
   art_sys_67: 0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
-  art_sys_71: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
+  art_sys_71: 0.0
   art_sys_72: 0.0
-  art_sys_73: -0.0
+  art_sys_73: 0.0
   art_sys_74: 0.0
-  art_sys_75: -0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_75: 0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 0.0
-  art_sys_88: -0.0
-  art_sys_89: -0.0
+  art_sys_88: 0.0
+  art_sys_89: 0.0
   art_sys_90: 0.0
   art_sys_91: 0.0
-  art_sys_92: -0.0
+  art_sys_92: 0.0
   art_sys_93: 0.0
   art_sys_94: 0.0
-  art_sys_95: -0.0
-  art_sys_96: -0.0
-  art_sys_97: -0.0
+  art_sys_95: 0.0
+  art_sys_96: 0.0
+  art_sys_97: 0.0
   art_sys_98: 0.0
   art_sys_99: 0.0
-  art_sys_100: -0.0
+  art_sys_100: 0.0
   art_sys_101: 0.0
-  art_sys_102: -0.0
+  art_sys_102: 0.0
   art_sys_103: 0.0
-  art_sys_104: -0.0
+  art_sys_104: 0.0
   art_sys_105: 0.0
   art_sys_106: 0.0
-  art_sys_107: -0.0
-  art_sys_108: -0.0
-  art_sys_109: -0.0
-  art_sys_110: -0.0
-  art_sys_111: -0.0
-  art_sys_112: -0.0
+  art_sys_107: 0.0
+  art_sys_108: 0.0
+  art_sys_109: 0.0
+  art_sys_110: 0.0
+  art_sys_111: 0.0
+  art_sys_112: 0.0
   art_sys_113: 0.0
-  art_sys_114: -0.0
+  art_sys_114: 0.0
   art_sys_115: 0.0
-  art_sys_116: -0.0
+  art_sys_116: 0.0
   art_sys_117: 0.0
   art_sys_118: 0.0
   art_sys_119: 0.0
   art_sys_120: 0.0
   art_sys_121: 0.0
   art_sys_122: 0.0
-  art_sys_123: -0.0
+  art_sys_123: 0.0
   art_sys_124: 0.0
   art_sys_125: 0.0
   art_sys_126: 0.0
-  art_sys_127: -0.0
-  art_sys_128: -0.0
+  art_sys_127: 0.0
+  art_sys_128: 0.0
   art_sys_129: 0.0
   art_sys_130: 0.0
   art_sys_131: 0.0
-  art_sys_132: -0.0
-  art_sys_133: -0.0
+  art_sys_132: 0.0
+  art_sys_133: 0.0
   art_sys_134: 0.0
   art_sys_135: 0.0
   art_sys_136: 0.0
   art_sys_137: 0.0
-  art_sys_138: -0.0
+  art_sys_138: 0.0
   art_sys_139: 0.0
   art_sys_140: 0.0
   art_sys_141: 0.0
-  art_sys_142: -0.0
+  art_sys_142: 0.0
   art_sys_143: 0.0
-  art_sys_144: -0.0
-  art_sys_145: -0.0
+  art_sys_144: 0.0
+  art_sys_145: 0.0
   art_sys_146: 0.0
-  art_sys_147: -0.0
+  art_sys_147: 0.0
   art_sys_148: 0.0
   art_sys_149: 0.0
-  art_sys_150: -0.0
-  art_sys_151: -0.0
-  art_sys_152: -0.0
+  art_sys_150: 0.0
+  art_sys_151: 0.0
+  art_sys_152: 0.0
   art_sys_153: 0.0
   art_sys_154: 0.0
   art_sys_155: 0.0
-  art_sys_156: -0.0
-  art_sys_157: -0.0
+  art_sys_156: 0.0
+  art_sys_157: 0.0
   art_sys_158: 0.0
-  art_sys_159: -0.0
-  art_sys_160: -0.0
-  art_sys_161: -0.0
+  art_sys_159: 0.0
+  art_sys_160: 0.0
+  art_sys_161: 0.0
   art_sys_162: 0.0
   art_sys_163: 0.0
-  art_sys_164: -0.0
+  art_sys_164: 0.0
   art_sys_165: 0.0
-  art_sys_166: -0.0
+  art_sys_166: 0.0
   art_sys_167: 0.0
-  art_sys_168: -0.0
+  art_sys_168: 0.0
   art_sys_169: 0.0
   art_sys_170: 0.0
-  art_sys_171: -0.0
+  art_sys_171: 0.0
   art_sys_172: 0.0
-  art_sys_173: -0.0
-  art_sys_174: -0.0
-  art_sys_175: -0.0
-  art_sys_176: -0.0
+  art_sys_173: 0.0
+  art_sys_174: 0.0
+  art_sys_175: 0.0
+  art_sys_176: 0.0
   art_sys_177: 0.0
   art_sys_178: 0.0
   art_sys_179: 0.0
-  art_sys_180: -0.0
+  art_sys_180: 0.0
   art_sys_181: 0.0
   art_sys_182: 0.0
   art_sys_183: 0.0
@@ -30739,8 +30739,8 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 1.03044542e+03
   Unfolding-: -1.11582985e+03
@@ -30794,56 +30794,56 @@ bins:
   RelativeStatFSR-: -2.33057500e+05
   luminosity_uncertainty: 8.57799800e+02
   uncorrelated_uncertainty: 329.923
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 2.16787412e+02
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 2.52349796e-19
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 4.37790419e+01
   art_sys_10: -4.92806498e-21
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 1.67063222e+01
   art_sys_16: -2.35585118e-20
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: -7.02054191e-21
   art_sys_22: 1.65771551e+00
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: -5.96340175e-02
   art_sys_28: 1.02071824e-21
-  art_sys_29: -0.0
-  art_sys_30: -0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
   art_sys_31: 2.49903218e-02
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: 8.34125208e-22
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: -1.15349606e-02
   art_sys_39: 3.58889628e-21
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -1.47018945e-22
   art_sys_46: 0.0
   art_sys_47: -1.40806357e-03
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: -7.31907572e-160
-  art_sys_50: -0.0
+  art_sys_50: 0.0
   art_sys_51: 6.69009329e-06
   art_sys_52: 1.48949148e-151
   art_sys_53: 0.0
@@ -30852,7 +30852,7 @@ bins:
   art_sys_56: 6.28425769e-24
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
+  art_sys_59: 0.0
   art_sys_60: 1.52618973e-64
   art_sys_61: 0.0
   art_sys_62: -8.41107409e-25
@@ -31085,56 +31085,56 @@ bins:
   RelativeStatFSR-: -2.44955330e+01
   luminosity_uncertainty: 8.57799800e+02
   uncorrelated_uncertainty: 329.923
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 1.16829074e+02
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -1.48089697e-18
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: -7.20190727e+01
   art_sys_10: 4.42214077e-20
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: -2.96178110e+01
   art_sys_16: 1.31588841e-19
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 4.09293166e-20
   art_sys_22: -5.21590718e+00
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 2.01750628e-01
   art_sys_28: -5.82198711e-21
-  art_sys_29: -0.0
-  art_sys_30: -0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
   art_sys_31: -8.71248165e-02
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: -5.49080706e-21
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 4.37592898e-02
   art_sys_39: -2.31290754e-20
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 1.06109873e-21
   art_sys_46: 0.0
   art_sys_47: 5.84608620e-03
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: -3.94432857e-160
-  art_sys_50: -0.0
+  art_sys_50: 0.0
   art_sys_51: -3.84425099e-05
   art_sys_52: 8.02702969e-152
   art_sys_53: 0.0
@@ -31143,7 +31143,7 @@ bins:
   art_sys_56: -4.08452580e-23
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
+  art_sys_59: 0.0
   art_sys_60: 8.22480103e-65
   art_sys_61: 0.0
   art_sys_62: 5.58744898e-24
@@ -31321,9 +31321,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
-  art_sys_239: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
+  art_sys_239: 0.0
   Unfolding+: 4.78116473e+02
   Unfolding-: -5.18095894e+02
   AbsoluteStat+: 1.70204788e+01
@@ -31376,56 +31376,56 @@ bins:
   RelativeStatFSR-: -1.23795928e+01
   luminosity_uncertainty: 4.29832000e+02
   uncorrelated_uncertainty: 165.32
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 1.77342112e+01
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 5.39488513e-18
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: -7.93233911e+01
   art_sys_10: -1.76248130e-19
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 2.09716342e+01
   art_sys_16: -4.91943481e-19
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: -1.48058479e-19
   art_sys_22: 8.34994666e+00
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: -5.61705271e-01
   art_sys_28: 2.09906635e-20
-  art_sys_29: -0.0
-  art_sys_30: -0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
   art_sys_31: 2.11673834e-01
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: 2.12073726e-20
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: -1.23598004e-01
   art_sys_39: 8.94562595e-20
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -4.42406526e-21
   art_sys_46: 0.0
   art_sys_47: -1.82633582e-02
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: -5.98733963e-161
-  art_sys_50: -0.0
+  art_sys_50: 0.0
   art_sys_51: 1.19068463e-04
   art_sys_52: 1.21847235e-152
   art_sys_53: 0.0
@@ -31434,7 +31434,7 @@ bins:
   art_sys_56: 1.72366690e-22
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
+  art_sys_59: 0.0
   art_sys_60: 1.24849366e-65
   art_sys_61: 0.0
   art_sys_62: -2.17280165e-23
@@ -31667,56 +31667,56 @@ bins:
   RelativeStatFSR-: -5.58252828e+00
   luminosity_uncertainty: 1.91659260e+02
   uncorrelated_uncertainty: 73.7151
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: -1.20672664e+01
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -1.59672419e-17
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: -2.75971364e+01
   art_sys_10: 5.51914648e-19
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 4.36120968e+01
   art_sys_16: 1.46060563e-18
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 3.75987535e-19
   art_sys_22: -7.95268450e+00
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 5.52125017e-01
   art_sys_28: -6.14829178e-20
-  art_sys_29: -0.0
-  art_sys_30: -0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
   art_sys_31: -3.52165304e-01
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: -6.52067312e-20
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 2.20183996e-01
   art_sys_39: -2.69444398e-19
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 1.26446961e-20
   art_sys_46: 0.0
   art_sys_47: 4.03383715e-02
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 4.07409501e-161
-  art_sys_50: -0.0
+  art_sys_50: 0.0
   art_sys_51: -3.45210108e-04
   art_sys_52: -8.29111496e-153
   art_sys_53: 0.0
@@ -31725,7 +31725,7 @@ bins:
   art_sys_56: -5.37199047e-22
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
+  art_sys_59: 0.0
   art_sys_60: -8.49539092e-66
   art_sys_61: 0.0
   art_sys_62: 6.94698993e-23
@@ -31903,9 +31903,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
-  art_sys_239: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
+  art_sys_239: 0.0
   Unfolding+: 7.43367104e+01
   Unfolding-: -8.07652342e+01
   AbsoluteStat+: 2.65093767e+00
@@ -31958,56 +31958,56 @@ bins:
   RelativeStatFSR-: -2.39688947e+00
   luminosity_uncertainty: 81.22816
   uncorrelated_uncertainty: 31.2416
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: -1.93051528e+00
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 9.58981700e-17
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 1.91473892e+00
   art_sys_10: -3.51611769e-18
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 3.26468412e+00
   art_sys_16: -8.63768304e-18
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: -2.34358243e-18
   art_sys_22: -2.99327304e+00
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: -3.66641440e+00
   art_sys_28: 3.64488925e-19
-  art_sys_29: -0.0
-  art_sys_30: -0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
   art_sys_31: 1.10523007e+00
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: 4.15380479e-19
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: -1.02159751e+00
   art_sys_39: 1.68845999e-18
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -7.96771913e-20
   art_sys_46: 0.0
   art_sys_47: -1.99410627e-01
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 6.51771525e-162
-  art_sys_50: -0.0
+  art_sys_50: 0.0
   art_sys_51: 1.93753230e-03
   art_sys_52: -1.32640810e-153
   art_sys_53: 0.0
@@ -32016,7 +32016,7 @@ bins:
   art_sys_56: 3.41783229e-21
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
+  art_sys_59: 0.0
   art_sys_60: -1.35908842e-66
   art_sys_61: 0.0
   art_sys_62: -4.43297874e-22
@@ -32249,56 +32249,56 @@ bins:
   RelativeStatFSR-: -1.08413438e+00
   luminosity_uncertainty: 36.2063
   uncorrelated_uncertainty: 13.9255
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 3.43467092e-01
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -2.75488932e-16
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 1.66166898e+00
   art_sys_10: 1.03713793e-17
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: -2.11306803e+00
   art_sys_16: 2.63449074e-17
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 7.09193524e-18
   art_sys_22: 2.11876220e-01
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: -3.04260091e+00
   art_sys_28: -9.89705436e-19
-  art_sys_29: -0.0
-  art_sys_30: -0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
   art_sys_31: -1.37019594e+00
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: -1.24826961e-18
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 1.02688199e+00
   art_sys_39: -5.12785761e-18
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 2.54735745e-19
   art_sys_46: 0.0
   art_sys_47: 3.79530747e-01
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: -1.15959804e-162
-  art_sys_50: -0.0
+  art_sys_50: 0.0
   art_sys_51: -4.02416382e-03
   art_sys_52: 2.35987639e-154
   art_sys_53: 0.0
@@ -32307,7 +32307,7 @@ bins:
   art_sys_56: -1.00014707e-20
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
+  art_sys_59: 0.0
   art_sys_60: 2.41801839e-67
   art_sys_61: 0.0
   art_sys_62: 1.45815403e-21
@@ -32485,9 +32485,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
-  art_sys_239: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
+  art_sys_239: 0.0
   Unfolding+: 1.28065200e+01
   Unfolding-: -1.39525381e+01
   AbsoluteStat+: 4.40937474e-01
@@ -32540,56 +32540,56 @@ bins:
   RelativeStatFSR-: -5.19900920e-01
   luminosity_uncertainty: 1.71295020e+01
   uncorrelated_uncertainty: 6.58827
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 2.09195669e-01
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 8.15025573e-16
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 9.72117903e-02
   art_sys_10: -3.27754155e-17
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: -5.21203204e-01
   art_sys_16: -7.67108569e-17
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: -1.94216266e-17
   art_sys_22: 4.67999087e-01
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: -2.99150030e-01
   art_sys_28: 2.85987268e-18
-  art_sys_29: -0.0
-  art_sys_30: -0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
   art_sys_31: -2.93428211e+00
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: 3.83113434e-18
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: -2.69479787e-01
   art_sys_39: 1.54239900e-17
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -7.48923052e-19
   art_sys_46: 0.0
   art_sys_47: -4.34233441e-01
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: -7.06276696e-163
-  art_sys_50: -0.0
+  art_sys_50: 0.0
   art_sys_51: 1.40853718e-02
   art_sys_52: 1.43733056e-154
   art_sys_53: 0.0
@@ -32598,7 +32598,7 @@ bins:
   art_sys_56: 3.32134129e-20
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
+  art_sys_59: 0.0
   art_sys_60: 1.47274363e-67
   art_sys_61: 0.0
   art_sys_62: -4.36795954e-21
@@ -32831,56 +32831,56 @@ bins:
   RelativeStatFSR-: -2.62951700e-01
   luminosity_uncertainty: 8.533642
   uncorrelated_uncertainty: 3.28217
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 2.02081914e-02
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -1.91836475e-15
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: -1.27852765e-01
   art_sys_10: 8.49553287e-17
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 9.67815616e-02
   art_sys_16: 1.85402272e-16
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 4.28373532e-17
   art_sys_22: 7.67061301e-02
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 5.64323162e-01
   art_sys_28: -6.34052822e-18
-  art_sys_29: -0.0
-  art_sys_30: -0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
   art_sys_31: -1.17849762e+00
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: -1.02211184e-17
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: -1.57544816e+00
   art_sys_39: -4.08074748e-17
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 2.05856638e-18
   art_sys_46: 0.0
   art_sys_47: 4.43368543e-01
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: -6.82259201e-164
-  art_sys_50: -0.0
+  art_sys_50: 0.0
   art_sys_51: -9.98240157e-03
   art_sys_52: 1.38845301e-155
   art_sys_53: 0.0
@@ -32889,7 +32889,7 @@ bins:
   art_sys_56: -8.66573160e-20
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
+  art_sys_59: 0.0
   art_sys_60: 1.42266259e-68
   art_sys_61: 0.0
   art_sys_62: 1.27850457e-20
@@ -33067,9 +33067,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
-  art_sys_239: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
+  art_sys_239: 0.0
   Unfolding+: 2.63326690e+00
   Unfolding-: -2.87838483e+00
   AbsoluteStat+: 8.63515448e-02
@@ -33122,56 +33122,56 @@ bins:
   RelativeStatFSR-: -1.34347970e-01
   luminosity_uncertainty: 4.291846
   uncorrelated_uncertainty: 1.65071
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: -4.40503860e-03
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 9.93108377e-15
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: -2.10391499e-02
   art_sys_10: -4.31227736e-16
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 3.26755347e-02
   art_sys_16: -9.78232818e-16
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: -2.38049235e-16
   art_sys_22: -1.63308905e-02
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 6.86244571e-02
   art_sys_28: 2.99238146e-17
-  art_sys_29: -0.0
-  art_sys_30: -0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
   art_sys_31: 7.21227374e-02
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: 5.17276543e-17
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: -1.57999570e-01
   art_sys_39: 2.05706070e-16
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -1.05248293e-17
   art_sys_46: 0.0
   art_sys_47: 1.30758121e-01
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 1.48720917e-164
-  art_sys_50: -0.0
+  art_sys_50: 0.0
   art_sys_51: 1.28530691e-01
   art_sys_52: -3.02659172e-156
   art_sys_53: 0.0
@@ -33180,7 +33180,7 @@ bins:
   art_sys_56: 4.79824452e-19
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
+  art_sys_59: 0.0
   art_sys_60: -3.10116008e-69
   art_sys_61: 0.0
   art_sys_62: -6.49252492e-20
@@ -33413,56 +33413,56 @@ bins:
   RelativeStatFSR-: -7.11796960e-02
   luminosity_uncertainty: 2.23887560e+00
   uncorrelated_uncertainty: 0.861106
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: -1.89926002e-03
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -1.47312434e-14
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: -1.15514208e-03
   art_sys_10: 9.41492287e-16
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 4.47839131e-03
   art_sys_16: 1.55598216e-15
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 2.63675281e-16
   art_sys_22: -7.03394410e-03
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: -2.28529119e-02
   art_sys_28: -2.35247081e-17
-  art_sys_29: -0.0
-  art_sys_30: -0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
   art_sys_31: 8.49182234e-02
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: -1.05585815e-16
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 9.10314569e-02
   art_sys_39: -4.24687523e-16
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 2.47719162e-17
   art_sys_46: 0.0
   art_sys_47: -2.25408899e-02
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 6.41219350e-165
-  art_sys_50: -0.0
+  art_sys_50: 0.0
   art_sys_51: 1.42578380e-01
   art_sys_52: -1.30493357e-156
   art_sys_53: 0.0
@@ -33471,7 +33471,7 @@ bins:
   art_sys_56: -1.32540957e-18
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
+  art_sys_59: 0.0
   art_sys_60: -1.33708462e-69
   art_sys_61: 0.0
   art_sys_62: 1.67608516e-19
@@ -33649,9 +33649,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
-  art_sys_239: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
+  art_sys_239: 0.0
   Unfolding+: 6.05609483e-01
   Unfolding-: -6.64269709e-01
   AbsoluteStat+: 1.96528142e-02
@@ -33704,56 +33704,56 @@ bins:
   RelativeStatFSR-: -3.89648093e-02
   luminosity_uncertainty: 1.20497780e+00
   uncorrelated_uncertainty: 0.463453
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: -4.30023124e-04
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 1.55589066e-14
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 1.19311629e-03
   art_sys_10: -1.05855396e-15
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: -1.12973738e-03
   art_sys_16: -2.26972606e-15
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: -8.69866362e-17
   art_sys_22: -3.65079577e-04
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: -1.14984477e-02
   art_sys_28: -5.78139291e-17
-  art_sys_29: -0.0
-  art_sys_30: -0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
   art_sys_31: 6.00041474e-03
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: 1.51063143e-16
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 3.02971354e-02
   art_sys_39: 5.65506259e-16
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -3.64760138e-17
   art_sys_46: 0.0
   art_sys_47: -2.18635288e-02
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 1.45182372e-165
-  art_sys_50: -0.0
+  art_sys_50: 0.0
   art_sys_51: 5.11831117e-02
   art_sys_52: -2.95457944e-157
   art_sys_53: 0.0
@@ -33762,7 +33762,7 @@ bins:
   art_sys_56: 2.11937747e-18
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
+  art_sys_59: 0.0
   art_sys_60: -3.02737539e-70
   art_sys_61: 0.0
   art_sys_62: -2.87087507e-19
@@ -33995,56 +33995,56 @@ bins:
   RelativeStatFSR-: -2.16859624e-02
   luminosity_uncertainty: 6.59539400e-01
   uncorrelated_uncertainty: 2.53669000e-01
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: -2.72721499e-05
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -2.21584072e-14
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 3.60285269e-04
   art_sys_10: 3.75082667e-15
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: -5.23186009e-04
   art_sys_16: 4.09847427e-15
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: -5.00267352e-16
   art_sys_22: 3.81528105e-04
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: -2.32361333e-04
   art_sys_28: 3.69849922e-16
-  art_sys_29: -0.0
-  art_sys_30: -0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
   art_sys_31: -6.27790428e-03
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: -3.60052870e-16
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: -3.40802396e-03
   art_sys_39: -1.30423763e-15
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 9.84335904e-17
   art_sys_46: 0.0
   art_sys_47: -7.72761699e-04
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 9.20748658e-167
-  art_sys_50: -0.0
+  art_sys_50: 0.0
   art_sys_51: -1.01361971e-02
   art_sys_52: -1.87379846e-158
   art_sys_53: 0.0
@@ -34053,7 +34053,7 @@ bins:
   art_sys_56: -6.34775144e-18
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
+  art_sys_59: 0.0
   art_sys_60: -1.91996734e-71
   art_sys_61: 0.0
   art_sys_62: 8.54734943e-19
@@ -34231,9 +34231,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
-  art_sys_239: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
+  art_sys_239: 0.0
   Unfolding+: 1.48308913e-01
   Unfolding-: -1.63296537e-01
   AbsoluteStat+: 5.47587069e-03
@@ -34286,56 +34286,56 @@ bins:
   RelativeStatFSR-: -1.20586705e-02
   luminosity_uncertainty: 3.60188400e-01
   uncorrelated_uncertainty: 1.38534000e-01
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 1.80223711e-06
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 3.06436693e-14
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 7.41697073e-05
   art_sys_10: -3.53934752e-16
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: -1.19884608e-04
   art_sys_16: -9.34699762e-15
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 7.77813667e-16
   art_sys_22: 1.10552010e-04
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 5.04522270e-04
   art_sys_28: -1.11638942e-15
-  art_sys_29: -0.0
-  art_sys_30: -0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
   art_sys_31: -1.83365138e-03
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: 2.73304089e-16
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: -2.46062640e-03
   art_sys_39: 1.28002108e-15
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -1.02202473e-16
   art_sys_46: 0.0
   art_sys_47: 1.35657430e-03
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: -6.08464878e-168
-  art_sys_50: -0.0
+  art_sys_50: 0.0
   art_sys_51: -6.71641193e-03
   art_sys_52: 1.23827555e-159
   art_sys_53: 0.0
@@ -34344,7 +34344,7 @@ bins:
   art_sys_56: 1.17120002e-17
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
+  art_sys_59: 0.0
   art_sys_60: 1.26878021e-72
   art_sys_61: 0.0
   art_sys_62: -1.63606967e-18
@@ -34577,56 +34577,56 @@ bins:
   RelativeStatFSR-: -6.87182218e-03
   luminosity_uncertainty: 2.01494280e-01
   uncorrelated_uncertainty: 7.74978000e-02
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 8.54941660e-07
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -4.45419513e-14
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 1.23406385e-05
   art_sys_10: 7.43763186e-15
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: -1.94181186e-05
   art_sys_16: 6.75582394e-15
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: -4.00094032e-16
   art_sys_22: 1.10803930e-05
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 1.51113552e-04
   art_sys_28: 1.74375244e-15
-  art_sys_29: -0.0
-  art_sys_30: -0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
   art_sys_31: -8.65548323e-05
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: -3.04527744e-17
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: -3.97357328e-04
   art_sys_39: -3.09190470e-16
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 7.67572588e-17
   art_sys_46: 0.0
   art_sys_47: 3.65017462e-04
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: -2.88641750e-168
-  art_sys_50: -0.0
+  art_sys_50: 0.0
   art_sys_51: -1.15567069e-04
   art_sys_52: 5.87409454e-160
   art_sys_53: 0.0
@@ -34635,7 +34635,7 @@ bins:
   art_sys_56: -1.64614786e-17
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
+  art_sys_59: 0.0
   art_sys_60: 6.01881433e-73
   art_sys_61: 0.0
   art_sys_62: 2.31061632e-18
@@ -34813,9 +34813,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
-  art_sys_239: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
+  art_sys_239: 0.0
   Unfolding+: 3.83168896e-02
   Unfolding-: -4.23924976e-02
   AbsoluteStat+: 2.02267481e-03
@@ -34868,56 +34868,56 @@ bins:
   RelativeStatFSR-: -3.94592949e-03
   luminosity_uncertainty: 1.13529000e-01
   uncorrelated_uncertainty: 0.043665
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 8.22964411e-08
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -4.92782746e-14
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 1.31486126e-06
   art_sys_10: 1.40449809e-14
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: -1.64162720e-06
   art_sys_16: -1.28295107e-16
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 1.84586189e-15
   art_sys_22: -1.98844325e-06
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 1.19840938e-05
   art_sys_28: -2.26490122e-15
-  art_sys_29: -0.0
-  art_sys_30: -0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
   art_sys_31: 7.97949859e-05
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: -8.08526663e-16
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 4.71002667e-05
   art_sys_39: -2.82890655e-17
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 2.65798512e-16
   art_sys_46: 0.0
   art_sys_47: -1.20878237e-05
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: -2.77845761e-169
-  art_sys_50: -0.0
+  art_sys_50: 0.0
   art_sys_51: 5.43849868e-04
   art_sys_52: 5.65438740e-161
   art_sys_53: 0.0
@@ -34926,7 +34926,7 @@ bins:
   art_sys_56: 2.82282809e-17
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
+  art_sys_59: 0.0
   art_sys_60: 5.79369356e-74
   art_sys_61: 0.0
   art_sys_62: -4.03944418e-18
@@ -35159,56 +35159,56 @@ bins:
   RelativeStatFSR-: -2.27589774e-03
   luminosity_uncertainty: 6.42239000e-02
   uncorrelated_uncertainty: 2.47015000e-02
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: -1.09193388e-09
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 3.21370175e-14
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 1.50647605e-07
   art_sys_10: 3.11385086e-14
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: -9.03857021e-08
   art_sys_16: 2.58520470e-15
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 4.01880954e-15
   art_sys_22: -9.50919604e-07
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: -1.79941395e-06
   art_sys_28: -2.26549989e-15
-  art_sys_29: -0.0
-  art_sys_30: -0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
   art_sys_31: 2.97311694e-05
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: 3.00543495e-16
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 3.22684082e-05
   art_sys_39: -4.82999003e-16
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 1.91031192e-17
   art_sys_46: 0.0
   art_sys_47: -2.14998368e-05
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 3.68649607e-171
-  art_sys_50: -0.0
+  art_sys_50: 0.0
   art_sys_51: 1.35453796e-04
   art_sys_52: -7.50231956e-163
   art_sys_53: 0.0
@@ -35217,7 +35217,7 @@ bins:
   art_sys_56: -1.51115450e-17
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
+  art_sys_59: 0.0
   art_sys_60: -7.68724647e-76
   art_sys_61: 0.0
   art_sys_62: 8.55190998e-19
@@ -35395,9 +35395,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
-  art_sys_239: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
+  art_sys_239: 0.0
   Unfolding+: 1.01821041e-02
   Unfolding-: -1.13024330e-02
   AbsoluteStat+: 9.24221756e-04
@@ -35450,56 +35450,56 @@ bins:
   RelativeStatFSR-: -1.31861718e-03
   luminosity_uncertainty: 3.64548600e-02
   uncorrelated_uncertainty: 1.40211000e-02
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: -2.28477486e-09
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -4.41160441e-15
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 1.94321300e-08
   art_sys_10: 1.51764469e-14
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 1.93851388e-09
   art_sys_16: 6.46789066e-15
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: -3.71277155e-15
   art_sys_22: -2.28727294e-07
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: -9.28098509e-07
   art_sys_28: -7.10978444e-16
-  art_sys_29: -0.0
-  art_sys_30: -0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
   art_sys_31: 6.89577051e-06
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: -1.43054172e-16
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 8.54355185e-06
   art_sys_39: -2.59445487e-16
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 4.54672500e-16
   art_sys_46: 0.0
   art_sys_47: -5.57429402e-06
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 7.71374524e-171
-  art_sys_50: -0.0
+  art_sys_50: 0.0
   art_sys_51: -5.28427859e-06
   art_sys_52: -1.56980994e-162
   art_sys_53: 0.0
@@ -35508,7 +35508,7 @@ bins:
   art_sys_56: -2.16091893e-17
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
+  art_sys_59: 0.0
   art_sys_60: -1.60848819e-75
   art_sys_61: 0.0
   art_sys_62: 4.28854609e-18
@@ -35741,56 +35741,56 @@ bins:
   RelativeStatFSR-: -7.78245993e-04
   luminosity_uncertainty: 2.10719860e-02
   uncorrelated_uncertainty: 8.10461000e-03
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: -2.94172244e-10
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 1.65931617e-14
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 1.48965673e-09
   art_sys_10: -1.76659818e-14
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 6.46668990e-10
   art_sys_16: 2.15231832e-14
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 1.08711211e-15
   art_sys_22: -2.19833606e-08
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: -1.08570479e-07
   art_sys_28: 2.00832198e-15
-  art_sys_29: -0.0
-  art_sys_30: -0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
   art_sys_31: 6.57746631e-07
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: -5.26156224e-17
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 7.99237837e-07
   art_sys_39: 8.34397468e-16
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -4.05381451e-16
   art_sys_46: 0.0
   art_sys_47: -2.93598887e-07
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 9.93170228e-172
-  art_sys_50: -0.0
+  art_sys_50: 0.0
   art_sys_51: -6.89006760e-06
   art_sys_52: -2.02118225e-163
   art_sys_53: 0.0
@@ -35799,7 +35799,7 @@ bins:
   art_sys_56: -2.96844450e-17
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
+  art_sys_59: 0.0
   art_sys_60: -2.07098122e-76
   art_sys_61: 0.0
   art_sys_62: -1.24761723e-17
@@ -35977,9 +35977,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
-  art_sys_239: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
+  art_sys_239: 0.0
   Unfolding+: 2.79225753e-03
   Unfolding-: -3.10978687e-03
   AbsoluteStat+: 4.66290550e-04
@@ -36032,56 +36032,56 @@ bins:
   RelativeStatFSR-: -4.47574390e-04
   luminosity_uncertainty: 1.18652560e-02
   uncorrelated_uncertainty: 4.56356000e-03
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: -3.97280847e-11
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 3.89963632e-14
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 1.82872138e-10
   art_sys_10: 2.00116993e-16
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 7.44974278e-11
   art_sys_16: 2.73011430e-15
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: -1.13185248e-15
   art_sys_22: -2.74757708e-09
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: -1.29677462e-08
   art_sys_28: 3.02669436e-17
-  art_sys_29: -0.0
-  art_sys_30: -0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
   art_sys_31: 8.27378828e-08
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: -1.00874926e-15
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 8.09328000e-08
   art_sys_39: -4.90206748e-16
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -2.90197831e-17
   art_sys_46: 0.0
   art_sys_47: 4.75944715e-08
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 1.34128060e-172
-  art_sys_50: -0.0
+  art_sys_50: 0.0
   art_sys_51: -1.98541534e-06
   art_sys_52: -2.72961519e-164
   art_sys_53: 0.0
@@ -36090,7 +36090,7 @@ bins:
   art_sys_56: 1.97213051e-17
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
+  art_sys_59: 0.0
   art_sys_60: -2.79686880e-77
   art_sys_61: 0.0
   art_sys_62: -1.79384561e-17
@@ -36323,56 +36323,56 @@ bins:
   RelativeStatFSR-: -2.60956824e-04
   luminosity_uncertainty: 6.76676000e-03
   uncorrelated_uncertainty: 2.60260000e-03
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: -3.73490735e-12
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -4.30510915e-15
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 1.87768726e-11
   art_sys_10: 3.29980414e-15
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 7.09997194e-12
   art_sys_16: -6.23815661e-15
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 4.54302624e-15
   art_sys_22: -2.86618160e-10
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: -8.70284781e-10
   art_sys_28: -1.11932359e-15
-  art_sys_29: -0.0
-  art_sys_30: -0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
   art_sys_31: 9.09601305e-09
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: -6.07330407e-16
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 4.74935554e-09
   art_sys_39: -8.99568313e-17
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -1.41265117e-16
   art_sys_46: 0.0
   art_sys_47: 1.98117235e-08
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 1.26096152e-173
-  art_sys_50: -0.0
+  art_sys_50: 0.0
   art_sys_51: -2.97435975e-07
   art_sys_52: -2.56615933e-165
   art_sys_53: 0.0
@@ -36381,7 +36381,7 @@ bins:
   art_sys_56: 1.14310614e-17
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
+  art_sys_59: 0.0
   art_sys_60: -2.62938572e-78
   art_sys_61: 0.0
   art_sys_62: 2.05684757e-17
@@ -36559,9 +36559,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
-  art_sys_239: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
+  art_sys_239: 0.0
   Unfolding+: 7.85134991e-04
   Unfolding-: -8.75159085e-04
   AbsoluteStat+: 2.35207460e-04
@@ -36614,56 +36614,56 @@ bins:
   RelativeStatFSR-: -1.50907441e-04
   luminosity_uncertainty: 3.82675800e-03
   uncorrelated_uncertainty: 1.47183000e-03
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: -1.63663737e-13
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 3.34904870e-14
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 1.08903284e-12
   art_sys_10: -2.85260987e-14
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 1.25469566e-12
   art_sys_16: 6.81453995e-15
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 1.87621975e-15
   art_sys_22: -2.43125422e-11
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: -1.73873544e-11
   art_sys_28: 1.47601505e-17
-  art_sys_29: -0.0
-  art_sys_30: -0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
   art_sys_31: 8.96794487e-10
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: 3.70469665e-16
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 3.27223802e-10
   art_sys_39: 6.47587423e-16
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -1.76951755e-16
   art_sys_46: 0.0
   art_sys_47: 2.00122274e-09
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 5.52553592e-175
-  art_sys_50: -0.0
+  art_sys_50: 0.0
   art_sys_51: -1.12711098e-08
   art_sys_52: -1.12449153e-166
   art_sys_53: 0.0
@@ -36672,7 +36672,7 @@ bins:
   art_sys_56: -6.84081915e-17
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
+  art_sys_59: 0.0
   art_sys_60: -1.15219750e-79
   art_sys_61: 0.0
   art_sys_62: -1.90856013e-17
@@ -36905,56 +36905,56 @@ bins:
   RelativeStatFSR-: -8.67555583e-05
   luminosity_uncertainty: 2.14957080e-03
   uncorrelated_uncertainty: 8.26758000e-04
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 6.55252105e-15
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -6.45414592e-14
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: -9.86402064e-15
   art_sys_10: -1.57010922e-14
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 3.01274945e-13
   art_sys_16: -2.23000253e-14
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 6.07939624e-16
   art_sys_22: -2.46897008e-12
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: -5.39384338e-12
   art_sys_28: -4.01320607e-16
-  art_sys_29: -0.0
-  art_sys_30: -0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
   art_sys_31: 1.02621537e-10
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: -1.28120627e-15
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 1.16533470e-10
   art_sys_39: 3.51007555e-16
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 1.54412012e-16
   art_sys_46: 0.0
   art_sys_47: -1.32340574e-10
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: -2.21223137e-176
-  art_sys_50: -0.0
+  art_sys_50: 0.0
   art_sys_51: 2.58232574e-09
   art_sys_52: 4.50207089e-168
   art_sys_53: 0.0
@@ -36963,7 +36963,7 @@ bins:
   art_sys_56: -2.68213635e-17
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
+  art_sys_59: 0.0
   art_sys_60: 4.61299401e-81
   art_sys_61: 0.0
   art_sys_62: 3.32646212e-17
@@ -37141,9 +37141,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
-  art_sys_239: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
+  art_sys_239: 0.0
   Unfolding+: 2.26242272e-04
   Unfolding-: -2.51612189e-04
   AbsoluteStat+: 1.12403735e-04
@@ -37196,56 +37196,56 @@ bins:
   RelativeStatFSR-: -4.95659056e-05
   luminosity_uncertainty: 1.19902380e-03
   uncorrelated_uncertainty: 4.61163000e-04
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 2.21499081e-15
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 2.92963754e-15
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: -1.33157173e-14
   art_sys_10: -9.38330569e-15
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 5.65367001e-14
   art_sys_16: -1.68144248e-15
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 5.32571772e-15
   art_sys_22: -3.05109246e-13
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: -2.46858353e-12
   art_sys_28: -1.30938140e-16
-  art_sys_29: -0.0
-  art_sys_30: -0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
   art_sys_31: 1.05130764e-11
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: -1.24313265e-15
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 2.63616333e-11
   art_sys_39: -6.65471177e-17
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -3.22713832e-17
   art_sys_46: 0.0
   art_sys_47: -7.06652002e-11
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: -7.47814521e-177
-  art_sys_50: -0.0
+  art_sys_50: 0.0
   art_sys_51: 3.31832410e-10
   art_sys_52: 1.52186342e-168
   art_sys_53: 0.0
@@ -37254,7 +37254,7 @@ bins:
   art_sys_56: 1.60324851e-17
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
+  art_sys_59: 0.0
   art_sys_60: 1.55936002e-81
   art_sys_61: 0.0
   art_sys_62: -4.54621616e-17
@@ -37487,56 +37487,56 @@ bins:
   RelativeStatFSR-: -2.81892246e-05
   luminosity_uncertainty: 6.65706600e-04
   uncorrelated_uncertainty: 2.56041000e-04
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 2.68538831e-16
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 6.72981582e-14
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: -2.20737114e-15
   art_sys_10: 5.45751405e-15
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 8.16888279e-15
   art_sys_16: -6.82579951e-15
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: -8.41548420e-15
   art_sys_22: -3.62963266e-14
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: -4.94003260e-13
   art_sys_28: -9.11829678e-16
-  art_sys_29: -0.0
-  art_sys_30: -0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
   art_sys_31: 4.34811439e-13
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: -1.65760983e-15
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 2.95152120e-12
   art_sys_39: -1.34950982e-15
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 3.72737493e-16
   art_sys_46: 0.0
   art_sys_47: -9.75849279e-12
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: -9.06627700e-178
-  art_sys_50: -0.0
+  art_sys_50: 0.0
   art_sys_51: -4.94496708e-11
   art_sys_52: 1.84506116e-169
   art_sys_53: 0.0
@@ -37545,7 +37545,7 @@ bins:
   art_sys_56: -1.89920712e-17
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
+  art_sys_59: 0.0
   art_sys_60: 1.89052123e-82
   art_sys_61: 0.0
   art_sys_62: 1.06283568e-16
@@ -37723,9 +37723,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
-  art_sys_239: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
+  art_sys_239: 0.0
   Unfolding+: 6.67497952e-05
   Unfolding-: -7.37982138e-05
   AbsoluteStat+: 4.97983973e-05
@@ -37778,56 +37778,56 @@ bins:
   RelativeStatFSR-: -1.55925488e-05
   luminosity_uncertainty: 3.59455200e-04
   uncorrelated_uncertainty: 1.38252000e-04
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 2.35902797e-17
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -6.98985133e-15
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: -2.54129500e-16
   art_sys_10: 7.78140456e-15
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 9.28334207e-16
   art_sys_16: -4.76617278e-15
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 1.52087400e-15
   art_sys_22: -3.20866718e-15
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: -5.86549202e-14
   art_sys_28: -1.34521660e-15
-  art_sys_29: -0.0
-  art_sys_30: -0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
   art_sys_31: -1.29029798e-13
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: 2.08609724e-15
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 3.53848435e-15
   art_sys_39: -2.90307420e-16
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 3.27184881e-18
   art_sys_46: 0.0
   art_sys_47: -2.81517318e-13
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: -7.96443354e-179
-  art_sys_50: -0.0
+  art_sys_50: 0.0
   art_sys_51: -2.19238637e-11
   art_sys_52: 1.62082705e-170
   art_sys_53: 0.0
@@ -37836,7 +37836,7 @@ bins:
   art_sys_56: 9.05686055e-17
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
+  art_sys_59: 0.0
   art_sys_60: 1.66076260e-83
   art_sys_61: 0.0
   art_sys_62: -1.74710130e-16
@@ -38069,56 +38069,56 @@ bins:
   RelativeStatFSR-: -8.55414342e-06
   luminosity_uncertainty: 1.92256740e-04
   uncorrelated_uncertainty: 7.39449000e-05
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 1.77307418e-18
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -2.74492324e-14
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: -2.39221073e-17
   art_sys_10: -2.32824178e-14
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 8.71534268e-17
   art_sys_16: -1.24360782e-14
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: -7.79543650e-15
   art_sys_22: -1.64769873e-16
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: -4.06652585e-15
   art_sys_28: -5.58414414e-16
-  art_sys_29: -0.0
-  art_sys_30: -0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
   art_sys_31: -3.74959397e-14
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: -1.70315724e-17
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: -6.03079124e-14
   art_sys_39: -6.59468344e-16
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 4.94095650e-16
   art_sys_46: 0.0
   art_sys_47: 1.42407827e-13
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: -5.98616407e-180
-  art_sys_50: -0.0
+  art_sys_50: 0.0
   art_sys_51: -3.67348290e-12
   art_sys_52: 1.21823311e-171
   art_sys_53: 0.0
@@ -38127,7 +38127,7 @@ bins:
   art_sys_56: -1.34376854e-16
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
+  art_sys_59: 0.0
   art_sys_60: 1.24824942e-84
   art_sys_61: 0.0
   art_sys_62: 3.28401945e-16
@@ -38305,8 +38305,8 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 1.91277674e-05
   Unfolding-: -2.09639695e-05
@@ -38360,56 +38360,56 @@ bins:
   RelativeStatFSR-: -4.44874933e-06
   luminosity_uncertainty: 9.74261600e-05
   uncorrelated_uncertainty: 3.74716000e-05
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 1.28255124e-19
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -9.82309807e-15
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: -2.01674009e-18
   art_sys_10: 4.23018827e-14
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 7.14610663e-18
   art_sys_16: -5.15418811e-15
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 4.99340866e-15
   art_sys_22: 4.49356031e-18
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: -4.09662878e-17
   art_sys_28: -1.38306984e-16
-  art_sys_29: -0.0
-  art_sys_30: -0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
   art_sys_31: -6.18275584e-15
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: 1.72920723e-15
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: -1.31230127e-14
   art_sys_39: -1.40333798e-15
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -1.05359457e-15
   art_sys_46: 0.0
   art_sys_47: 3.48551495e-14
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: -4.33008435e-181
-  art_sys_50: -0.0
+  art_sys_50: 0.0
   art_sys_51: -3.78360604e-13
   art_sys_52: 8.81207410e-173
   art_sys_53: 0.0
@@ -38418,7 +38418,7 @@ bins:
   art_sys_56: 2.26591577e-16
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
+  art_sys_59: 0.0
   art_sys_60: 9.02919828e-86
   art_sys_61: 0.0
   art_sys_62: -6.05836478e-16
@@ -38598,7 +38598,7 @@ bins:
   art_sys_236: 0.0
   art_sys_237: 0.0
   art_sys_238: 0.0
-  art_sys_239: -0.0
+  art_sys_239: 0.0
   Unfolding+: 1.07308126e-05
   Unfolding-: -1.17041609e-05
   AbsoluteStat+: 1.22486717e-05
@@ -38651,56 +38651,56 @@ bins:
   RelativeStatFSR-: -2.43054951e-06
   luminosity_uncertainty: 5.18689600e-05
   uncorrelated_uncertainty: 1.99496000e-05
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 8.78344678e-21
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -2.07007836e-14
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: -1.44901701e-19
   art_sys_10: -5.24119710e-14
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 4.82086974e-19
   art_sys_16: 1.80307603e-14
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: -9.12722424e-15
   art_sys_22: 2.09907885e-18
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 3.06089000e-17
   art_sys_28: 2.85291318e-15
-  art_sys_29: -0.0
-  art_sys_30: -0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
   art_sys_31: -7.13436485e-16
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: 7.54400369e-16
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: -1.69047730e-15
   art_sys_39: 2.43894129e-15
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 2.89547740e-15
   art_sys_46: 0.0
   art_sys_47: 4.56264222e-15
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: -2.96542251e-182
-  art_sys_50: -0.0
+  art_sys_50: 0.0
   art_sys_51: -1.98145605e-14
   art_sys_52: 6.03487618e-174
   art_sys_53: 0.0
@@ -38709,7 +38709,7 @@ bins:
   art_sys_56: -4.63603755e-16
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
+  art_sys_59: 0.0
   art_sys_60: 6.18357226e-87
   art_sys_61: 0.0
   art_sys_62: 1.12763595e-15
@@ -38887,8 +38887,8 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 5.47039845e-06
   Unfolding-: -5.93815521e-06
@@ -38942,56 +38942,56 @@ bins:
   RelativeStatFSR-: -1.19126541e-06
   luminosity_uncertainty: 2.47470600e-05
   uncorrelated_uncertainty: 9.51810000e-06
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 5.92066063e-22
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -9.09341889e-14
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: -9.51577016e-21
   art_sys_10: 5.82586820e-15
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 2.87793198e-20
   art_sys_16: -4.76604935e-15
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 1.81701389e-14
   art_sys_22: 2.70545254e-19
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 4.43295628e-18
   art_sys_28: -5.06916876e-15
-  art_sys_29: -0.0
-  art_sys_30: -0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
   art_sys_31: -6.67668516e-17
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: -1.32105521e-15
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: -1.64150633e-16
   art_sys_39: -4.53853501e-15
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -5.56166250e-15
   art_sys_46: 0.0
   art_sys_47: 4.28305986e-16
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: -1.99890332e-183
-  art_sys_50: -0.0
+  art_sys_50: 0.0
   art_sys_51: -3.66411013e-17
   art_sys_52: 4.06793096e-175
   art_sys_53: 0.0
@@ -39000,7 +39000,7 @@ bins:
   art_sys_56: 8.52794697e-16
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
+  art_sys_59: 0.0
   art_sys_60: 4.16816243e-88
   art_sys_61: 0.0
   art_sys_62: -1.91732641e-15
@@ -39233,56 +39233,56 @@ bins:
   RelativeStatFSR-: -5.84783212e-07
   luminosity_uncertainty: 1.18209000e-05
   uncorrelated_uncertainty: 4.54650000e-06
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 3.76532772e-23
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -6.96543049e-15
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: -5.78354577e-22
   art_sys_10: 3.66642222e-14
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 1.52023090e-21
   art_sys_16: -8.10244361e-15
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: -1.73311407e-14
   art_sys_22: 2.58532840e-20
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 3.93258845e-19
   art_sys_28: 8.60392748e-15
-  art_sys_29: -0.0
-  art_sys_30: -0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
   art_sys_31: -5.65994534e-18
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: 2.01758006e-15
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: -1.36499601e-17
   art_sys_39: 7.47853297e-15
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 1.01640779e-14
   art_sys_46: 0.0
   art_sys_47: 3.28877015e-17
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: -1.27123086e-184
-  art_sys_50: -0.0
+  art_sys_50: 0.0
   art_sys_51: 2.41137039e-17
   art_sys_52: 2.58705827e-176
   art_sys_53: 0.0
@@ -39291,7 +39291,7 @@ bins:
   art_sys_56: -1.37037253e-15
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
+  art_sys_59: 0.0
   art_sys_60: 2.65080174e-89
   art_sys_61: 0.0
   art_sys_62: 3.07641101e-15
@@ -39469,9 +39469,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
-  art_sys_239: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
+  art_sys_239: 0.0
   Unfolding+: 1.47097436e-06
   Unfolding-: -1.58334580e-06
   AbsoluteStat+: 2.15519496e-06
@@ -39524,56 +39524,56 @@ bins:
   RelativeStatFSR-: -2.87461810e-07
   luminosity_uncertainty: 5.65232200e-06
   uncorrelated_uncertainty: 2.17397000e-06
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 1.92844718e-24
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 8.20587723e-14
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: -2.80855432e-23
   art_sys_10: 1.50109846e-14
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 4.98485813e-23
   art_sys_16: -1.89337304e-14
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 2.23585962e-14
   art_sys_22: 2.17899558e-21
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 2.65850980e-20
   art_sys_28: -1.01284804e-14
-  art_sys_29: -0.0
-  art_sys_30: -0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
   art_sys_31: -4.65479165e-19
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: -4.64532466e-15
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: -1.06517513e-18
   art_sys_39: -1.12688869e-14
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -1.41597789e-14
   art_sys_46: 0.0
   art_sys_47: 2.38288278e-18
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: -6.51072603e-186
-  art_sys_50: -0.0
+  art_sys_50: 0.0
   art_sys_51: -1.11157644e-17
   art_sys_52: 1.32498574e-177
   art_sys_53: 0.0
@@ -39582,7 +39582,7 @@ bins:
   art_sys_56: 2.09896347e-15
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
+  art_sys_59: 0.0
   art_sys_60: 1.35763246e-90
   art_sys_61: 0.0
   art_sys_62: -4.05124450e-15
@@ -39762,7 +39762,7 @@ bins:
   art_sys_236: 0.0
   art_sys_237: 0.0
   art_sys_238: 0.0
-  art_sys_239: -0.0
+  art_sys_239: 0.0
   Unfolding+: 7.71640882e-07
   Unfolding-: -8.27492983e-07
   AbsoluteStat+: 1.19714571e-06
@@ -39815,56 +39815,56 @@ bins:
   RelativeStatFSR-: -1.41394005e-07
   luminosity_uncertainty: 2.70218000e-06
   uncorrelated_uncertainty: 1.03930000e-06
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 4.88539080e-26
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 4.39148778e-14
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: -4.10946629e-25
   art_sys_10: 4.07796016e-15
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: -3.18773093e-24
   art_sys_16: 6.91881053e-15
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: -2.58837578e-15
   art_sys_22: 1.76557990e-22
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 1.92859028e-21
   art_sys_28: 1.48553801e-14
-  art_sys_29: -0.0
-  art_sys_30: -0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
   art_sys_31: -3.74634878e-20
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: 9.30482101e-15
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: -8.57572565e-20
   art_sys_39: 1.48761585e-14
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 1.69140914e-14
   art_sys_46: 0.0
   art_sys_47: 2.10149065e-19
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: -1.64938179e-187
-  art_sys_50: -0.0
+  art_sys_50: 0.0
   art_sys_51: -7.84425669e-19
   art_sys_52: 3.35662618e-179
   art_sys_53: 0.0
@@ -39873,7 +39873,7 @@ bins:
   art_sys_56: -2.35436242e-15
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
+  art_sys_59: 0.0
   art_sys_60: 3.43932944e-92
   art_sys_61: 0.0
   art_sys_62: 4.02702692e-15
@@ -40051,9 +40051,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
-  art_sys_239: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
+  art_sys_239: 0.0
   Unfolding+: 3.72652365e-07
   Unfolding-: -3.98419167e-07
   AbsoluteStat+: 6.06486088e-07
@@ -40106,56 +40106,56 @@ bins:
   RelativeStatFSR-: -6.37728335e-08
   luminosity_uncertainty: 1.18429220e-06
   uncorrelated_uncertainty: 4.55497000e-07
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: -2.68992989e-27
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 1.14253255e-15
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 1.05202758e-25
   art_sys_10: 1.76530803e-14
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: -7.81142500e-25
   art_sys_16: 1.56648714e-16
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: -1.53427782e-14
   art_sys_22: 1.27999187e-23
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 2.02928855e-22
   art_sys_28: -1.48159269e-14
-  art_sys_29: -0.0
-  art_sys_30: -0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
   art_sys_31: -2.42751732e-21
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: -9.45104286e-15
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: -6.28895478e-21
   art_sys_39: -1.16061565e-14
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -1.28776084e-14
   art_sys_46: 0.0
   art_sys_47: 1.88434804e-20
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 9.08158791e-189
-  art_sys_50: -0.0
+  art_sys_50: 0.0
   art_sys_51: 4.28236886e-19
   art_sys_52: -1.84817706e-180
   art_sys_53: 0.0
@@ -40164,7 +40164,7 @@ bins:
   art_sys_56: 2.15718684e-15
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
+  art_sys_59: 0.0
   art_sys_60: -1.89371852e-93
   art_sys_61: 0.0
   art_sys_62: -2.41547622e-15
@@ -40397,56 +40397,56 @@ bins:
   RelativeStatFSR-: -2.52892882e-08
   luminosity_uncertainty: 4.56268800e-07
   uncorrelated_uncertainty: 1.75488000e-07
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: -4.88517613e-28
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 3.24937670e-15
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 1.85361059e-26
   art_sys_10: -5.54722029e-15
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: -1.10305955e-25
   art_sys_16: -7.01595557e-15
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 4.01289704e-14
   art_sys_22: 1.08795800e-24
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 2.99808523e-23
   art_sys_28: 9.45882769e-15
-  art_sys_29: -0.0
-  art_sys_30: -0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
   art_sys_31: -1.37111886e-22
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: 2.92370360e-15
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: -4.77718831e-22
   art_sys_39: 1.52922409e-15
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -3.40019676e-15
   art_sys_46: 0.0
   art_sys_47: 1.63180738e-21
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 1.64930546e-189
-  art_sys_50: -0.0
+  art_sys_50: 0.0
   art_sys_51: 1.42181339e-19
   art_sys_52: -3.35647085e-181
   art_sys_53: 0.0
@@ -40455,7 +40455,7 @@ bins:
   art_sys_56: 2.41430253e-15
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
+  art_sys_59: 0.0
   art_sys_60: -3.43917830e-94
   art_sys_61: 0.0
   art_sys_62: -5.72598470e-15
@@ -40633,8 +40633,8 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 5.86525966e-08
   Unfolding-: -6.23390946e-08
@@ -40688,56 +40688,56 @@ bins:
   RelativeStatFSR-: -8.69433618e-09
   luminosity_uncertainty: 1.52304360e-07
   uncorrelated_uncertainty: 5.85786000e-08
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: -3.80909612e-31
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -1.45744541e-15
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 1.86010871e-29
   art_sys_10: 1.65739753e-14
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: -1.04737674e-28
   art_sys_16: -1.64663584e-15
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: -3.84178928e-14
   art_sys_22: 6.11669721e-28
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 3.15066711e-26
   art_sys_28: -3.46041522e-14
-  art_sys_29: -0.0
-  art_sys_30: -0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
   art_sys_31: 2.94781022e-26
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: -1.71140531e-14
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: -1.03498373e-25
   art_sys_39: -3.16553539e-14
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -3.65737475e-14
   art_sys_46: 0.0
   art_sys_47: 3.25068340e-25
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 1.28600432e-192
-  art_sys_50: -0.0
+  art_sys_50: 0.0
   art_sys_51: 2.13326673e-22
   art_sys_52: -2.61712347e-184
   art_sys_53: 0.0
@@ -40746,7 +40746,7 @@ bins:
   art_sys_56: 4.64656978e-15
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
+  art_sys_59: 0.0
   art_sys_60: -2.68161483e-97
   art_sys_61: 0.0
   art_sys_62: -7.84136526e-15
@@ -40924,7 +40924,7 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
+  art_sys_237: 0.0
   art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 7.82233663e-09
@@ -40979,56 +40979,56 @@ bins:
   RelativeStatFSR-: -1.03966567e-09
   luminosity_uncertainty: 1.74001100e-08
   uncorrelated_uncertainty: 6.69235000e-09
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: -5.45447424e-34
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -6.90174004e-15
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
   art_sys_9: 4.56269778e-32
   art_sys_10: 2.23629504e-14
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: -2.46717240e-31
   art_sys_16: 1.13341819e-15
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: -2.42929889e-14
   art_sys_22: -4.91848043e-31
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 6.49182809e-29
   art_sys_28: -2.37587140e-14
-  art_sys_29: -0.0
-  art_sys_30: -0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
   art_sys_31: 8.65467716e-28
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: -1.08088133e-14
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 1.86437845e-27
   art_sys_39: -1.12183468e-14
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -6.71634670e-15
   art_sys_46: 0.0
   art_sys_47: -7.43743559e-27
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 1.84150200e-195
-  art_sys_50: -0.0
+  art_sys_50: 0.0
   art_sys_51: 5.20483772e-25
   art_sys_52: -3.74760647e-187
   art_sys_53: 0.0
@@ -41037,7 +41037,7 @@ bins:
   art_sys_56: -1.67663563e-15
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
+  art_sys_59: 0.0
   art_sys_60: -3.83996584e-100
   art_sys_61: 0.0
   art_sys_62: 4.18634253e-15
@@ -41216,8 +41216,8 @@ bins:
   art_sys_235: 0.0
   art_sys_236: 0.0
   art_sys_237: 0.0
-  art_sys_238: -0.0
-  art_sys_239: -0.0
+  art_sys_238: 0.0
+  art_sys_239: 0.0
   Unfolding+: 1.30144378e-09
   Unfolding-: -1.37459285e-09
   AbsoluteStat+: 2.55473110e-09
@@ -41270,186 +41270,186 @@ bins:
   RelativeStatFSR-: -1.44835149e-10
   luminosity_uncertainty: 2.24138200e-09
   uncorrelated_uncertainty: 8.62070000e-10
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
-  art_sys_4: -0.0
+  art_sys_3: 0.0
+  art_sys_4: 0.0
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
-  art_sys_28: -0.0
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_28: 0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
-  art_sys_39: -0.0
+  art_sys_39: 0.0
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
-  art_sys_45: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
+  art_sys_45: 0.0
   art_sys_46: 0.0
-  art_sys_47: -0.0
-  art_sys_48: -0.0
+  art_sys_47: 0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 0.0
   art_sys_54: 0.0
   art_sys_55: 0.0
-  art_sys_56: -0.0
+  art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
-  art_sys_62: -0.0
-  art_sys_63: -0.0
+  art_sys_62: 0.0
+  art_sys_63: 0.0
   art_sys_64: 0.0
   art_sys_65: 0.0
   art_sys_66: 0.0
   art_sys_67: 0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
-  art_sys_71: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
+  art_sys_71: 0.0
   art_sys_72: 0.0
-  art_sys_73: -0.0
+  art_sys_73: 0.0
   art_sys_74: 0.0
-  art_sys_75: -0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_75: 0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 0.0
-  art_sys_88: -0.0
-  art_sys_89: -0.0
+  art_sys_88: 0.0
+  art_sys_89: 0.0
   art_sys_90: 0.0
   art_sys_91: 0.0
-  art_sys_92: -0.0
+  art_sys_92: 0.0
   art_sys_93: 0.0
   art_sys_94: 0.0
-  art_sys_95: -0.0
-  art_sys_96: -0.0
-  art_sys_97: -0.0
+  art_sys_95: 0.0
+  art_sys_96: 0.0
+  art_sys_97: 0.0
   art_sys_98: 0.0
   art_sys_99: 0.0
-  art_sys_100: -0.0
+  art_sys_100: 0.0
   art_sys_101: 0.0
-  art_sys_102: -0.0
+  art_sys_102: 0.0
   art_sys_103: 0.0
-  art_sys_104: -0.0
+  art_sys_104: 0.0
   art_sys_105: 0.0
   art_sys_106: 0.0
-  art_sys_107: -0.0
-  art_sys_108: -0.0
-  art_sys_109: -0.0
-  art_sys_110: -0.0
-  art_sys_111: -0.0
-  art_sys_112: -0.0
+  art_sys_107: 0.0
+  art_sys_108: 0.0
+  art_sys_109: 0.0
+  art_sys_110: 0.0
+  art_sys_111: 0.0
+  art_sys_112: 0.0
   art_sys_113: 0.0
-  art_sys_114: -0.0
+  art_sys_114: 0.0
   art_sys_115: 0.0
-  art_sys_116: -0.0
+  art_sys_116: 0.0
   art_sys_117: 0.0
   art_sys_118: 0.0
   art_sys_119: 0.0
   art_sys_120: 0.0
   art_sys_121: 0.0
   art_sys_122: 0.0
-  art_sys_123: -0.0
+  art_sys_123: 0.0
   art_sys_124: 0.0
   art_sys_125: 0.0
   art_sys_126: 0.0
-  art_sys_127: -0.0
-  art_sys_128: -0.0
+  art_sys_127: 0.0
+  art_sys_128: 0.0
   art_sys_129: 0.0
   art_sys_130: 0.0
   art_sys_131: 0.0
-  art_sys_132: -0.0
-  art_sys_133: -0.0
+  art_sys_132: 0.0
+  art_sys_133: 0.0
   art_sys_134: 0.0
   art_sys_135: 0.0
   art_sys_136: 0.0
   art_sys_137: 0.0
-  art_sys_138: -0.0
+  art_sys_138: 0.0
   art_sys_139: 0.0
   art_sys_140: 0.0
   art_sys_141: 0.0
-  art_sys_142: -0.0
+  art_sys_142: 0.0
   art_sys_143: 0.0
-  art_sys_144: -0.0
-  art_sys_145: -0.0
+  art_sys_144: 0.0
+  art_sys_145: 0.0
   art_sys_146: 0.0
-  art_sys_147: -0.0
+  art_sys_147: 0.0
   art_sys_148: 0.0
   art_sys_149: 0.0
-  art_sys_150: -0.0
-  art_sys_151: -0.0
-  art_sys_152: -0.0
+  art_sys_150: 0.0
+  art_sys_151: 0.0
+  art_sys_152: 0.0
   art_sys_153: 0.0
   art_sys_154: 0.0
   art_sys_155: 0.0
-  art_sys_156: -0.0
-  art_sys_157: -0.0
+  art_sys_156: 0.0
+  art_sys_157: 0.0
   art_sys_158: 0.0
-  art_sys_159: -0.0
-  art_sys_160: -0.0
-  art_sys_161: -0.0
+  art_sys_159: 0.0
+  art_sys_160: 0.0
+  art_sys_161: 0.0
   art_sys_162: 0.0
   art_sys_163: 0.0
-  art_sys_164: -0.0
+  art_sys_164: 0.0
   art_sys_165: 0.0
-  art_sys_166: -0.0
+  art_sys_166: 0.0
   art_sys_167: 0.0
-  art_sys_168: -0.0
+  art_sys_168: 0.0
   art_sys_169: 0.0
   art_sys_170: 0.0
-  art_sys_171: -0.0
+  art_sys_171: 0.0
   art_sys_172: 0.0
-  art_sys_173: -0.0
-  art_sys_174: -0.0
-  art_sys_175: -0.0
-  art_sys_176: -0.0
+  art_sys_173: 0.0
+  art_sys_174: 0.0
+  art_sys_175: 0.0
+  art_sys_176: 0.0
   art_sys_177: 0.0
   art_sys_178: 0.0
   art_sys_179: 0.0
-  art_sys_180: -0.0
+  art_sys_180: 0.0
   art_sys_181: 0.0
   art_sys_182: 0.0
   art_sys_183: 0.0
@@ -41506,8 +41506,8 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 7.84918418e+02
   Unfolding-: -8.59836200e+02
@@ -41561,186 +41561,186 @@ bins:
   RelativeStatFSR-: -1.71657946e+05
   luminosity_uncertainty: 6.31810400e+02
   uncorrelated_uncertainty: 2.43004000e+02
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
-  art_sys_4: -0.0
+  art_sys_3: 0.0
+  art_sys_4: 0.0
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
-  art_sys_28: -0.0
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_28: 0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
-  art_sys_39: -0.0
+  art_sys_39: 0.0
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
-  art_sys_45: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
+  art_sys_45: 0.0
   art_sys_46: 0.0
-  art_sys_47: -0.0
-  art_sys_48: -0.0
+  art_sys_47: 0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 0.0
   art_sys_54: 0.0
   art_sys_55: 0.0
-  art_sys_56: -0.0
+  art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
-  art_sys_62: -0.0
-  art_sys_63: -0.0
+  art_sys_62: 0.0
+  art_sys_63: 0.0
   art_sys_64: 0.0
   art_sys_65: 0.0
   art_sys_66: 0.0
   art_sys_67: 0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
-  art_sys_71: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
+  art_sys_71: 0.0
   art_sys_72: 0.0
-  art_sys_73: -0.0
+  art_sys_73: 0.0
   art_sys_74: 0.0
-  art_sys_75: -0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_75: 0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 0.0
-  art_sys_88: -0.0
-  art_sys_89: -0.0
+  art_sys_88: 0.0
+  art_sys_89: 0.0
   art_sys_90: 0.0
   art_sys_91: 0.0
-  art_sys_92: -0.0
+  art_sys_92: 0.0
   art_sys_93: 0.0
   art_sys_94: 0.0
-  art_sys_95: -0.0
-  art_sys_96: -0.0
-  art_sys_97: -0.0
+  art_sys_95: 0.0
+  art_sys_96: 0.0
+  art_sys_97: 0.0
   art_sys_98: 0.0
   art_sys_99: 0.0
-  art_sys_100: -0.0
+  art_sys_100: 0.0
   art_sys_101: 0.0
-  art_sys_102: -0.0
+  art_sys_102: 0.0
   art_sys_103: 0.0
-  art_sys_104: -0.0
+  art_sys_104: 0.0
   art_sys_105: 0.0
   art_sys_106: 0.0
-  art_sys_107: -0.0
-  art_sys_108: -0.0
-  art_sys_109: -0.0
-  art_sys_110: -0.0
-  art_sys_111: -0.0
-  art_sys_112: -0.0
+  art_sys_107: 0.0
+  art_sys_108: 0.0
+  art_sys_109: 0.0
+  art_sys_110: 0.0
+  art_sys_111: 0.0
+  art_sys_112: 0.0
   art_sys_113: 0.0
-  art_sys_114: -0.0
+  art_sys_114: 0.0
   art_sys_115: 0.0
-  art_sys_116: -0.0
+  art_sys_116: 0.0
   art_sys_117: 0.0
   art_sys_118: 0.0
   art_sys_119: 0.0
   art_sys_120: 0.0
   art_sys_121: 0.0
   art_sys_122: 0.0
-  art_sys_123: -0.0
+  art_sys_123: 0.0
   art_sys_124: 0.0
   art_sys_125: 0.0
   art_sys_126: 0.0
-  art_sys_127: -0.0
-  art_sys_128: -0.0
+  art_sys_127: 0.0
+  art_sys_128: 0.0
   art_sys_129: 0.0
   art_sys_130: 0.0
   art_sys_131: 0.0
-  art_sys_132: -0.0
-  art_sys_133: -0.0
+  art_sys_132: 0.0
+  art_sys_133: 0.0
   art_sys_134: 0.0
   art_sys_135: 0.0
   art_sys_136: 0.0
   art_sys_137: 0.0
-  art_sys_138: -0.0
+  art_sys_138: 0.0
   art_sys_139: 0.0
   art_sys_140: 0.0
   art_sys_141: 0.0
-  art_sys_142: -0.0
+  art_sys_142: 0.0
   art_sys_143: 0.0
-  art_sys_144: -0.0
-  art_sys_145: -0.0
+  art_sys_144: 0.0
+  art_sys_145: 0.0
   art_sys_146: 0.0
-  art_sys_147: -0.0
+  art_sys_147: 0.0
   art_sys_148: 0.0
   art_sys_149: 0.0
-  art_sys_150: -0.0
-  art_sys_151: -0.0
-  art_sys_152: -0.0
+  art_sys_150: 0.0
+  art_sys_151: 0.0
+  art_sys_152: 0.0
   art_sys_153: 0.0
   art_sys_154: 0.0
   art_sys_155: 0.0
-  art_sys_156: -0.0
-  art_sys_157: -0.0
+  art_sys_156: 0.0
+  art_sys_157: 0.0
   art_sys_158: 0.0
-  art_sys_159: -0.0
-  art_sys_160: -0.0
-  art_sys_161: -0.0
+  art_sys_159: 0.0
+  art_sys_160: 0.0
+  art_sys_161: 0.0
   art_sys_162: 0.0
   art_sys_163: 0.0
-  art_sys_164: -0.0
+  art_sys_164: 0.0
   art_sys_165: 0.0
-  art_sys_166: -0.0
+  art_sys_166: 0.0
   art_sys_167: 0.0
-  art_sys_168: -0.0
+  art_sys_168: 0.0
   art_sys_169: 0.0
   art_sys_170: 0.0
-  art_sys_171: -0.0
+  art_sys_171: 0.0
   art_sys_172: 0.0
-  art_sys_173: -0.0
-  art_sys_174: -0.0
-  art_sys_175: -0.0
-  art_sys_176: -0.0
+  art_sys_173: 0.0
+  art_sys_174: 0.0
+  art_sys_175: 0.0
+  art_sys_176: 0.0
   art_sys_177: 0.0
   art_sys_178: 0.0
   art_sys_179: 0.0
-  art_sys_180: -0.0
+  art_sys_180: 0.0
   art_sys_181: 0.0
   art_sys_182: 0.0
   art_sys_183: 0.0
@@ -41797,8 +41797,8 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 7.84918418e+02
   Unfolding-: -8.59836200e+02
@@ -41852,186 +41852,186 @@ bins:
   RelativeStatFSR-: -1.71657946e+05
   luminosity_uncertainty: 6.31810400e+02
   uncorrelated_uncertainty: 2.43004000e+02
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
-  art_sys_4: -0.0
+  art_sys_3: 0.0
+  art_sys_4: 0.0
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
-  art_sys_28: -0.0
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_28: 0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
-  art_sys_39: -0.0
+  art_sys_39: 0.0
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
-  art_sys_45: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
+  art_sys_45: 0.0
   art_sys_46: 0.0
-  art_sys_47: -0.0
-  art_sys_48: -0.0
+  art_sys_47: 0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 0.0
   art_sys_54: 0.0
   art_sys_55: 0.0
-  art_sys_56: -0.0
+  art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
-  art_sys_62: -0.0
-  art_sys_63: -0.0
+  art_sys_62: 0.0
+  art_sys_63: 0.0
   art_sys_64: 0.0
   art_sys_65: 0.0
   art_sys_66: 0.0
   art_sys_67: 0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
-  art_sys_71: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
+  art_sys_71: 0.0
   art_sys_72: 0.0
-  art_sys_73: -0.0
+  art_sys_73: 0.0
   art_sys_74: 0.0
-  art_sys_75: -0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_75: 0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 0.0
-  art_sys_88: -0.0
-  art_sys_89: -0.0
+  art_sys_88: 0.0
+  art_sys_89: 0.0
   art_sys_90: 0.0
   art_sys_91: 0.0
-  art_sys_92: -0.0
+  art_sys_92: 0.0
   art_sys_93: 0.0
   art_sys_94: 0.0
-  art_sys_95: -0.0
-  art_sys_96: -0.0
-  art_sys_97: -0.0
+  art_sys_95: 0.0
+  art_sys_96: 0.0
+  art_sys_97: 0.0
   art_sys_98: 0.0
   art_sys_99: 0.0
-  art_sys_100: -0.0
+  art_sys_100: 0.0
   art_sys_101: 0.0
-  art_sys_102: -0.0
+  art_sys_102: 0.0
   art_sys_103: 0.0
-  art_sys_104: -0.0
+  art_sys_104: 0.0
   art_sys_105: 0.0
   art_sys_106: 0.0
-  art_sys_107: -0.0
-  art_sys_108: -0.0
-  art_sys_109: -0.0
-  art_sys_110: -0.0
-  art_sys_111: -0.0
-  art_sys_112: -0.0
+  art_sys_107: 0.0
+  art_sys_108: 0.0
+  art_sys_109: 0.0
+  art_sys_110: 0.0
+  art_sys_111: 0.0
+  art_sys_112: 0.0
   art_sys_113: 0.0
-  art_sys_114: -0.0
+  art_sys_114: 0.0
   art_sys_115: 0.0
-  art_sys_116: -0.0
+  art_sys_116: 0.0
   art_sys_117: 0.0
   art_sys_118: 0.0
   art_sys_119: 0.0
   art_sys_120: 0.0
   art_sys_121: 0.0
   art_sys_122: 0.0
-  art_sys_123: -0.0
+  art_sys_123: 0.0
   art_sys_124: 0.0
   art_sys_125: 0.0
   art_sys_126: 0.0
-  art_sys_127: -0.0
-  art_sys_128: -0.0
+  art_sys_127: 0.0
+  art_sys_128: 0.0
   art_sys_129: 0.0
   art_sys_130: 0.0
   art_sys_131: 0.0
-  art_sys_132: -0.0
-  art_sys_133: -0.0
+  art_sys_132: 0.0
+  art_sys_133: 0.0
   art_sys_134: 0.0
   art_sys_135: 0.0
   art_sys_136: 0.0
   art_sys_137: 0.0
-  art_sys_138: -0.0
+  art_sys_138: 0.0
   art_sys_139: 0.0
   art_sys_140: 0.0
   art_sys_141: 0.0
-  art_sys_142: -0.0
+  art_sys_142: 0.0
   art_sys_143: 0.0
-  art_sys_144: -0.0
-  art_sys_145: -0.0
+  art_sys_144: 0.0
+  art_sys_145: 0.0
   art_sys_146: 0.0
-  art_sys_147: -0.0
+  art_sys_147: 0.0
   art_sys_148: 0.0
   art_sys_149: 0.0
-  art_sys_150: -0.0
-  art_sys_151: -0.0
-  art_sys_152: -0.0
+  art_sys_150: 0.0
+  art_sys_151: 0.0
+  art_sys_152: 0.0
   art_sys_153: 0.0
   art_sys_154: 0.0
   art_sys_155: 0.0
-  art_sys_156: -0.0
-  art_sys_157: -0.0
+  art_sys_156: 0.0
+  art_sys_157: 0.0
   art_sys_158: 0.0
-  art_sys_159: -0.0
-  art_sys_160: -0.0
-  art_sys_161: -0.0
+  art_sys_159: 0.0
+  art_sys_160: 0.0
+  art_sys_161: 0.0
   art_sys_162: 0.0
   art_sys_163: 0.0
-  art_sys_164: -0.0
+  art_sys_164: 0.0
   art_sys_165: 0.0
-  art_sys_166: -0.0
+  art_sys_166: 0.0
   art_sys_167: 0.0
-  art_sys_168: -0.0
+  art_sys_168: 0.0
   art_sys_169: 0.0
   art_sys_170: 0.0
-  art_sys_171: -0.0
+  art_sys_171: 0.0
   art_sys_172: 0.0
-  art_sys_173: -0.0
-  art_sys_174: -0.0
-  art_sys_175: -0.0
-  art_sys_176: -0.0
+  art_sys_173: 0.0
+  art_sys_174: 0.0
+  art_sys_175: 0.0
+  art_sys_176: 0.0
   art_sys_177: 0.0
   art_sys_178: 0.0
   art_sys_179: 0.0
-  art_sys_180: -0.0
+  art_sys_180: 0.0
   art_sys_181: 0.0
   art_sys_182: 0.0
   art_sys_183: 0.0
@@ -42088,8 +42088,8 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 7.84918418e+02
   Unfolding-: -8.59836200e+02
@@ -42143,186 +42143,186 @@ bins:
   RelativeStatFSR-: -1.71657946e+05
   luminosity_uncertainty: 6.31810400e+02
   uncorrelated_uncertainty: 2.43004000e+02
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
-  art_sys_4: -0.0
+  art_sys_3: 0.0
+  art_sys_4: 0.0
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
-  art_sys_28: -0.0
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_28: 0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
-  art_sys_39: -0.0
+  art_sys_39: 0.0
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
-  art_sys_45: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
+  art_sys_45: 0.0
   art_sys_46: 0.0
-  art_sys_47: -0.0
-  art_sys_48: -0.0
+  art_sys_47: 0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 0.0
   art_sys_54: 0.0
   art_sys_55: 0.0
-  art_sys_56: -0.0
+  art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
-  art_sys_62: -0.0
-  art_sys_63: -0.0
+  art_sys_62: 0.0
+  art_sys_63: 0.0
   art_sys_64: 0.0
   art_sys_65: 0.0
   art_sys_66: 0.0
   art_sys_67: 0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
-  art_sys_71: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
+  art_sys_71: 0.0
   art_sys_72: 0.0
-  art_sys_73: -0.0
+  art_sys_73: 0.0
   art_sys_74: 0.0
-  art_sys_75: -0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_75: 0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 0.0
-  art_sys_88: -0.0
-  art_sys_89: -0.0
+  art_sys_88: 0.0
+  art_sys_89: 0.0
   art_sys_90: 0.0
   art_sys_91: 0.0
-  art_sys_92: -0.0
+  art_sys_92: 0.0
   art_sys_93: 0.0
   art_sys_94: 0.0
-  art_sys_95: -0.0
-  art_sys_96: -0.0
-  art_sys_97: -0.0
+  art_sys_95: 0.0
+  art_sys_96: 0.0
+  art_sys_97: 0.0
   art_sys_98: 0.0
   art_sys_99: 0.0
-  art_sys_100: -0.0
+  art_sys_100: 0.0
   art_sys_101: 0.0
-  art_sys_102: -0.0
+  art_sys_102: 0.0
   art_sys_103: 0.0
-  art_sys_104: -0.0
+  art_sys_104: 0.0
   art_sys_105: 0.0
   art_sys_106: 0.0
-  art_sys_107: -0.0
-  art_sys_108: -0.0
-  art_sys_109: -0.0
-  art_sys_110: -0.0
-  art_sys_111: -0.0
-  art_sys_112: -0.0
+  art_sys_107: 0.0
+  art_sys_108: 0.0
+  art_sys_109: 0.0
+  art_sys_110: 0.0
+  art_sys_111: 0.0
+  art_sys_112: 0.0
   art_sys_113: 0.0
-  art_sys_114: -0.0
+  art_sys_114: 0.0
   art_sys_115: 0.0
-  art_sys_116: -0.0
+  art_sys_116: 0.0
   art_sys_117: 0.0
   art_sys_118: 0.0
   art_sys_119: 0.0
   art_sys_120: 0.0
   art_sys_121: 0.0
   art_sys_122: 0.0
-  art_sys_123: -0.0
+  art_sys_123: 0.0
   art_sys_124: 0.0
   art_sys_125: 0.0
   art_sys_126: 0.0
-  art_sys_127: -0.0
-  art_sys_128: -0.0
+  art_sys_127: 0.0
+  art_sys_128: 0.0
   art_sys_129: 0.0
   art_sys_130: 0.0
   art_sys_131: 0.0
-  art_sys_132: -0.0
-  art_sys_133: -0.0
+  art_sys_132: 0.0
+  art_sys_133: 0.0
   art_sys_134: 0.0
   art_sys_135: 0.0
   art_sys_136: 0.0
   art_sys_137: 0.0
-  art_sys_138: -0.0
+  art_sys_138: 0.0
   art_sys_139: 0.0
   art_sys_140: 0.0
   art_sys_141: 0.0
-  art_sys_142: -0.0
+  art_sys_142: 0.0
   art_sys_143: 0.0
-  art_sys_144: -0.0
-  art_sys_145: -0.0
+  art_sys_144: 0.0
+  art_sys_145: 0.0
   art_sys_146: 0.0
-  art_sys_147: -0.0
+  art_sys_147: 0.0
   art_sys_148: 0.0
   art_sys_149: 0.0
-  art_sys_150: -0.0
-  art_sys_151: -0.0
-  art_sys_152: -0.0
+  art_sys_150: 0.0
+  art_sys_151: 0.0
+  art_sys_152: 0.0
   art_sys_153: 0.0
   art_sys_154: 0.0
   art_sys_155: 0.0
-  art_sys_156: -0.0
-  art_sys_157: -0.0
+  art_sys_156: 0.0
+  art_sys_157: 0.0
   art_sys_158: 0.0
-  art_sys_159: -0.0
-  art_sys_160: -0.0
-  art_sys_161: -0.0
+  art_sys_159: 0.0
+  art_sys_160: 0.0
+  art_sys_161: 0.0
   art_sys_162: 0.0
   art_sys_163: 0.0
-  art_sys_164: -0.0
+  art_sys_164: 0.0
   art_sys_165: 0.0
-  art_sys_166: -0.0
+  art_sys_166: 0.0
   art_sys_167: 0.0
-  art_sys_168: -0.0
+  art_sys_168: 0.0
   art_sys_169: 0.0
   art_sys_170: 0.0
-  art_sys_171: -0.0
+  art_sys_171: 0.0
   art_sys_172: 0.0
-  art_sys_173: -0.0
-  art_sys_174: -0.0
-  art_sys_175: -0.0
-  art_sys_176: -0.0
+  art_sys_173: 0.0
+  art_sys_174: 0.0
+  art_sys_175: 0.0
+  art_sys_176: 0.0
   art_sys_177: 0.0
   art_sys_178: 0.0
   art_sys_179: 0.0
-  art_sys_180: -0.0
+  art_sys_180: 0.0
   art_sys_181: 0.0
   art_sys_182: 0.0
   art_sys_183: 0.0
@@ -42379,8 +42379,8 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 7.84918418e+02
   Unfolding-: -8.59836200e+02
@@ -42434,186 +42434,186 @@ bins:
   RelativeStatFSR-: -1.71657946e+05
   luminosity_uncertainty: 6.31810400e+02
   uncorrelated_uncertainty: 2.43004000e+02
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
-  art_sys_4: -0.0
+  art_sys_3: 0.0
+  art_sys_4: 0.0
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
-  art_sys_28: -0.0
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_28: 0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
-  art_sys_39: -0.0
+  art_sys_39: 0.0
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
-  art_sys_45: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
+  art_sys_45: 0.0
   art_sys_46: 0.0
-  art_sys_47: -0.0
-  art_sys_48: -0.0
+  art_sys_47: 0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 0.0
   art_sys_54: 0.0
   art_sys_55: 0.0
-  art_sys_56: -0.0
+  art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
-  art_sys_62: -0.0
-  art_sys_63: -0.0
+  art_sys_62: 0.0
+  art_sys_63: 0.0
   art_sys_64: 0.0
   art_sys_65: 0.0
   art_sys_66: 0.0
   art_sys_67: 0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
-  art_sys_71: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
+  art_sys_71: 0.0
   art_sys_72: 0.0
-  art_sys_73: -0.0
+  art_sys_73: 0.0
   art_sys_74: 0.0
-  art_sys_75: -0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_75: 0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 0.0
-  art_sys_88: -0.0
-  art_sys_89: -0.0
+  art_sys_88: 0.0
+  art_sys_89: 0.0
   art_sys_90: 0.0
   art_sys_91: 0.0
-  art_sys_92: -0.0
+  art_sys_92: 0.0
   art_sys_93: 0.0
   art_sys_94: 0.0
-  art_sys_95: -0.0
-  art_sys_96: -0.0
-  art_sys_97: -0.0
+  art_sys_95: 0.0
+  art_sys_96: 0.0
+  art_sys_97: 0.0
   art_sys_98: 0.0
   art_sys_99: 0.0
-  art_sys_100: -0.0
+  art_sys_100: 0.0
   art_sys_101: 0.0
-  art_sys_102: -0.0
+  art_sys_102: 0.0
   art_sys_103: 0.0
-  art_sys_104: -0.0
+  art_sys_104: 0.0
   art_sys_105: 0.0
   art_sys_106: 0.0
-  art_sys_107: -0.0
-  art_sys_108: -0.0
-  art_sys_109: -0.0
-  art_sys_110: -0.0
-  art_sys_111: -0.0
-  art_sys_112: -0.0
+  art_sys_107: 0.0
+  art_sys_108: 0.0
+  art_sys_109: 0.0
+  art_sys_110: 0.0
+  art_sys_111: 0.0
+  art_sys_112: 0.0
   art_sys_113: 0.0
-  art_sys_114: -0.0
+  art_sys_114: 0.0
   art_sys_115: 0.0
-  art_sys_116: -0.0
+  art_sys_116: 0.0
   art_sys_117: 0.0
   art_sys_118: 0.0
   art_sys_119: 0.0
   art_sys_120: 0.0
   art_sys_121: 0.0
   art_sys_122: 0.0
-  art_sys_123: -0.0
+  art_sys_123: 0.0
   art_sys_124: 0.0
   art_sys_125: 0.0
   art_sys_126: 0.0
-  art_sys_127: -0.0
-  art_sys_128: -0.0
+  art_sys_127: 0.0
+  art_sys_128: 0.0
   art_sys_129: 0.0
   art_sys_130: 0.0
   art_sys_131: 0.0
-  art_sys_132: -0.0
-  art_sys_133: -0.0
+  art_sys_132: 0.0
+  art_sys_133: 0.0
   art_sys_134: 0.0
   art_sys_135: 0.0
   art_sys_136: 0.0
   art_sys_137: 0.0
-  art_sys_138: -0.0
+  art_sys_138: 0.0
   art_sys_139: 0.0
   art_sys_140: 0.0
   art_sys_141: 0.0
-  art_sys_142: -0.0
+  art_sys_142: 0.0
   art_sys_143: 0.0
-  art_sys_144: -0.0
-  art_sys_145: -0.0
+  art_sys_144: 0.0
+  art_sys_145: 0.0
   art_sys_146: 0.0
-  art_sys_147: -0.0
+  art_sys_147: 0.0
   art_sys_148: 0.0
   art_sys_149: 0.0
-  art_sys_150: -0.0
-  art_sys_151: -0.0
-  art_sys_152: -0.0
+  art_sys_150: 0.0
+  art_sys_151: 0.0
+  art_sys_152: 0.0
   art_sys_153: 0.0
   art_sys_154: 0.0
   art_sys_155: 0.0
-  art_sys_156: -0.0
-  art_sys_157: -0.0
+  art_sys_156: 0.0
+  art_sys_157: 0.0
   art_sys_158: 0.0
-  art_sys_159: -0.0
-  art_sys_160: -0.0
-  art_sys_161: -0.0
+  art_sys_159: 0.0
+  art_sys_160: 0.0
+  art_sys_161: 0.0
   art_sys_162: 0.0
   art_sys_163: 0.0
-  art_sys_164: -0.0
+  art_sys_164: 0.0
   art_sys_165: 0.0
-  art_sys_166: -0.0
+  art_sys_166: 0.0
   art_sys_167: 0.0
-  art_sys_168: -0.0
+  art_sys_168: 0.0
   art_sys_169: 0.0
   art_sys_170: 0.0
-  art_sys_171: -0.0
+  art_sys_171: 0.0
   art_sys_172: 0.0
-  art_sys_173: -0.0
-  art_sys_174: -0.0
-  art_sys_175: -0.0
-  art_sys_176: -0.0
+  art_sys_173: 0.0
+  art_sys_174: 0.0
+  art_sys_175: 0.0
+  art_sys_176: 0.0
   art_sys_177: 0.0
   art_sys_178: 0.0
   art_sys_179: 0.0
-  art_sys_180: -0.0
+  art_sys_180: 0.0
   art_sys_181: 0.0
   art_sys_182: 0.0
   art_sys_183: 0.0
@@ -42670,8 +42670,8 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 7.84918418e+02
   Unfolding-: -8.59836200e+02
@@ -42725,186 +42725,186 @@ bins:
   RelativeStatFSR-: -1.71657946e+05
   luminosity_uncertainty: 6.31810400e+02
   uncorrelated_uncertainty: 2.43004000e+02
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
-  art_sys_4: -0.0
+  art_sys_3: 0.0
+  art_sys_4: 0.0
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
-  art_sys_28: -0.0
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_28: 0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
-  art_sys_39: -0.0
+  art_sys_39: 0.0
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
-  art_sys_45: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
+  art_sys_45: 0.0
   art_sys_46: 0.0
-  art_sys_47: -0.0
-  art_sys_48: -0.0
+  art_sys_47: 0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 0.0
   art_sys_54: 0.0
   art_sys_55: 0.0
-  art_sys_56: -0.0
+  art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
-  art_sys_62: -0.0
-  art_sys_63: -0.0
+  art_sys_62: 0.0
+  art_sys_63: 0.0
   art_sys_64: 0.0
   art_sys_65: 0.0
   art_sys_66: 0.0
   art_sys_67: 0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
-  art_sys_71: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
+  art_sys_71: 0.0
   art_sys_72: 0.0
-  art_sys_73: -0.0
+  art_sys_73: 0.0
   art_sys_74: 0.0
-  art_sys_75: -0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_75: 0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 0.0
-  art_sys_88: -0.0
-  art_sys_89: -0.0
+  art_sys_88: 0.0
+  art_sys_89: 0.0
   art_sys_90: 0.0
   art_sys_91: 0.0
-  art_sys_92: -0.0
+  art_sys_92: 0.0
   art_sys_93: 0.0
   art_sys_94: 0.0
-  art_sys_95: -0.0
-  art_sys_96: -0.0
-  art_sys_97: -0.0
+  art_sys_95: 0.0
+  art_sys_96: 0.0
+  art_sys_97: 0.0
   art_sys_98: 0.0
   art_sys_99: 0.0
-  art_sys_100: -0.0
+  art_sys_100: 0.0
   art_sys_101: 0.0
-  art_sys_102: -0.0
+  art_sys_102: 0.0
   art_sys_103: 0.0
-  art_sys_104: -0.0
+  art_sys_104: 0.0
   art_sys_105: 0.0
   art_sys_106: 0.0
-  art_sys_107: -0.0
-  art_sys_108: -0.0
-  art_sys_109: -0.0
-  art_sys_110: -0.0
-  art_sys_111: -0.0
-  art_sys_112: -0.0
+  art_sys_107: 0.0
+  art_sys_108: 0.0
+  art_sys_109: 0.0
+  art_sys_110: 0.0
+  art_sys_111: 0.0
+  art_sys_112: 0.0
   art_sys_113: 0.0
-  art_sys_114: -0.0
+  art_sys_114: 0.0
   art_sys_115: 0.0
-  art_sys_116: -0.0
+  art_sys_116: 0.0
   art_sys_117: 0.0
   art_sys_118: 0.0
   art_sys_119: 0.0
   art_sys_120: 0.0
   art_sys_121: 0.0
   art_sys_122: 0.0
-  art_sys_123: -0.0
+  art_sys_123: 0.0
   art_sys_124: 0.0
   art_sys_125: 0.0
   art_sys_126: 0.0
-  art_sys_127: -0.0
-  art_sys_128: -0.0
+  art_sys_127: 0.0
+  art_sys_128: 0.0
   art_sys_129: 0.0
   art_sys_130: 0.0
   art_sys_131: 0.0
-  art_sys_132: -0.0
-  art_sys_133: -0.0
+  art_sys_132: 0.0
+  art_sys_133: 0.0
   art_sys_134: 0.0
   art_sys_135: 0.0
   art_sys_136: 0.0
   art_sys_137: 0.0
-  art_sys_138: -0.0
+  art_sys_138: 0.0
   art_sys_139: 0.0
   art_sys_140: 0.0
   art_sys_141: 0.0
-  art_sys_142: -0.0
+  art_sys_142: 0.0
   art_sys_143: 0.0
-  art_sys_144: -0.0
-  art_sys_145: -0.0
+  art_sys_144: 0.0
+  art_sys_145: 0.0
   art_sys_146: 0.0
-  art_sys_147: -0.0
+  art_sys_147: 0.0
   art_sys_148: 0.0
   art_sys_149: 0.0
-  art_sys_150: -0.0
-  art_sys_151: -0.0
-  art_sys_152: -0.0
+  art_sys_150: 0.0
+  art_sys_151: 0.0
+  art_sys_152: 0.0
   art_sys_153: 0.0
   art_sys_154: 0.0
   art_sys_155: 0.0
-  art_sys_156: -0.0
-  art_sys_157: -0.0
+  art_sys_156: 0.0
+  art_sys_157: 0.0
   art_sys_158: 0.0
-  art_sys_159: -0.0
-  art_sys_160: -0.0
-  art_sys_161: -0.0
+  art_sys_159: 0.0
+  art_sys_160: 0.0
+  art_sys_161: 0.0
   art_sys_162: 0.0
   art_sys_163: 0.0
-  art_sys_164: -0.0
+  art_sys_164: 0.0
   art_sys_165: 0.0
-  art_sys_166: -0.0
+  art_sys_166: 0.0
   art_sys_167: 0.0
-  art_sys_168: -0.0
+  art_sys_168: 0.0
   art_sys_169: 0.0
   art_sys_170: 0.0
-  art_sys_171: -0.0
+  art_sys_171: 0.0
   art_sys_172: 0.0
-  art_sys_173: -0.0
-  art_sys_174: -0.0
-  art_sys_175: -0.0
-  art_sys_176: -0.0
+  art_sys_173: 0.0
+  art_sys_174: 0.0
+  art_sys_175: 0.0
+  art_sys_176: 0.0
   art_sys_177: 0.0
   art_sys_178: 0.0
   art_sys_179: 0.0
-  art_sys_180: -0.0
+  art_sys_180: 0.0
   art_sys_181: 0.0
   art_sys_182: 0.0
   art_sys_183: 0.0
@@ -42961,8 +42961,8 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 7.84918418e+02
   Unfolding-: -8.59836200e+02
@@ -43016,186 +43016,186 @@ bins:
   RelativeStatFSR-: -1.71657946e+05
   luminosity_uncertainty: 6.31810400e+02
   uncorrelated_uncertainty: 2.43004000e+02
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
-  art_sys_4: -0.0
+  art_sys_3: 0.0
+  art_sys_4: 0.0
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
-  art_sys_28: -0.0
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_28: 0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
-  art_sys_39: -0.0
+  art_sys_39: 0.0
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
-  art_sys_45: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
+  art_sys_45: 0.0
   art_sys_46: 0.0
-  art_sys_47: -0.0
-  art_sys_48: -0.0
+  art_sys_47: 0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 0.0
   art_sys_54: 0.0
   art_sys_55: 0.0
-  art_sys_56: -0.0
+  art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
-  art_sys_62: -0.0
-  art_sys_63: -0.0
+  art_sys_62: 0.0
+  art_sys_63: 0.0
   art_sys_64: 0.0
   art_sys_65: 0.0
   art_sys_66: 0.0
   art_sys_67: 0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
-  art_sys_71: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
+  art_sys_71: 0.0
   art_sys_72: 0.0
-  art_sys_73: -0.0
+  art_sys_73: 0.0
   art_sys_74: 0.0
-  art_sys_75: -0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_75: 0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 0.0
-  art_sys_88: -0.0
-  art_sys_89: -0.0
+  art_sys_88: 0.0
+  art_sys_89: 0.0
   art_sys_90: 0.0
   art_sys_91: 0.0
-  art_sys_92: -0.0
+  art_sys_92: 0.0
   art_sys_93: 0.0
   art_sys_94: 0.0
-  art_sys_95: -0.0
-  art_sys_96: -0.0
-  art_sys_97: -0.0
+  art_sys_95: 0.0
+  art_sys_96: 0.0
+  art_sys_97: 0.0
   art_sys_98: 0.0
   art_sys_99: 0.0
-  art_sys_100: -0.0
+  art_sys_100: 0.0
   art_sys_101: 0.0
-  art_sys_102: -0.0
+  art_sys_102: 0.0
   art_sys_103: 0.0
-  art_sys_104: -0.0
+  art_sys_104: 0.0
   art_sys_105: 0.0
   art_sys_106: 0.0
-  art_sys_107: -0.0
-  art_sys_108: -0.0
-  art_sys_109: -0.0
-  art_sys_110: -0.0
-  art_sys_111: -0.0
-  art_sys_112: -0.0
+  art_sys_107: 0.0
+  art_sys_108: 0.0
+  art_sys_109: 0.0
+  art_sys_110: 0.0
+  art_sys_111: 0.0
+  art_sys_112: 0.0
   art_sys_113: 0.0
-  art_sys_114: -0.0
+  art_sys_114: 0.0
   art_sys_115: 0.0
-  art_sys_116: -0.0
+  art_sys_116: 0.0
   art_sys_117: 0.0
   art_sys_118: 0.0
   art_sys_119: 0.0
   art_sys_120: 0.0
   art_sys_121: 0.0
   art_sys_122: 0.0
-  art_sys_123: -0.0
+  art_sys_123: 0.0
   art_sys_124: 0.0
   art_sys_125: 0.0
   art_sys_126: 0.0
-  art_sys_127: -0.0
-  art_sys_128: -0.0
+  art_sys_127: 0.0
+  art_sys_128: 0.0
   art_sys_129: 0.0
   art_sys_130: 0.0
   art_sys_131: 0.0
-  art_sys_132: -0.0
-  art_sys_133: -0.0
+  art_sys_132: 0.0
+  art_sys_133: 0.0
   art_sys_134: 0.0
   art_sys_135: 0.0
   art_sys_136: 0.0
   art_sys_137: 0.0
-  art_sys_138: -0.0
+  art_sys_138: 0.0
   art_sys_139: 0.0
   art_sys_140: 0.0
   art_sys_141: 0.0
-  art_sys_142: -0.0
+  art_sys_142: 0.0
   art_sys_143: 0.0
-  art_sys_144: -0.0
-  art_sys_145: -0.0
+  art_sys_144: 0.0
+  art_sys_145: 0.0
   art_sys_146: 0.0
-  art_sys_147: -0.0
+  art_sys_147: 0.0
   art_sys_148: 0.0
   art_sys_149: 0.0
-  art_sys_150: -0.0
-  art_sys_151: -0.0
-  art_sys_152: -0.0
+  art_sys_150: 0.0
+  art_sys_151: 0.0
+  art_sys_152: 0.0
   art_sys_153: 0.0
   art_sys_154: 0.0
   art_sys_155: 0.0
-  art_sys_156: -0.0
-  art_sys_157: -0.0
+  art_sys_156: 0.0
+  art_sys_157: 0.0
   art_sys_158: 0.0
-  art_sys_159: -0.0
-  art_sys_160: -0.0
-  art_sys_161: -0.0
+  art_sys_159: 0.0
+  art_sys_160: 0.0
+  art_sys_161: 0.0
   art_sys_162: 0.0
   art_sys_163: 0.0
-  art_sys_164: -0.0
+  art_sys_164: 0.0
   art_sys_165: 0.0
-  art_sys_166: -0.0
+  art_sys_166: 0.0
   art_sys_167: 0.0
-  art_sys_168: -0.0
+  art_sys_168: 0.0
   art_sys_169: 0.0
   art_sys_170: 0.0
-  art_sys_171: -0.0
+  art_sys_171: 0.0
   art_sys_172: 0.0
-  art_sys_173: -0.0
-  art_sys_174: -0.0
-  art_sys_175: -0.0
-  art_sys_176: -0.0
+  art_sys_173: 0.0
+  art_sys_174: 0.0
+  art_sys_175: 0.0
+  art_sys_176: 0.0
   art_sys_177: 0.0
   art_sys_178: 0.0
   art_sys_179: 0.0
-  art_sys_180: -0.0
+  art_sys_180: 0.0
   art_sys_181: 0.0
   art_sys_182: 0.0
   art_sys_183: 0.0
@@ -43252,8 +43252,8 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 7.84918418e+02
   Unfolding-: -8.59836200e+02
@@ -43307,186 +43307,186 @@ bins:
   RelativeStatFSR-: -1.71657946e+05
   luminosity_uncertainty: 6.31810400e+02
   uncorrelated_uncertainty: 2.43004000e+02
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
-  art_sys_4: -0.0
+  art_sys_3: 0.0
+  art_sys_4: 0.0
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
-  art_sys_28: -0.0
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_28: 0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
-  art_sys_39: -0.0
+  art_sys_39: 0.0
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
-  art_sys_45: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
+  art_sys_45: 0.0
   art_sys_46: 0.0
-  art_sys_47: -0.0
-  art_sys_48: -0.0
+  art_sys_47: 0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 0.0
   art_sys_54: 0.0
   art_sys_55: 0.0
-  art_sys_56: -0.0
+  art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
-  art_sys_62: -0.0
-  art_sys_63: -0.0
+  art_sys_62: 0.0
+  art_sys_63: 0.0
   art_sys_64: 0.0
   art_sys_65: 0.0
   art_sys_66: 0.0
   art_sys_67: 0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
-  art_sys_71: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
+  art_sys_71: 0.0
   art_sys_72: 0.0
-  art_sys_73: -0.0
+  art_sys_73: 0.0
   art_sys_74: 0.0
-  art_sys_75: -0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_75: 0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 0.0
-  art_sys_88: -0.0
-  art_sys_89: -0.0
+  art_sys_88: 0.0
+  art_sys_89: 0.0
   art_sys_90: 0.0
   art_sys_91: 0.0
-  art_sys_92: -0.0
+  art_sys_92: 0.0
   art_sys_93: 0.0
   art_sys_94: 0.0
-  art_sys_95: -0.0
-  art_sys_96: -0.0
-  art_sys_97: -0.0
+  art_sys_95: 0.0
+  art_sys_96: 0.0
+  art_sys_97: 0.0
   art_sys_98: 0.0
   art_sys_99: 0.0
-  art_sys_100: -0.0
+  art_sys_100: 0.0
   art_sys_101: 0.0
-  art_sys_102: -0.0
+  art_sys_102: 0.0
   art_sys_103: 0.0
-  art_sys_104: -0.0
+  art_sys_104: 0.0
   art_sys_105: 0.0
   art_sys_106: 0.0
-  art_sys_107: -0.0
-  art_sys_108: -0.0
-  art_sys_109: -0.0
-  art_sys_110: -0.0
-  art_sys_111: -0.0
-  art_sys_112: -0.0
+  art_sys_107: 0.0
+  art_sys_108: 0.0
+  art_sys_109: 0.0
+  art_sys_110: 0.0
+  art_sys_111: 0.0
+  art_sys_112: 0.0
   art_sys_113: 0.0
-  art_sys_114: -0.0
+  art_sys_114: 0.0
   art_sys_115: 0.0
-  art_sys_116: -0.0
+  art_sys_116: 0.0
   art_sys_117: 0.0
   art_sys_118: 0.0
   art_sys_119: 0.0
   art_sys_120: 0.0
   art_sys_121: 0.0
   art_sys_122: 0.0
-  art_sys_123: -0.0
+  art_sys_123: 0.0
   art_sys_124: 0.0
   art_sys_125: 0.0
   art_sys_126: 0.0
-  art_sys_127: -0.0
-  art_sys_128: -0.0
+  art_sys_127: 0.0
+  art_sys_128: 0.0
   art_sys_129: 0.0
   art_sys_130: 0.0
   art_sys_131: 0.0
-  art_sys_132: -0.0
-  art_sys_133: -0.0
+  art_sys_132: 0.0
+  art_sys_133: 0.0
   art_sys_134: 0.0
   art_sys_135: 0.0
   art_sys_136: 0.0
   art_sys_137: 0.0
-  art_sys_138: -0.0
+  art_sys_138: 0.0
   art_sys_139: 0.0
   art_sys_140: 0.0
   art_sys_141: 0.0
-  art_sys_142: -0.0
+  art_sys_142: 0.0
   art_sys_143: 0.0
-  art_sys_144: -0.0
-  art_sys_145: -0.0
+  art_sys_144: 0.0
+  art_sys_145: 0.0
   art_sys_146: 0.0
-  art_sys_147: -0.0
+  art_sys_147: 0.0
   art_sys_148: 0.0
   art_sys_149: 0.0
-  art_sys_150: -0.0
-  art_sys_151: -0.0
-  art_sys_152: -0.0
+  art_sys_150: 0.0
+  art_sys_151: 0.0
+  art_sys_152: 0.0
   art_sys_153: 0.0
   art_sys_154: 0.0
   art_sys_155: 0.0
-  art_sys_156: -0.0
-  art_sys_157: -0.0
+  art_sys_156: 0.0
+  art_sys_157: 0.0
   art_sys_158: 0.0
-  art_sys_159: -0.0
-  art_sys_160: -0.0
-  art_sys_161: -0.0
+  art_sys_159: 0.0
+  art_sys_160: 0.0
+  art_sys_161: 0.0
   art_sys_162: 0.0
   art_sys_163: 0.0
-  art_sys_164: -0.0
+  art_sys_164: 0.0
   art_sys_165: 0.0
-  art_sys_166: -0.0
+  art_sys_166: 0.0
   art_sys_167: 0.0
-  art_sys_168: -0.0
+  art_sys_168: 0.0
   art_sys_169: 0.0
   art_sys_170: 0.0
-  art_sys_171: -0.0
+  art_sys_171: 0.0
   art_sys_172: 0.0
-  art_sys_173: -0.0
-  art_sys_174: -0.0
-  art_sys_175: -0.0
-  art_sys_176: -0.0
+  art_sys_173: 0.0
+  art_sys_174: 0.0
+  art_sys_175: 0.0
+  art_sys_176: 0.0
   art_sys_177: 0.0
   art_sys_178: 0.0
   art_sys_179: 0.0
-  art_sys_180: -0.0
+  art_sys_180: 0.0
   art_sys_181: 0.0
   art_sys_182: 0.0
   art_sys_183: 0.0
@@ -43543,8 +43543,8 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 7.84918418e+02
   Unfolding-: -8.59836200e+02
@@ -43598,186 +43598,186 @@ bins:
   RelativeStatFSR-: -1.71657946e+05
   luminosity_uncertainty: 6.31810400e+02
   uncorrelated_uncertainty: 2.43004000e+02
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
-  art_sys_4: -0.0
+  art_sys_3: 0.0
+  art_sys_4: 0.0
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
-  art_sys_28: -0.0
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_28: 0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
-  art_sys_39: -0.0
+  art_sys_39: 0.0
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
-  art_sys_45: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
+  art_sys_45: 0.0
   art_sys_46: 0.0
-  art_sys_47: -0.0
-  art_sys_48: -0.0
+  art_sys_47: 0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 0.0
   art_sys_54: 0.0
   art_sys_55: 0.0
-  art_sys_56: -0.0
+  art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
-  art_sys_62: -0.0
-  art_sys_63: -0.0
+  art_sys_62: 0.0
+  art_sys_63: 0.0
   art_sys_64: 0.0
   art_sys_65: 0.0
   art_sys_66: 0.0
   art_sys_67: 0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
-  art_sys_71: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
+  art_sys_71: 0.0
   art_sys_72: 0.0
-  art_sys_73: -0.0
+  art_sys_73: 0.0
   art_sys_74: 0.0
-  art_sys_75: -0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_75: 0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 0.0
-  art_sys_88: -0.0
-  art_sys_89: -0.0
+  art_sys_88: 0.0
+  art_sys_89: 0.0
   art_sys_90: 0.0
   art_sys_91: 0.0
-  art_sys_92: -0.0
+  art_sys_92: 0.0
   art_sys_93: 0.0
   art_sys_94: 0.0
-  art_sys_95: -0.0
-  art_sys_96: -0.0
-  art_sys_97: -0.0
+  art_sys_95: 0.0
+  art_sys_96: 0.0
+  art_sys_97: 0.0
   art_sys_98: 0.0
   art_sys_99: 0.0
-  art_sys_100: -0.0
+  art_sys_100: 0.0
   art_sys_101: 0.0
-  art_sys_102: -0.0
+  art_sys_102: 0.0
   art_sys_103: 0.0
-  art_sys_104: -0.0
+  art_sys_104: 0.0
   art_sys_105: 0.0
   art_sys_106: 0.0
-  art_sys_107: -0.0
-  art_sys_108: -0.0
-  art_sys_109: -0.0
-  art_sys_110: -0.0
-  art_sys_111: -0.0
-  art_sys_112: -0.0
+  art_sys_107: 0.0
+  art_sys_108: 0.0
+  art_sys_109: 0.0
+  art_sys_110: 0.0
+  art_sys_111: 0.0
+  art_sys_112: 0.0
   art_sys_113: 0.0
-  art_sys_114: -0.0
+  art_sys_114: 0.0
   art_sys_115: 0.0
-  art_sys_116: -0.0
+  art_sys_116: 0.0
   art_sys_117: 0.0
   art_sys_118: 0.0
   art_sys_119: 0.0
   art_sys_120: 0.0
   art_sys_121: 0.0
   art_sys_122: 0.0
-  art_sys_123: -0.0
+  art_sys_123: 0.0
   art_sys_124: 0.0
   art_sys_125: 0.0
   art_sys_126: 0.0
-  art_sys_127: -0.0
-  art_sys_128: -0.0
+  art_sys_127: 0.0
+  art_sys_128: 0.0
   art_sys_129: 0.0
   art_sys_130: 0.0
   art_sys_131: 0.0
-  art_sys_132: -0.0
-  art_sys_133: -0.0
+  art_sys_132: 0.0
+  art_sys_133: 0.0
   art_sys_134: 0.0
   art_sys_135: 0.0
   art_sys_136: 0.0
   art_sys_137: 0.0
-  art_sys_138: -0.0
+  art_sys_138: 0.0
   art_sys_139: 0.0
   art_sys_140: 0.0
   art_sys_141: 0.0
-  art_sys_142: -0.0
+  art_sys_142: 0.0
   art_sys_143: 0.0
-  art_sys_144: -0.0
-  art_sys_145: -0.0
+  art_sys_144: 0.0
+  art_sys_145: 0.0
   art_sys_146: 0.0
-  art_sys_147: -0.0
+  art_sys_147: 0.0
   art_sys_148: 0.0
   art_sys_149: 0.0
-  art_sys_150: -0.0
-  art_sys_151: -0.0
-  art_sys_152: -0.0
+  art_sys_150: 0.0
+  art_sys_151: 0.0
+  art_sys_152: 0.0
   art_sys_153: 0.0
   art_sys_154: 0.0
   art_sys_155: 0.0
-  art_sys_156: -0.0
-  art_sys_157: -0.0
+  art_sys_156: 0.0
+  art_sys_157: 0.0
   art_sys_158: 0.0
-  art_sys_159: -0.0
-  art_sys_160: -0.0
-  art_sys_161: -0.0
+  art_sys_159: 0.0
+  art_sys_160: 0.0
+  art_sys_161: 0.0
   art_sys_162: 0.0
   art_sys_163: 0.0
-  art_sys_164: -0.0
+  art_sys_164: 0.0
   art_sys_165: 0.0
-  art_sys_166: -0.0
+  art_sys_166: 0.0
   art_sys_167: 0.0
-  art_sys_168: -0.0
+  art_sys_168: 0.0
   art_sys_169: 0.0
   art_sys_170: 0.0
-  art_sys_171: -0.0
+  art_sys_171: 0.0
   art_sys_172: 0.0
-  art_sys_173: -0.0
-  art_sys_174: -0.0
-  art_sys_175: -0.0
-  art_sys_176: -0.0
+  art_sys_173: 0.0
+  art_sys_174: 0.0
+  art_sys_175: 0.0
+  art_sys_176: 0.0
   art_sys_177: 0.0
   art_sys_178: 0.0
   art_sys_179: 0.0
-  art_sys_180: -0.0
+  art_sys_180: 0.0
   art_sys_181: 0.0
   art_sys_182: 0.0
   art_sys_183: 0.0
@@ -43834,8 +43834,8 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 7.84918418e+02
   Unfolding-: -8.59836200e+02
@@ -43889,56 +43889,56 @@ bins:
   RelativeStatFSR-: -1.71657946e+05
   luminosity_uncertainty: 6.31810400e+02
   uncorrelated_uncertainty: 2.43004000e+02
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -1.79211144e+02
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 3.83863567e+01
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: -1.36807570e+01
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 2.26473660e+00
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
   art_sys_28: 3.64301698e-02
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: 1.13971321e-02
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 2.20518517e-312
   art_sys_39: 6.14263486e-03
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 1.49833498e-03
   art_sys_46: 0.0
   art_sys_47: -1.24905694e-237
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
+  art_sys_50: 0.0
   art_sys_51: -4.69574292e-85
   art_sys_52: 0.0
   art_sys_53: 0.0
@@ -43947,8 +43947,8 @@ bins:
   art_sys_56: -5.81535322e-07
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 5.44945876e-07
   art_sys_63: -7.03503555e-22
@@ -43957,21 +43957,21 @@ bins:
   art_sys_66: 0.0
   art_sys_67: 0.0
   art_sys_68: 2.74385676e-18
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 7.53591434e-09
   art_sys_72: 1.63069786e-18
   art_sys_73: 5.64255371e-09
   art_sys_74: 0.0
-  art_sys_75: -0.0
+  art_sys_75: 0.0
   art_sys_76: 4.84442773e-237
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: -1.61016227e-09
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: -4.83863176e-19
   art_sys_81: -2.21018165e-79
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 8.42412453e-19
   art_sys_85: 0.0
   art_sys_86: 8.74324575e-66
@@ -44126,7 +44126,7 @@ bins:
   art_sys_235: 0.0
   art_sys_236: 0.0
   art_sys_237: 0.0
-  art_sys_238: -0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 7.84918418e+02
   Unfolding-: -8.59836200e+02
@@ -44180,56 +44180,56 @@ bins:
   RelativeStatFSR-: -2.90048662e+01
   luminosity_uncertainty: 6.31810400e+02
   uncorrelated_uncertainty: 2.43004000e+02
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -9.73152501e+01
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: -6.56877066e+01
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 2.29836532e+01
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: -6.21644206e+00
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
   art_sys_28: -1.14070556e-01
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: -3.64296223e-02
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 1.18357302e-312
   art_sys_39: -2.17062190e-02
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -5.60326851e-03
   art_sys_46: 0.0
   art_sys_47: -6.78262899e-238
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
+  art_sys_50: 0.0
   art_sys_51: -2.54988271e-85
   art_sys_52: 0.0
   art_sys_53: 0.0
@@ -44238,8 +44238,8 @@ bins:
   art_sys_56: 3.84173046e-06
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: -2.96674061e-06
   art_sys_63: -3.82016559e-22
@@ -44248,21 +44248,21 @@ bins:
   art_sys_66: 0.0
   art_sys_67: 0.0
   art_sys_68: -5.09032306e-18
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: -1.00536705e-07
   art_sys_72: 4.73769042e-18
   art_sys_73: -3.26340826e-08
   art_sys_74: 0.0
-  art_sys_75: -0.0
+  art_sys_75: 0.0
   art_sys_76: 2.63062114e-237
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 1.26781678e-08
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: -7.88196185e-19
   art_sys_81: -1.20017302e-79
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 7.63540524e-19
   art_sys_85: 0.0
   art_sys_86: 4.74775803e-66
@@ -44416,9 +44416,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
+  art_sys_237: 0.0
   art_sys_238: 0.0
-  art_sys_239: -0.0
+  art_sys_239: 0.0
   Unfolding+: 3.68678429e+02
   Unfolding-: -4.03845222e+02
   AbsoluteStat+: -1.73189843e+01
@@ -44471,56 +44471,56 @@ bins:
   RelativeStatFSR-: -1.50891100e+01
   luminosity_uncertainty: 324.077
   uncorrelated_uncertainty: 124.645
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -9.79660221e+00
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: -6.54564256e+01
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: -2.22022920e+01
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 9.61246934e+00
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
   art_sys_28: 3.85474990e-01
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: 9.48794213e-02
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 1.09896589e-313
   art_sys_39: 6.75969295e-02
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 1.81977130e-02
   art_sys_46: 0.0
   art_sys_47: -6.82797899e-239
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
+  art_sys_50: 0.0
   art_sys_51: -2.56693443e-86
   art_sys_52: 0.0
   art_sys_53: 0.0
@@ -44529,8 +44529,8 @@ bins:
   art_sys_56: -1.53406808e-05
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 1.03079106e-05
   art_sys_63: -3.84571201e-23
@@ -44539,21 +44539,21 @@ bins:
   art_sys_66: 0.0
   art_sys_67: 0.0
   art_sys_68: -5.53778970e-19
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 3.85313393e-07
   art_sys_72: 3.30933772e-18
   art_sys_73: 1.28012802e-07
   art_sys_74: 0.0
-  art_sys_75: -0.0
+  art_sys_75: 0.0
   art_sys_76: 2.64820999e-238
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: -4.82793484e-08
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: 9.93944795e-19
   art_sys_81: -1.20819889e-80
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 7.95745809e-19
   art_sys_85: 0.0
   art_sys_86: 4.77950750e-67
@@ -44708,7 +44708,7 @@ bins:
   art_sys_235: 0.0
   art_sys_236: 0.0
   art_sys_237: 0.0
-  art_sys_238: -0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 1.44225006e+02
   Unfolding-: -1.57918710e+02
@@ -44762,56 +44762,56 @@ bins:
   RelativeStatFSR-: -6.68958540e+00
   luminosity_uncertainty: 141.0396
   uncorrelated_uncertainty: 54.246
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 1.07369541e+01
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: -1.45718422e+01
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: -4.00754141e+01
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: -9.54766392e+00
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
   art_sys_28: -3.48278746e-01
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: -2.07018675e-01
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: -1.33896103e-313
   art_sys_39: -1.29071419e-01
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -4.14218804e-02
   art_sys_46: 0.0
   art_sys_47: 7.48339054e-239
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
+  art_sys_50: 0.0
   art_sys_51: 2.81332819e-86
   art_sys_52: 0.0
   art_sys_53: 0.0
@@ -44820,8 +44820,8 @@ bins:
   art_sys_56: 4.31992767e-05
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: -3.44811731e-05
   art_sys_63: 4.21485251e-23
@@ -44830,21 +44830,21 @@ bins:
   art_sys_66: 0.0
   art_sys_67: 0.0
   art_sys_68: 1.87665313e-18
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: -1.37271019e-06
   art_sys_72: -1.92055227e-19
   art_sys_73: -4.14285433e-07
   art_sys_74: 0.0
-  art_sys_75: -0.0
+  art_sys_75: 0.0
   art_sys_76: -2.90240928e-238
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 1.72150319e-07
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: 1.87749709e-19
   art_sys_81: 1.32417095e-80
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: -9.23692150e-20
   art_sys_85: 0.0
   art_sys_86: -5.23828076e-67
@@ -44998,7 +44998,7 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
+  art_sys_237: 0.0
   art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 5.53929910e+01
@@ -45053,56 +45053,56 @@ bins:
   RelativeStatFSR-: -2.95550980e+00
   luminosity_uncertainty: 6.10178400e+01
   uncorrelated_uncertainty: 2.34684000e+01
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 9.51420511e-01
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 2.48584661e+00
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: -1.55320620e+00
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: -2.26076306e+00
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
   art_sys_28: 3.89979444e+00
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: 6.58564307e-01
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: -1.12726839e-314
   art_sys_39: 7.33558540e-01
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 2.17859452e-01
   art_sys_46: 0.0
   art_sys_47: 6.63116023e-240
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
+  art_sys_50: 0.0
   art_sys_51: 2.49293991e-87
   art_sys_52: 0.0
   art_sys_53: 0.0
@@ -45111,8 +45111,8 @@ bins:
   art_sys_56: -2.85774007e-04
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 1.93413205e-04
   art_sys_63: 3.73485542e-24
@@ -45121,21 +45121,21 @@ bins:
   art_sys_66: 0.0
   art_sys_67: 0.0
   art_sys_68: 8.94434100e-20
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 8.67287171e-06
   art_sys_72: 5.84596682e-19
   art_sys_73: 2.49206367e-06
   art_sys_74: 0.0
-  art_sys_75: -0.0
+  art_sys_75: 0.0
   art_sys_76: -2.57187446e-239
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: -1.01580368e-06
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: -2.52875852e-19
   art_sys_81: 1.17337132e-81
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 7.83020562e-19
   art_sys_85: 0.0
   art_sys_86: -4.64173331e-68
@@ -45290,8 +45290,8 @@ bins:
   art_sys_235: 0.0
   art_sys_236: 0.0
   art_sys_237: 0.0
-  art_sys_238: -0.0
-  art_sys_239: -0.0
+  art_sys_238: 0.0
+  art_sys_239: 0.0
   Unfolding+: 2.15260388e+01
   Unfolding-: -2.35404688e+01
   AbsoluteStat+: -7.01559784e-01
@@ -45344,56 +45344,56 @@ bins:
   RelativeStatFSR-: -1.32428772e+00
   luminosity_uncertainty: 26.73996
   uncorrelated_uncertainty: 1.02846000e+01
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -4.14990841e-01
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 7.71322404e-01
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 1.95915411e+00
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 5.65278531e-01
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
   art_sys_28: 1.93699114e+00
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: -1.99323586e+00
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 5.20653405e-315
   art_sys_39: -9.71138353e-01
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -4.72301328e-01
   art_sys_46: 0.0
   art_sys_47: -2.89238342e-240
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
+  art_sys_50: 0.0
   art_sys_51: -1.08737117e-87
   art_sys_52: 0.0
   art_sys_53: 0.0
@@ -45402,8 +45402,8 @@ bins:
   art_sys_56: 7.79906198e-04
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: -6.06904599e-04
   art_sys_63: -1.62907019e-24
@@ -45412,21 +45412,21 @@ bins:
   art_sys_66: 0.0
   art_sys_67: 0.0
   art_sys_68: -8.30153469e-20
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: -2.55091632e-05
   art_sys_72: -8.36360675e-19
   art_sys_73: -8.50277782e-06
   art_sys_74: 0.0
-  art_sys_75: -0.0
+  art_sys_75: 0.0
   art_sys_76: 1.12180174e-239
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 3.44112666e-06
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: -3.27031894e-19
   art_sys_81: -5.11801400e-82
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: -3.93710990e-19
   art_sys_85: 0.0
   art_sys_86: 2.02463242e-68
@@ -45580,7 +45580,7 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
+  art_sys_237: 0.0
   art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 8.79839658e+00
@@ -45635,56 +45635,56 @@ bins:
   RelativeStatFSR-: -6.23959377e-01
   luminosity_uncertainty: 1.23149260e+01
   uncorrelated_uncertainty: 4.73651
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -8.72832674e-02
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: -1.09606082e-01
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 1.29949206e-01
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 2.33708687e-01
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
   art_sys_28: -4.73613539e-01
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: -2.26881092e+00
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 1.05304081e-315
   art_sys_39: 9.14928319e-01
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 5.61238569e-01
   art_sys_46: 0.0
   art_sys_47: -6.08342433e-241
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
+  art_sys_50: 0.0
   art_sys_51: -2.28702176e-88
   art_sys_52: 0.0
   art_sys_53: 0.0
@@ -45693,8 +45693,8 @@ bins:
   art_sys_56: -2.46589436e-03
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 2.16759950e-03
   art_sys_63: -3.42635439e-25
@@ -45703,21 +45703,21 @@ bins:
   art_sys_66: 0.0
   art_sys_67: 0.0
   art_sys_68: -4.49518445e-22
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 1.00527489e-04
   art_sys_72: -1.03116142e-19
   art_sys_73: 2.84992003e-05
   art_sys_74: 0.0
-  art_sys_75: -0.0
+  art_sys_75: 0.0
   art_sys_76: 2.35943683e-240
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: -1.22701055e-05
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: -2.19965982e-19
   art_sys_81: -1.07645022e-82
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 6.83631020e-19
   art_sys_85: 0.0
   art_sys_86: 4.25832368e-69
@@ -45872,8 +45872,8 @@ bins:
   art_sys_235: 0.0
   art_sys_236: 0.0
   art_sys_237: 0.0
-  art_sys_238: -0.0
-  art_sys_239: -0.0
+  art_sys_238: 0.0
+  art_sys_239: 0.0
   Unfolding+: 3.84152761e+00
   Unfolding-: -4.19554752e+00
   AbsoluteStat+: 0.0
@@ -45926,56 +45926,56 @@ bins:
   RelativeStatFSR-: -3.13842762e-01
   luminosity_uncertainty: 6.05449
   uncorrelated_uncertainty: 2.32865
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 1.02324392e-02
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: -6.09757045e-02
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: -1.09840418e-01
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: -2.46817492e-02
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
   art_sys_28: -4.11002677e-01
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: -2.51577085e-01
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: -1.34788564e-316
   art_sys_39: 1.50524545e+00
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -7.51931830e-01
   art_sys_46: 0.0
   art_sys_47: 7.13176193e-242
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
+  art_sys_50: 0.0
   art_sys_51: 2.68113372e-89
   art_sys_52: 0.0
   art_sys_53: 0.0
@@ -45984,8 +45984,8 @@ bins:
   art_sys_56: 7.64305344e-03
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: -5.01562437e-03
   art_sys_63: 4.01680232e-26
@@ -45994,21 +45994,21 @@ bins:
   art_sys_66: 0.0
   art_sys_67: 0.0
   art_sys_68: 4.30464218e-21
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: -2.79340298e-04
   art_sys_72: 6.66136667e-19
   art_sys_73: -8.90654986e-05
   art_sys_74: 0.0
-  art_sys_75: -0.0
+  art_sys_75: 0.0
   art_sys_76: -2.76603124e-241
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 3.71210514e-05
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: -1.43538105e-18
   art_sys_81: 1.26194995e-83
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: -1.06606557e-18
   art_sys_85: 0.0
   art_sys_86: -4.99214106e-70
@@ -46162,9 +46162,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
+  art_sys_237: 0.0
   art_sys_238: 0.0
-  art_sys_239: -0.0
+  art_sys_239: 0.0
   Unfolding+: 1.70845222e+00
   Unfolding-: -1.86384120e+00
   AbsoluteStat+: 2.02666901e-02
@@ -46217,56 +46217,56 @@ bins:
   RelativeStatFSR-: -1.61422699e-01
   luminosity_uncertainty: 3.03914000e+00
   uncorrelated_uncertainty: 1.1689
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 3.36194855e-03
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: -3.04001063e-03
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: -1.33022593e-02
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: -1.08982924e-02
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
   art_sys_28: 1.03393318e-02
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: 1.11457007e-01
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: -4.16802030e-317
   art_sys_39: 2.57757398e-02
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -1.06619479e-01
   art_sys_46: 0.0
   art_sys_47: 2.34319451e-242
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
+  art_sys_50: 0.0
   art_sys_51: 8.80907614e-90
   art_sys_52: 0.0
   art_sys_53: 0.0
@@ -46275,8 +46275,8 @@ bins:
   art_sys_56: -2.24298315e-02
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 3.06550642e-02
   art_sys_63: 1.31975206e-26
@@ -46285,21 +46285,21 @@ bins:
   art_sys_66: 0.0
   art_sys_67: 0.0
   art_sys_68: 2.24146371e-22
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 1.33238599e-03
   art_sys_72: 3.99929139e-20
   art_sys_73: 4.47610907e-04
   art_sys_74: 0.0
-  art_sys_75: -0.0
+  art_sys_75: 0.0
   art_sys_76: -9.08800559e-242
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: -1.92101654e-04
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: -9.55888055e-20
   art_sys_81: 4.14623602e-84
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 5.15459919e-19
   art_sys_85: 0.0
   art_sys_86: -1.64020729e-70
@@ -46454,7 +46454,7 @@ bins:
   art_sys_235: 0.0
   art_sys_236: 0.0
   art_sys_237: 0.0
-  art_sys_238: -0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 7.66140232e-01
   Unfolding-: -8.34912535e-01
@@ -46508,56 +46508,56 @@ bins:
   RelativeStatFSR-: -8.39105969e-02
   luminosity_uncertainty: 1.54190660e+00
   uncorrelated_uncertainty: 5.93041000e-01
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 3.68113545e-04
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 1.08250018e-03
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 1.16858131e-03
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: -2.53615436e-04
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
   art_sys_28: 1.96357255e-02
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: 1.42344586e-02
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: -4.34979347e-318
   art_sys_39: -8.30493993e-02
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 4.91203192e-02
   art_sys_46: 0.0
   art_sys_47: 2.56565812e-243
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
+  art_sys_50: 0.0
   art_sys_51: 9.64541900e-91
   art_sys_52: 0.0
   art_sys_53: 0.0
@@ -46566,8 +46566,8 @@ bins:
   art_sys_56: 9.20702885e-02
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: -4.80288106e-02
   art_sys_63: 1.44505069e-27
@@ -46576,21 +46576,21 @@ bins:
   art_sys_66: 0.0
   art_sys_67: 0.0
   art_sys_68: -5.84033832e-23
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: -4.88467869e-03
   art_sys_72: -3.68988621e-20
   art_sys_73: -1.27830347e-03
   art_sys_74: 0.0
-  art_sys_75: -0.0
+  art_sys_75: 0.0
   art_sys_76: -9.95082361e-243
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 6.26384981e-04
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: 8.64008077e-20
   art_sys_81: 4.53988399e-85
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 3.37858315e-19
   art_sys_85: 0.0
   art_sys_86: -1.79593028e-71
@@ -46744,7 +46744,7 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
+  art_sys_237: 0.0
   art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 3.52361576e-01
@@ -46799,56 +46799,56 @@ bins:
   RelativeStatFSR-: -4.49036819e-02
   luminosity_uncertainty: 0.804232
   uncorrelated_uncertainty: 0.30932
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -8.97314949e-06
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 3.78401236e-04
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 7.88297274e-04
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 4.32530253e-04
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
   art_sys_28: 1.99822595e-04
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: -7.51026517e-03
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 1.66939841e-319
   art_sys_39: -3.62769579e-04
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 6.55998977e-03
   art_sys_46: 0.0
   art_sys_47: -6.25410716e-245
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
+  art_sys_50: 0.0
   art_sys_51: -2.35117093e-92
   art_sys_52: 0.0
   art_sys_53: 0.0
@@ -46857,8 +46857,8 @@ bins:
   art_sys_56: 9.75427685e-02
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 5.29020574e-02
   art_sys_63: -3.52246096e-29
@@ -46867,21 +46867,21 @@ bins:
   art_sys_66: 0.0
   art_sys_67: 0.0
   art_sys_68: -1.76688021e-23
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 3.09653715e-03
   art_sys_72: -1.97429786e-21
   art_sys_73: 2.55839587e-03
   art_sys_74: 0.0
-  art_sys_75: -0.0
+  art_sys_75: 0.0
   art_sys_76: 2.42563562e-244
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: -1.08840712e-03
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: 5.17481270e-21
   art_sys_81: -1.10664381e-86
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: -1.60258369e-19
   art_sys_85: 0.0
   art_sys_86: 4.37776634e-73
@@ -47036,7 +47036,7 @@ bins:
   art_sys_235: 0.0
   art_sys_236: 0.0
   art_sys_237: 0.0
-  art_sys_238: -0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 1.64463160e-01
   Unfolding-: -1.78729006e-01
@@ -47090,56 +47090,56 @@ bins:
   RelativeStatFSR-: -2.44375091e-02
   luminosity_uncertainty: 4.26462400e-01
   uncorrelated_uncertainty: 0.164024
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -6.91420344e-06
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 4.43448108e-05
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 1.05908136e-04
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 6.09551521e-05
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
   art_sys_28: -9.06624040e-04
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: -1.49866755e-03
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 9.14466104e-320
   art_sys_39: 4.42117708e-03
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -2.44412873e-03
   art_sys_46: 0.0
   art_sys_47: -4.81903246e-245
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
+  art_sys_50: 0.0
   art_sys_51: -1.81167985e-92
   art_sys_52: 0.0
   art_sys_53: 0.0
@@ -47148,8 +47148,8 @@ bins:
   art_sys_56: -2.61815222e-03
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 1.63842154e-02
   art_sys_63: -2.71420995e-29
@@ -47158,21 +47158,21 @@ bins:
   art_sys_66: 0.0
   art_sys_67: 0.0
   art_sys_68: -2.48542152e-24
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: -3.06116706e-02
   art_sys_72: 1.78887515e-21
   art_sys_73: -5.91395387e-03
   art_sys_74: 0.0
-  art_sys_75: -0.0
+  art_sys_75: 0.0
   art_sys_76: 1.86904645e-244
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 4.61418038e-03
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: -4.55239101e-21
   art_sys_81: -8.52717373e-87
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: -3.47940994e-20
   art_sys_85: 0.0
   art_sys_86: 3.37326009e-73
@@ -47326,7 +47326,7 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
+  art_sys_237: 0.0
   art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 7.66069671e-02
@@ -47381,56 +47381,56 @@ bins:
   RelativeStatFSR-: -1.32941040e-02
   luminosity_uncertainty: 2.25886440e-01
   uncorrelated_uncertainty: 8.68794000e-02
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -7.76712415e-07
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 3.81866279e-06
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 8.41035134e-06
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 6.31672737e-08
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
   art_sys_28: -1.10360371e-04
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: 7.19439318e-05
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 1.01036425e-320
   art_sys_39: 4.47231162e-04
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -4.65266960e-04
   art_sys_46: 0.0
   art_sys_47: -5.41349614e-246
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
+  art_sys_50: 0.0
   art_sys_51: -2.03516464e-93
   art_sys_52: 0.0
   art_sys_53: 0.0
@@ -47439,8 +47439,8 @@ bins:
   art_sys_56: -7.37817817e-03
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: -4.98788088e-03
   art_sys_63: -3.04902884e-30
@@ -47449,21 +47449,21 @@ bins:
   art_sys_66: 0.0
   art_sys_67: 0.0
   art_sys_68: -4.79394678e-25
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: -1.33094888e-02
   art_sys_72: 2.31040614e-22
   art_sys_73: 1.89645824e-02
   art_sys_74: 0.0
-  art_sys_75: -0.0
+  art_sys_75: 0.0
   art_sys_76: 2.09960730e-245
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: -6.98784270e-03
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: -6.30535941e-22
   art_sys_81: -9.57906686e-88
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 1.72344579e-20
   art_sys_85: 0.0
   art_sys_86: 3.78937793e-74
@@ -47618,7 +47618,7 @@ bins:
   art_sys_235: 0.0
   art_sys_236: 0.0
   art_sys_237: 0.0
-  art_sys_238: -0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 3.53492993e-02
   Unfolding-: -3.82224387e-02
@@ -47672,56 +47672,56 @@ bins:
   RelativeStatFSR-: -7.18284849e-03
   luminosity_uncertainty: 1.18701180e-01
   uncorrelated_uncertainty: 4.56543000e-02
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -3.94067400e-08
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 3.49835555e-07
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 5.48509185e-07
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: -9.95029366e-07
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
   art_sys_28: 1.05272557e-05
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: 6.42413964e-05
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 5.4e-322
   art_sys_39: -9.58745176e-05
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 4.28592571e-05
   art_sys_46: 0.0
   art_sys_47: -2.74655559e-247
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
+  art_sys_50: 0.0
   art_sys_51: -1.03254695e-94
   art_sys_52: 0.0
   art_sys_53: 0.0
@@ -47730,8 +47730,8 @@ bins:
   art_sys_56: 2.81838063e-04
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: -1.41387088e-03
   art_sys_63: -1.54693403e-31
@@ -47740,21 +47740,21 @@ bins:
   art_sys_66: 0.0
   art_sys_67: 0.0
   art_sys_68: -8.85219956e-26
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 4.24917491e-03
   art_sys_72: -3.19299855e-23
   art_sys_73: 1.35293148e-02
   art_sys_74: 0.0
-  art_sys_75: -0.0
+  art_sys_75: 0.0
   art_sys_76: 1.06524287e-246
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 1.21974535e-02
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: 9.42503668e-23
   art_sys_81: -4.85996862e-89
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 1.78431704e-21
   art_sys_85: 0.0
   art_sys_86: 1.92255238e-75
@@ -47908,9 +47908,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
+  art_sys_237: 0.0
   art_sys_238: 0.0
-  art_sys_239: -0.0
+  art_sys_239: 0.0
   Unfolding+: 1.67798940e-02
   Unfolding-: -1.80843381e-02
   AbsoluteStat+: 5.80896145e-03
@@ -47963,56 +47963,56 @@ bins:
   RelativeStatFSR-: -3.99006418e-03
   luminosity_uncertainty: 6.41227600e-02
   uncorrelated_uncertainty: 2.46626000e-02
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 1.50071884e-10
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 3.55595890e-08
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 5.05408703e-08
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: -1.24110762e-07
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
   art_sys_28: 4.11028600e-06
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: 1.01035468e-05
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: -2.79553589e-05
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 2.01579474e-05
   art_sys_46: 0.0
   art_sys_47: 1.04592017e-249
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
+  art_sys_50: 0.0
   art_sys_51: 3.93222750e-97
   art_sys_52: 0.0
   art_sys_53: 0.0
@@ -48021,8 +48021,8 @@ bins:
   art_sys_56: 3.93034303e-04
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 2.63341017e-04
   art_sys_63: 5.89115731e-34
@@ -48031,21 +48031,21 @@ bins:
   art_sys_66: 0.0
   art_sys_67: 0.0
   art_sys_68: -1.00100852e-26
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 1.11801976e-03
   art_sys_72: -1.13086960e-23
   art_sys_73: -1.06805899e-03
   art_sys_74: 0.0
-  art_sys_75: -0.0
+  art_sys_75: 0.0
   art_sys_76: -4.05656819e-249
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 2.46177898e-03
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: 3.33256305e-23
   art_sys_81: 1.85081194e-91
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: -7.71673700e-25
   art_sys_85: 0.0
   art_sys_86: -7.32161704e-78
@@ -48200,8 +48200,8 @@ bins:
   art_sys_235: 0.0
   art_sys_236: 0.0
   art_sys_237: 0.0
-  art_sys_238: -0.0
-  art_sys_239: -0.0
+  art_sys_238: 0.0
+  art_sys_239: 0.0
   Unfolding+: 7.93795222e-03
   Unfolding-: -8.52445894e-03
   AbsoluteStat+: 3.68180296e-03
@@ -48254,56 +48254,56 @@ bins:
   RelativeStatFSR-: -2.20197260e-03
   luminosity_uncertainty: 3.43948800e-02
   uncorrelated_uncertainty: 1.32288000e-02
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 1.07123086e-10
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 3.33635311e-09
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 5.83709522e-09
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: -7.54725820e-09
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
   art_sys_28: 5.02770125e-07
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: 9.45176410e-07
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: -3.14491946e-06
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 2.12075160e-06
   art_sys_46: 0.0
   art_sys_47: 7.46617074e-250
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
+  art_sys_50: 0.0
   art_sys_51: 2.80687049e-97
   art_sys_52: 0.0
   art_sys_53: 0.0
@@ -48312,8 +48312,8 @@ bins:
   art_sys_56: 1.30603949e-05
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 7.89370340e-05
   art_sys_63: 4.20517776e-34
@@ -48322,21 +48322,21 @@ bins:
   art_sys_66: 0.0
   art_sys_67: 0.0
   art_sys_68: -7.70810365e-28
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: -3.04898453e-04
   art_sys_72: -1.31221607e-24
   art_sys_73: -9.63034362e-04
   art_sys_74: 0.0
-  art_sys_75: -0.0
+  art_sys_75: 0.0
   art_sys_76: -2.89573064e-249
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: -1.14728062e-03
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: 3.58292319e-24
   art_sys_81: 1.32113145e-91
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: -9.01240055e-23
   art_sys_85: 0.0
   art_sys_86: -5.22625683e-78
@@ -48490,7 +48490,7 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
+  art_sys_237: 0.0
   art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 3.69309327e-03
@@ -48545,56 +48545,56 @@ bins:
   RelativeStatFSR-: -1.19249475e-03
   luminosity_uncertainty: 1.80889020e-02
   uncorrelated_uncertainty: 6.95727000e-03
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 1.45191118e-12
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 2.22519756e-10
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 4.58784486e-10
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: -3.10805926e-10
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
   art_sys_28: 3.40600854e-08
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: 7.43309308e-08
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: -1.93872712e-07
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 2.90637597e-08
   art_sys_46: 0.0
   art_sys_47: 1.01191867e-251
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
+  art_sys_50: 0.0
   art_sys_51: 3.80434022e-99
   art_sys_52: 0.0
   art_sys_53: 0.0
@@ -48603,8 +48603,8 @@ bins:
   art_sys_56: -1.21400774e-05
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: -7.97817680e-06
   art_sys_63: 5.69956005e-36
@@ -48613,21 +48613,21 @@ bins:
   art_sys_66: 0.0
   art_sys_67: 0.0
   art_sys_68: -4.48935591e-29
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: -5.82848541e-05
   art_sys_72: -7.74934267e-26
   art_sys_73: 1.03424095e-04
   art_sys_74: 0.0
-  art_sys_75: -0.0
+  art_sys_75: 0.0
   art_sys_76: -3.92469448e-251
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: -1.56515089e-04
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: 1.28401603e-25
   art_sys_81: 1.79061825e-93
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: -1.51594380e-24
   art_sys_85: 0.0
   art_sys_86: -7.08349713e-80
@@ -48782,7 +48782,7 @@ bins:
   art_sys_235: 0.0
   art_sys_236: 0.0
   art_sys_237: 0.0
-  art_sys_238: -0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 1.70231345e-03
   Unfolding-: -1.81129606e-03
@@ -48836,56 +48836,56 @@ bins:
   RelativeStatFSR-: -6.34334678e-04
   luminosity_uncertainty: 9.34089000e-03
   uncorrelated_uncertainty: 3.59265000e-03
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -5.05576406e-13
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 7.33461006e-12
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 1.44916423e-11
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: -2.50459715e-11
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
   art_sys_28: 1.26525157e-09
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: 5.54804294e-09
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: -7.10252642e-09
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -9.26594511e-09
   art_sys_46: 0.0
   art_sys_47: -3.52375018e-252
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
+  art_sys_50: 0.0
   art_sys_51: -1.32472612e-99
   art_sys_52: 0.0
   art_sys_53: 0.0
@@ -48894,8 +48894,8 @@ bins:
   art_sys_56: -1.50389482e-06
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: -2.74459749e-06
   art_sys_63: -1.98466899e-36
@@ -48904,21 +48904,21 @@ bins:
   art_sys_66: 0.0
   art_sys_67: 0.0
   art_sys_68: -2.34488439e-30
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 8.39945972e-06
   art_sys_72: -2.08287764e-27
   art_sys_73: 3.97889774e-05
   art_sys_74: 0.0
-  art_sys_75: -0.0
+  art_sys_75: 0.0
   art_sys_76: 1.36667533e-251
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 5.00739265e-05
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: -4.49894676e-27
   art_sys_81: -6.23519091e-94
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 1.41946143e-24
   art_sys_85: 0.0
   art_sys_86: 2.46657583e-80
@@ -49072,9 +49072,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
+  art_sys_237: 0.0
   art_sys_238: 0.0
-  art_sys_239: -0.0
+  art_sys_239: 0.0
   Unfolding+: 8.01510650e-04
   Unfolding-: -8.48231343e-04
   AbsoluteStat+: 7.86728961e-04
@@ -49127,56 +49127,56 @@ bins:
   RelativeStatFSR-: -3.39714871e-04
   luminosity_uncertainty: 4.85282200e-03
   uncorrelated_uncertainty: 1.86647000e-03
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -5.07195661e-14
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 2.73720301e-15
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: -3.97525068e-13
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: -3.13058554e-12
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
   art_sys_28: 5.43018193e-11
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: 3.77012908e-10
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: -4.16767233e-10
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -4.47136836e-10
   art_sys_46: 0.0
   art_sys_47: -3.53502707e-253
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
+  art_sys_50: 0.0
   art_sys_51: -1.32896894e-100
   art_sys_52: 0.0
   art_sys_53: 0.0
@@ -49185,8 +49185,8 @@ bins:
   art_sys_56: -8.22208769e-09
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: -6.77868744e-08
   art_sys_63: -1.99102547e-37
@@ -49195,21 +49195,21 @@ bins:
   art_sys_66: 0.0
   art_sys_67: 0.0
   art_sys_68: -1.62422524e-31
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 2.05374805e-06
   art_sys_72: -1.11880796e-28
   art_sys_73: -1.59076530e-06
   art_sys_74: 0.0
-  art_sys_75: -0.0
+  art_sys_75: 0.0
   art_sys_76: 1.37104904e-252
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 6.79374442e-06
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: -1.65922035e-28
   art_sys_81: -6.25516092e-95
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 8.09617537e-26
   art_sys_85: 0.0
   art_sys_86: 2.47447576e-81
@@ -49364,7 +49364,7 @@ bins:
   art_sys_235: 0.0
   art_sys_236: 0.0
   art_sys_237: 0.0
-  art_sys_238: -0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 3.72192603e-04
   Unfolding-: -3.91788680e-04
@@ -49418,56 +49418,56 @@ bins:
   RelativeStatFSR-: -1.76298263e-04
   luminosity_uncertainty: 2.44250500e-03
   uncorrelated_uncertainty: 9.39425000e-04
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -2.96211653e-15
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: -1.77413255e-14
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: -8.50287906e-14
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: -2.61004393e-13
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
   art_sys_28: 4.24870017e-12
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: 6.61939702e-12
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: -2.21789879e-11
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 2.50936504e-11
   art_sys_46: 0.0
   art_sys_47: -2.06451905e-254
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
+  art_sys_50: 0.0
   art_sys_51: -7.76142455e-102
   art_sys_52: 0.0
   art_sys_53: 0.0
@@ -49476,8 +49476,8 @@ bins:
   art_sys_56: 7.31576203e-09
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 3.85384728e-08
   art_sys_63: -1.16279572e-38
@@ -49486,21 +49486,21 @@ bins:
   art_sys_66: 0.0
   art_sys_67: 0.0
   art_sys_68: -1.03187467e-32
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: -6.64108385e-08
   art_sys_72: -9.23776949e-30
   art_sys_73: -1.19583320e-06
   art_sys_74: 0.0
-  art_sys_75: -0.0
+  art_sys_75: 0.0
   art_sys_76: 8.00717164e-254
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: -1.51479471e-06
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: 3.46866861e-29
   art_sys_81: -3.65312974e-96
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: -1.97335014e-26
   art_sys_85: 0.0
   art_sys_86: 1.44513964e-82
@@ -49654,9 +49654,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
+  art_sys_237: 0.0
   art_sys_238: 0.0
-  art_sys_239: -0.0
+  art_sys_239: 0.0
   Unfolding+: 1.73375117e-04
   Unfolding-: -1.81559365e-04
   AbsoluteStat+: 2.45069132e-04
@@ -49709,56 +49709,56 @@ bins:
   RelativeStatFSR-: -8.96666248e-05
   luminosity_uncertainty: 1.20372460e-03
   uncorrelated_uncertainty: 4.62971000e-04
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -1.08366855e-16
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: -1.15121762e-15
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: -5.23194668e-15
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: -1.04212893e-14
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
   art_sys_28: 1.42472166e-13
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: -2.09987779e-12
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 2.79564671e-12
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -9.26258479e-13
   art_sys_46: 0.0
   art_sys_47: -7.55288499e-256
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
+  art_sys_50: 0.0
   art_sys_51: -2.83946009e-103
   art_sys_52: 0.0
   art_sys_53: 0.0
@@ -49767,8 +49767,8 @@ bins:
   art_sys_56: -4.49214237e-10
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 4.00652732e-09
   art_sys_63: -4.25400263e-40
@@ -49777,21 +49777,21 @@ bins:
   art_sys_66: 0.0
   art_sys_67: 0.0
   art_sys_68: -2.89499267e-34
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: -3.99361402e-08
   art_sys_72: 9.00793446e-31
   art_sys_73: -9.70988872e-08
   art_sys_74: 0.0
-  art_sys_75: -0.0
+  art_sys_75: 0.0
   art_sys_76: 2.92936248e-255
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: -3.11700333e-07
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: -2.49559316e-30
   art_sys_81: -1.33647065e-97
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: -3.15442517e-27
   art_sys_85: 0.0
   art_sys_86: 5.28693709e-84
@@ -49946,8 +49946,8 @@ bins:
   art_sys_235: 0.0
   art_sys_236: 0.0
   art_sys_237: 0.0
-  art_sys_238: -0.0
-  art_sys_239: -0.0
+  art_sys_238: 0.0
+  art_sys_239: 0.0
   Unfolding+: 8.15421090e-05
   Unfolding-: -8.50392574e-05
   AbsoluteStat+: 1.31325046e-04
@@ -50000,56 +50000,56 @@ bins:
   RelativeStatFSR-: -4.47508411e-05
   luminosity_uncertainty: 5.81848800e-04
   uncorrelated_uncertainty: 2.23788000e-04
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -3.08841562e-18
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: -4.96150528e-17
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: -2.23280032e-16
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: -1.55973711e-16
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
   art_sys_28: -1.35917614e-14
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: -2.44068329e-13
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 5.70157823e-13
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -6.85424392e-13
   art_sys_46: 0.0
   art_sys_47: -2.15254248e-257
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
+  art_sys_50: 0.0
   art_sys_51: -8.09235714e-105
   art_sys_52: 0.0
   art_sys_53: 0.0
@@ -50058,8 +50058,8 @@ bins:
   art_sys_56: -8.64467966e-11
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 5.77653768e-11
   art_sys_63: -1.21237515e-41
@@ -50068,21 +50068,21 @@ bins:
   art_sys_66: 0.0
   art_sys_67: 0.0
   art_sys_68: 5.44554637e-36
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: -1.07194052e-09
   art_sys_72: 2.24265713e-31
   art_sys_73: 8.16774315e-10
   art_sys_74: 0.0
-  art_sys_75: -0.0
+  art_sys_75: 0.0
   art_sys_76: 8.34856771e-257
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: -2.41879631e-09
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: -9.42595724e-31
   art_sys_81: -3.80889234e-99
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: -9.57669906e-29
   art_sys_85: 0.0
   art_sys_86: 1.50675768e-85
@@ -50236,7 +50236,7 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
+  art_sys_237: 0.0
   art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 3.78438887e-05
@@ -50291,56 +50291,56 @@ bins:
   RelativeStatFSR-: -2.13690313e-05
   luminosity_uncertainty: 2.68993400e-04
   uncorrelated_uncertainty: 1.03459000e-04
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -7.05485994e-20
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: -2.03420626e-18
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: -9.28789434e-18
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 7.35012951e-19
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
   art_sys_28: -1.87522118e-15
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: -1.41718951e-14
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 4.53663004e-14
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -6.69936006e-14
   art_sys_46: 0.0
   art_sys_47: -4.91703631e-259
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
+  art_sys_50: 0.0
   art_sys_51: -1.84853508e-106
   art_sys_52: 0.0
   art_sys_53: 0.0
@@ -50349,8 +50349,8 @@ bins:
   art_sys_56: 4.40390859e-12
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: -9.52340230e-12
   art_sys_63: -2.76942546e-43
@@ -50359,21 +50359,21 @@ bins:
   art_sys_66: 0.0
   art_sys_67: 0.0
   art_sys_68: 6.73606905e-37
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 4.44785513e-10
   art_sys_72: 1.91217431e-32
   art_sys_73: 3.09873485e-10
   art_sys_74: 0.0
-  art_sys_75: -0.0
+  art_sys_75: 0.0
   art_sys_76: 1.90705693e-258
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 3.51394825e-09
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: -8.58208406e-32
   art_sys_81: -8.70064308e-101
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 8.12114850e-30
   art_sys_85: 0.0
   art_sys_86: 3.44188274e-87
@@ -50528,7 +50528,7 @@ bins:
   art_sys_235: 0.0
   art_sys_236: 0.0
   art_sys_237: 0.0
-  art_sys_238: -0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 1.77440703e-05
   Unfolding-: -1.84332891e-05
@@ -50582,56 +50582,56 @@ bins:
   RelativeStatFSR-: -1.00002996e-05
   luminosity_uncertainty: 1.21837820e-04
   uncorrelated_uncertainty: 4.68607000e-05
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -6.32697332e-22
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: -8.66572271e-20
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: -4.24065718e-19
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: -2.51834783e-19
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
   art_sys_28: -1.05031275e-16
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: -5.30665500e-16
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 2.10518437e-15
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -3.15751051e-15
   art_sys_46: 0.0
   art_sys_47: -4.40963663e-261
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
+  art_sys_50: 0.0
   art_sys_51: -1.65781210e-108
   art_sys_52: 0.0
   art_sys_53: 0.0
@@ -50640,8 +50640,8 @@ bins:
   art_sys_56: 1.37609316e-12
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: -1.00532884e-13
   art_sys_63: -2.48368942e-45
@@ -50650,21 +50650,21 @@ bins:
   art_sys_66: 0.0
   art_sys_67: 0.0
   art_sys_68: 1.34163498e-38
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 5.40817654e-11
   art_sys_72: 9.28354797e-34
   art_sys_73: -1.71803021e-11
   art_sys_74: 0.0
-  art_sys_75: -0.0
+  art_sys_75: 0.0
   art_sys_76: 1.71026358e-260
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 3.41049313e-10
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: -4.00864330e-33
   art_sys_81: -7.80295245e-103
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 1.62015603e-31
   art_sys_85: 0.0
   art_sys_86: 3.08676578e-89
@@ -50818,7 +50818,7 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
+  art_sys_237: 0.0
   art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 8.08580493e-06
@@ -50873,56 +50873,56 @@ bins:
   RelativeStatFSR-: -4.42449572e-06
   luminosity_uncertainty: 5.21599000e-05
   uncorrelated_uncertainty: 2.00615000e-05
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 4.89017701e-23
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: -3.02785462e-21
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: -1.60304190e-20
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: -2.48508140e-20
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
   art_sys_28: -3.43402357e-18
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: -1.47218484e-17
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 6.30703000e-17
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -7.99229009e-17
   art_sys_46: 0.0
   art_sys_47: 3.40836813e-262
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
+  art_sys_50: 0.0
   art_sys_51: 1.28133851e-109
   art_sys_52: 0.0
   art_sys_53: 0.0
@@ -50931,8 +50931,8 @@ bins:
   art_sys_56: 1.00314439e-13
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 4.64327510e-14
   art_sys_63: 1.91966685e-46
@@ -50941,21 +50941,21 @@ bins:
   art_sys_66: 0.0
   art_sys_67: 0.0
   art_sys_68: -4.28079774e-40
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 2.57706171e-12
   art_sys_72: 2.76808505e-35
   art_sys_73: -2.08729600e-12
   art_sys_74: 0.0
-  art_sys_75: -0.0
+  art_sys_75: 0.0
   art_sys_76: -1.32192477e-261
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 1.37012707e-11
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: -1.06250649e-34
   art_sys_81: 6.03097512e-104
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: -3.33686094e-32
   art_sys_85: 0.0
   art_sys_86: -2.38579022e-90
@@ -51110,7 +51110,7 @@ bins:
   art_sys_235: 0.0
   art_sys_236: 0.0
   art_sys_237: 0.0
-  art_sys_238: -0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 3.53075846e-06
   Unfolding-: -3.67628642e-06
@@ -51164,56 +51164,56 @@ bins:
   RelativeStatFSR-: -1.83331123e-06
   luminosity_uncertainty: 2.09023360e-05
   uncorrelated_uncertainty: 8.03936000e-06
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 2.92374146e-24
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: -7.54411463e-23
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: -4.16499482e-22
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: -7.93468082e-22
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
   art_sys_28: -9.89137205e-20
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: -4.58101166e-19
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 1.85322941e-18
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -2.02118847e-18
   art_sys_46: 0.0
   art_sys_47: 2.03778395e-263
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
+  art_sys_50: 0.0
   art_sys_51: 7.66087307e-111
   art_sys_52: 0.0
   art_sys_53: 0.0
@@ -51222,8 +51222,8 @@ bins:
   art_sys_56: 3.63316941e-15
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 1.57564314e-15
   art_sys_63: 1.14773137e-47
@@ -51232,21 +51232,21 @@ bins:
   art_sys_66: 0.0
   art_sys_67: 0.0
   art_sys_68: -2.01012743e-41
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 7.30460612e-14
   art_sys_72: 8.09161097e-37
   art_sys_73: 1.79970662e-13
   art_sys_74: 0.0
-  art_sys_75: -0.0
+  art_sys_75: 0.0
   art_sys_76: -7.90348040e-263
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 9.23405513e-13
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: -2.82040883e-36
   art_sys_81: 3.60580240e-105
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 1.24181738e-33
   art_sys_85: 0.0
   art_sys_86: -1.42641744e-91
@@ -51400,7 +51400,7 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
+  art_sys_237: 0.0
   art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 1.62093490e-06
@@ -51455,56 +51455,56 @@ bins:
   RelativeStatFSR-: -7.84831655e-07
   luminosity_uncertainty: 8.64786000e-06
   uncorrelated_uncertainty: 3.32610000e-06
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 1.97923070e-26
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: -2.00675446e-25
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: -9.44407162e-25
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: -5.41726791e-27
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
   art_sys_28: -9.68698546e-22
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: -3.64914000e-21
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 1.78298191e-20
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -2.79539165e-20
   art_sys_46: 0.0
   art_sys_47: 1.37947679e-265
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
+  art_sys_50: 0.0
   art_sys_51: 5.18603829e-113
   art_sys_52: 0.0
   art_sys_53: 0.0
@@ -51513,8 +51513,8 @@ bins:
   art_sys_56: 1.98110517e-17
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: -2.66556023e-17
   art_sys_63: 7.76958287e-50
@@ -51523,21 +51523,21 @@ bins:
   art_sys_66: 0.0
   art_sys_67: 0.0
   art_sys_68: 6.38346535e-44
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 1.08676209e-15
   art_sys_72: 7.99230121e-39
   art_sys_73: 7.27394198e-15
   art_sys_74: 0.0
-  art_sys_75: -0.0
+  art_sys_75: 0.0
   art_sys_76: -5.35025698e-265
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 2.86222450e-14
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: -3.49497285e-38
   art_sys_81: 2.44095276e-107
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 4.86020005e-36
   art_sys_85: 0.0
   art_sys_86: -9.65615197e-94
@@ -51746,56 +51746,56 @@ bins:
   RelativeStatFSR-: -2.46051788e-07
   luminosity_uncertainty: 2.61934400e-06
   uncorrelated_uncertainty: 1.00744000e-06
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: 1.66344136e-28
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 4.49631437e-27
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 3.73005099e-26
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 1.33083549e-25
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
   art_sys_28: -2.47820777e-23
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: 3.36093567e-25
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: 2.75708846e-22
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: -5.62284973e-22
   art_sys_46: 0.0
   art_sys_47: 1.15937158e-267
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
+  art_sys_50: 0.0
   art_sys_51: 4.35859782e-115
   art_sys_52: 0.0
   art_sys_53: 0.0
@@ -51804,8 +51804,8 @@ bins:
   art_sys_56: 8.39974492e-19
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: -5.51475169e-19
   art_sys_63: 6.52993384e-52
@@ -51814,21 +51814,21 @@ bins:
   art_sys_66: 0.0
   art_sys_67: 0.0
   art_sys_68: 5.52950834e-45
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 5.28782274e-17
   art_sys_72: 1.36448484e-40
   art_sys_73: 1.47385390e-16
   art_sys_74: 0.0
-  art_sys_75: -0.0
+  art_sys_75: 0.0
   art_sys_76: -4.49658592e-267
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 1.00315949e-15
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: -6.52914583e-40
   art_sys_81: 2.05149495e-109
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 3.35916098e-37
   art_sys_85: 0.0
   art_sys_86: -8.11549791e-96
@@ -52037,56 +52037,56 @@ bins:
   RelativeStatFSR-: -9.53470533e-08
   luminosity_uncertainty: 9.80114200e-07
   uncorrelated_uncertainty: 3.76967000e-07
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -1.46902420e-31
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 1.76525214e-29
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 1.31452798e-28
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 1.68449024e-28
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
   art_sys_28: -3.20898403e-28
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: 4.65376448e-25
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: -1.20999157e-24
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 2.60379251e-24
   art_sys_46: 0.0
   art_sys_47: -1.02389470e-270
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
+  art_sys_50: 0.0
   art_sys_51: -3.84918028e-118
   art_sys_52: 0.0
   art_sys_53: 0.0
@@ -52095,8 +52095,8 @@ bins:
   art_sys_56: 4.09421335e-21
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: 6.89356040e-21
   art_sys_63: -5.76673821e-55
@@ -52105,21 +52105,21 @@ bins:
   art_sys_66: 0.0
   art_sys_67: 0.0
   art_sys_68: 1.01715758e-48
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: 1.11337770e-19
   art_sys_72: -4.92693953e-43
   art_sys_73: -4.65806179e-19
   art_sys_74: 0.0
-  art_sys_75: -0.0
+  art_sys_75: 0.0
   art_sys_76: 3.97114310e-270
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: 3.43902765e-18
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: 3.06382337e-42
   art_sys_81: -1.81172346e-112
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: -3.51462368e-40
   art_sys_85: 0.0
   art_sys_86: 7.16698714e-99
@@ -52328,56 +52328,56 @@ bins:
   RelativeStatFSR-: -3.78756690e-08
   luminosity_uncertainty: 3.75991200e-07
   uncorrelated_uncertainty: 1.44612000e-07
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -2.23790035e-33
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 1.29232269e-31
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 9.37243277e-31
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: -1.35291914e-30
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
   art_sys_28: 8.14019943e-28
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: 8.35278301e-27
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: -3.39301063e-26
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 8.23679038e-26
   art_sys_46: 0.0
   art_sys_47: -1.55977639e-272
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
+  art_sys_50: 0.0
   art_sys_51: -5.86381210e-120
   art_sys_52: 0.0
   art_sys_53: 0.0
@@ -52386,8 +52386,8 @@ bins:
   art_sys_56: -3.90935891e-23
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: -1.64158313e-22
   art_sys_63: -8.78500533e-57
@@ -52396,21 +52396,21 @@ bins:
   art_sys_66: 0.0
   art_sys_67: 0.0
   art_sys_68: -1.50209680e-49
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: -6.49350058e-20
   art_sys_72: -1.48593395e-44
   art_sys_73: 6.74702253e-20
   art_sys_74: 0.0
-  art_sys_75: -0.0
+  art_sys_75: 0.0
   art_sys_76: 6.04954326e-272
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: -2.26342659e-18
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: 9.39111962e-44
   art_sys_81: -2.75996581e-114
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 1.72791028e-41
   art_sys_85: 0.0
   art_sys_86: 1.09181340e-100
@@ -52565,8 +52565,8 @@ bins:
   art_sys_235: 0.0
   art_sys_236: 0.0
   art_sys_237: 0.0
-  art_sys_238: -0.0
-  art_sys_239: -0.0
+  art_sys_238: 0.0
+  art_sys_239: 0.0
   Unfolding+: 2.81144050e-08
   Unfolding-: -2.97478123e-08
   AbsoluteStat+: 4.35327802e-08
@@ -52619,56 +52619,56 @@ bins:
   RelativeStatFSR-: -9.49851111e-09
   luminosity_uncertainty: 9.09994800e-08
   uncorrelated_uncertainty: 3.49998000e-08
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -6.25778260e-36
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 3.89756025e-34
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 3.04139459e-33
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: -2.04105604e-33
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
   art_sys_28: 8.03534243e-30
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: 1.35609385e-28
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: -7.15854783e-28
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 3.20875585e-27
   art_sys_46: 0.0
   art_sys_47: -4.36156566e-275
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
+  art_sys_50: 0.0
   art_sys_51: -1.63968254e-122
   art_sys_52: 0.0
   art_sys_53: 0.0
@@ -52677,8 +52677,8 @@ bins:
   art_sys_56: -1.45596142e-23
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: -5.64166670e-23
   art_sys_63: -2.45652821e-59
@@ -52687,21 +52687,21 @@ bins:
   art_sys_66: 0.0
   art_sys_67: 0.0
   art_sys_68: -3.43752326e-52
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: -1.42274661e-20
   art_sys_72: -3.20675488e-46
   art_sys_73: 1.50359301e-20
   art_sys_74: 0.0
-  art_sys_75: -0.0
+  art_sys_75: 0.0
   art_sys_76: 1.69161941e-274
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: -5.10853352e-19
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: 3.34470656e-45
   art_sys_81: -7.71762066e-117
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: -4.29466357e-42
   art_sys_85: 0.0
   art_sys_86: 3.05300943e-103
@@ -52855,7 +52855,7 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
+  art_sys_237: 0.0
   art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 4.70690717e-09
@@ -52910,56 +52910,56 @@ bins:
   RelativeStatFSR-: -1.44587465e-09
   luminosity_uncertainty: 1.33645460e-08
   uncorrelated_uncertainty: 5.14021000e-09
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
+  art_sys_3: 0.0
   art_sys_4: -1.62670533e-36
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 9.47948125e-35
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 6.58560642e-34
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: -4.76422594e-33
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
   art_sys_28: 2.43334102e-30
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
   art_sys_34: 1.73115754e-29
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
   art_sys_39: -8.65137561e-29
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
   art_sys_45: 2.25493709e-28
   art_sys_46: 0.0
   art_sys_47: -1.13378454e-275
-  art_sys_48: -0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
+  art_sys_50: 0.0
   art_sys_51: -4.26234100e-123
   art_sys_52: 0.0
   art_sys_53: 0.0
@@ -52968,8 +52968,8 @@ bins:
   art_sys_56: -5.91862959e-25
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
   art_sys_62: -2.04009500e-24
   art_sys_63: -6.38572447e-60
@@ -52978,21 +52978,21 @@ bins:
   art_sys_66: 0.0
   art_sys_67: 0.0
   art_sys_68: -3.40715099e-52
-  art_sys_69: -0.0
-  art_sys_70: -0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
   art_sys_71: -4.33122166e-22
   art_sys_72: -3.89174690e-47
   art_sys_73: 5.00707895e-22
   art_sys_74: 0.0
-  art_sys_75: -0.0
+  art_sys_75: 0.0
   art_sys_76: 4.39734736e-275
-  art_sys_77: -0.0
+  art_sys_77: 0.0
   art_sys_78: -1.54457218e-20
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: 2.53218537e-46
   art_sys_81: -2.00618901e-117
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 9.46633045e-43
   art_sys_85: 0.0
   art_sys_86: 7.93627238e-104
@@ -53146,7 +53146,7 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
+  art_sys_237: 0.0
   art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 2.01758686e-09
@@ -53201,186 +53201,186 @@ bins:
   RelativeStatFSR-: -5.65774697e-10
   luminosity_uncertainty: 5.04322000e-09
   uncorrelated_uncertainty: 1.93970000e-09
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
-  art_sys_4: -0.0
+  art_sys_3: 0.0
+  art_sys_4: 0.0
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
-  art_sys_28: -0.0
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_28: 0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
-  art_sys_39: -0.0
+  art_sys_39: 0.0
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
-  art_sys_45: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
+  art_sys_45: 0.0
   art_sys_46: 0.0
-  art_sys_47: -0.0
-  art_sys_48: -0.0
+  art_sys_47: 0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 0.0
   art_sys_54: 0.0
   art_sys_55: 0.0
-  art_sys_56: -0.0
+  art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
-  art_sys_62: -0.0
-  art_sys_63: -0.0
+  art_sys_62: 0.0
+  art_sys_63: 0.0
   art_sys_64: 0.0
   art_sys_65: 0.0
   art_sys_66: 0.0
   art_sys_67: 0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
-  art_sys_71: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
+  art_sys_71: 0.0
   art_sys_72: 0.0
-  art_sys_73: -0.0
+  art_sys_73: 0.0
   art_sys_74: 0.0
-  art_sys_75: -0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_75: 0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 0.0
-  art_sys_88: -0.0
-  art_sys_89: -0.0
+  art_sys_88: 0.0
+  art_sys_89: 0.0
   art_sys_90: 0.0
   art_sys_91: 0.0
-  art_sys_92: -0.0
+  art_sys_92: 0.0
   art_sys_93: 0.0
   art_sys_94: 0.0
-  art_sys_95: -0.0
-  art_sys_96: -0.0
-  art_sys_97: -0.0
+  art_sys_95: 0.0
+  art_sys_96: 0.0
+  art_sys_97: 0.0
   art_sys_98: 0.0
   art_sys_99: 0.0
-  art_sys_100: -0.0
+  art_sys_100: 0.0
   art_sys_101: 0.0
-  art_sys_102: -0.0
+  art_sys_102: 0.0
   art_sys_103: 0.0
-  art_sys_104: -0.0
+  art_sys_104: 0.0
   art_sys_105: 0.0
   art_sys_106: 0.0
-  art_sys_107: -0.0
-  art_sys_108: -0.0
-  art_sys_109: -0.0
-  art_sys_110: -0.0
-  art_sys_111: -0.0
-  art_sys_112: -0.0
+  art_sys_107: 0.0
+  art_sys_108: 0.0
+  art_sys_109: 0.0
+  art_sys_110: 0.0
+  art_sys_111: 0.0
+  art_sys_112: 0.0
   art_sys_113: 0.0
-  art_sys_114: -0.0
+  art_sys_114: 0.0
   art_sys_115: 0.0
-  art_sys_116: -0.0
+  art_sys_116: 0.0
   art_sys_117: 0.0
   art_sys_118: 0.0
   art_sys_119: 0.0
   art_sys_120: 0.0
   art_sys_121: 0.0
   art_sys_122: 0.0
-  art_sys_123: -0.0
+  art_sys_123: 0.0
   art_sys_124: 0.0
   art_sys_125: 0.0
   art_sys_126: 0.0
-  art_sys_127: -0.0
-  art_sys_128: -0.0
+  art_sys_127: 0.0
+  art_sys_128: 0.0
   art_sys_129: 0.0
   art_sys_130: 0.0
   art_sys_131: 0.0
-  art_sys_132: -0.0
-  art_sys_133: -0.0
+  art_sys_132: 0.0
+  art_sys_133: 0.0
   art_sys_134: 0.0
   art_sys_135: 0.0
   art_sys_136: 0.0
   art_sys_137: 0.0
-  art_sys_138: -0.0
+  art_sys_138: 0.0
   art_sys_139: 0.0
   art_sys_140: 0.0
   art_sys_141: 0.0
-  art_sys_142: -0.0
+  art_sys_142: 0.0
   art_sys_143: 0.0
-  art_sys_144: -0.0
-  art_sys_145: -0.0
+  art_sys_144: 0.0
+  art_sys_145: 0.0
   art_sys_146: 0.0
-  art_sys_147: -0.0
+  art_sys_147: 0.0
   art_sys_148: 0.0
   art_sys_149: 0.0
-  art_sys_150: -0.0
-  art_sys_151: -0.0
-  art_sys_152: -0.0
+  art_sys_150: 0.0
+  art_sys_151: 0.0
+  art_sys_152: 0.0
   art_sys_153: 0.0
   art_sys_154: 0.0
   art_sys_155: 0.0
-  art_sys_156: -0.0
-  art_sys_157: -0.0
+  art_sys_156: 0.0
+  art_sys_157: 0.0
   art_sys_158: 0.0
-  art_sys_159: -0.0
-  art_sys_160: -0.0
-  art_sys_161: -0.0
+  art_sys_159: 0.0
+  art_sys_160: 0.0
+  art_sys_161: 0.0
   art_sys_162: 0.0
   art_sys_163: 0.0
-  art_sys_164: -0.0
+  art_sys_164: 0.0
   art_sys_165: 0.0
-  art_sys_166: -0.0
+  art_sys_166: 0.0
   art_sys_167: 0.0
-  art_sys_168: -0.0
+  art_sys_168: 0.0
   art_sys_169: 0.0
   art_sys_170: 0.0
-  art_sys_171: -0.0
+  art_sys_171: 0.0
   art_sys_172: 0.0
-  art_sys_173: -0.0
-  art_sys_174: -0.0
-  art_sys_175: -0.0
-  art_sys_176: -0.0
+  art_sys_173: 0.0
+  art_sys_174: 0.0
+  art_sys_175: 0.0
+  art_sys_176: 0.0
   art_sys_177: 0.0
   art_sys_178: 0.0
   art_sys_179: 0.0
-  art_sys_180: -0.0
+  art_sys_180: 0.0
   art_sys_181: 0.0
   art_sys_182: 0.0
   art_sys_183: 0.0
@@ -53437,8 +53437,8 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 5.75016819e+02
   Unfolding-: -6.17479195e+02
@@ -53492,186 +53492,186 @@ bins:
   RelativeStatFSR-: -1.31331002e+05
   luminosity_uncertainty: 4.83381600e+02
   uncorrelated_uncertainty: 185.916
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
-  art_sys_4: -0.0
+  art_sys_3: 0.0
+  art_sys_4: 0.0
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
-  art_sys_28: -0.0
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_28: 0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
-  art_sys_39: -0.0
+  art_sys_39: 0.0
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
-  art_sys_45: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
+  art_sys_45: 0.0
   art_sys_46: 0.0
-  art_sys_47: -0.0
-  art_sys_48: -0.0
+  art_sys_47: 0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 0.0
   art_sys_54: 0.0
   art_sys_55: 0.0
-  art_sys_56: -0.0
+  art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
-  art_sys_62: -0.0
-  art_sys_63: -0.0
+  art_sys_62: 0.0
+  art_sys_63: 0.0
   art_sys_64: 0.0
   art_sys_65: 0.0
   art_sys_66: 0.0
   art_sys_67: 0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
-  art_sys_71: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
+  art_sys_71: 0.0
   art_sys_72: 0.0
-  art_sys_73: -0.0
+  art_sys_73: 0.0
   art_sys_74: 0.0
-  art_sys_75: -0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_75: 0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 0.0
-  art_sys_88: -0.0
-  art_sys_89: -0.0
+  art_sys_88: 0.0
+  art_sys_89: 0.0
   art_sys_90: 0.0
   art_sys_91: 0.0
-  art_sys_92: -0.0
+  art_sys_92: 0.0
   art_sys_93: 0.0
   art_sys_94: 0.0
-  art_sys_95: -0.0
-  art_sys_96: -0.0
-  art_sys_97: -0.0
+  art_sys_95: 0.0
+  art_sys_96: 0.0
+  art_sys_97: 0.0
   art_sys_98: 0.0
   art_sys_99: 0.0
-  art_sys_100: -0.0
+  art_sys_100: 0.0
   art_sys_101: 0.0
-  art_sys_102: -0.0
+  art_sys_102: 0.0
   art_sys_103: 0.0
-  art_sys_104: -0.0
+  art_sys_104: 0.0
   art_sys_105: 0.0
   art_sys_106: 0.0
-  art_sys_107: -0.0
-  art_sys_108: -0.0
-  art_sys_109: -0.0
-  art_sys_110: -0.0
-  art_sys_111: -0.0
-  art_sys_112: -0.0
+  art_sys_107: 0.0
+  art_sys_108: 0.0
+  art_sys_109: 0.0
+  art_sys_110: 0.0
+  art_sys_111: 0.0
+  art_sys_112: 0.0
   art_sys_113: 0.0
-  art_sys_114: -0.0
+  art_sys_114: 0.0
   art_sys_115: 0.0
-  art_sys_116: -0.0
+  art_sys_116: 0.0
   art_sys_117: 0.0
   art_sys_118: 0.0
   art_sys_119: 0.0
   art_sys_120: 0.0
   art_sys_121: 0.0
   art_sys_122: 0.0
-  art_sys_123: -0.0
+  art_sys_123: 0.0
   art_sys_124: 0.0
   art_sys_125: 0.0
   art_sys_126: 0.0
-  art_sys_127: -0.0
-  art_sys_128: -0.0
+  art_sys_127: 0.0
+  art_sys_128: 0.0
   art_sys_129: 0.0
   art_sys_130: 0.0
   art_sys_131: 0.0
-  art_sys_132: -0.0
-  art_sys_133: -0.0
+  art_sys_132: 0.0
+  art_sys_133: 0.0
   art_sys_134: 0.0
   art_sys_135: 0.0
   art_sys_136: 0.0
   art_sys_137: 0.0
-  art_sys_138: -0.0
+  art_sys_138: 0.0
   art_sys_139: 0.0
   art_sys_140: 0.0
   art_sys_141: 0.0
-  art_sys_142: -0.0
+  art_sys_142: 0.0
   art_sys_143: 0.0
-  art_sys_144: -0.0
-  art_sys_145: -0.0
+  art_sys_144: 0.0
+  art_sys_145: 0.0
   art_sys_146: 0.0
-  art_sys_147: -0.0
+  art_sys_147: 0.0
   art_sys_148: 0.0
   art_sys_149: 0.0
-  art_sys_150: -0.0
-  art_sys_151: -0.0
-  art_sys_152: -0.0
+  art_sys_150: 0.0
+  art_sys_151: 0.0
+  art_sys_152: 0.0
   art_sys_153: 0.0
   art_sys_154: 0.0
   art_sys_155: 0.0
-  art_sys_156: -0.0
-  art_sys_157: -0.0
+  art_sys_156: 0.0
+  art_sys_157: 0.0
   art_sys_158: 0.0
-  art_sys_159: -0.0
-  art_sys_160: -0.0
-  art_sys_161: -0.0
+  art_sys_159: 0.0
+  art_sys_160: 0.0
+  art_sys_161: 0.0
   art_sys_162: 0.0
   art_sys_163: 0.0
-  art_sys_164: -0.0
+  art_sys_164: 0.0
   art_sys_165: 0.0
-  art_sys_166: -0.0
+  art_sys_166: 0.0
   art_sys_167: 0.0
-  art_sys_168: -0.0
+  art_sys_168: 0.0
   art_sys_169: 0.0
   art_sys_170: 0.0
-  art_sys_171: -0.0
+  art_sys_171: 0.0
   art_sys_172: 0.0
-  art_sys_173: -0.0
-  art_sys_174: -0.0
-  art_sys_175: -0.0
-  art_sys_176: -0.0
+  art_sys_173: 0.0
+  art_sys_174: 0.0
+  art_sys_175: 0.0
+  art_sys_176: 0.0
   art_sys_177: 0.0
   art_sys_178: 0.0
   art_sys_179: 0.0
-  art_sys_180: -0.0
+  art_sys_180: 0.0
   art_sys_181: 0.0
   art_sys_182: 0.0
   art_sys_183: 0.0
@@ -53728,8 +53728,8 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 5.75016819e+02
   Unfolding-: -6.17479195e+02
@@ -53783,186 +53783,186 @@ bins:
   RelativeStatFSR-: -1.31331002e+05
   luminosity_uncertainty: 4.83381600e+02
   uncorrelated_uncertainty: 185.916
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
-  art_sys_4: -0.0
+  art_sys_3: 0.0
+  art_sys_4: 0.0
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
-  art_sys_28: -0.0
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_28: 0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
-  art_sys_39: -0.0
+  art_sys_39: 0.0
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
-  art_sys_45: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
+  art_sys_45: 0.0
   art_sys_46: 0.0
-  art_sys_47: -0.0
-  art_sys_48: -0.0
+  art_sys_47: 0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 0.0
   art_sys_54: 0.0
   art_sys_55: 0.0
-  art_sys_56: -0.0
+  art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
-  art_sys_62: -0.0
-  art_sys_63: -0.0
+  art_sys_62: 0.0
+  art_sys_63: 0.0
   art_sys_64: 0.0
   art_sys_65: 0.0
   art_sys_66: 0.0
   art_sys_67: 0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
-  art_sys_71: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
+  art_sys_71: 0.0
   art_sys_72: 0.0
-  art_sys_73: -0.0
+  art_sys_73: 0.0
   art_sys_74: 0.0
-  art_sys_75: -0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_75: 0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 0.0
-  art_sys_88: -0.0
-  art_sys_89: -0.0
+  art_sys_88: 0.0
+  art_sys_89: 0.0
   art_sys_90: 0.0
   art_sys_91: 0.0
-  art_sys_92: -0.0
+  art_sys_92: 0.0
   art_sys_93: 0.0
   art_sys_94: 0.0
-  art_sys_95: -0.0
-  art_sys_96: -0.0
-  art_sys_97: -0.0
+  art_sys_95: 0.0
+  art_sys_96: 0.0
+  art_sys_97: 0.0
   art_sys_98: 0.0
   art_sys_99: 0.0
-  art_sys_100: -0.0
+  art_sys_100: 0.0
   art_sys_101: 0.0
-  art_sys_102: -0.0
+  art_sys_102: 0.0
   art_sys_103: 0.0
-  art_sys_104: -0.0
+  art_sys_104: 0.0
   art_sys_105: 0.0
   art_sys_106: 0.0
-  art_sys_107: -0.0
-  art_sys_108: -0.0
-  art_sys_109: -0.0
-  art_sys_110: -0.0
-  art_sys_111: -0.0
-  art_sys_112: -0.0
+  art_sys_107: 0.0
+  art_sys_108: 0.0
+  art_sys_109: 0.0
+  art_sys_110: 0.0
+  art_sys_111: 0.0
+  art_sys_112: 0.0
   art_sys_113: 0.0
-  art_sys_114: -0.0
+  art_sys_114: 0.0
   art_sys_115: 0.0
-  art_sys_116: -0.0
+  art_sys_116: 0.0
   art_sys_117: 0.0
   art_sys_118: 0.0
   art_sys_119: 0.0
   art_sys_120: 0.0
   art_sys_121: 0.0
   art_sys_122: 0.0
-  art_sys_123: -0.0
+  art_sys_123: 0.0
   art_sys_124: 0.0
   art_sys_125: 0.0
   art_sys_126: 0.0
-  art_sys_127: -0.0
-  art_sys_128: -0.0
+  art_sys_127: 0.0
+  art_sys_128: 0.0
   art_sys_129: 0.0
   art_sys_130: 0.0
   art_sys_131: 0.0
-  art_sys_132: -0.0
-  art_sys_133: -0.0
+  art_sys_132: 0.0
+  art_sys_133: 0.0
   art_sys_134: 0.0
   art_sys_135: 0.0
   art_sys_136: 0.0
   art_sys_137: 0.0
-  art_sys_138: -0.0
+  art_sys_138: 0.0
   art_sys_139: 0.0
   art_sys_140: 0.0
   art_sys_141: 0.0
-  art_sys_142: -0.0
+  art_sys_142: 0.0
   art_sys_143: 0.0
-  art_sys_144: -0.0
-  art_sys_145: -0.0
+  art_sys_144: 0.0
+  art_sys_145: 0.0
   art_sys_146: 0.0
-  art_sys_147: -0.0
+  art_sys_147: 0.0
   art_sys_148: 0.0
   art_sys_149: 0.0
-  art_sys_150: -0.0
-  art_sys_151: -0.0
-  art_sys_152: -0.0
+  art_sys_150: 0.0
+  art_sys_151: 0.0
+  art_sys_152: 0.0
   art_sys_153: 0.0
   art_sys_154: 0.0
   art_sys_155: 0.0
-  art_sys_156: -0.0
-  art_sys_157: -0.0
+  art_sys_156: 0.0
+  art_sys_157: 0.0
   art_sys_158: 0.0
-  art_sys_159: -0.0
-  art_sys_160: -0.0
-  art_sys_161: -0.0
+  art_sys_159: 0.0
+  art_sys_160: 0.0
+  art_sys_161: 0.0
   art_sys_162: 0.0
   art_sys_163: 0.0
-  art_sys_164: -0.0
+  art_sys_164: 0.0
   art_sys_165: 0.0
-  art_sys_166: -0.0
+  art_sys_166: 0.0
   art_sys_167: 0.0
-  art_sys_168: -0.0
+  art_sys_168: 0.0
   art_sys_169: 0.0
   art_sys_170: 0.0
-  art_sys_171: -0.0
+  art_sys_171: 0.0
   art_sys_172: 0.0
-  art_sys_173: -0.0
-  art_sys_174: -0.0
-  art_sys_175: -0.0
-  art_sys_176: -0.0
+  art_sys_173: 0.0
+  art_sys_174: 0.0
+  art_sys_175: 0.0
+  art_sys_176: 0.0
   art_sys_177: 0.0
   art_sys_178: 0.0
   art_sys_179: 0.0
-  art_sys_180: -0.0
+  art_sys_180: 0.0
   art_sys_181: 0.0
   art_sys_182: 0.0
   art_sys_183: 0.0
@@ -54019,8 +54019,8 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 5.75016819e+02
   Unfolding-: -6.17479195e+02
@@ -54074,186 +54074,186 @@ bins:
   RelativeStatFSR-: -1.31331002e+05
   luminosity_uncertainty: 4.83381600e+02
   uncorrelated_uncertainty: 185.916
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
-  art_sys_4: -0.0
+  art_sys_3: 0.0
+  art_sys_4: 0.0
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
-  art_sys_28: -0.0
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_28: 0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
-  art_sys_39: -0.0
+  art_sys_39: 0.0
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
-  art_sys_45: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
+  art_sys_45: 0.0
   art_sys_46: 0.0
-  art_sys_47: -0.0
-  art_sys_48: -0.0
+  art_sys_47: 0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 0.0
   art_sys_54: 0.0
   art_sys_55: 0.0
-  art_sys_56: -0.0
+  art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
-  art_sys_62: -0.0
-  art_sys_63: -0.0
+  art_sys_62: 0.0
+  art_sys_63: 0.0
   art_sys_64: 0.0
   art_sys_65: 0.0
   art_sys_66: 0.0
   art_sys_67: 0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
-  art_sys_71: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
+  art_sys_71: 0.0
   art_sys_72: 0.0
-  art_sys_73: -0.0
+  art_sys_73: 0.0
   art_sys_74: 0.0
-  art_sys_75: -0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_75: 0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 0.0
-  art_sys_88: -0.0
-  art_sys_89: -0.0
+  art_sys_88: 0.0
+  art_sys_89: 0.0
   art_sys_90: 0.0
   art_sys_91: 0.0
-  art_sys_92: -0.0
+  art_sys_92: 0.0
   art_sys_93: 0.0
   art_sys_94: 0.0
-  art_sys_95: -0.0
-  art_sys_96: -0.0
-  art_sys_97: -0.0
+  art_sys_95: 0.0
+  art_sys_96: 0.0
+  art_sys_97: 0.0
   art_sys_98: 0.0
   art_sys_99: 0.0
-  art_sys_100: -0.0
+  art_sys_100: 0.0
   art_sys_101: 0.0
-  art_sys_102: -0.0
+  art_sys_102: 0.0
   art_sys_103: 0.0
-  art_sys_104: -0.0
+  art_sys_104: 0.0
   art_sys_105: 0.0
   art_sys_106: 0.0
-  art_sys_107: -0.0
-  art_sys_108: -0.0
-  art_sys_109: -0.0
-  art_sys_110: -0.0
-  art_sys_111: -0.0
-  art_sys_112: -0.0
+  art_sys_107: 0.0
+  art_sys_108: 0.0
+  art_sys_109: 0.0
+  art_sys_110: 0.0
+  art_sys_111: 0.0
+  art_sys_112: 0.0
   art_sys_113: 0.0
-  art_sys_114: -0.0
+  art_sys_114: 0.0
   art_sys_115: 0.0
-  art_sys_116: -0.0
+  art_sys_116: 0.0
   art_sys_117: 0.0
   art_sys_118: 0.0
   art_sys_119: 0.0
   art_sys_120: 0.0
   art_sys_121: 0.0
   art_sys_122: 0.0
-  art_sys_123: -0.0
+  art_sys_123: 0.0
   art_sys_124: 0.0
   art_sys_125: 0.0
   art_sys_126: 0.0
-  art_sys_127: -0.0
-  art_sys_128: -0.0
+  art_sys_127: 0.0
+  art_sys_128: 0.0
   art_sys_129: 0.0
   art_sys_130: 0.0
   art_sys_131: 0.0
-  art_sys_132: -0.0
-  art_sys_133: -0.0
+  art_sys_132: 0.0
+  art_sys_133: 0.0
   art_sys_134: 0.0
   art_sys_135: 0.0
   art_sys_136: 0.0
   art_sys_137: 0.0
-  art_sys_138: -0.0
+  art_sys_138: 0.0
   art_sys_139: 0.0
   art_sys_140: 0.0
   art_sys_141: 0.0
-  art_sys_142: -0.0
+  art_sys_142: 0.0
   art_sys_143: 0.0
-  art_sys_144: -0.0
-  art_sys_145: -0.0
+  art_sys_144: 0.0
+  art_sys_145: 0.0
   art_sys_146: 0.0
-  art_sys_147: -0.0
+  art_sys_147: 0.0
   art_sys_148: 0.0
   art_sys_149: 0.0
-  art_sys_150: -0.0
-  art_sys_151: -0.0
-  art_sys_152: -0.0
+  art_sys_150: 0.0
+  art_sys_151: 0.0
+  art_sys_152: 0.0
   art_sys_153: 0.0
   art_sys_154: 0.0
   art_sys_155: 0.0
-  art_sys_156: -0.0
-  art_sys_157: -0.0
+  art_sys_156: 0.0
+  art_sys_157: 0.0
   art_sys_158: 0.0
-  art_sys_159: -0.0
-  art_sys_160: -0.0
-  art_sys_161: -0.0
+  art_sys_159: 0.0
+  art_sys_160: 0.0
+  art_sys_161: 0.0
   art_sys_162: 0.0
   art_sys_163: 0.0
-  art_sys_164: -0.0
+  art_sys_164: 0.0
   art_sys_165: 0.0
-  art_sys_166: -0.0
+  art_sys_166: 0.0
   art_sys_167: 0.0
-  art_sys_168: -0.0
+  art_sys_168: 0.0
   art_sys_169: 0.0
   art_sys_170: 0.0
-  art_sys_171: -0.0
+  art_sys_171: 0.0
   art_sys_172: 0.0
-  art_sys_173: -0.0
-  art_sys_174: -0.0
-  art_sys_175: -0.0
-  art_sys_176: -0.0
+  art_sys_173: 0.0
+  art_sys_174: 0.0
+  art_sys_175: 0.0
+  art_sys_176: 0.0
   art_sys_177: 0.0
   art_sys_178: 0.0
   art_sys_179: 0.0
-  art_sys_180: -0.0
+  art_sys_180: 0.0
   art_sys_181: 0.0
   art_sys_182: 0.0
   art_sys_183: 0.0
@@ -54310,8 +54310,8 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 5.75016819e+02
   Unfolding-: -6.17479195e+02
@@ -54365,186 +54365,186 @@ bins:
   RelativeStatFSR-: -1.31331002e+05
   luminosity_uncertainty: 4.83381600e+02
   uncorrelated_uncertainty: 185.916
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
-  art_sys_4: -0.0
+  art_sys_3: 0.0
+  art_sys_4: 0.0
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
-  art_sys_28: -0.0
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_28: 0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
-  art_sys_39: -0.0
+  art_sys_39: 0.0
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
-  art_sys_45: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
+  art_sys_45: 0.0
   art_sys_46: 0.0
-  art_sys_47: -0.0
-  art_sys_48: -0.0
+  art_sys_47: 0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 0.0
   art_sys_54: 0.0
   art_sys_55: 0.0
-  art_sys_56: -0.0
+  art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
-  art_sys_62: -0.0
-  art_sys_63: -0.0
+  art_sys_62: 0.0
+  art_sys_63: 0.0
   art_sys_64: 0.0
   art_sys_65: 0.0
   art_sys_66: 0.0
   art_sys_67: 0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
-  art_sys_71: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
+  art_sys_71: 0.0
   art_sys_72: 0.0
-  art_sys_73: -0.0
+  art_sys_73: 0.0
   art_sys_74: 0.0
-  art_sys_75: -0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_75: 0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 0.0
-  art_sys_88: -0.0
-  art_sys_89: -0.0
+  art_sys_88: 0.0
+  art_sys_89: 0.0
   art_sys_90: 0.0
   art_sys_91: 0.0
-  art_sys_92: -0.0
+  art_sys_92: 0.0
   art_sys_93: 0.0
   art_sys_94: 0.0
-  art_sys_95: -0.0
-  art_sys_96: -0.0
-  art_sys_97: -0.0
+  art_sys_95: 0.0
+  art_sys_96: 0.0
+  art_sys_97: 0.0
   art_sys_98: 0.0
   art_sys_99: 0.0
-  art_sys_100: -0.0
+  art_sys_100: 0.0
   art_sys_101: 0.0
-  art_sys_102: -0.0
+  art_sys_102: 0.0
   art_sys_103: 0.0
-  art_sys_104: -0.0
+  art_sys_104: 0.0
   art_sys_105: 0.0
   art_sys_106: 0.0
-  art_sys_107: -0.0
-  art_sys_108: -0.0
-  art_sys_109: -0.0
-  art_sys_110: -0.0
-  art_sys_111: -0.0
-  art_sys_112: -0.0
+  art_sys_107: 0.0
+  art_sys_108: 0.0
+  art_sys_109: 0.0
+  art_sys_110: 0.0
+  art_sys_111: 0.0
+  art_sys_112: 0.0
   art_sys_113: 0.0
-  art_sys_114: -0.0
+  art_sys_114: 0.0
   art_sys_115: 0.0
-  art_sys_116: -0.0
+  art_sys_116: 0.0
   art_sys_117: 0.0
   art_sys_118: 0.0
   art_sys_119: 0.0
   art_sys_120: 0.0
   art_sys_121: 0.0
   art_sys_122: 0.0
-  art_sys_123: -0.0
+  art_sys_123: 0.0
   art_sys_124: 0.0
   art_sys_125: 0.0
   art_sys_126: 0.0
-  art_sys_127: -0.0
-  art_sys_128: -0.0
+  art_sys_127: 0.0
+  art_sys_128: 0.0
   art_sys_129: 0.0
   art_sys_130: 0.0
   art_sys_131: 0.0
-  art_sys_132: -0.0
-  art_sys_133: -0.0
+  art_sys_132: 0.0
+  art_sys_133: 0.0
   art_sys_134: 0.0
   art_sys_135: 0.0
   art_sys_136: 0.0
   art_sys_137: 0.0
-  art_sys_138: -0.0
+  art_sys_138: 0.0
   art_sys_139: 0.0
   art_sys_140: 0.0
   art_sys_141: 0.0
-  art_sys_142: -0.0
+  art_sys_142: 0.0
   art_sys_143: 0.0
-  art_sys_144: -0.0
-  art_sys_145: -0.0
+  art_sys_144: 0.0
+  art_sys_145: 0.0
   art_sys_146: 0.0
-  art_sys_147: -0.0
+  art_sys_147: 0.0
   art_sys_148: 0.0
   art_sys_149: 0.0
-  art_sys_150: -0.0
-  art_sys_151: -0.0
-  art_sys_152: -0.0
+  art_sys_150: 0.0
+  art_sys_151: 0.0
+  art_sys_152: 0.0
   art_sys_153: 0.0
   art_sys_154: 0.0
   art_sys_155: 0.0
-  art_sys_156: -0.0
-  art_sys_157: -0.0
+  art_sys_156: 0.0
+  art_sys_157: 0.0
   art_sys_158: 0.0
-  art_sys_159: -0.0
-  art_sys_160: -0.0
-  art_sys_161: -0.0
+  art_sys_159: 0.0
+  art_sys_160: 0.0
+  art_sys_161: 0.0
   art_sys_162: 0.0
   art_sys_163: 0.0
-  art_sys_164: -0.0
+  art_sys_164: 0.0
   art_sys_165: 0.0
-  art_sys_166: -0.0
+  art_sys_166: 0.0
   art_sys_167: 0.0
-  art_sys_168: -0.0
+  art_sys_168: 0.0
   art_sys_169: 0.0
   art_sys_170: 0.0
-  art_sys_171: -0.0
+  art_sys_171: 0.0
   art_sys_172: 0.0
-  art_sys_173: -0.0
-  art_sys_174: -0.0
-  art_sys_175: -0.0
-  art_sys_176: -0.0
+  art_sys_173: 0.0
+  art_sys_174: 0.0
+  art_sys_175: 0.0
+  art_sys_176: 0.0
   art_sys_177: 0.0
   art_sys_178: 0.0
   art_sys_179: 0.0
-  art_sys_180: -0.0
+  art_sys_180: 0.0
   art_sys_181: 0.0
   art_sys_182: 0.0
   art_sys_183: 0.0
@@ -54601,8 +54601,8 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 5.75016819e+02
   Unfolding-: -6.17479195e+02
@@ -54656,186 +54656,186 @@ bins:
   RelativeStatFSR-: -1.31331002e+05
   luminosity_uncertainty: 4.83381600e+02
   uncorrelated_uncertainty: 185.916
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
-  art_sys_4: -0.0
+  art_sys_3: 0.0
+  art_sys_4: 0.0
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
-  art_sys_28: -0.0
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_28: 0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
-  art_sys_39: -0.0
+  art_sys_39: 0.0
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
-  art_sys_45: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
+  art_sys_45: 0.0
   art_sys_46: 0.0
-  art_sys_47: -0.0
-  art_sys_48: -0.0
+  art_sys_47: 0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 0.0
   art_sys_54: 0.0
   art_sys_55: 0.0
-  art_sys_56: -0.0
+  art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
-  art_sys_62: -0.0
-  art_sys_63: -0.0
+  art_sys_62: 0.0
+  art_sys_63: 0.0
   art_sys_64: 0.0
   art_sys_65: 0.0
   art_sys_66: 0.0
   art_sys_67: 0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
-  art_sys_71: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
+  art_sys_71: 0.0
   art_sys_72: 0.0
-  art_sys_73: -0.0
+  art_sys_73: 0.0
   art_sys_74: 0.0
-  art_sys_75: -0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_75: 0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 0.0
-  art_sys_88: -0.0
-  art_sys_89: -0.0
+  art_sys_88: 0.0
+  art_sys_89: 0.0
   art_sys_90: 0.0
   art_sys_91: 0.0
-  art_sys_92: -0.0
+  art_sys_92: 0.0
   art_sys_93: 0.0
   art_sys_94: 0.0
-  art_sys_95: -0.0
-  art_sys_96: -0.0
-  art_sys_97: -0.0
+  art_sys_95: 0.0
+  art_sys_96: 0.0
+  art_sys_97: 0.0
   art_sys_98: 0.0
   art_sys_99: 0.0
-  art_sys_100: -0.0
+  art_sys_100: 0.0
   art_sys_101: 0.0
-  art_sys_102: -0.0
+  art_sys_102: 0.0
   art_sys_103: 0.0
-  art_sys_104: -0.0
+  art_sys_104: 0.0
   art_sys_105: 0.0
   art_sys_106: 0.0
-  art_sys_107: -0.0
-  art_sys_108: -0.0
-  art_sys_109: -0.0
-  art_sys_110: -0.0
-  art_sys_111: -0.0
-  art_sys_112: -0.0
+  art_sys_107: 0.0
+  art_sys_108: 0.0
+  art_sys_109: 0.0
+  art_sys_110: 0.0
+  art_sys_111: 0.0
+  art_sys_112: 0.0
   art_sys_113: 0.0
-  art_sys_114: -0.0
+  art_sys_114: 0.0
   art_sys_115: 0.0
-  art_sys_116: -0.0
+  art_sys_116: 0.0
   art_sys_117: 0.0
   art_sys_118: 0.0
   art_sys_119: 0.0
   art_sys_120: 0.0
   art_sys_121: 0.0
   art_sys_122: 0.0
-  art_sys_123: -0.0
+  art_sys_123: 0.0
   art_sys_124: 0.0
   art_sys_125: 0.0
   art_sys_126: 0.0
-  art_sys_127: -0.0
-  art_sys_128: -0.0
+  art_sys_127: 0.0
+  art_sys_128: 0.0
   art_sys_129: 0.0
   art_sys_130: 0.0
   art_sys_131: 0.0
-  art_sys_132: -0.0
-  art_sys_133: -0.0
+  art_sys_132: 0.0
+  art_sys_133: 0.0
   art_sys_134: 0.0
   art_sys_135: 0.0
   art_sys_136: 0.0
   art_sys_137: 0.0
-  art_sys_138: -0.0
+  art_sys_138: 0.0
   art_sys_139: 0.0
   art_sys_140: 0.0
   art_sys_141: 0.0
-  art_sys_142: -0.0
+  art_sys_142: 0.0
   art_sys_143: 0.0
-  art_sys_144: -0.0
-  art_sys_145: -0.0
+  art_sys_144: 0.0
+  art_sys_145: 0.0
   art_sys_146: 0.0
-  art_sys_147: -0.0
+  art_sys_147: 0.0
   art_sys_148: 0.0
   art_sys_149: 0.0
-  art_sys_150: -0.0
-  art_sys_151: -0.0
-  art_sys_152: -0.0
+  art_sys_150: 0.0
+  art_sys_151: 0.0
+  art_sys_152: 0.0
   art_sys_153: 0.0
   art_sys_154: 0.0
   art_sys_155: 0.0
-  art_sys_156: -0.0
-  art_sys_157: -0.0
+  art_sys_156: 0.0
+  art_sys_157: 0.0
   art_sys_158: 0.0
-  art_sys_159: -0.0
-  art_sys_160: -0.0
-  art_sys_161: -0.0
+  art_sys_159: 0.0
+  art_sys_160: 0.0
+  art_sys_161: 0.0
   art_sys_162: 0.0
   art_sys_163: 0.0
-  art_sys_164: -0.0
+  art_sys_164: 0.0
   art_sys_165: 0.0
-  art_sys_166: -0.0
+  art_sys_166: 0.0
   art_sys_167: 0.0
-  art_sys_168: -0.0
+  art_sys_168: 0.0
   art_sys_169: 0.0
   art_sys_170: 0.0
-  art_sys_171: -0.0
+  art_sys_171: 0.0
   art_sys_172: 0.0
-  art_sys_173: -0.0
-  art_sys_174: -0.0
-  art_sys_175: -0.0
-  art_sys_176: -0.0
+  art_sys_173: 0.0
+  art_sys_174: 0.0
+  art_sys_175: 0.0
+  art_sys_176: 0.0
   art_sys_177: 0.0
   art_sys_178: 0.0
   art_sys_179: 0.0
-  art_sys_180: -0.0
+  art_sys_180: 0.0
   art_sys_181: 0.0
   art_sys_182: 0.0
   art_sys_183: 0.0
@@ -54892,8 +54892,8 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 5.75016819e+02
   Unfolding-: -6.17479195e+02
@@ -54947,186 +54947,186 @@ bins:
   RelativeStatFSR-: -1.31331002e+05
   luminosity_uncertainty: 4.83381600e+02
   uncorrelated_uncertainty: 185.916
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
-  art_sys_4: -0.0
+  art_sys_3: 0.0
+  art_sys_4: 0.0
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
-  art_sys_28: -0.0
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_28: 0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
-  art_sys_39: -0.0
+  art_sys_39: 0.0
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
-  art_sys_45: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
+  art_sys_45: 0.0
   art_sys_46: 0.0
-  art_sys_47: -0.0
-  art_sys_48: -0.0
+  art_sys_47: 0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 0.0
   art_sys_54: 0.0
   art_sys_55: 0.0
-  art_sys_56: -0.0
+  art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
-  art_sys_62: -0.0
-  art_sys_63: -0.0
+  art_sys_62: 0.0
+  art_sys_63: 0.0
   art_sys_64: 0.0
   art_sys_65: 0.0
   art_sys_66: 0.0
   art_sys_67: 0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
-  art_sys_71: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
+  art_sys_71: 0.0
   art_sys_72: 0.0
-  art_sys_73: -0.0
+  art_sys_73: 0.0
   art_sys_74: 0.0
-  art_sys_75: -0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_75: 0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 0.0
-  art_sys_88: -0.0
-  art_sys_89: -0.0
+  art_sys_88: 0.0
+  art_sys_89: 0.0
   art_sys_90: 0.0
   art_sys_91: 0.0
-  art_sys_92: -0.0
+  art_sys_92: 0.0
   art_sys_93: 0.0
   art_sys_94: 0.0
-  art_sys_95: -0.0
-  art_sys_96: -0.0
-  art_sys_97: -0.0
+  art_sys_95: 0.0
+  art_sys_96: 0.0
+  art_sys_97: 0.0
   art_sys_98: 0.0
   art_sys_99: 0.0
-  art_sys_100: -0.0
+  art_sys_100: 0.0
   art_sys_101: 0.0
-  art_sys_102: -0.0
+  art_sys_102: 0.0
   art_sys_103: 0.0
-  art_sys_104: -0.0
+  art_sys_104: 0.0
   art_sys_105: 0.0
   art_sys_106: 0.0
-  art_sys_107: -0.0
-  art_sys_108: -0.0
-  art_sys_109: -0.0
-  art_sys_110: -0.0
-  art_sys_111: -0.0
-  art_sys_112: -0.0
+  art_sys_107: 0.0
+  art_sys_108: 0.0
+  art_sys_109: 0.0
+  art_sys_110: 0.0
+  art_sys_111: 0.0
+  art_sys_112: 0.0
   art_sys_113: 0.0
-  art_sys_114: -0.0
+  art_sys_114: 0.0
   art_sys_115: 0.0
-  art_sys_116: -0.0
+  art_sys_116: 0.0
   art_sys_117: 0.0
   art_sys_118: 0.0
   art_sys_119: 0.0
   art_sys_120: 0.0
   art_sys_121: 0.0
   art_sys_122: 0.0
-  art_sys_123: -0.0
+  art_sys_123: 0.0
   art_sys_124: 0.0
   art_sys_125: 0.0
   art_sys_126: 0.0
-  art_sys_127: -0.0
-  art_sys_128: -0.0
+  art_sys_127: 0.0
+  art_sys_128: 0.0
   art_sys_129: 0.0
   art_sys_130: 0.0
   art_sys_131: 0.0
-  art_sys_132: -0.0
-  art_sys_133: -0.0
+  art_sys_132: 0.0
+  art_sys_133: 0.0
   art_sys_134: 0.0
   art_sys_135: 0.0
   art_sys_136: 0.0
   art_sys_137: 0.0
-  art_sys_138: -0.0
+  art_sys_138: 0.0
   art_sys_139: 0.0
   art_sys_140: 0.0
   art_sys_141: 0.0
-  art_sys_142: -0.0
+  art_sys_142: 0.0
   art_sys_143: 0.0
-  art_sys_144: -0.0
-  art_sys_145: -0.0
+  art_sys_144: 0.0
+  art_sys_145: 0.0
   art_sys_146: 0.0
-  art_sys_147: -0.0
+  art_sys_147: 0.0
   art_sys_148: 0.0
   art_sys_149: 0.0
-  art_sys_150: -0.0
-  art_sys_151: -0.0
-  art_sys_152: -0.0
+  art_sys_150: 0.0
+  art_sys_151: 0.0
+  art_sys_152: 0.0
   art_sys_153: 0.0
   art_sys_154: 0.0
   art_sys_155: 0.0
-  art_sys_156: -0.0
-  art_sys_157: -0.0
+  art_sys_156: 0.0
+  art_sys_157: 0.0
   art_sys_158: 0.0
-  art_sys_159: -0.0
-  art_sys_160: -0.0
-  art_sys_161: -0.0
+  art_sys_159: 0.0
+  art_sys_160: 0.0
+  art_sys_161: 0.0
   art_sys_162: 0.0
   art_sys_163: 0.0
-  art_sys_164: -0.0
+  art_sys_164: 0.0
   art_sys_165: 0.0
-  art_sys_166: -0.0
+  art_sys_166: 0.0
   art_sys_167: 0.0
-  art_sys_168: -0.0
+  art_sys_168: 0.0
   art_sys_169: 0.0
   art_sys_170: 0.0
-  art_sys_171: -0.0
+  art_sys_171: 0.0
   art_sys_172: 0.0
-  art_sys_173: -0.0
-  art_sys_174: -0.0
-  art_sys_175: -0.0
-  art_sys_176: -0.0
+  art_sys_173: 0.0
+  art_sys_174: 0.0
+  art_sys_175: 0.0
+  art_sys_176: 0.0
   art_sys_177: 0.0
   art_sys_178: 0.0
   art_sys_179: 0.0
-  art_sys_180: -0.0
+  art_sys_180: 0.0
   art_sys_181: 0.0
   art_sys_182: 0.0
   art_sys_183: 0.0
@@ -55183,8 +55183,8 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 5.75016819e+02
   Unfolding-: -6.17479195e+02
@@ -55238,186 +55238,186 @@ bins:
   RelativeStatFSR-: -1.31331002e+05
   luminosity_uncertainty: 4.83381600e+02
   uncorrelated_uncertainty: 185.916
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
-  art_sys_4: -0.0
+  art_sys_3: 0.0
+  art_sys_4: 0.0
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
-  art_sys_28: -0.0
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_28: 0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
-  art_sys_39: -0.0
+  art_sys_39: 0.0
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
-  art_sys_45: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
+  art_sys_45: 0.0
   art_sys_46: 0.0
-  art_sys_47: -0.0
-  art_sys_48: -0.0
+  art_sys_47: 0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 0.0
   art_sys_54: 0.0
   art_sys_55: 0.0
-  art_sys_56: -0.0
+  art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
-  art_sys_62: -0.0
-  art_sys_63: -0.0
+  art_sys_62: 0.0
+  art_sys_63: 0.0
   art_sys_64: 0.0
   art_sys_65: 0.0
   art_sys_66: 0.0
   art_sys_67: 0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
-  art_sys_71: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
+  art_sys_71: 0.0
   art_sys_72: 0.0
-  art_sys_73: -0.0
+  art_sys_73: 0.0
   art_sys_74: 0.0
-  art_sys_75: -0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_75: 0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 0.0
-  art_sys_88: -0.0
-  art_sys_89: -0.0
+  art_sys_88: 0.0
+  art_sys_89: 0.0
   art_sys_90: 0.0
   art_sys_91: 0.0
-  art_sys_92: -0.0
+  art_sys_92: 0.0
   art_sys_93: 0.0
   art_sys_94: 0.0
-  art_sys_95: -0.0
-  art_sys_96: -0.0
-  art_sys_97: -0.0
+  art_sys_95: 0.0
+  art_sys_96: 0.0
+  art_sys_97: 0.0
   art_sys_98: 0.0
   art_sys_99: 0.0
-  art_sys_100: -0.0
+  art_sys_100: 0.0
   art_sys_101: 0.0
-  art_sys_102: -0.0
+  art_sys_102: 0.0
   art_sys_103: 0.0
-  art_sys_104: -0.0
+  art_sys_104: 0.0
   art_sys_105: 0.0
   art_sys_106: 0.0
-  art_sys_107: -0.0
-  art_sys_108: -0.0
-  art_sys_109: -0.0
-  art_sys_110: -0.0
-  art_sys_111: -0.0
-  art_sys_112: -0.0
+  art_sys_107: 0.0
+  art_sys_108: 0.0
+  art_sys_109: 0.0
+  art_sys_110: 0.0
+  art_sys_111: 0.0
+  art_sys_112: 0.0
   art_sys_113: 0.0
-  art_sys_114: -0.0
+  art_sys_114: 0.0
   art_sys_115: 0.0
-  art_sys_116: -0.0
+  art_sys_116: 0.0
   art_sys_117: 0.0
   art_sys_118: 0.0
   art_sys_119: 0.0
   art_sys_120: 0.0
   art_sys_121: 0.0
   art_sys_122: 0.0
-  art_sys_123: -0.0
+  art_sys_123: 0.0
   art_sys_124: 0.0
   art_sys_125: 0.0
   art_sys_126: 0.0
-  art_sys_127: -0.0
-  art_sys_128: -0.0
+  art_sys_127: 0.0
+  art_sys_128: 0.0
   art_sys_129: 0.0
   art_sys_130: 0.0
   art_sys_131: 0.0
-  art_sys_132: -0.0
-  art_sys_133: -0.0
+  art_sys_132: 0.0
+  art_sys_133: 0.0
   art_sys_134: 0.0
   art_sys_135: 0.0
   art_sys_136: 0.0
   art_sys_137: 0.0
-  art_sys_138: -0.0
+  art_sys_138: 0.0
   art_sys_139: 0.0
   art_sys_140: 0.0
   art_sys_141: 0.0
-  art_sys_142: -0.0
+  art_sys_142: 0.0
   art_sys_143: 0.0
-  art_sys_144: -0.0
-  art_sys_145: -0.0
+  art_sys_144: 0.0
+  art_sys_145: 0.0
   art_sys_146: 0.0
-  art_sys_147: -0.0
+  art_sys_147: 0.0
   art_sys_148: 0.0
   art_sys_149: 0.0
-  art_sys_150: -0.0
-  art_sys_151: -0.0
-  art_sys_152: -0.0
+  art_sys_150: 0.0
+  art_sys_151: 0.0
+  art_sys_152: 0.0
   art_sys_153: 0.0
   art_sys_154: 0.0
   art_sys_155: 0.0
-  art_sys_156: -0.0
-  art_sys_157: -0.0
+  art_sys_156: 0.0
+  art_sys_157: 0.0
   art_sys_158: 0.0
-  art_sys_159: -0.0
-  art_sys_160: -0.0
-  art_sys_161: -0.0
+  art_sys_159: 0.0
+  art_sys_160: 0.0
+  art_sys_161: 0.0
   art_sys_162: 0.0
   art_sys_163: 0.0
-  art_sys_164: -0.0
+  art_sys_164: 0.0
   art_sys_165: 0.0
-  art_sys_166: -0.0
+  art_sys_166: 0.0
   art_sys_167: 0.0
-  art_sys_168: -0.0
+  art_sys_168: 0.0
   art_sys_169: 0.0
   art_sys_170: 0.0
-  art_sys_171: -0.0
+  art_sys_171: 0.0
   art_sys_172: 0.0
-  art_sys_173: -0.0
-  art_sys_174: -0.0
-  art_sys_175: -0.0
-  art_sys_176: -0.0
+  art_sys_173: 0.0
+  art_sys_174: 0.0
+  art_sys_175: 0.0
+  art_sys_176: 0.0
   art_sys_177: 0.0
   art_sys_178: 0.0
   art_sys_179: 0.0
-  art_sys_180: -0.0
+  art_sys_180: 0.0
   art_sys_181: 0.0
   art_sys_182: 0.0
   art_sys_183: 0.0
@@ -55474,8 +55474,8 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 5.75016819e+02
   Unfolding-: -6.17479195e+02
@@ -55529,186 +55529,186 @@ bins:
   RelativeStatFSR-: -1.31331002e+05
   luminosity_uncertainty: 4.83381600e+02
   uncorrelated_uncertainty: 185.916
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
-  art_sys_4: -0.0
+  art_sys_3: 0.0
+  art_sys_4: 0.0
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
-  art_sys_28: -0.0
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_28: 0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
-  art_sys_39: -0.0
+  art_sys_39: 0.0
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
-  art_sys_45: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
+  art_sys_45: 0.0
   art_sys_46: 0.0
-  art_sys_47: -0.0
-  art_sys_48: -0.0
+  art_sys_47: 0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 0.0
   art_sys_54: 0.0
   art_sys_55: 0.0
-  art_sys_56: -0.0
+  art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
-  art_sys_62: -0.0
-  art_sys_63: -0.0
+  art_sys_62: 0.0
+  art_sys_63: 0.0
   art_sys_64: 0.0
   art_sys_65: 0.0
   art_sys_66: 0.0
   art_sys_67: 0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
-  art_sys_71: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
+  art_sys_71: 0.0
   art_sys_72: 0.0
-  art_sys_73: -0.0
+  art_sys_73: 0.0
   art_sys_74: 0.0
-  art_sys_75: -0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_75: 0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 0.0
-  art_sys_88: -0.0
-  art_sys_89: -0.0
+  art_sys_88: 0.0
+  art_sys_89: 0.0
   art_sys_90: 0.0
   art_sys_91: 0.0
-  art_sys_92: -0.0
+  art_sys_92: 0.0
   art_sys_93: 0.0
   art_sys_94: 0.0
-  art_sys_95: -0.0
-  art_sys_96: -0.0
-  art_sys_97: -0.0
+  art_sys_95: 0.0
+  art_sys_96: 0.0
+  art_sys_97: 0.0
   art_sys_98: 0.0
   art_sys_99: 0.0
-  art_sys_100: -0.0
+  art_sys_100: 0.0
   art_sys_101: 0.0
-  art_sys_102: -0.0
+  art_sys_102: 0.0
   art_sys_103: 0.0
-  art_sys_104: -0.0
+  art_sys_104: 0.0
   art_sys_105: 0.0
   art_sys_106: 0.0
-  art_sys_107: -0.0
-  art_sys_108: -0.0
-  art_sys_109: -0.0
-  art_sys_110: -0.0
-  art_sys_111: -0.0
-  art_sys_112: -0.0
+  art_sys_107: 0.0
+  art_sys_108: 0.0
+  art_sys_109: 0.0
+  art_sys_110: 0.0
+  art_sys_111: 0.0
+  art_sys_112: 0.0
   art_sys_113: 0.0
-  art_sys_114: -0.0
+  art_sys_114: 0.0
   art_sys_115: 0.0
-  art_sys_116: -0.0
+  art_sys_116: 0.0
   art_sys_117: 0.0
   art_sys_118: 0.0
   art_sys_119: 0.0
   art_sys_120: 0.0
   art_sys_121: 0.0
   art_sys_122: 0.0
-  art_sys_123: -0.0
+  art_sys_123: 0.0
   art_sys_124: 0.0
   art_sys_125: 0.0
   art_sys_126: 0.0
-  art_sys_127: -0.0
-  art_sys_128: -0.0
+  art_sys_127: 0.0
+  art_sys_128: 0.0
   art_sys_129: 0.0
   art_sys_130: 0.0
   art_sys_131: 0.0
-  art_sys_132: -0.0
-  art_sys_133: -0.0
+  art_sys_132: 0.0
+  art_sys_133: 0.0
   art_sys_134: 0.0
   art_sys_135: 0.0
   art_sys_136: 0.0
   art_sys_137: 0.0
-  art_sys_138: -0.0
+  art_sys_138: 0.0
   art_sys_139: 0.0
   art_sys_140: 0.0
   art_sys_141: 0.0
-  art_sys_142: -0.0
+  art_sys_142: 0.0
   art_sys_143: 0.0
-  art_sys_144: -0.0
-  art_sys_145: -0.0
+  art_sys_144: 0.0
+  art_sys_145: 0.0
   art_sys_146: 0.0
-  art_sys_147: -0.0
+  art_sys_147: 0.0
   art_sys_148: 0.0
   art_sys_149: 0.0
-  art_sys_150: -0.0
-  art_sys_151: -0.0
-  art_sys_152: -0.0
+  art_sys_150: 0.0
+  art_sys_151: 0.0
+  art_sys_152: 0.0
   art_sys_153: 0.0
   art_sys_154: 0.0
   art_sys_155: 0.0
-  art_sys_156: -0.0
-  art_sys_157: -0.0
+  art_sys_156: 0.0
+  art_sys_157: 0.0
   art_sys_158: 0.0
-  art_sys_159: -0.0
-  art_sys_160: -0.0
-  art_sys_161: -0.0
+  art_sys_159: 0.0
+  art_sys_160: 0.0
+  art_sys_161: 0.0
   art_sys_162: 0.0
   art_sys_163: 0.0
-  art_sys_164: -0.0
+  art_sys_164: 0.0
   art_sys_165: 0.0
-  art_sys_166: -0.0
+  art_sys_166: 0.0
   art_sys_167: 0.0
-  art_sys_168: -0.0
+  art_sys_168: 0.0
   art_sys_169: 0.0
   art_sys_170: 0.0
-  art_sys_171: -0.0
+  art_sys_171: 0.0
   art_sys_172: 0.0
-  art_sys_173: -0.0
-  art_sys_174: -0.0
-  art_sys_175: -0.0
-  art_sys_176: -0.0
+  art_sys_173: 0.0
+  art_sys_174: 0.0
+  art_sys_175: 0.0
+  art_sys_176: 0.0
   art_sys_177: 0.0
   art_sys_178: 0.0
   art_sys_179: 0.0
-  art_sys_180: -0.0
+  art_sys_180: 0.0
   art_sys_181: 0.0
   art_sys_182: 0.0
   art_sys_183: 0.0
@@ -55765,8 +55765,8 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 5.75016819e+02
   Unfolding-: -6.17479195e+02
@@ -56347,9 +56347,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
-  art_sys_239: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
+  art_sys_239: 0.0
   Unfolding+: 2.58010645e+02
   Unfolding-: -2.77215108e+02
   AbsoluteStat+: -1.36075459e+00
@@ -56929,9 +56929,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
-  art_sys_239: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
+  art_sys_239: 0.0
   Unfolding+: 3.34305721e+01
   Unfolding-: -3.59751860e+01
   AbsoluteStat+: 2.77758745e-01
@@ -57511,9 +57511,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
-  art_sys_239: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
+  art_sys_239: 0.0
   Unfolding+: 4.79857454e+00
   Unfolding-: -5.17717767e+00
   AbsoluteStat+: 1.72704660e-01
@@ -58093,9 +58093,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
-  art_sys_239: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
+  art_sys_239: 0.0
   Unfolding+: 7.69552449e-01
   Unfolding-: -8.33641963e-01
   AbsoluteStat+: 6.57634939e-02
@@ -58675,9 +58675,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
-  art_sys_239: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
+  art_sys_239: 0.0
   Unfolding+: 1.30094077e-01
   Unfolding-: -1.41701798e-01
   AbsoluteStat+: 2.23065349e-02
@@ -59257,9 +59257,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
-  art_sys_239: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
+  art_sys_239: 0.0
   Unfolding+: 2.20601587e-02
   Unfolding-: -2.42519549e-02
   AbsoluteStat+: 6.78378074e-03
@@ -59839,9 +59839,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
-  art_sys_239: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
+  art_sys_239: 0.0
   Unfolding+: 3.79075153e-03
   Unfolding-: -4.20877667e-03
   AbsoluteStat+: 1.85673697e-03
@@ -60421,9 +60421,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
-  art_sys_239: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
+  art_sys_239: 0.0
   Unfolding+: 6.38299810e-04
   Unfolding-: -7.14150521e-04
   AbsoluteStat+: 4.22948103e-04
@@ -61003,9 +61003,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
-  art_sys_239: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
+  art_sys_239: 0.0
   Unfolding+: 1.04525664e-04
   Unfolding-: -1.17147522e-04
   AbsoluteStat+: 7.84337810e-05
@@ -61585,9 +61585,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
-  art_sys_239: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
+  art_sys_239: 0.0
   Unfolding+: 1.46144905e-05
   Unfolding-: -1.63195967e-05
   AbsoluteStat+: 1.07792370e-05
@@ -61878,7 +61878,7 @@ bins:
   art_sys_236: 0.0
   art_sys_237: 0.0
   art_sys_238: 0.0
-  art_sys_239: -0.0
+  art_sys_239: 0.0
   Unfolding+: 4.94031228e-06
   Unfolding-: -5.49959292e-06
   AbsoluteStat+: 3.49452278e-06
@@ -62167,9 +62167,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
-  art_sys_239: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
+  art_sys_239: 0.0
   Unfolding+: 1.48351471e-06
   Unfolding-: -1.64677846e-06
   AbsoluteStat+: 9.93852011e-07
@@ -62460,7 +62460,7 @@ bins:
   art_sys_236: 0.0
   art_sys_237: 0.0
   art_sys_238: 0.0
-  art_sys_239: -0.0
+  art_sys_239: 0.0
   Unfolding+: 4.04110987e-07
   Unfolding-: -4.47289136e-07
   AbsoluteStat+: 2.54416601e-07
@@ -62749,8 +62749,8 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 6.30749488e-08
   Unfolding-: -6.96297964e-08
@@ -63040,8 +63040,8 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 9.50618331e-09
   Unfolding-: -1.04670582e-08
@@ -63095,186 +63095,186 @@ bins:
   RelativeStatFSR-: -5.57631310e-09
   luminosity_uncertainty: 1.98488420e-08
   uncorrelated_uncertainty: 7.63417000e-09
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
-  art_sys_4: -0.0
+  art_sys_3: 0.0
+  art_sys_4: 0.0
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
-  art_sys_28: -0.0
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_28: 0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
-  art_sys_39: -0.0
+  art_sys_39: 0.0
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
-  art_sys_45: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
+  art_sys_45: 0.0
   art_sys_46: 0.0
-  art_sys_47: -0.0
-  art_sys_48: -0.0
+  art_sys_47: 0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 0.0
   art_sys_54: 0.0
   art_sys_55: 0.0
-  art_sys_56: -0.0
+  art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
-  art_sys_62: -0.0
-  art_sys_63: -0.0
+  art_sys_62: 0.0
+  art_sys_63: 0.0
   art_sys_64: 0.0
   art_sys_65: 0.0
   art_sys_66: 0.0
   art_sys_67: 0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
-  art_sys_71: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
+  art_sys_71: 0.0
   art_sys_72: 0.0
-  art_sys_73: -0.0
+  art_sys_73: 0.0
   art_sys_74: 0.0
-  art_sys_75: -0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_75: 0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 0.0
-  art_sys_88: -0.0
-  art_sys_89: -0.0
+  art_sys_88: 0.0
+  art_sys_89: 0.0
   art_sys_90: 0.0
   art_sys_91: 0.0
-  art_sys_92: -0.0
+  art_sys_92: 0.0
   art_sys_93: 0.0
   art_sys_94: 0.0
-  art_sys_95: -0.0
-  art_sys_96: -0.0
-  art_sys_97: -0.0
+  art_sys_95: 0.0
+  art_sys_96: 0.0
+  art_sys_97: 0.0
   art_sys_98: 0.0
   art_sys_99: 0.0
-  art_sys_100: -0.0
+  art_sys_100: 0.0
   art_sys_101: 0.0
-  art_sys_102: -0.0
+  art_sys_102: 0.0
   art_sys_103: 0.0
-  art_sys_104: -0.0
+  art_sys_104: 0.0
   art_sys_105: 0.0
   art_sys_106: 0.0
-  art_sys_107: -0.0
-  art_sys_108: -0.0
-  art_sys_109: -0.0
-  art_sys_110: -0.0
-  art_sys_111: -0.0
-  art_sys_112: -0.0
+  art_sys_107: 0.0
+  art_sys_108: 0.0
+  art_sys_109: 0.0
+  art_sys_110: 0.0
+  art_sys_111: 0.0
+  art_sys_112: 0.0
   art_sys_113: 0.0
-  art_sys_114: -0.0
+  art_sys_114: 0.0
   art_sys_115: 0.0
-  art_sys_116: -0.0
+  art_sys_116: 0.0
   art_sys_117: 0.0
   art_sys_118: 0.0
   art_sys_119: 0.0
   art_sys_120: 0.0
   art_sys_121: 0.0
   art_sys_122: 0.0
-  art_sys_123: -0.0
+  art_sys_123: 0.0
   art_sys_124: 0.0
   art_sys_125: 0.0
   art_sys_126: 0.0
-  art_sys_127: -0.0
-  art_sys_128: -0.0
+  art_sys_127: 0.0
+  art_sys_128: 0.0
   art_sys_129: 0.0
   art_sys_130: 0.0
   art_sys_131: 0.0
-  art_sys_132: -0.0
-  art_sys_133: -0.0
+  art_sys_132: 0.0
+  art_sys_133: 0.0
   art_sys_134: 0.0
   art_sys_135: 0.0
   art_sys_136: 0.0
   art_sys_137: 0.0
-  art_sys_138: -0.0
+  art_sys_138: 0.0
   art_sys_139: 0.0
   art_sys_140: 0.0
   art_sys_141: 0.0
-  art_sys_142: -0.0
+  art_sys_142: 0.0
   art_sys_143: 0.0
-  art_sys_144: -0.0
-  art_sys_145: -0.0
+  art_sys_144: 0.0
+  art_sys_145: 0.0
   art_sys_146: 0.0
-  art_sys_147: -0.0
+  art_sys_147: 0.0
   art_sys_148: 0.0
   art_sys_149: 0.0
-  art_sys_150: -0.0
-  art_sys_151: -0.0
-  art_sys_152: -0.0
+  art_sys_150: 0.0
+  art_sys_151: 0.0
+  art_sys_152: 0.0
   art_sys_153: 0.0
   art_sys_154: 0.0
   art_sys_155: 0.0
-  art_sys_156: -0.0
-  art_sys_157: -0.0
+  art_sys_156: 0.0
+  art_sys_157: 0.0
   art_sys_158: 0.0
-  art_sys_159: -0.0
-  art_sys_160: -0.0
-  art_sys_161: -0.0
+  art_sys_159: 0.0
+  art_sys_160: 0.0
+  art_sys_161: 0.0
   art_sys_162: 0.0
   art_sys_163: 0.0
-  art_sys_164: -0.0
+  art_sys_164: 0.0
   art_sys_165: 0.0
-  art_sys_166: -0.0
+  art_sys_166: 0.0
   art_sys_167: 0.0
-  art_sys_168: -0.0
+  art_sys_168: 0.0
   art_sys_169: 0.0
   art_sys_170: 0.0
-  art_sys_171: -0.0
+  art_sys_171: 0.0
   art_sys_172: 0.0
-  art_sys_173: -0.0
-  art_sys_174: -0.0
-  art_sys_175: -0.0
-  art_sys_176: -0.0
+  art_sys_173: 0.0
+  art_sys_174: 0.0
+  art_sys_175: 0.0
+  art_sys_176: 0.0
   art_sys_177: 0.0
   art_sys_178: 0.0
   art_sys_179: 0.0
-  art_sys_180: -0.0
+  art_sys_180: 0.0
   art_sys_181: 0.0
   art_sys_182: 0.0
   art_sys_183: 0.0
@@ -63331,8 +63331,8 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 5.48566695e+02
   Unfolding-: -6.09518550e+02
@@ -63386,186 +63386,186 @@ bins:
   RelativeStatFSR-: -8.82476857e+04
   luminosity_uncertainty: 3.24807600e+02
   uncorrelated_uncertainty: 124.926
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
-  art_sys_4: -0.0
+  art_sys_3: 0.0
+  art_sys_4: 0.0
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
-  art_sys_28: -0.0
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_28: 0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
-  art_sys_39: -0.0
+  art_sys_39: 0.0
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
-  art_sys_45: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
+  art_sys_45: 0.0
   art_sys_46: 0.0
-  art_sys_47: -0.0
-  art_sys_48: -0.0
+  art_sys_47: 0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 0.0
   art_sys_54: 0.0
   art_sys_55: 0.0
-  art_sys_56: -0.0
+  art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
-  art_sys_62: -0.0
-  art_sys_63: -0.0
+  art_sys_62: 0.0
+  art_sys_63: 0.0
   art_sys_64: 0.0
   art_sys_65: 0.0
   art_sys_66: 0.0
   art_sys_67: 0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
-  art_sys_71: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
+  art_sys_71: 0.0
   art_sys_72: 0.0
-  art_sys_73: -0.0
+  art_sys_73: 0.0
   art_sys_74: 0.0
-  art_sys_75: -0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_75: 0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 0.0
-  art_sys_88: -0.0
-  art_sys_89: -0.0
+  art_sys_88: 0.0
+  art_sys_89: 0.0
   art_sys_90: 0.0
   art_sys_91: 0.0
-  art_sys_92: -0.0
+  art_sys_92: 0.0
   art_sys_93: 0.0
   art_sys_94: 0.0
-  art_sys_95: -0.0
-  art_sys_96: -0.0
-  art_sys_97: -0.0
+  art_sys_95: 0.0
+  art_sys_96: 0.0
+  art_sys_97: 0.0
   art_sys_98: 0.0
   art_sys_99: 0.0
-  art_sys_100: -0.0
+  art_sys_100: 0.0
   art_sys_101: 0.0
-  art_sys_102: -0.0
+  art_sys_102: 0.0
   art_sys_103: 0.0
-  art_sys_104: -0.0
+  art_sys_104: 0.0
   art_sys_105: 0.0
   art_sys_106: 0.0
-  art_sys_107: -0.0
-  art_sys_108: -0.0
-  art_sys_109: -0.0
-  art_sys_110: -0.0
-  art_sys_111: -0.0
-  art_sys_112: -0.0
+  art_sys_107: 0.0
+  art_sys_108: 0.0
+  art_sys_109: 0.0
+  art_sys_110: 0.0
+  art_sys_111: 0.0
+  art_sys_112: 0.0
   art_sys_113: 0.0
-  art_sys_114: -0.0
+  art_sys_114: 0.0
   art_sys_115: 0.0
-  art_sys_116: -0.0
+  art_sys_116: 0.0
   art_sys_117: 0.0
   art_sys_118: 0.0
   art_sys_119: 0.0
   art_sys_120: 0.0
   art_sys_121: 0.0
   art_sys_122: 0.0
-  art_sys_123: -0.0
+  art_sys_123: 0.0
   art_sys_124: 0.0
   art_sys_125: 0.0
   art_sys_126: 0.0
-  art_sys_127: -0.0
-  art_sys_128: -0.0
+  art_sys_127: 0.0
+  art_sys_128: 0.0
   art_sys_129: 0.0
   art_sys_130: 0.0
   art_sys_131: 0.0
-  art_sys_132: -0.0
-  art_sys_133: -0.0
+  art_sys_132: 0.0
+  art_sys_133: 0.0
   art_sys_134: 0.0
   art_sys_135: 0.0
   art_sys_136: 0.0
   art_sys_137: 0.0
-  art_sys_138: -0.0
+  art_sys_138: 0.0
   art_sys_139: 0.0
   art_sys_140: 0.0
   art_sys_141: 0.0
-  art_sys_142: -0.0
+  art_sys_142: 0.0
   art_sys_143: 0.0
-  art_sys_144: -0.0
-  art_sys_145: -0.0
+  art_sys_144: 0.0
+  art_sys_145: 0.0
   art_sys_146: 0.0
-  art_sys_147: -0.0
+  art_sys_147: 0.0
   art_sys_148: 0.0
   art_sys_149: 0.0
-  art_sys_150: -0.0
-  art_sys_151: -0.0
-  art_sys_152: -0.0
+  art_sys_150: 0.0
+  art_sys_151: 0.0
+  art_sys_152: 0.0
   art_sys_153: 0.0
   art_sys_154: 0.0
   art_sys_155: 0.0
-  art_sys_156: -0.0
-  art_sys_157: -0.0
+  art_sys_156: 0.0
+  art_sys_157: 0.0
   art_sys_158: 0.0
-  art_sys_159: -0.0
-  art_sys_160: -0.0
-  art_sys_161: -0.0
+  art_sys_159: 0.0
+  art_sys_160: 0.0
+  art_sys_161: 0.0
   art_sys_162: 0.0
   art_sys_163: 0.0
-  art_sys_164: -0.0
+  art_sys_164: 0.0
   art_sys_165: 0.0
-  art_sys_166: -0.0
+  art_sys_166: 0.0
   art_sys_167: 0.0
-  art_sys_168: -0.0
+  art_sys_168: 0.0
   art_sys_169: 0.0
   art_sys_170: 0.0
-  art_sys_171: -0.0
+  art_sys_171: 0.0
   art_sys_172: 0.0
-  art_sys_173: -0.0
-  art_sys_174: -0.0
-  art_sys_175: -0.0
-  art_sys_176: -0.0
+  art_sys_173: 0.0
+  art_sys_174: 0.0
+  art_sys_175: 0.0
+  art_sys_176: 0.0
   art_sys_177: 0.0
   art_sys_178: 0.0
   art_sys_179: 0.0
-  art_sys_180: -0.0
+  art_sys_180: 0.0
   art_sys_181: 0.0
   art_sys_182: 0.0
   art_sys_183: 0.0
@@ -63622,8 +63622,8 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 5.48566695e+02
   Unfolding-: -6.09518550e+02
@@ -63677,186 +63677,186 @@ bins:
   RelativeStatFSR-: -8.82476857e+04
   luminosity_uncertainty: 3.24807600e+02
   uncorrelated_uncertainty: 124.926
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
-  art_sys_4: -0.0
+  art_sys_3: 0.0
+  art_sys_4: 0.0
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
-  art_sys_28: -0.0
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_28: 0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
-  art_sys_39: -0.0
+  art_sys_39: 0.0
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
-  art_sys_45: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
+  art_sys_45: 0.0
   art_sys_46: 0.0
-  art_sys_47: -0.0
-  art_sys_48: -0.0
+  art_sys_47: 0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 0.0
   art_sys_54: 0.0
   art_sys_55: 0.0
-  art_sys_56: -0.0
+  art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
-  art_sys_62: -0.0
-  art_sys_63: -0.0
+  art_sys_62: 0.0
+  art_sys_63: 0.0
   art_sys_64: 0.0
   art_sys_65: 0.0
   art_sys_66: 0.0
   art_sys_67: 0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
-  art_sys_71: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
+  art_sys_71: 0.0
   art_sys_72: 0.0
-  art_sys_73: -0.0
+  art_sys_73: 0.0
   art_sys_74: 0.0
-  art_sys_75: -0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_75: 0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 0.0
-  art_sys_88: -0.0
-  art_sys_89: -0.0
+  art_sys_88: 0.0
+  art_sys_89: 0.0
   art_sys_90: 0.0
   art_sys_91: 0.0
-  art_sys_92: -0.0
+  art_sys_92: 0.0
   art_sys_93: 0.0
   art_sys_94: 0.0
-  art_sys_95: -0.0
-  art_sys_96: -0.0
-  art_sys_97: -0.0
+  art_sys_95: 0.0
+  art_sys_96: 0.0
+  art_sys_97: 0.0
   art_sys_98: 0.0
   art_sys_99: 0.0
-  art_sys_100: -0.0
+  art_sys_100: 0.0
   art_sys_101: 0.0
-  art_sys_102: -0.0
+  art_sys_102: 0.0
   art_sys_103: 0.0
-  art_sys_104: -0.0
+  art_sys_104: 0.0
   art_sys_105: 0.0
   art_sys_106: 0.0
-  art_sys_107: -0.0
-  art_sys_108: -0.0
-  art_sys_109: -0.0
-  art_sys_110: -0.0
-  art_sys_111: -0.0
-  art_sys_112: -0.0
+  art_sys_107: 0.0
+  art_sys_108: 0.0
+  art_sys_109: 0.0
+  art_sys_110: 0.0
+  art_sys_111: 0.0
+  art_sys_112: 0.0
   art_sys_113: 0.0
-  art_sys_114: -0.0
+  art_sys_114: 0.0
   art_sys_115: 0.0
-  art_sys_116: -0.0
+  art_sys_116: 0.0
   art_sys_117: 0.0
   art_sys_118: 0.0
   art_sys_119: 0.0
   art_sys_120: 0.0
   art_sys_121: 0.0
   art_sys_122: 0.0
-  art_sys_123: -0.0
+  art_sys_123: 0.0
   art_sys_124: 0.0
   art_sys_125: 0.0
   art_sys_126: 0.0
-  art_sys_127: -0.0
-  art_sys_128: -0.0
+  art_sys_127: 0.0
+  art_sys_128: 0.0
   art_sys_129: 0.0
   art_sys_130: 0.0
   art_sys_131: 0.0
-  art_sys_132: -0.0
-  art_sys_133: -0.0
+  art_sys_132: 0.0
+  art_sys_133: 0.0
   art_sys_134: 0.0
   art_sys_135: 0.0
   art_sys_136: 0.0
   art_sys_137: 0.0
-  art_sys_138: -0.0
+  art_sys_138: 0.0
   art_sys_139: 0.0
   art_sys_140: 0.0
   art_sys_141: 0.0
-  art_sys_142: -0.0
+  art_sys_142: 0.0
   art_sys_143: 0.0
-  art_sys_144: -0.0
-  art_sys_145: -0.0
+  art_sys_144: 0.0
+  art_sys_145: 0.0
   art_sys_146: 0.0
-  art_sys_147: -0.0
+  art_sys_147: 0.0
   art_sys_148: 0.0
   art_sys_149: 0.0
-  art_sys_150: -0.0
-  art_sys_151: -0.0
-  art_sys_152: -0.0
+  art_sys_150: 0.0
+  art_sys_151: 0.0
+  art_sys_152: 0.0
   art_sys_153: 0.0
   art_sys_154: 0.0
   art_sys_155: 0.0
-  art_sys_156: -0.0
-  art_sys_157: -0.0
+  art_sys_156: 0.0
+  art_sys_157: 0.0
   art_sys_158: 0.0
-  art_sys_159: -0.0
-  art_sys_160: -0.0
-  art_sys_161: -0.0
+  art_sys_159: 0.0
+  art_sys_160: 0.0
+  art_sys_161: 0.0
   art_sys_162: 0.0
   art_sys_163: 0.0
-  art_sys_164: -0.0
+  art_sys_164: 0.0
   art_sys_165: 0.0
-  art_sys_166: -0.0
+  art_sys_166: 0.0
   art_sys_167: 0.0
-  art_sys_168: -0.0
+  art_sys_168: 0.0
   art_sys_169: 0.0
   art_sys_170: 0.0
-  art_sys_171: -0.0
+  art_sys_171: 0.0
   art_sys_172: 0.0
-  art_sys_173: -0.0
-  art_sys_174: -0.0
-  art_sys_175: -0.0
-  art_sys_176: -0.0
+  art_sys_173: 0.0
+  art_sys_174: 0.0
+  art_sys_175: 0.0
+  art_sys_176: 0.0
   art_sys_177: 0.0
   art_sys_178: 0.0
   art_sys_179: 0.0
-  art_sys_180: -0.0
+  art_sys_180: 0.0
   art_sys_181: 0.0
   art_sys_182: 0.0
   art_sys_183: 0.0
@@ -63913,8 +63913,8 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 5.48566695e+02
   Unfolding-: -6.09518550e+02
@@ -63968,186 +63968,186 @@ bins:
   RelativeStatFSR-: -8.82476857e+04
   luminosity_uncertainty: 3.24807600e+02
   uncorrelated_uncertainty: 124.926
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
-  art_sys_4: -0.0
+  art_sys_3: 0.0
+  art_sys_4: 0.0
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
-  art_sys_28: -0.0
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_28: 0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
-  art_sys_39: -0.0
+  art_sys_39: 0.0
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
-  art_sys_45: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
+  art_sys_45: 0.0
   art_sys_46: 0.0
-  art_sys_47: -0.0
-  art_sys_48: -0.0
+  art_sys_47: 0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 0.0
   art_sys_54: 0.0
   art_sys_55: 0.0
-  art_sys_56: -0.0
+  art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
-  art_sys_62: -0.0
-  art_sys_63: -0.0
+  art_sys_62: 0.0
+  art_sys_63: 0.0
   art_sys_64: 0.0
   art_sys_65: 0.0
   art_sys_66: 0.0
   art_sys_67: 0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
-  art_sys_71: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
+  art_sys_71: 0.0
   art_sys_72: 0.0
-  art_sys_73: -0.0
+  art_sys_73: 0.0
   art_sys_74: 0.0
-  art_sys_75: -0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_75: 0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 0.0
-  art_sys_88: -0.0
-  art_sys_89: -0.0
+  art_sys_88: 0.0
+  art_sys_89: 0.0
   art_sys_90: 0.0
   art_sys_91: 0.0
-  art_sys_92: -0.0
+  art_sys_92: 0.0
   art_sys_93: 0.0
   art_sys_94: 0.0
-  art_sys_95: -0.0
-  art_sys_96: -0.0
-  art_sys_97: -0.0
+  art_sys_95: 0.0
+  art_sys_96: 0.0
+  art_sys_97: 0.0
   art_sys_98: 0.0
   art_sys_99: 0.0
-  art_sys_100: -0.0
+  art_sys_100: 0.0
   art_sys_101: 0.0
-  art_sys_102: -0.0
+  art_sys_102: 0.0
   art_sys_103: 0.0
-  art_sys_104: -0.0
+  art_sys_104: 0.0
   art_sys_105: 0.0
   art_sys_106: 0.0
-  art_sys_107: -0.0
-  art_sys_108: -0.0
-  art_sys_109: -0.0
-  art_sys_110: -0.0
-  art_sys_111: -0.0
-  art_sys_112: -0.0
+  art_sys_107: 0.0
+  art_sys_108: 0.0
+  art_sys_109: 0.0
+  art_sys_110: 0.0
+  art_sys_111: 0.0
+  art_sys_112: 0.0
   art_sys_113: 0.0
-  art_sys_114: -0.0
+  art_sys_114: 0.0
   art_sys_115: 0.0
-  art_sys_116: -0.0
+  art_sys_116: 0.0
   art_sys_117: 0.0
   art_sys_118: 0.0
   art_sys_119: 0.0
   art_sys_120: 0.0
   art_sys_121: 0.0
   art_sys_122: 0.0
-  art_sys_123: -0.0
+  art_sys_123: 0.0
   art_sys_124: 0.0
   art_sys_125: 0.0
   art_sys_126: 0.0
-  art_sys_127: -0.0
-  art_sys_128: -0.0
+  art_sys_127: 0.0
+  art_sys_128: 0.0
   art_sys_129: 0.0
   art_sys_130: 0.0
   art_sys_131: 0.0
-  art_sys_132: -0.0
-  art_sys_133: -0.0
+  art_sys_132: 0.0
+  art_sys_133: 0.0
   art_sys_134: 0.0
   art_sys_135: 0.0
   art_sys_136: 0.0
   art_sys_137: 0.0
-  art_sys_138: -0.0
+  art_sys_138: 0.0
   art_sys_139: 0.0
   art_sys_140: 0.0
   art_sys_141: 0.0
-  art_sys_142: -0.0
+  art_sys_142: 0.0
   art_sys_143: 0.0
-  art_sys_144: -0.0
-  art_sys_145: -0.0
+  art_sys_144: 0.0
+  art_sys_145: 0.0
   art_sys_146: 0.0
-  art_sys_147: -0.0
+  art_sys_147: 0.0
   art_sys_148: 0.0
   art_sys_149: 0.0
-  art_sys_150: -0.0
-  art_sys_151: -0.0
-  art_sys_152: -0.0
+  art_sys_150: 0.0
+  art_sys_151: 0.0
+  art_sys_152: 0.0
   art_sys_153: 0.0
   art_sys_154: 0.0
   art_sys_155: 0.0
-  art_sys_156: -0.0
-  art_sys_157: -0.0
+  art_sys_156: 0.0
+  art_sys_157: 0.0
   art_sys_158: 0.0
-  art_sys_159: -0.0
-  art_sys_160: -0.0
-  art_sys_161: -0.0
+  art_sys_159: 0.0
+  art_sys_160: 0.0
+  art_sys_161: 0.0
   art_sys_162: 0.0
   art_sys_163: 0.0
-  art_sys_164: -0.0
+  art_sys_164: 0.0
   art_sys_165: 0.0
-  art_sys_166: -0.0
+  art_sys_166: 0.0
   art_sys_167: 0.0
-  art_sys_168: -0.0
+  art_sys_168: 0.0
   art_sys_169: 0.0
   art_sys_170: 0.0
-  art_sys_171: -0.0
+  art_sys_171: 0.0
   art_sys_172: 0.0
-  art_sys_173: -0.0
-  art_sys_174: -0.0
-  art_sys_175: -0.0
-  art_sys_176: -0.0
+  art_sys_173: 0.0
+  art_sys_174: 0.0
+  art_sys_175: 0.0
+  art_sys_176: 0.0
   art_sys_177: 0.0
   art_sys_178: 0.0
   art_sys_179: 0.0
-  art_sys_180: -0.0
+  art_sys_180: 0.0
   art_sys_181: 0.0
   art_sys_182: 0.0
   art_sys_183: 0.0
@@ -64204,8 +64204,8 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 5.48566695e+02
   Unfolding-: -6.09518550e+02
@@ -64259,186 +64259,186 @@ bins:
   RelativeStatFSR-: -8.82476857e+04
   luminosity_uncertainty: 3.24807600e+02
   uncorrelated_uncertainty: 124.926
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
-  art_sys_4: -0.0
+  art_sys_3: 0.0
+  art_sys_4: 0.0
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
-  art_sys_28: -0.0
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_28: 0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
-  art_sys_39: -0.0
+  art_sys_39: 0.0
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
-  art_sys_45: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
+  art_sys_45: 0.0
   art_sys_46: 0.0
-  art_sys_47: -0.0
-  art_sys_48: -0.0
+  art_sys_47: 0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 0.0
   art_sys_54: 0.0
   art_sys_55: 0.0
-  art_sys_56: -0.0
+  art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
-  art_sys_62: -0.0
-  art_sys_63: -0.0
+  art_sys_62: 0.0
+  art_sys_63: 0.0
   art_sys_64: 0.0
   art_sys_65: 0.0
   art_sys_66: 0.0
   art_sys_67: 0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
-  art_sys_71: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
+  art_sys_71: 0.0
   art_sys_72: 0.0
-  art_sys_73: -0.0
+  art_sys_73: 0.0
   art_sys_74: 0.0
-  art_sys_75: -0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_75: 0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 0.0
-  art_sys_88: -0.0
-  art_sys_89: -0.0
+  art_sys_88: 0.0
+  art_sys_89: 0.0
   art_sys_90: 0.0
   art_sys_91: 0.0
-  art_sys_92: -0.0
+  art_sys_92: 0.0
   art_sys_93: 0.0
   art_sys_94: 0.0
-  art_sys_95: -0.0
-  art_sys_96: -0.0
-  art_sys_97: -0.0
+  art_sys_95: 0.0
+  art_sys_96: 0.0
+  art_sys_97: 0.0
   art_sys_98: 0.0
   art_sys_99: 0.0
-  art_sys_100: -0.0
+  art_sys_100: 0.0
   art_sys_101: 0.0
-  art_sys_102: -0.0
+  art_sys_102: 0.0
   art_sys_103: 0.0
-  art_sys_104: -0.0
+  art_sys_104: 0.0
   art_sys_105: 0.0
   art_sys_106: 0.0
-  art_sys_107: -0.0
-  art_sys_108: -0.0
-  art_sys_109: -0.0
-  art_sys_110: -0.0
-  art_sys_111: -0.0
-  art_sys_112: -0.0
+  art_sys_107: 0.0
+  art_sys_108: 0.0
+  art_sys_109: 0.0
+  art_sys_110: 0.0
+  art_sys_111: 0.0
+  art_sys_112: 0.0
   art_sys_113: 0.0
-  art_sys_114: -0.0
+  art_sys_114: 0.0
   art_sys_115: 0.0
-  art_sys_116: -0.0
+  art_sys_116: 0.0
   art_sys_117: 0.0
   art_sys_118: 0.0
   art_sys_119: 0.0
   art_sys_120: 0.0
   art_sys_121: 0.0
   art_sys_122: 0.0
-  art_sys_123: -0.0
+  art_sys_123: 0.0
   art_sys_124: 0.0
   art_sys_125: 0.0
   art_sys_126: 0.0
-  art_sys_127: -0.0
-  art_sys_128: -0.0
+  art_sys_127: 0.0
+  art_sys_128: 0.0
   art_sys_129: 0.0
   art_sys_130: 0.0
   art_sys_131: 0.0
-  art_sys_132: -0.0
-  art_sys_133: -0.0
+  art_sys_132: 0.0
+  art_sys_133: 0.0
   art_sys_134: 0.0
   art_sys_135: 0.0
   art_sys_136: 0.0
   art_sys_137: 0.0
-  art_sys_138: -0.0
+  art_sys_138: 0.0
   art_sys_139: 0.0
   art_sys_140: 0.0
   art_sys_141: 0.0
-  art_sys_142: -0.0
+  art_sys_142: 0.0
   art_sys_143: 0.0
-  art_sys_144: -0.0
-  art_sys_145: -0.0
+  art_sys_144: 0.0
+  art_sys_145: 0.0
   art_sys_146: 0.0
-  art_sys_147: -0.0
+  art_sys_147: 0.0
   art_sys_148: 0.0
   art_sys_149: 0.0
-  art_sys_150: -0.0
-  art_sys_151: -0.0
-  art_sys_152: -0.0
+  art_sys_150: 0.0
+  art_sys_151: 0.0
+  art_sys_152: 0.0
   art_sys_153: 0.0
   art_sys_154: 0.0
   art_sys_155: 0.0
-  art_sys_156: -0.0
-  art_sys_157: -0.0
+  art_sys_156: 0.0
+  art_sys_157: 0.0
   art_sys_158: 0.0
-  art_sys_159: -0.0
-  art_sys_160: -0.0
-  art_sys_161: -0.0
+  art_sys_159: 0.0
+  art_sys_160: 0.0
+  art_sys_161: 0.0
   art_sys_162: 0.0
   art_sys_163: 0.0
-  art_sys_164: -0.0
+  art_sys_164: 0.0
   art_sys_165: 0.0
-  art_sys_166: -0.0
+  art_sys_166: 0.0
   art_sys_167: 0.0
-  art_sys_168: -0.0
+  art_sys_168: 0.0
   art_sys_169: 0.0
   art_sys_170: 0.0
-  art_sys_171: -0.0
+  art_sys_171: 0.0
   art_sys_172: 0.0
-  art_sys_173: -0.0
-  art_sys_174: -0.0
-  art_sys_175: -0.0
-  art_sys_176: -0.0
+  art_sys_173: 0.0
+  art_sys_174: 0.0
+  art_sys_175: 0.0
+  art_sys_176: 0.0
   art_sys_177: 0.0
   art_sys_178: 0.0
   art_sys_179: 0.0
-  art_sys_180: -0.0
+  art_sys_180: 0.0
   art_sys_181: 0.0
   art_sys_182: 0.0
   art_sys_183: 0.0
@@ -64495,8 +64495,8 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 5.48566695e+02
   Unfolding-: -6.09518550e+02
@@ -64550,186 +64550,186 @@ bins:
   RelativeStatFSR-: -8.82476857e+04
   luminosity_uncertainty: 3.24807600e+02
   uncorrelated_uncertainty: 124.926
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
-  art_sys_4: -0.0
+  art_sys_3: 0.0
+  art_sys_4: 0.0
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
-  art_sys_28: -0.0
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_28: 0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
-  art_sys_39: -0.0
+  art_sys_39: 0.0
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
-  art_sys_45: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
+  art_sys_45: 0.0
   art_sys_46: 0.0
-  art_sys_47: -0.0
-  art_sys_48: -0.0
+  art_sys_47: 0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 0.0
   art_sys_54: 0.0
   art_sys_55: 0.0
-  art_sys_56: -0.0
+  art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
-  art_sys_62: -0.0
-  art_sys_63: -0.0
+  art_sys_62: 0.0
+  art_sys_63: 0.0
   art_sys_64: 0.0
   art_sys_65: 0.0
   art_sys_66: 0.0
   art_sys_67: 0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
-  art_sys_71: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
+  art_sys_71: 0.0
   art_sys_72: 0.0
-  art_sys_73: -0.0
+  art_sys_73: 0.0
   art_sys_74: 0.0
-  art_sys_75: -0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_75: 0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 0.0
-  art_sys_88: -0.0
-  art_sys_89: -0.0
+  art_sys_88: 0.0
+  art_sys_89: 0.0
   art_sys_90: 0.0
   art_sys_91: 0.0
-  art_sys_92: -0.0
+  art_sys_92: 0.0
   art_sys_93: 0.0
   art_sys_94: 0.0
-  art_sys_95: -0.0
-  art_sys_96: -0.0
-  art_sys_97: -0.0
+  art_sys_95: 0.0
+  art_sys_96: 0.0
+  art_sys_97: 0.0
   art_sys_98: 0.0
   art_sys_99: 0.0
-  art_sys_100: -0.0
+  art_sys_100: 0.0
   art_sys_101: 0.0
-  art_sys_102: -0.0
+  art_sys_102: 0.0
   art_sys_103: 0.0
-  art_sys_104: -0.0
+  art_sys_104: 0.0
   art_sys_105: 0.0
   art_sys_106: 0.0
-  art_sys_107: -0.0
-  art_sys_108: -0.0
-  art_sys_109: -0.0
-  art_sys_110: -0.0
-  art_sys_111: -0.0
-  art_sys_112: -0.0
+  art_sys_107: 0.0
+  art_sys_108: 0.0
+  art_sys_109: 0.0
+  art_sys_110: 0.0
+  art_sys_111: 0.0
+  art_sys_112: 0.0
   art_sys_113: 0.0
-  art_sys_114: -0.0
+  art_sys_114: 0.0
   art_sys_115: 0.0
-  art_sys_116: -0.0
+  art_sys_116: 0.0
   art_sys_117: 0.0
   art_sys_118: 0.0
   art_sys_119: 0.0
   art_sys_120: 0.0
   art_sys_121: 0.0
   art_sys_122: 0.0
-  art_sys_123: -0.0
+  art_sys_123: 0.0
   art_sys_124: 0.0
   art_sys_125: 0.0
   art_sys_126: 0.0
-  art_sys_127: -0.0
-  art_sys_128: -0.0
+  art_sys_127: 0.0
+  art_sys_128: 0.0
   art_sys_129: 0.0
   art_sys_130: 0.0
   art_sys_131: 0.0
-  art_sys_132: -0.0
-  art_sys_133: -0.0
+  art_sys_132: 0.0
+  art_sys_133: 0.0
   art_sys_134: 0.0
   art_sys_135: 0.0
   art_sys_136: 0.0
   art_sys_137: 0.0
-  art_sys_138: -0.0
+  art_sys_138: 0.0
   art_sys_139: 0.0
   art_sys_140: 0.0
   art_sys_141: 0.0
-  art_sys_142: -0.0
+  art_sys_142: 0.0
   art_sys_143: 0.0
-  art_sys_144: -0.0
-  art_sys_145: -0.0
+  art_sys_144: 0.0
+  art_sys_145: 0.0
   art_sys_146: 0.0
-  art_sys_147: -0.0
+  art_sys_147: 0.0
   art_sys_148: 0.0
   art_sys_149: 0.0
-  art_sys_150: -0.0
-  art_sys_151: -0.0
-  art_sys_152: -0.0
+  art_sys_150: 0.0
+  art_sys_151: 0.0
+  art_sys_152: 0.0
   art_sys_153: 0.0
   art_sys_154: 0.0
   art_sys_155: 0.0
-  art_sys_156: -0.0
-  art_sys_157: -0.0
+  art_sys_156: 0.0
+  art_sys_157: 0.0
   art_sys_158: 0.0
-  art_sys_159: -0.0
-  art_sys_160: -0.0
-  art_sys_161: -0.0
+  art_sys_159: 0.0
+  art_sys_160: 0.0
+  art_sys_161: 0.0
   art_sys_162: 0.0
   art_sys_163: 0.0
-  art_sys_164: -0.0
+  art_sys_164: 0.0
   art_sys_165: 0.0
-  art_sys_166: -0.0
+  art_sys_166: 0.0
   art_sys_167: 0.0
-  art_sys_168: -0.0
+  art_sys_168: 0.0
   art_sys_169: 0.0
   art_sys_170: 0.0
-  art_sys_171: -0.0
+  art_sys_171: 0.0
   art_sys_172: 0.0
-  art_sys_173: -0.0
-  art_sys_174: -0.0
-  art_sys_175: -0.0
-  art_sys_176: -0.0
+  art_sys_173: 0.0
+  art_sys_174: 0.0
+  art_sys_175: 0.0
+  art_sys_176: 0.0
   art_sys_177: 0.0
   art_sys_178: 0.0
   art_sys_179: 0.0
-  art_sys_180: -0.0
+  art_sys_180: 0.0
   art_sys_181: 0.0
   art_sys_182: 0.0
   art_sys_183: 0.0
@@ -64786,8 +64786,8 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 5.48566695e+02
   Unfolding-: -6.09518550e+02
@@ -64841,186 +64841,186 @@ bins:
   RelativeStatFSR-: -8.82476857e+04
   luminosity_uncertainty: 3.24807600e+02
   uncorrelated_uncertainty: 124.926
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
-  art_sys_4: -0.0
+  art_sys_3: 0.0
+  art_sys_4: 0.0
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
-  art_sys_28: -0.0
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_28: 0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
-  art_sys_39: -0.0
+  art_sys_39: 0.0
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
-  art_sys_45: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
+  art_sys_45: 0.0
   art_sys_46: 0.0
-  art_sys_47: -0.0
-  art_sys_48: -0.0
+  art_sys_47: 0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 0.0
   art_sys_54: 0.0
   art_sys_55: 0.0
-  art_sys_56: -0.0
+  art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
-  art_sys_62: -0.0
-  art_sys_63: -0.0
+  art_sys_62: 0.0
+  art_sys_63: 0.0
   art_sys_64: 0.0
   art_sys_65: 0.0
   art_sys_66: 0.0
   art_sys_67: 0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
-  art_sys_71: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
+  art_sys_71: 0.0
   art_sys_72: 0.0
-  art_sys_73: -0.0
+  art_sys_73: 0.0
   art_sys_74: 0.0
-  art_sys_75: -0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_75: 0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 0.0
-  art_sys_88: -0.0
-  art_sys_89: -0.0
+  art_sys_88: 0.0
+  art_sys_89: 0.0
   art_sys_90: 0.0
   art_sys_91: 0.0
-  art_sys_92: -0.0
+  art_sys_92: 0.0
   art_sys_93: 0.0
   art_sys_94: 0.0
-  art_sys_95: -0.0
-  art_sys_96: -0.0
-  art_sys_97: -0.0
+  art_sys_95: 0.0
+  art_sys_96: 0.0
+  art_sys_97: 0.0
   art_sys_98: 0.0
   art_sys_99: 0.0
-  art_sys_100: -0.0
+  art_sys_100: 0.0
   art_sys_101: 0.0
-  art_sys_102: -0.0
+  art_sys_102: 0.0
   art_sys_103: 0.0
-  art_sys_104: -0.0
+  art_sys_104: 0.0
   art_sys_105: 0.0
   art_sys_106: 0.0
-  art_sys_107: -0.0
-  art_sys_108: -0.0
-  art_sys_109: -0.0
-  art_sys_110: -0.0
-  art_sys_111: -0.0
-  art_sys_112: -0.0
+  art_sys_107: 0.0
+  art_sys_108: 0.0
+  art_sys_109: 0.0
+  art_sys_110: 0.0
+  art_sys_111: 0.0
+  art_sys_112: 0.0
   art_sys_113: 0.0
-  art_sys_114: -0.0
+  art_sys_114: 0.0
   art_sys_115: 0.0
-  art_sys_116: -0.0
+  art_sys_116: 0.0
   art_sys_117: 0.0
   art_sys_118: 0.0
   art_sys_119: 0.0
   art_sys_120: 0.0
   art_sys_121: 0.0
   art_sys_122: 0.0
-  art_sys_123: -0.0
+  art_sys_123: 0.0
   art_sys_124: 0.0
   art_sys_125: 0.0
   art_sys_126: 0.0
-  art_sys_127: -0.0
-  art_sys_128: -0.0
+  art_sys_127: 0.0
+  art_sys_128: 0.0
   art_sys_129: 0.0
   art_sys_130: 0.0
   art_sys_131: 0.0
-  art_sys_132: -0.0
-  art_sys_133: -0.0
+  art_sys_132: 0.0
+  art_sys_133: 0.0
   art_sys_134: 0.0
   art_sys_135: 0.0
   art_sys_136: 0.0
   art_sys_137: 0.0
-  art_sys_138: -0.0
+  art_sys_138: 0.0
   art_sys_139: 0.0
   art_sys_140: 0.0
   art_sys_141: 0.0
-  art_sys_142: -0.0
+  art_sys_142: 0.0
   art_sys_143: 0.0
-  art_sys_144: -0.0
-  art_sys_145: -0.0
+  art_sys_144: 0.0
+  art_sys_145: 0.0
   art_sys_146: 0.0
-  art_sys_147: -0.0
+  art_sys_147: 0.0
   art_sys_148: 0.0
   art_sys_149: 0.0
-  art_sys_150: -0.0
-  art_sys_151: -0.0
-  art_sys_152: -0.0
+  art_sys_150: 0.0
+  art_sys_151: 0.0
+  art_sys_152: 0.0
   art_sys_153: 0.0
   art_sys_154: 0.0
   art_sys_155: 0.0
-  art_sys_156: -0.0
-  art_sys_157: -0.0
+  art_sys_156: 0.0
+  art_sys_157: 0.0
   art_sys_158: 0.0
-  art_sys_159: -0.0
-  art_sys_160: -0.0
-  art_sys_161: -0.0
+  art_sys_159: 0.0
+  art_sys_160: 0.0
+  art_sys_161: 0.0
   art_sys_162: 0.0
   art_sys_163: 0.0
-  art_sys_164: -0.0
+  art_sys_164: 0.0
   art_sys_165: 0.0
-  art_sys_166: -0.0
+  art_sys_166: 0.0
   art_sys_167: 0.0
-  art_sys_168: -0.0
+  art_sys_168: 0.0
   art_sys_169: 0.0
   art_sys_170: 0.0
-  art_sys_171: -0.0
+  art_sys_171: 0.0
   art_sys_172: 0.0
-  art_sys_173: -0.0
-  art_sys_174: -0.0
-  art_sys_175: -0.0
-  art_sys_176: -0.0
+  art_sys_173: 0.0
+  art_sys_174: 0.0
+  art_sys_175: 0.0
+  art_sys_176: 0.0
   art_sys_177: 0.0
   art_sys_178: 0.0
   art_sys_179: 0.0
-  art_sys_180: -0.0
+  art_sys_180: 0.0
   art_sys_181: 0.0
   art_sys_182: 0.0
   art_sys_183: 0.0
@@ -65077,8 +65077,8 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 5.48566695e+02
   Unfolding-: -6.09518550e+02
@@ -65132,186 +65132,186 @@ bins:
   RelativeStatFSR-: -8.82476857e+04
   luminosity_uncertainty: 3.24807600e+02
   uncorrelated_uncertainty: 124.926
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
-  art_sys_4: -0.0
+  art_sys_3: 0.0
+  art_sys_4: 0.0
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
-  art_sys_28: -0.0
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_28: 0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
-  art_sys_39: -0.0
+  art_sys_39: 0.0
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
-  art_sys_45: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
+  art_sys_45: 0.0
   art_sys_46: 0.0
-  art_sys_47: -0.0
-  art_sys_48: -0.0
+  art_sys_47: 0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 0.0
   art_sys_54: 0.0
   art_sys_55: 0.0
-  art_sys_56: -0.0
+  art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
-  art_sys_62: -0.0
-  art_sys_63: -0.0
+  art_sys_62: 0.0
+  art_sys_63: 0.0
   art_sys_64: 0.0
   art_sys_65: 0.0
   art_sys_66: 0.0
   art_sys_67: 0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
-  art_sys_71: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
+  art_sys_71: 0.0
   art_sys_72: 0.0
-  art_sys_73: -0.0
+  art_sys_73: 0.0
   art_sys_74: 0.0
-  art_sys_75: -0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_75: 0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 0.0
-  art_sys_88: -0.0
-  art_sys_89: -0.0
+  art_sys_88: 0.0
+  art_sys_89: 0.0
   art_sys_90: 0.0
   art_sys_91: 0.0
-  art_sys_92: -0.0
+  art_sys_92: 0.0
   art_sys_93: 0.0
   art_sys_94: 0.0
-  art_sys_95: -0.0
-  art_sys_96: -0.0
-  art_sys_97: -0.0
+  art_sys_95: 0.0
+  art_sys_96: 0.0
+  art_sys_97: 0.0
   art_sys_98: 0.0
   art_sys_99: 0.0
-  art_sys_100: -0.0
+  art_sys_100: 0.0
   art_sys_101: 0.0
-  art_sys_102: -0.0
+  art_sys_102: 0.0
   art_sys_103: 0.0
-  art_sys_104: -0.0
+  art_sys_104: 0.0
   art_sys_105: 0.0
   art_sys_106: 0.0
-  art_sys_107: -0.0
-  art_sys_108: -0.0
-  art_sys_109: -0.0
-  art_sys_110: -0.0
-  art_sys_111: -0.0
-  art_sys_112: -0.0
+  art_sys_107: 0.0
+  art_sys_108: 0.0
+  art_sys_109: 0.0
+  art_sys_110: 0.0
+  art_sys_111: 0.0
+  art_sys_112: 0.0
   art_sys_113: 0.0
-  art_sys_114: -0.0
+  art_sys_114: 0.0
   art_sys_115: 0.0
-  art_sys_116: -0.0
+  art_sys_116: 0.0
   art_sys_117: 0.0
   art_sys_118: 0.0
   art_sys_119: 0.0
   art_sys_120: 0.0
   art_sys_121: 0.0
   art_sys_122: 0.0
-  art_sys_123: -0.0
+  art_sys_123: 0.0
   art_sys_124: 0.0
   art_sys_125: 0.0
   art_sys_126: 0.0
-  art_sys_127: -0.0
-  art_sys_128: -0.0
+  art_sys_127: 0.0
+  art_sys_128: 0.0
   art_sys_129: 0.0
   art_sys_130: 0.0
   art_sys_131: 0.0
-  art_sys_132: -0.0
-  art_sys_133: -0.0
+  art_sys_132: 0.0
+  art_sys_133: 0.0
   art_sys_134: 0.0
   art_sys_135: 0.0
   art_sys_136: 0.0
   art_sys_137: 0.0
-  art_sys_138: -0.0
+  art_sys_138: 0.0
   art_sys_139: 0.0
   art_sys_140: 0.0
   art_sys_141: 0.0
-  art_sys_142: -0.0
+  art_sys_142: 0.0
   art_sys_143: 0.0
-  art_sys_144: -0.0
-  art_sys_145: -0.0
+  art_sys_144: 0.0
+  art_sys_145: 0.0
   art_sys_146: 0.0
-  art_sys_147: -0.0
+  art_sys_147: 0.0
   art_sys_148: 0.0
   art_sys_149: 0.0
-  art_sys_150: -0.0
-  art_sys_151: -0.0
-  art_sys_152: -0.0
+  art_sys_150: 0.0
+  art_sys_151: 0.0
+  art_sys_152: 0.0
   art_sys_153: 0.0
   art_sys_154: 0.0
   art_sys_155: 0.0
-  art_sys_156: -0.0
-  art_sys_157: -0.0
+  art_sys_156: 0.0
+  art_sys_157: 0.0
   art_sys_158: 0.0
-  art_sys_159: -0.0
-  art_sys_160: -0.0
-  art_sys_161: -0.0
+  art_sys_159: 0.0
+  art_sys_160: 0.0
+  art_sys_161: 0.0
   art_sys_162: 0.0
   art_sys_163: 0.0
-  art_sys_164: -0.0
+  art_sys_164: 0.0
   art_sys_165: 0.0
-  art_sys_166: -0.0
+  art_sys_166: 0.0
   art_sys_167: 0.0
-  art_sys_168: -0.0
+  art_sys_168: 0.0
   art_sys_169: 0.0
   art_sys_170: 0.0
-  art_sys_171: -0.0
+  art_sys_171: 0.0
   art_sys_172: 0.0
-  art_sys_173: -0.0
-  art_sys_174: -0.0
-  art_sys_175: -0.0
-  art_sys_176: -0.0
+  art_sys_173: 0.0
+  art_sys_174: 0.0
+  art_sys_175: 0.0
+  art_sys_176: 0.0
   art_sys_177: 0.0
   art_sys_178: 0.0
   art_sys_179: 0.0
-  art_sys_180: -0.0
+  art_sys_180: 0.0
   art_sys_181: 0.0
   art_sys_182: 0.0
   art_sys_183: 0.0
@@ -65368,8 +65368,8 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 5.48566695e+02
   Unfolding-: -6.09518550e+02
@@ -65423,186 +65423,186 @@ bins:
   RelativeStatFSR-: -8.82476857e+04
   luminosity_uncertainty: 3.24807600e+02
   uncorrelated_uncertainty: 124.926
-- art_sys_1: -0.0
+- art_sys_1: 0.0
   art_sys_2: 0.0
-  art_sys_3: -0.0
-  art_sys_4: -0.0
+  art_sys_3: 0.0
+  art_sys_4: 0.0
   art_sys_5: 0.0
   art_sys_6: 0.0
-  art_sys_7: -0.0
+  art_sys_7: 0.0
   art_sys_8: 0.0
-  art_sys_9: -0.0
+  art_sys_9: 0.0
   art_sys_10: 0.0
-  art_sys_11: -0.0
-  art_sys_12: -0.0
+  art_sys_11: 0.0
+  art_sys_12: 0.0
   art_sys_13: 0.0
   art_sys_14: 0.0
   art_sys_15: 0.0
   art_sys_16: 0.0
   art_sys_17: 0.0
-  art_sys_18: -0.0
+  art_sys_18: 0.0
   art_sys_19: 0.0
   art_sys_20: 0.0
   art_sys_21: 0.0
   art_sys_22: 0.0
-  art_sys_23: -0.0
-  art_sys_24: -0.0
+  art_sys_23: 0.0
+  art_sys_24: 0.0
   art_sys_25: 0.0
-  art_sys_26: -0.0
+  art_sys_26: 0.0
   art_sys_27: 0.0
-  art_sys_28: -0.0
-  art_sys_29: -0.0
-  art_sys_30: -0.0
-  art_sys_31: -0.0
-  art_sys_32: -0.0
-  art_sys_33: -0.0
-  art_sys_34: -0.0
+  art_sys_28: 0.0
+  art_sys_29: 0.0
+  art_sys_30: 0.0
+  art_sys_31: 0.0
+  art_sys_32: 0.0
+  art_sys_33: 0.0
+  art_sys_34: 0.0
   art_sys_35: 0.0
-  art_sys_36: -0.0
-  art_sys_37: -0.0
+  art_sys_36: 0.0
+  art_sys_37: 0.0
   art_sys_38: 0.0
-  art_sys_39: -0.0
+  art_sys_39: 0.0
   art_sys_40: 0.0
   art_sys_41: 0.0
-  art_sys_42: -0.0
-  art_sys_43: -0.0
-  art_sys_44: -0.0
-  art_sys_45: -0.0
+  art_sys_42: 0.0
+  art_sys_43: 0.0
+  art_sys_44: 0.0
+  art_sys_45: 0.0
   art_sys_46: 0.0
-  art_sys_47: -0.0
-  art_sys_48: -0.0
+  art_sys_47: 0.0
+  art_sys_48: 0.0
   art_sys_49: 0.0
-  art_sys_50: -0.0
-  art_sys_51: -0.0
+  art_sys_50: 0.0
+  art_sys_51: 0.0
   art_sys_52: 0.0
   art_sys_53: 0.0
   art_sys_54: 0.0
   art_sys_55: 0.0
-  art_sys_56: -0.0
+  art_sys_56: 0.0
   art_sys_57: 0.0
   art_sys_58: 0.0
-  art_sys_59: -0.0
-  art_sys_60: -0.0
+  art_sys_59: 0.0
+  art_sys_60: 0.0
   art_sys_61: 0.0
-  art_sys_62: -0.0
-  art_sys_63: -0.0
+  art_sys_62: 0.0
+  art_sys_63: 0.0
   art_sys_64: 0.0
   art_sys_65: 0.0
   art_sys_66: 0.0
   art_sys_67: 0.0
-  art_sys_68: -0.0
-  art_sys_69: -0.0
-  art_sys_70: -0.0
-  art_sys_71: -0.0
+  art_sys_68: 0.0
+  art_sys_69: 0.0
+  art_sys_70: 0.0
+  art_sys_71: 0.0
   art_sys_72: 0.0
-  art_sys_73: -0.0
+  art_sys_73: 0.0
   art_sys_74: 0.0
-  art_sys_75: -0.0
-  art_sys_76: -0.0
-  art_sys_77: -0.0
+  art_sys_75: 0.0
+  art_sys_76: 0.0
+  art_sys_77: 0.0
   art_sys_78: 0.0
-  art_sys_79: -0.0
+  art_sys_79: 0.0
   art_sys_80: 0.0
   art_sys_81: 0.0
   art_sys_82: 0.0
-  art_sys_83: -0.0
+  art_sys_83: 0.0
   art_sys_84: 0.0
   art_sys_85: 0.0
-  art_sys_86: -0.0
+  art_sys_86: 0.0
   art_sys_87: 0.0
-  art_sys_88: -0.0
-  art_sys_89: -0.0
+  art_sys_88: 0.0
+  art_sys_89: 0.0
   art_sys_90: 0.0
   art_sys_91: 0.0
-  art_sys_92: -0.0
+  art_sys_92: 0.0
   art_sys_93: 0.0
   art_sys_94: 0.0
-  art_sys_95: -0.0
-  art_sys_96: -0.0
-  art_sys_97: -0.0
+  art_sys_95: 0.0
+  art_sys_96: 0.0
+  art_sys_97: 0.0
   art_sys_98: 0.0
   art_sys_99: 0.0
-  art_sys_100: -0.0
+  art_sys_100: 0.0
   art_sys_101: 0.0
-  art_sys_102: -0.0
+  art_sys_102: 0.0
   art_sys_103: 0.0
-  art_sys_104: -0.0
+  art_sys_104: 0.0
   art_sys_105: 0.0
   art_sys_106: 0.0
-  art_sys_107: -0.0
-  art_sys_108: -0.0
-  art_sys_109: -0.0
-  art_sys_110: -0.0
-  art_sys_111: -0.0
-  art_sys_112: -0.0
+  art_sys_107: 0.0
+  art_sys_108: 0.0
+  art_sys_109: 0.0
+  art_sys_110: 0.0
+  art_sys_111: 0.0
+  art_sys_112: 0.0
   art_sys_113: 0.0
-  art_sys_114: -0.0
+  art_sys_114: 0.0
   art_sys_115: 0.0
-  art_sys_116: -0.0
+  art_sys_116: 0.0
   art_sys_117: 0.0
   art_sys_118: 0.0
   art_sys_119: 0.0
   art_sys_120: 0.0
   art_sys_121: 0.0
   art_sys_122: 0.0
-  art_sys_123: -0.0
+  art_sys_123: 0.0
   art_sys_124: 0.0
   art_sys_125: 0.0
   art_sys_126: 0.0
-  art_sys_127: -0.0
-  art_sys_128: -0.0
+  art_sys_127: 0.0
+  art_sys_128: 0.0
   art_sys_129: 0.0
   art_sys_130: 0.0
   art_sys_131: 0.0
-  art_sys_132: -0.0
-  art_sys_133: -0.0
+  art_sys_132: 0.0
+  art_sys_133: 0.0
   art_sys_134: 0.0
   art_sys_135: 0.0
   art_sys_136: 0.0
   art_sys_137: 0.0
-  art_sys_138: -0.0
+  art_sys_138: 0.0
   art_sys_139: 0.0
   art_sys_140: 0.0
   art_sys_141: 0.0
-  art_sys_142: -0.0
+  art_sys_142: 0.0
   art_sys_143: 0.0
-  art_sys_144: -0.0
-  art_sys_145: -0.0
+  art_sys_144: 0.0
+  art_sys_145: 0.0
   art_sys_146: 0.0
-  art_sys_147: -0.0
+  art_sys_147: 0.0
   art_sys_148: 0.0
   art_sys_149: 0.0
-  art_sys_150: -0.0
-  art_sys_151: -0.0
-  art_sys_152: -0.0
+  art_sys_150: 0.0
+  art_sys_151: 0.0
+  art_sys_152: 0.0
   art_sys_153: 0.0
   art_sys_154: 0.0
   art_sys_155: 0.0
-  art_sys_156: -0.0
-  art_sys_157: -0.0
+  art_sys_156: 0.0
+  art_sys_157: 0.0
   art_sys_158: 0.0
-  art_sys_159: -0.0
-  art_sys_160: -0.0
-  art_sys_161: -0.0
+  art_sys_159: 0.0
+  art_sys_160: 0.0
+  art_sys_161: 0.0
   art_sys_162: 0.0
   art_sys_163: 0.0
-  art_sys_164: -0.0
+  art_sys_164: 0.0
   art_sys_165: 0.0
-  art_sys_166: -0.0
+  art_sys_166: 0.0
   art_sys_167: 0.0
-  art_sys_168: -0.0
+  art_sys_168: 0.0
   art_sys_169: 0.0
   art_sys_170: 0.0
-  art_sys_171: -0.0
+  art_sys_171: 0.0
   art_sys_172: 0.0
-  art_sys_173: -0.0
-  art_sys_174: -0.0
-  art_sys_175: -0.0
-  art_sys_176: -0.0
+  art_sys_173: 0.0
+  art_sys_174: 0.0
+  art_sys_175: 0.0
+  art_sys_176: 0.0
   art_sys_177: 0.0
   art_sys_178: 0.0
   art_sys_179: 0.0
-  art_sys_180: -0.0
+  art_sys_180: 0.0
   art_sys_181: 0.0
   art_sys_182: 0.0
   art_sys_183: 0.0
@@ -65659,8 +65659,8 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
   art_sys_239: 0.0
   Unfolding+: 5.48566695e+02
   Unfolding-: -6.09518550e+02
@@ -66241,9 +66241,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
-  art_sys_239: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
+  art_sys_239: 0.0
   Unfolding+: 2.28319684e+02
   Unfolding-: -2.53082756e+02
   AbsoluteStat+: 0.0
@@ -66532,9 +66532,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
-  art_sys_239: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
+  art_sys_239: 0.0
   Unfolding+: 8.29458163e+01
   Unfolding-: -9.17351256e+01
   AbsoluteStat+: 0.0
@@ -66823,9 +66823,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
-  art_sys_239: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
+  art_sys_239: 0.0
   Unfolding+: 2.72562633e+01
   Unfolding-: -3.00936234e+01
   AbsoluteStat+: 2.82313942e-01
@@ -67405,9 +67405,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
-  art_sys_239: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
+  art_sys_239: 0.0
   Unfolding+: 3.20055673e+00
   Unfolding-: -3.52818958e+00
   AbsoluteStat+: 9.27297014e-02
@@ -67987,9 +67987,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
-  art_sys_239: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
+  art_sys_239: 0.0
   Unfolding+: 4.17187416e-01
   Unfolding-: -4.59322305e-01
   AbsoluteStat+: 2.36510239e-02
@@ -68569,9 +68569,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
-  art_sys_239: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
+  art_sys_239: 0.0
   Unfolding+: 5.44265104e-02
   Unfolding-: -5.96015729e-02
   AbsoluteStat+: 4.83931449e-03
@@ -69151,9 +69151,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
-  art_sys_239: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
+  art_sys_239: 0.0
   Unfolding+: 6.65919020e-03
   Unfolding-: -7.20261375e-03
   AbsoluteStat+: 7.58691327e-04
@@ -69733,9 +69733,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
-  art_sys_239: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
+  art_sys_239: 0.0
   Unfolding+: 6.98425801e-04
   Unfolding-: -7.41313977e-04
   AbsoluteStat+: 8.69978504e-05
@@ -70315,9 +70315,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
-  art_sys_239: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
+  art_sys_239: 0.0
   Unfolding+: 4.50304561e-05
   Unfolding-: -4.68558254e-05
   AbsoluteStat+: 5.54631437e-06
@@ -70897,9 +70897,9 @@ bins:
   art_sys_234: 0.0
   art_sys_235: 0.0
   art_sys_236: 0.0
-  art_sys_237: -0.0
-  art_sys_238: -0.0
-  art_sys_239: -0.0
+  art_sys_237: 0.0
+  art_sys_238: 0.0
+  art_sys_239: 0.0
   Unfolding+: 1.12636024e-06
   Unfolding-: -1.14986023e-06
   AbsoluteStat+: 1.30315671e-07

--- a/nnpdf_data/nnpdf_data/commondata/CMS_2JET_7TEV/uncertainties.yaml
+++ b/nnpdf_data/nnpdf_data/commondata/CMS_2JET_7TEV/uncertainties.yaml
@@ -347,49 +347,49 @@ bins:
 - art_sys_corr_1: 2.79981072e+00
   art_sys_corr_2: 0.0
   art_sys_corr_3: 0.0
-  art_sys_corr_4: -0.0
+  art_sys_corr_4: 0.0
   art_sys_corr_5: 3.25563430e-02
-  art_sys_corr_6: -0.0
-  art_sys_corr_7: -0.0
-  art_sys_corr_8: -0.0
-  art_sys_corr_9: -0.0
+  art_sys_corr_6: 0.0
+  art_sys_corr_7: 0.0
+  art_sys_corr_8: 0.0
+  art_sys_corr_9: 0.0
   art_sys_corr_10: 1.06299438e-04
-  art_sys_corr_11: -0.0
-  art_sys_corr_12: -0.0
-  art_sys_corr_13: -0.0
+  art_sys_corr_11: 0.0
+  art_sys_corr_12: 0.0
+  art_sys_corr_13: 0.0
   art_sys_corr_14: 0.0
   art_sys_corr_15: 0.0
-  art_sys_corr_16: -0.0
-  art_sys_corr_17: -0.0
+  art_sys_corr_16: 0.0
+  art_sys_corr_17: 0.0
   art_sys_corr_18: 0.0
   art_sys_corr_19: 0.0
-  art_sys_corr_20: -0.0
+  art_sys_corr_20: 0.0
   art_sys_corr_21: 4.78177415e-07
-  art_sys_corr_22: -0.0
+  art_sys_corr_22: 0.0
   art_sys_corr_23: 0.0
   art_sys_corr_24: 0.0
   art_sys_corr_25: 1.09447820e-08
   art_sys_corr_26: 0.0
-  art_sys_corr_27: -0.0
-  art_sys_corr_28: -0.0
+  art_sys_corr_27: 0.0
+  art_sys_corr_28: 0.0
   art_sys_corr_29: 3.00504564e-10
   art_sys_corr_30: 0.0
   art_sys_corr_31: 0.0
   art_sys_corr_32: 0.0
   art_sys_corr_33: 0.0
-  art_sys_corr_34: -0.0
+  art_sys_corr_34: 0.0
   art_sys_corr_35: 1.79090195e-13
   art_sys_corr_36: 0.0
-  art_sys_corr_37: -0.0
+  art_sys_corr_37: 0.0
   art_sys_corr_38: 5.04550465e-15
   art_sys_corr_39: 0.0
-  art_sys_corr_40: -0.0
+  art_sys_corr_40: 0.0
   art_sys_corr_41: 0.0
   art_sys_corr_42: 1.63448238e-16
   art_sys_corr_43: 0.0
   art_sys_corr_44: 3.51530426e-18
-  art_sys_corr_45: -0.0
-  art_sys_corr_46: -0.0
+  art_sys_corr_45: 0.0
+  art_sys_corr_46: 0.0
   art_sys_corr_47: 9.14311392e-20
   art_sys_corr_48: 0.0
   art_sys_corr_49: 0.0
@@ -433,49 +433,49 @@ bins:
 - art_sys_corr_1: -1.18172584e-01
   art_sys_corr_2: 0.0
   art_sys_corr_3: 0.0
-  art_sys_corr_4: -0.0
+  art_sys_corr_4: 0.0
   art_sys_corr_5: 7.70982978e-01
-  art_sys_corr_6: -0.0
-  art_sys_corr_7: -0.0
-  art_sys_corr_8: -0.0
-  art_sys_corr_9: -0.0
+  art_sys_corr_6: 0.0
+  art_sys_corr_7: 0.0
+  art_sys_corr_8: 0.0
+  art_sys_corr_9: 0.0
   art_sys_corr_10: 4.52638410e-03
-  art_sys_corr_11: -0.0
-  art_sys_corr_12: -0.0
-  art_sys_corr_13: -0.0
+  art_sys_corr_11: 0.0
+  art_sys_corr_12: 0.0
+  art_sys_corr_13: 0.0
   art_sys_corr_14: 0.0
   art_sys_corr_15: 0.0
-  art_sys_corr_16: -0.0
-  art_sys_corr_17: -0.0
+  art_sys_corr_16: 0.0
+  art_sys_corr_17: 0.0
   art_sys_corr_18: 0.0
   art_sys_corr_19: 0.0
-  art_sys_corr_20: -0.0
+  art_sys_corr_20: 0.0
   art_sys_corr_21: -7.78808161e-06
-  art_sys_corr_22: -0.0
+  art_sys_corr_22: 0.0
   art_sys_corr_23: 0.0
   art_sys_corr_24: 0.0
   art_sys_corr_25: 9.30013734e-08
   art_sys_corr_26: 0.0
-  art_sys_corr_27: -0.0
-  art_sys_corr_28: -0.0
+  art_sys_corr_27: 0.0
+  art_sys_corr_28: 0.0
   art_sys_corr_29: 4.85547116e-09
   art_sys_corr_30: 0.0
   art_sys_corr_31: 0.0
   art_sys_corr_32: 0.0
   art_sys_corr_33: 0.0
-  art_sys_corr_34: -0.0
+  art_sys_corr_34: 0.0
   art_sys_corr_35: 4.29903113e-11
   art_sys_corr_36: 0.0
-  art_sys_corr_37: -0.0
+  art_sys_corr_37: 0.0
   art_sys_corr_38: 1.48643689e-12
   art_sys_corr_39: 0.0
-  art_sys_corr_40: -0.0
+  art_sys_corr_40: 0.0
   art_sys_corr_41: 0.0
   art_sys_corr_42: 5.03965910e-14
   art_sys_corr_43: 0.0
   art_sys_corr_44: 1.09677429e-15
-  art_sys_corr_45: -0.0
-  art_sys_corr_46: -0.0
+  art_sys_corr_45: 0.0
+  art_sys_corr_46: 0.0
   art_sys_corr_47: 2.85853827e-17
   art_sys_corr_48: 0.0
   art_sys_corr_49: 0.0
@@ -519,49 +519,49 @@ bins:
 - art_sys_corr_1: 1.70527617e-03
   art_sys_corr_2: 0.0
   art_sys_corr_3: 0.0
-  art_sys_corr_4: -0.0
+  art_sys_corr_4: 0.0
   art_sys_corr_5: -2.49815615e-02
-  art_sys_corr_6: -0.0
-  art_sys_corr_7: -0.0
-  art_sys_corr_8: -0.0
-  art_sys_corr_9: -0.0
+  art_sys_corr_6: 0.0
+  art_sys_corr_7: 0.0
+  art_sys_corr_8: 0.0
+  art_sys_corr_9: 0.0
   art_sys_corr_10: 1.39774479e-01
-  art_sys_corr_11: -0.0
-  art_sys_corr_12: -0.0
-  art_sys_corr_13: -0.0
+  art_sys_corr_11: 0.0
+  art_sys_corr_12: 0.0
+  art_sys_corr_13: 0.0
   art_sys_corr_14: 0.0
   art_sys_corr_15: 0.0
-  art_sys_corr_16: -0.0
-  art_sys_corr_17: -0.0
+  art_sys_corr_16: 0.0
+  art_sys_corr_17: 0.0
   art_sys_corr_18: 0.0
   art_sys_corr_19: 0.0
-  art_sys_corr_20: -0.0
+  art_sys_corr_20: 0.0
   art_sys_corr_21: -3.29788489e-04
-  art_sys_corr_22: -0.0
+  art_sys_corr_22: 0.0
   art_sys_corr_23: 0.0
   art_sys_corr_24: 0.0
   art_sys_corr_25: -2.74722850e-06
   art_sys_corr_26: 0.0
-  art_sys_corr_27: -0.0
-  art_sys_corr_28: -0.0
+  art_sys_corr_27: 0.0
+  art_sys_corr_28: 0.0
   art_sys_corr_29: 2.61419550e-08
   art_sys_corr_30: 0.0
   art_sys_corr_31: 0.0
   art_sys_corr_32: 0.0
   art_sys_corr_33: 0.0
-  art_sys_corr_34: -0.0
+  art_sys_corr_34: 0.0
   art_sys_corr_35: 1.08480535e-09
   art_sys_corr_36: 0.0
-  art_sys_corr_37: -0.0
+  art_sys_corr_37: 0.0
   art_sys_corr_38: 3.78939062e-11
   art_sys_corr_39: 0.0
-  art_sys_corr_40: -0.0
+  art_sys_corr_40: 0.0
   art_sys_corr_41: 0.0
   art_sys_corr_42: 1.28732569e-12
   art_sys_corr_43: 0.0
   art_sys_corr_44: 2.80299437e-14
-  art_sys_corr_45: -0.0
-  art_sys_corr_46: -0.0
+  art_sys_corr_45: 0.0
+  art_sys_corr_46: 0.0
   art_sys_corr_47: 7.30611789e-16
   art_sys_corr_48: 0.0
   art_sys_corr_49: 0.0
@@ -605,49 +605,49 @@ bins:
 - art_sys_corr_1: 1.99120861e-04
   art_sys_corr_2: 0.0
   art_sys_corr_3: 0.0
-  art_sys_corr_4: -0.0
+  art_sys_corr_4: 0.0
   art_sys_corr_5: 2.66576757e-04
-  art_sys_corr_6: -0.0
-  art_sys_corr_7: -0.0
-  art_sys_corr_8: -0.0
-  art_sys_corr_9: -0.0
+  art_sys_corr_6: 0.0
+  art_sys_corr_7: 0.0
+  art_sys_corr_8: 0.0
+  art_sys_corr_9: 0.0
   art_sys_corr_10: -5.41312040e-03
-  art_sys_corr_11: -0.0
-  art_sys_corr_12: -0.0
-  art_sys_corr_13: -0.0
+  art_sys_corr_11: 0.0
+  art_sys_corr_12: 0.0
+  art_sys_corr_13: 0.0
   art_sys_corr_14: 0.0
   art_sys_corr_15: 0.0
-  art_sys_corr_16: -0.0
-  art_sys_corr_17: -0.0
+  art_sys_corr_16: 0.0
+  art_sys_corr_17: 0.0
   art_sys_corr_18: 0.0
   art_sys_corr_19: 0.0
-  art_sys_corr_20: -0.0
+  art_sys_corr_20: 0.0
   art_sys_corr_21: -8.52001575e-03
-  art_sys_corr_22: -0.0
+  art_sys_corr_22: 0.0
   art_sys_corr_23: 0.0
   art_sys_corr_24: 0.0
   art_sys_corr_25: -8.21215841e-05
   art_sys_corr_26: 0.0
-  art_sys_corr_27: -0.0
-  art_sys_corr_28: -0.0
+  art_sys_corr_27: 0.0
+  art_sys_corr_28: 0.0
   art_sys_corr_29: -1.72434081e-06
   art_sys_corr_30: 0.0
   art_sys_corr_31: 0.0
   art_sys_corr_32: 0.0
   art_sys_corr_33: 0.0
-  art_sys_corr_34: -0.0
+  art_sys_corr_34: 0.0
   art_sys_corr_35: 1.31320092e-08
   art_sys_corr_36: 0.0
-  art_sys_corr_37: -0.0
+  art_sys_corr_37: 0.0
   art_sys_corr_38: 4.67238361e-10
   art_sys_corr_39: 0.0
-  art_sys_corr_40: -0.0
+  art_sys_corr_40: 0.0
   art_sys_corr_41: 0.0
   art_sys_corr_42: 1.59289613e-11
   art_sys_corr_43: 0.0
   art_sys_corr_44: 3.47140499e-13
-  art_sys_corr_45: -0.0
-  art_sys_corr_46: -0.0
+  art_sys_corr_45: 0.0
+  art_sys_corr_46: 0.0
   art_sys_corr_47: 9.04974191e-15
   art_sys_corr_48: 0.0
   art_sys_corr_49: 0.0
@@ -691,49 +691,49 @@ bins:
 - art_sys_corr_1: -7.03718960e-07
   art_sys_corr_2: 0.0
   art_sys_corr_3: 0.0
-  art_sys_corr_4: -0.0
+  art_sys_corr_4: 0.0
   art_sys_corr_5: 6.04102682e-05
-  art_sys_corr_6: -0.0
-  art_sys_corr_7: -0.0
-  art_sys_corr_8: -0.0
-  art_sys_corr_9: -0.0
+  art_sys_corr_6: 0.0
+  art_sys_corr_7: 0.0
+  art_sys_corr_8: 0.0
+  art_sys_corr_9: 0.0
   art_sys_corr_10: 3.19257694e-05
-  art_sys_corr_11: -0.0
-  art_sys_corr_12: -0.0
-  art_sys_corr_13: -0.0
+  art_sys_corr_11: 0.0
+  art_sys_corr_12: 0.0
+  art_sys_corr_13: 0.0
   art_sys_corr_14: 0.0
   art_sys_corr_15: 0.0
-  art_sys_corr_16: -0.0
-  art_sys_corr_17: -0.0
+  art_sys_corr_16: 0.0
+  art_sys_corr_17: 0.0
   art_sys_corr_18: 0.0
   art_sys_corr_19: 0.0
-  art_sys_corr_20: -0.0
+  art_sys_corr_20: 0.0
   art_sys_corr_21: 3.56184934e-04
-  art_sys_corr_22: -0.0
+  art_sys_corr_22: 0.0
   art_sys_corr_23: 0.0
   art_sys_corr_24: 0.0
   art_sys_corr_25: -1.96632982e-03
   art_sys_corr_26: 0.0
-  art_sys_corr_27: -0.0
-  art_sys_corr_28: -0.0
+  art_sys_corr_27: 0.0
+  art_sys_corr_28: 0.0
   art_sys_corr_29: -4.48347092e-05
   art_sys_corr_30: 0.0
   art_sys_corr_31: 0.0
   art_sys_corr_32: 0.0
   art_sys_corr_33: 0.0
-  art_sys_corr_34: -0.0
+  art_sys_corr_34: 0.0
   art_sys_corr_35: -1.65461724e-07
   art_sys_corr_36: 0.0
-  art_sys_corr_37: -0.0
+  art_sys_corr_37: 0.0
   art_sys_corr_38: -5.61776977e-09
   art_sys_corr_39: 0.0
-  art_sys_corr_40: -0.0
+  art_sys_corr_40: 0.0
   art_sys_corr_41: 0.0
   art_sys_corr_42: -1.89781286e-10
   art_sys_corr_43: 0.0
   art_sys_corr_44: -4.12642481e-12
-  art_sys_corr_45: -0.0
-  art_sys_corr_46: -0.0
+  art_sys_corr_45: 0.0
+  art_sys_corr_46: 0.0
   art_sys_corr_47: -1.07530613e-13
   art_sys_corr_48: 0.0
   art_sys_corr_49: 0.0
@@ -777,49 +777,49 @@ bins:
 - art_sys_corr_1: 4.66772689e-10
   art_sys_corr_2: 0.0
   art_sys_corr_3: 0.0
-  art_sys_corr_4: -0.0
+  art_sys_corr_4: 0.0
   art_sys_corr_5: -9.05095802e-08
-  art_sys_corr_6: -0.0
-  art_sys_corr_7: -0.0
-  art_sys_corr_8: -0.0
-  art_sys_corr_9: -0.0
+  art_sys_corr_6: 0.0
+  art_sys_corr_7: 0.0
+  art_sys_corr_8: 0.0
+  art_sys_corr_9: 0.0
   art_sys_corr_10: 1.54241006e-05
-  art_sys_corr_11: -0.0
-  art_sys_corr_12: -0.0
-  art_sys_corr_13: -0.0
+  art_sys_corr_11: 0.0
+  art_sys_corr_12: 0.0
+  art_sys_corr_13: 0.0
   art_sys_corr_14: 0.0
   art_sys_corr_15: 0.0
-  art_sys_corr_16: -0.0
-  art_sys_corr_17: -0.0
+  art_sys_corr_16: 0.0
+  art_sys_corr_17: 0.0
   art_sys_corr_18: 0.0
   art_sys_corr_19: 0.0
-  art_sys_corr_20: -0.0
+  art_sys_corr_20: 0.0
   art_sys_corr_21: -1.77398019e-06
-  art_sys_corr_22: -0.0
+  art_sys_corr_22: 0.0
   art_sys_corr_23: 0.0
   art_sys_corr_24: 0.0
   art_sys_corr_25: 1.17534922e-04
   art_sys_corr_26: 0.0
-  art_sys_corr_27: -0.0
-  art_sys_corr_28: -0.0
+  art_sys_corr_27: 0.0
+  art_sys_corr_28: 0.0
   art_sys_corr_29: -7.50679876e-04
   art_sys_corr_30: 0.0
   art_sys_corr_31: 0.0
   art_sys_corr_32: 0.0
   art_sys_corr_33: 0.0
-  art_sys_corr_34: -0.0
+  art_sys_corr_34: 0.0
   art_sys_corr_35: -4.91722870e-06
   art_sys_corr_36: 0.0
-  art_sys_corr_37: -0.0
+  art_sys_corr_37: 0.0
   art_sys_corr_38: -1.69111273e-07
   art_sys_corr_39: 0.0
-  art_sys_corr_40: -0.0
+  art_sys_corr_40: 0.0
   art_sys_corr_41: 0.0
   art_sys_corr_42: -5.72755759e-09
   art_sys_corr_43: 0.0
   art_sys_corr_44: -1.24614905e-10
-  art_sys_corr_45: -0.0
-  art_sys_corr_46: -0.0
+  art_sys_corr_45: 0.0
+  art_sys_corr_46: 0.0
   art_sys_corr_47: -3.24770602e-12
   art_sys_corr_48: 0.0
   art_sys_corr_49: 0.0
@@ -863,49 +863,49 @@ bins:
 - art_sys_corr_1: 3.07102148e-13
   art_sys_corr_2: 0.0
   art_sys_corr_3: 0.0
-  art_sys_corr_4: -0.0
+  art_sys_corr_4: 0.0
   art_sys_corr_5: 5.66691472e-12
-  art_sys_corr_6: -0.0
-  art_sys_corr_7: -0.0
-  art_sys_corr_8: -0.0
-  art_sys_corr_9: -0.0
+  art_sys_corr_6: 0.0
+  art_sys_corr_7: 0.0
+  art_sys_corr_8: 0.0
+  art_sys_corr_9: 0.0
   art_sys_corr_10: -3.36433177e-09
-  art_sys_corr_11: -0.0
-  art_sys_corr_12: -0.0
-  art_sys_corr_13: -0.0
+  art_sys_corr_11: 0.0
+  art_sys_corr_12: 0.0
+  art_sys_corr_13: 0.0
   art_sys_corr_14: 0.0
   art_sys_corr_15: 0.0
-  art_sys_corr_16: -0.0
-  art_sys_corr_17: -0.0
+  art_sys_corr_16: 0.0
+  art_sys_corr_17: 0.0
   art_sys_corr_18: 0.0
   art_sys_corr_19: 0.0
-  art_sys_corr_20: -0.0
+  art_sys_corr_20: 0.0
   art_sys_corr_21: -1.40589100e-06
-  art_sys_corr_22: -0.0
+  art_sys_corr_22: 0.0
   art_sys_corr_23: 0.0
   art_sys_corr_24: 0.0
   art_sys_corr_25: -2.19528004e-06
   art_sys_corr_26: 0.0
-  art_sys_corr_27: -0.0
-  art_sys_corr_28: -0.0
+  art_sys_corr_27: 0.0
+  art_sys_corr_28: 0.0
   art_sys_corr_29: 3.20047289e-05
   art_sys_corr_30: 0.0
   art_sys_corr_31: 0.0
   art_sys_corr_32: 0.0
   art_sys_corr_33: 0.0
-  art_sys_corr_34: -0.0
+  art_sys_corr_34: 0.0
   art_sys_corr_35: -1.15552899e-04
   art_sys_corr_36: 0.0
-  art_sys_corr_37: -0.0
+  art_sys_corr_37: 0.0
   art_sys_corr_38: -4.05094330e-06
   art_sys_corr_39: 0.0
-  art_sys_corr_40: -0.0
+  art_sys_corr_40: 0.0
   art_sys_corr_41: 0.0
   art_sys_corr_42: -1.37713766e-07
   art_sys_corr_43: 0.0
   art_sys_corr_44: -2.99907399e-09
-  art_sys_corr_45: -0.0
-  art_sys_corr_46: -0.0
+  art_sys_corr_45: 0.0
+  art_sys_corr_46: 0.0
   art_sys_corr_47: -7.81744433e-11
   art_sys_corr_48: 0.0
   art_sys_corr_49: 0.0
@@ -949,49 +949,49 @@ bins:
 - art_sys_corr_1: -3.23335080e-23
   art_sys_corr_2: 0.0
   art_sys_corr_3: 0.0
-  art_sys_corr_4: -0.0
+  art_sys_corr_4: 0.0
   art_sys_corr_5: -7.86011425e-21
-  art_sys_corr_6: -0.0
-  art_sys_corr_7: -0.0
-  art_sys_corr_8: -0.0
-  art_sys_corr_9: -0.0
+  art_sys_corr_6: 0.0
+  art_sys_corr_7: 0.0
+  art_sys_corr_8: 0.0
+  art_sys_corr_9: 0.0
   art_sys_corr_10: 1.42016208e-16
-  art_sys_corr_11: -0.0
-  art_sys_corr_12: -0.0
-  art_sys_corr_13: -0.0
+  art_sys_corr_11: 0.0
+  art_sys_corr_12: 0.0
+  art_sys_corr_13: 0.0
   art_sys_corr_14: 0.0
   art_sys_corr_15: 0.0
-  art_sys_corr_16: -0.0
-  art_sys_corr_17: -0.0
+  art_sys_corr_16: 0.0
+  art_sys_corr_17: 0.0
   art_sys_corr_18: 0.0
   art_sys_corr_19: 0.0
-  art_sys_corr_20: -0.0
+  art_sys_corr_20: 0.0
   art_sys_corr_21: 1.59617407e-11
-  art_sys_corr_22: -0.0
+  art_sys_corr_22: 0.0
   art_sys_corr_23: 0.0
   art_sys_corr_24: 0.0
   art_sys_corr_25: 4.67290728e-10
   art_sys_corr_26: 0.0
-  art_sys_corr_27: -0.0
-  art_sys_corr_28: -0.0
+  art_sys_corr_27: 0.0
+  art_sys_corr_28: 0.0
   art_sys_corr_29: -4.69384890e-08
   art_sys_corr_30: 0.0
   art_sys_corr_31: 0.0
   art_sys_corr_32: 0.0
   art_sys_corr_33: 0.0
-  art_sys_corr_34: -0.0
+  art_sys_corr_34: 0.0
   art_sys_corr_35: 8.97436405e-06
   art_sys_corr_36: 0.0
-  art_sys_corr_37: -0.0
+  art_sys_corr_37: 0.0
   art_sys_corr_38: -5.21913190e-05
   art_sys_corr_39: 0.0
-  art_sys_corr_40: -0.0
+  art_sys_corr_40: 0.0
   art_sys_corr_41: 0.0
   art_sys_corr_42: -2.12661075e-06
   art_sys_corr_43: 0.0
   art_sys_corr_44: -4.82505301e-08
-  art_sys_corr_45: -0.0
-  art_sys_corr_46: -0.0
+  art_sys_corr_45: 0.0
+  art_sys_corr_46: 0.0
   art_sys_corr_47: -1.26646293e-09
   art_sys_corr_48: 0.0
   art_sys_corr_49: 0.0
@@ -1035,49 +1035,49 @@ bins:
 - art_sys_corr_1: 7.29079575e-34
   art_sys_corr_2: 0.0
   art_sys_corr_3: 0.0
-  art_sys_corr_4: -0.0
+  art_sys_corr_4: 0.0
   art_sys_corr_5: 2.33374665e-30
-  art_sys_corr_6: -0.0
-  art_sys_corr_7: -0.0
-  art_sys_corr_8: -0.0
-  art_sys_corr_9: -0.0
+  art_sys_corr_6: 0.0
+  art_sys_corr_7: 0.0
+  art_sys_corr_8: 0.0
+  art_sys_corr_9: 0.0
   art_sys_corr_10: -1.28390990e-24
-  art_sys_corr_11: -0.0
-  art_sys_corr_12: -0.0
-  art_sys_corr_13: -0.0
+  art_sys_corr_11: 0.0
+  art_sys_corr_12: 0.0
+  art_sys_corr_13: 0.0
   art_sys_corr_14: 0.0
   art_sys_corr_15: 0.0
-  art_sys_corr_16: -0.0
-  art_sys_corr_17: -0.0
+  art_sys_corr_16: 0.0
+  art_sys_corr_17: 0.0
   art_sys_corr_18: 0.0
   art_sys_corr_19: 0.0
-  art_sys_corr_20: -0.0
+  art_sys_corr_20: 0.0
   art_sys_corr_21: -3.88103819e-17
-  art_sys_corr_22: -0.0
+  art_sys_corr_22: 0.0
   art_sys_corr_23: 0.0
   art_sys_corr_24: 0.0
   art_sys_corr_25: -2.12910028e-14
   art_sys_corr_26: 0.0
-  art_sys_corr_27: -0.0
-  art_sys_corr_28: -0.0
+  art_sys_corr_27: 0.0
+  art_sys_corr_28: 0.0
   art_sys_corr_29: 1.46873652e-11
   art_sys_corr_30: 0.0
   art_sys_corr_31: 0.0
   art_sys_corr_32: 0.0
   art_sys_corr_33: 0.0
-  art_sys_corr_34: -0.0
+  art_sys_corr_34: 0.0
   art_sys_corr_35: -1.24182348e-07
   art_sys_corr_36: 0.0
-  art_sys_corr_37: -0.0
+  art_sys_corr_37: 0.0
   art_sys_corr_38: 4.40334860e-06
   art_sys_corr_39: 0.0
-  art_sys_corr_40: -0.0
+  art_sys_corr_40: 0.0
   art_sys_corr_41: 0.0
   art_sys_corr_42: -2.53094068e-05
   art_sys_corr_43: 0.0
   art_sys_corr_44: -7.20168508e-07
-  art_sys_corr_45: -0.0
-  art_sys_corr_46: -0.0
+  art_sys_corr_45: 0.0
+  art_sys_corr_46: 0.0
   art_sys_corr_47: -1.95664133e-08
   art_sys_corr_48: 0.0
   art_sys_corr_49: 0.0
@@ -1121,49 +1121,49 @@ bins:
 - art_sys_corr_1: -3.56511816e-45
   art_sys_corr_2: 0.0
   art_sys_corr_3: 0.0
-  art_sys_corr_4: -0.0
+  art_sys_corr_4: 0.0
   art_sys_corr_5: 4.15571845e-40
-  art_sys_corr_6: -0.0
-  art_sys_corr_7: -0.0
-  art_sys_corr_8: -0.0
-  art_sys_corr_9: -0.0
+  art_sys_corr_6: 0.0
+  art_sys_corr_7: 0.0
+  art_sys_corr_8: 0.0
+  art_sys_corr_9: 0.0
   art_sys_corr_10: 2.46397755e-33
-  art_sys_corr_11: -0.0
-  art_sys_corr_12: -0.0
-  art_sys_corr_13: -0.0
+  art_sys_corr_11: 0.0
+  art_sys_corr_12: 0.0
+  art_sys_corr_13: 0.0
   art_sys_corr_14: 0.0
   art_sys_corr_15: 0.0
-  art_sys_corr_16: -0.0
-  art_sys_corr_17: -0.0
+  art_sys_corr_16: 0.0
+  art_sys_corr_17: 0.0
   art_sys_corr_18: 0.0
   art_sys_corr_19: 0.0
-  art_sys_corr_20: -0.0
+  art_sys_corr_20: 0.0
   art_sys_corr_21: 1.92291561e-23
-  art_sys_corr_22: -0.0
+  art_sys_corr_22: 0.0
   art_sys_corr_23: 0.0
   art_sys_corr_24: 0.0
   art_sys_corr_25: 1.97647892e-19
   art_sys_corr_26: 0.0
-  art_sys_corr_27: -0.0
-  art_sys_corr_28: -0.0
+  art_sys_corr_27: 0.0
+  art_sys_corr_28: 0.0
   art_sys_corr_29: -9.35598402e-16
   art_sys_corr_30: 0.0
   art_sys_corr_31: 0.0
   art_sys_corr_32: 0.0
   art_sys_corr_33: 0.0
-  art_sys_corr_34: -0.0
+  art_sys_corr_34: 0.0
   art_sys_corr_35: 3.35880699e-10
   art_sys_corr_36: 0.0
-  art_sys_corr_37: -0.0
+  art_sys_corr_37: 0.0
   art_sys_corr_38: -6.01129681e-08
   art_sys_corr_39: 0.0
-  art_sys_corr_40: -0.0
+  art_sys_corr_40: 0.0
   art_sys_corr_41: 0.0
   art_sys_corr_42: 1.71870435e-06
   art_sys_corr_43: 0.0
   art_sys_corr_44: -1.06567754e-05
-  art_sys_corr_45: -0.0
-  art_sys_corr_46: -0.0
+  art_sys_corr_45: 0.0
+  art_sys_corr_46: 0.0
   art_sys_corr_47: -3.39880799e-07
   art_sys_corr_48: 0.0
   art_sys_corr_49: 0.0
@@ -1207,49 +1207,49 @@ bins:
 - art_sys_corr_1: 1.97943657e-53
   art_sys_corr_2: 0.0
   art_sys_corr_3: 0.0
-  art_sys_corr_4: -0.0
+  art_sys_corr_4: 0.0
   art_sys_corr_5: -5.28821181e-47
-  art_sys_corr_6: -0.0
-  art_sys_corr_7: -0.0
-  art_sys_corr_8: -0.0
-  art_sys_corr_9: -0.0
+  art_sys_corr_6: 0.0
+  art_sys_corr_7: 0.0
+  art_sys_corr_8: 0.0
+  art_sys_corr_9: 0.0
   art_sys_corr_10: 4.22944840e-40
-  art_sys_corr_11: -0.0
-  art_sys_corr_12: -0.0
-  art_sys_corr_13: -0.0
+  art_sys_corr_11: 0.0
+  art_sys_corr_12: 0.0
+  art_sys_corr_13: 0.0
   art_sys_corr_14: 0.0
   art_sys_corr_15: 0.0
-  art_sys_corr_16: -0.0
-  art_sys_corr_17: -0.0
+  art_sys_corr_16: 0.0
+  art_sys_corr_17: 0.0
   art_sys_corr_18: 0.0
   art_sys_corr_19: 0.0
-  art_sys_corr_20: -0.0
+  art_sys_corr_20: 0.0
   art_sys_corr_21: -1.76459806e-30
-  art_sys_corr_22: -0.0
+  art_sys_corr_22: 0.0
   art_sys_corr_23: 0.0
   art_sys_corr_24: 0.0
   art_sys_corr_25: -3.39822131e-25
   art_sys_corr_26: 0.0
-  art_sys_corr_27: -0.0
-  art_sys_corr_28: -0.0
+  art_sys_corr_27: 0.0
+  art_sys_corr_28: 0.0
   art_sys_corr_29: 1.10370236e-20
   art_sys_corr_30: 0.0
   art_sys_corr_31: 0.0
   art_sys_corr_32: 0.0
   art_sys_corr_33: 0.0
-  art_sys_corr_34: -0.0
+  art_sys_corr_34: 0.0
   art_sys_corr_35: -1.67084107e-13
   art_sys_corr_36: 0.0
-  art_sys_corr_37: -0.0
+  art_sys_corr_37: 0.0
   art_sys_corr_38: 1.46774418e-10
   art_sys_corr_39: 0.0
-  art_sys_corr_40: -0.0
+  art_sys_corr_40: 0.0
   art_sys_corr_41: 0.0
   art_sys_corr_42: -1.83660547e-08
   art_sys_corr_43: 0.0
   art_sys_corr_44: 7.73982032e-07
-  art_sys_corr_45: -0.0
-  art_sys_corr_46: -0.0
+  art_sys_corr_45: 0.0
+  art_sys_corr_46: 0.0
   art_sys_corr_47: -4.69487343e-06
   art_sys_corr_48: 0.0
   art_sys_corr_49: 0.0
@@ -1293,49 +1293,49 @@ bins:
 - art_sys_corr_1: -3.15114282e-61
   art_sys_corr_2: 0.0
   art_sys_corr_3: 0.0
-  art_sys_corr_4: -0.0
+  art_sys_corr_4: 0.0
   art_sys_corr_5: 8.41851207e-55
-  art_sys_corr_6: -0.0
-  art_sys_corr_7: -0.0
-  art_sys_corr_8: -0.0
-  art_sys_corr_9: -0.0
+  art_sys_corr_6: 0.0
+  art_sys_corr_7: 0.0
+  art_sys_corr_8: 0.0
+  art_sys_corr_9: 0.0
   art_sys_corr_10: -6.73302501e-48
-  art_sys_corr_11: -0.0
-  art_sys_corr_12: -0.0
-  art_sys_corr_13: -0.0
+  art_sys_corr_11: 0.0
+  art_sys_corr_12: 0.0
+  art_sys_corr_13: 0.0
   art_sys_corr_14: 0.0
   art_sys_corr_15: 0.0
-  art_sys_corr_16: -0.0
-  art_sys_corr_17: -0.0
+  art_sys_corr_16: 0.0
+  art_sys_corr_17: 0.0
   art_sys_corr_18: 0.0
   art_sys_corr_19: 0.0
-  art_sys_corr_20: -0.0
+  art_sys_corr_20: 0.0
   art_sys_corr_21: 2.80957807e-38
-  art_sys_corr_22: -0.0
+  art_sys_corr_22: 0.0
   art_sys_corr_23: 0.0
   art_sys_corr_24: 0.0
   art_sys_corr_25: 1.01377892e-31
   art_sys_corr_26: 0.0
-  art_sys_corr_27: -0.0
-  art_sys_corr_28: -0.0
+  art_sys_corr_27: 0.0
+  art_sys_corr_28: 0.0
   art_sys_corr_29: -2.27230772e-26
   art_sys_corr_30: 0.0
   art_sys_corr_31: 0.0
   art_sys_corr_32: 0.0
   art_sys_corr_33: 0.0
-  art_sys_corr_34: -0.0
+  art_sys_corr_34: 0.0
   art_sys_corr_35: 1.44011308e-17
   art_sys_corr_36: 0.0
-  art_sys_corr_37: -0.0
+  art_sys_corr_37: 0.0
   art_sys_corr_38: -6.17605820e-14
   art_sys_corr_39: 0.0
-  art_sys_corr_40: -0.0
+  art_sys_corr_40: 0.0
   art_sys_corr_41: 0.0
   art_sys_corr_42: 3.30715194e-11
   art_sys_corr_43: 0.0
   art_sys_corr_44: -8.11699907e-09
-  art_sys_corr_45: -0.0
-  art_sys_corr_46: -0.0
+  art_sys_corr_45: 0.0
+  art_sys_corr_46: 0.0
   art_sys_corr_47: 3.00366216e-07
   art_sys_corr_48: 0.0
   art_sys_corr_49: 0.0
@@ -1379,49 +1379,49 @@ bins:
 - art_sys_corr_1: 1.09439304e-69
   art_sys_corr_2: 0.0
   art_sys_corr_3: 0.0
-  art_sys_corr_4: -0.0
+  art_sys_corr_4: 0.0
   art_sys_corr_5: -2.92375228e-63
-  art_sys_corr_6: -0.0
-  art_sys_corr_7: -0.0
-  art_sys_corr_8: -0.0
-  art_sys_corr_9: -0.0
+  art_sys_corr_6: 0.0
+  art_sys_corr_7: 0.0
+  art_sys_corr_8: 0.0
+  art_sys_corr_9: 0.0
   art_sys_corr_10: 2.33838202e-56
-  art_sys_corr_11: -0.0
-  art_sys_corr_12: -0.0
-  art_sys_corr_13: -0.0
+  art_sys_corr_11: 0.0
+  art_sys_corr_12: 0.0
+  art_sys_corr_13: 0.0
   art_sys_corr_14: 0.0
   art_sys_corr_15: 0.0
-  art_sys_corr_16: -0.0
-  art_sys_corr_17: -0.0
+  art_sys_corr_16: 0.0
+  art_sys_corr_17: 0.0
   art_sys_corr_18: 0.0
   art_sys_corr_19: 0.0
-  art_sys_corr_20: -0.0
+  art_sys_corr_20: 0.0
   art_sys_corr_21: -9.75763697e-47
-  art_sys_corr_22: -0.0
+  art_sys_corr_22: 0.0
   art_sys_corr_23: 0.0
   art_sys_corr_24: 0.0
   art_sys_corr_25: -6.70575103e-39
   art_sys_corr_26: 0.0
-  art_sys_corr_27: -0.0
-  art_sys_corr_28: -0.0
+  art_sys_corr_27: 0.0
+  art_sys_corr_28: 0.0
   art_sys_corr_29: 1.31554007e-32
   art_sys_corr_30: 0.0
   art_sys_corr_31: 0.0
   art_sys_corr_32: 0.0
   art_sys_corr_33: 0.0
-  art_sys_corr_34: -0.0
+  art_sys_corr_34: 0.0
   art_sys_corr_35: -2.70711746e-22
   art_sys_corr_36: 0.0
-  art_sys_corr_37: -0.0
+  art_sys_corr_37: 0.0
   art_sys_corr_38: 5.66203656e-18
   art_sys_corr_39: 0.0
-  art_sys_corr_40: -0.0
+  art_sys_corr_40: 0.0
   art_sys_corr_41: 0.0
   art_sys_corr_42: -1.29195341e-14
   art_sys_corr_43: 0.0
   art_sys_corr_44: 1.79874574e-11
-  art_sys_corr_45: -0.0
-  art_sys_corr_46: -0.0
+  art_sys_corr_45: 0.0
+  art_sys_corr_46: 0.0
   art_sys_corr_47: -3.49966545e-09
   art_sys_corr_48: 0.0
   art_sys_corr_49: 0.0
@@ -1462,60 +1462,60 @@ bins:
   JEC13+: 8.06101731e-09
   luminosity_uncertainty: 2.50800000e-08
   bin_by_bin_uncertainty: 1.14000000e-08
-- art_sys_corr_1: -0.0
+- art_sys_corr_1: 0.0
   art_sys_corr_2: 2.49983718e+00
   art_sys_corr_3: 0.0
-  art_sys_corr_4: -0.0
+  art_sys_corr_4: 0.0
   art_sys_corr_5: 0.0
   art_sys_corr_6: 2.85313006e-02
-  art_sys_corr_7: -0.0
-  art_sys_corr_8: -0.0
-  art_sys_corr_9: -0.0
+  art_sys_corr_7: 0.0
+  art_sys_corr_8: 0.0
+  art_sys_corr_9: 0.0
   art_sys_corr_10: 0.0
   art_sys_corr_11: 1.38645456e-04
-  art_sys_corr_12: -0.0
-  art_sys_corr_13: -0.0
+  art_sys_corr_12: 0.0
+  art_sys_corr_13: 0.0
   art_sys_corr_14: 0.0
   art_sys_corr_15: 0.0
-  art_sys_corr_16: -0.0
-  art_sys_corr_17: -0.0
+  art_sys_corr_16: 0.0
+  art_sys_corr_17: 0.0
   art_sys_corr_18: 0.0
   art_sys_corr_19: 0.0
   art_sys_corr_20: 5.30838284e-07
   art_sys_corr_21: 0.0
-  art_sys_corr_22: -0.0
+  art_sys_corr_22: 0.0
   art_sys_corr_23: 0.0
   art_sys_corr_24: 1.82109599e-08
   art_sys_corr_25: 0.0
   art_sys_corr_26: 0.0
   art_sys_corr_27: 6.82696916e-10
-  art_sys_corr_28: -0.0
+  art_sys_corr_28: 0.0
   art_sys_corr_29: 0.0
   art_sys_corr_30: 0.0
   art_sys_corr_31: 0.0
   art_sys_corr_32: 0.0
   art_sys_corr_33: 0.0
   art_sys_corr_34: 1.15913762e-12
-  art_sys_corr_35: -0.0
+  art_sys_corr_35: 0.0
   art_sys_corr_36: 0.0
   art_sys_corr_37: 6.82707049e-14
-  art_sys_corr_38: -0.0
+  art_sys_corr_38: 0.0
   art_sys_corr_39: 0.0
-  art_sys_corr_40: -0.0
+  art_sys_corr_40: 0.0
   art_sys_corr_41: 6.40820422e-15
-  art_sys_corr_42: -0.0
+  art_sys_corr_42: 0.0
   art_sys_corr_43: 0.0
   art_sys_corr_44: 0.0
-  art_sys_corr_45: -0.0
+  art_sys_corr_45: 0.0
   art_sys_corr_46: 1.55953487e-16
-  art_sys_corr_47: -0.0
+  art_sys_corr_47: 0.0
   art_sys_corr_48: 2.25278701e-18
   art_sys_corr_49: 0.0
   art_sys_corr_50: 0.0
   art_sys_corr_51: 6.07993901e-20
   art_sys_corr_52: 0.0
   art_sys_corr_53: 0.0
-  art_sys_corr_54: -0.0
+  art_sys_corr_54: 0.0
   Unfolding+: -1.28693434e+00
   Unfolding-: 1.28693434e+00
   JEC0-: -2.57386868e+00
@@ -1548,60 +1548,60 @@ bins:
   JEC13+: 3.86080303e+00
   luminosity_uncertainty: 4.004
   bin_by_bin_uncertainty: 1.82
-- art_sys_corr_1: -0.0
+- art_sys_corr_1: 0.0
   art_sys_corr_2: -1.11315850e-01
   art_sys_corr_3: 0.0
-  art_sys_corr_4: -0.0
+  art_sys_corr_4: 0.0
   art_sys_corr_5: 0.0
   art_sys_corr_6: 6.40377363e-01
-  art_sys_corr_7: -0.0
-  art_sys_corr_8: -0.0
-  art_sys_corr_9: -0.0
+  art_sys_corr_7: 0.0
+  art_sys_corr_8: 0.0
+  art_sys_corr_9: 0.0
   art_sys_corr_10: 0.0
   art_sys_corr_11: 5.06103531e-03
-  art_sys_corr_12: -0.0
-  art_sys_corr_13: -0.0
+  art_sys_corr_12: 0.0
+  art_sys_corr_13: 0.0
   art_sys_corr_14: 0.0
   art_sys_corr_15: 0.0
-  art_sys_corr_16: -0.0
-  art_sys_corr_17: -0.0
+  art_sys_corr_16: 0.0
+  art_sys_corr_17: 0.0
   art_sys_corr_18: 0.0
   art_sys_corr_19: 0.0
   art_sys_corr_20: -1.23652864e-05
   art_sys_corr_21: 0.0
-  art_sys_corr_22: -0.0
+  art_sys_corr_22: 0.0
   art_sys_corr_23: 0.0
   art_sys_corr_24: 1.41928424e-07
   art_sys_corr_25: 0.0
   art_sys_corr_26: 0.0
   art_sys_corr_27: 1.02056139e-08
-  art_sys_corr_28: -0.0
+  art_sys_corr_28: 0.0
   art_sys_corr_29: 0.0
   art_sys_corr_30: 0.0
   art_sys_corr_31: 0.0
   art_sys_corr_32: 0.0
   art_sys_corr_33: 0.0
   art_sys_corr_34: 6.75322593e-11
-  art_sys_corr_35: -0.0
+  art_sys_corr_35: 0.0
   art_sys_corr_36: 0.0
   art_sys_corr_37: -1.57731967e-12
-  art_sys_corr_38: -0.0
+  art_sys_corr_38: 0.0
   art_sys_corr_39: 0.0
-  art_sys_corr_40: -0.0
+  art_sys_corr_40: 0.0
   art_sys_corr_41: 3.51188170e-14
-  art_sys_corr_42: -0.0
+  art_sys_corr_42: 0.0
   art_sys_corr_43: 0.0
   art_sys_corr_44: 0.0
-  art_sys_corr_45: -0.0
+  art_sys_corr_45: 0.0
   art_sys_corr_46: 1.11076115e-15
-  art_sys_corr_47: -0.0
+  art_sys_corr_47: 0.0
   art_sys_corr_48: 1.65928797e-17
   art_sys_corr_49: 0.0
   art_sys_corr_50: 0.0
   art_sys_corr_51: 4.49440653e-19
   art_sys_corr_52: 0.0
   art_sys_corr_53: 0.0
-  art_sys_corr_54: -0.0
+  art_sys_corr_54: 0.0
   Unfolding+: -2.10717821e-01
   Unfolding-: 2.10717821e-01
   JEC0-: -4.21435642e-01
@@ -1634,60 +1634,60 @@ bins:
   JEC13+: 4.21435642e-01
   luminosity_uncertainty: 0.6556
   bin_by_bin_uncertainty: 0.298
-- art_sys_corr_1: -0.0
+- art_sys_corr_1: 0.0
   art_sys_corr_2: 1.62934454e-03
   art_sys_corr_3: 0.0
-  art_sys_corr_4: -0.0
+  art_sys_corr_4: 0.0
   art_sys_corr_5: 0.0
   art_sys_corr_6: -2.42417343e-02
-  art_sys_corr_7: -0.0
-  art_sys_corr_8: -0.0
-  art_sys_corr_9: -0.0
+  art_sys_corr_7: 0.0
+  art_sys_corr_8: 0.0
+  art_sys_corr_9: 0.0
   art_sys_corr_10: 0.0
   art_sys_corr_11: 1.33811522e-01
-  art_sys_corr_12: -0.0
-  art_sys_corr_13: -0.0
+  art_sys_corr_12: 0.0
+  art_sys_corr_13: 0.0
   art_sys_corr_14: 0.0
   art_sys_corr_15: 0.0
-  art_sys_corr_16: -0.0
-  art_sys_corr_17: -0.0
+  art_sys_corr_16: 0.0
+  art_sys_corr_17: 0.0
   art_sys_corr_18: 0.0
   art_sys_corr_19: 0.0
   art_sys_corr_20: -4.00076043e-04
   art_sys_corr_21: 0.0
-  art_sys_corr_22: -0.0
+  art_sys_corr_22: 0.0
   art_sys_corr_23: 0.0
   art_sys_corr_24: -4.19719088e-06
   art_sys_corr_25: 0.0
   art_sys_corr_26: 0.0
   art_sys_corr_27: 4.02847364e-08
-  art_sys_corr_28: -0.0
+  art_sys_corr_28: 0.0
   art_sys_corr_29: 0.0
   art_sys_corr_30: 0.0
   art_sys_corr_31: 0.0
   art_sys_corr_32: 0.0
   art_sys_corr_33: 0.0
   art_sys_corr_34: 1.28748725e-09
-  art_sys_corr_35: -0.0
+  art_sys_corr_35: 0.0
   art_sys_corr_36: 0.0
   art_sys_corr_37: -7.20904564e-11
-  art_sys_corr_38: -0.0
+  art_sys_corr_38: 0.0
   art_sys_corr_39: 0.0
-  art_sys_corr_40: -0.0
+  art_sys_corr_40: 0.0
   art_sys_corr_41: -1.44124830e-12
-  art_sys_corr_42: -0.0
+  art_sys_corr_42: 0.0
   art_sys_corr_43: 0.0
   art_sys_corr_44: 0.0
-  art_sys_corr_45: -0.0
+  art_sys_corr_45: 0.0
   art_sys_corr_46: -2.75510641e-14
-  art_sys_corr_47: -0.0
+  art_sys_corr_47: 0.0
   art_sys_corr_48: -3.81859208e-16
   art_sys_corr_49: 0.0
   art_sys_corr_50: 0.0
   art_sys_corr_51: -1.02580084e-17
   art_sys_corr_52: 0.0
   art_sys_corr_53: 0.0
-  art_sys_corr_54: -0.0
+  art_sys_corr_54: 0.0
   Unfolding+: 0.0
   Unfolding-: 3.98101118e-02
   JEC0-: -7.96202236e-02
@@ -1720,60 +1720,60 @@ bins:
   JEC13+: 7.96202236e-02
   luminosity_uncertainty: 1.23860000e-01
   bin_by_bin_uncertainty: 0.0563
-- art_sys_corr_1: -0.0
+- art_sys_corr_1: 0.0
   art_sys_corr_2: 2.18113426e-04
   art_sys_corr_3: 0.0
-  art_sys_corr_4: -0.0
+  art_sys_corr_4: 0.0
   art_sys_corr_5: 0.0
   art_sys_corr_6: 1.94412690e-04
-  art_sys_corr_7: -0.0
-  art_sys_corr_8: -0.0
-  art_sys_corr_9: -0.0
+  art_sys_corr_7: 0.0
+  art_sys_corr_8: 0.0
+  art_sys_corr_9: 0.0
   art_sys_corr_10: 0.0
   art_sys_corr_11: -5.69730777e-03
-  art_sys_corr_12: -0.0
-  art_sys_corr_13: -0.0
+  art_sys_corr_12: 0.0
+  art_sys_corr_13: 0.0
   art_sys_corr_14: 0.0
   art_sys_corr_15: 0.0
-  art_sys_corr_16: -0.0
-  art_sys_corr_17: -0.0
+  art_sys_corr_16: 0.0
+  art_sys_corr_17: 0.0
   art_sys_corr_18: 0.0
   art_sys_corr_19: 0.0
   art_sys_corr_20: -9.40437826e-03
   art_sys_corr_21: 0.0
-  art_sys_corr_22: -0.0
+  art_sys_corr_22: 0.0
   art_sys_corr_23: 0.0
   art_sys_corr_24: -1.13902834e-04
   art_sys_corr_25: 0.0
   art_sys_corr_26: 0.0
   art_sys_corr_27: -3.18247914e-06
-  art_sys_corr_28: -0.0
+  art_sys_corr_28: 0.0
   art_sys_corr_29: 0.0
   art_sys_corr_30: 0.0
   art_sys_corr_31: 0.0
   art_sys_corr_32: 0.0
   art_sys_corr_33: 0.0
   art_sys_corr_34: 1.07933102e-08
-  art_sys_corr_35: -0.0
+  art_sys_corr_35: 0.0
   art_sys_corr_36: 0.0
   art_sys_corr_37: -1.07579540e-09
-  art_sys_corr_38: -0.0
+  art_sys_corr_38: 0.0
   art_sys_corr_39: 0.0
-  art_sys_corr_40: -0.0
+  art_sys_corr_40: 0.0
   art_sys_corr_41: -4.73093449e-11
-  art_sys_corr_42: -0.0
+  art_sys_corr_42: 0.0
   art_sys_corr_43: 0.0
   art_sys_corr_44: 0.0
-  art_sys_corr_45: -0.0
+  art_sys_corr_45: 0.0
   art_sys_corr_46: -1.07679596e-12
-  art_sys_corr_47: -0.0
+  art_sys_corr_47: 0.0
   art_sys_corr_48: -1.53953614e-14
   art_sys_corr_49: 0.0
   art_sys_corr_50: 0.0
   art_sys_corr_51: -4.15026163e-16
   art_sys_corr_52: 0.0
   art_sys_corr_53: 0.0
-  art_sys_corr_54: -0.0
+  art_sys_corr_54: 0.0
   Unfolding+: -8.98025612e-03
   Unfolding-: 0.0
   JEC0-: -2.69407684e-02
@@ -1806,60 +1806,60 @@ bins:
   JEC13+: 8.98025612e-03
   luminosity_uncertainty: 0.02794
   bin_by_bin_uncertainty: 1.27000000e-02
-- art_sys_corr_1: -0.0
+- art_sys_corr_1: 0.0
   art_sys_corr_2: -8.31290155e-07
   art_sys_corr_3: 0.0
-  art_sys_corr_4: -0.0
+  art_sys_corr_4: 0.0
   art_sys_corr_5: 0.0
   art_sys_corr_6: 7.26396821e-05
-  art_sys_corr_7: -0.0
-  art_sys_corr_8: -0.0
-  art_sys_corr_9: -0.0
+  art_sys_corr_7: 0.0
+  art_sys_corr_8: 0.0
+  art_sys_corr_9: 0.0
   art_sys_corr_10: 0.0
   art_sys_corr_11: 3.88507415e-05
-  art_sys_corr_12: -0.0
-  art_sys_corr_13: -0.0
+  art_sys_corr_12: 0.0
+  art_sys_corr_13: 0.0
   art_sys_corr_14: 0.0
   art_sys_corr_15: 0.0
-  art_sys_corr_16: -0.0
-  art_sys_corr_17: -0.0
+  art_sys_corr_16: 0.0
+  art_sys_corr_17: 0.0
   art_sys_corr_18: 0.0
   art_sys_corr_19: 0.0
   art_sys_corr_20: 4.55631553e-04
   art_sys_corr_21: 0.0
-  art_sys_corr_22: -0.0
+  art_sys_corr_22: 0.0
   art_sys_corr_23: 0.0
   art_sys_corr_24: -2.35385576e-03
   art_sys_corr_25: 0.0
   art_sys_corr_26: 0.0
   art_sys_corr_27: -7.05430338e-05
-  art_sys_corr_28: -0.0
+  art_sys_corr_28: 0.0
   art_sys_corr_29: 0.0
   art_sys_corr_30: 0.0
   art_sys_corr_31: 0.0
   art_sys_corr_32: 0.0
   art_sys_corr_33: 0.0
   art_sys_corr_34: -2.06289871e-07
-  art_sys_corr_35: -0.0
+  art_sys_corr_35: 0.0
   art_sys_corr_36: 0.0
   art_sys_corr_37: -6.88649723e-09
-  art_sys_corr_38: -0.0
+  art_sys_corr_38: 0.0
   art_sys_corr_39: 0.0
-  art_sys_corr_40: -0.0
+  art_sys_corr_40: 0.0
   art_sys_corr_41: -6.71966419e-10
-  art_sys_corr_42: -0.0
+  art_sys_corr_42: 0.0
   art_sys_corr_43: 0.0
   art_sys_corr_44: 0.0
-  art_sys_corr_45: -0.0
+  art_sys_corr_45: 0.0
   art_sys_corr_46: -1.63631444e-11
-  art_sys_corr_47: -0.0
+  art_sys_corr_47: 0.0
   art_sys_corr_48: -2.36379891e-13
   art_sys_corr_49: 0.0
   art_sys_corr_50: 0.0
   art_sys_corr_51: -6.37956869e-15
   art_sys_corr_52: 0.0
   art_sys_corr_53: 0.0
-  art_sys_corr_54: -0.0
+  art_sys_corr_54: 0.0
   Unfolding+: -2.10717821e-03
   Unfolding-: 0.0
   JEC0-: -6.32153462e-03
@@ -1892,60 +1892,60 @@ bins:
   JEC13+: 2.10717821e-03
   luminosity_uncertainty: 6.55600000e-03
   bin_by_bin_uncertainty: 0.00298
-- art_sys_corr_1: -0.0
+- art_sys_corr_1: 0.0
   art_sys_corr_2: 7.18069010e-10
   art_sys_corr_3: 0.0
-  art_sys_corr_4: -0.0
+  art_sys_corr_4: 0.0
   art_sys_corr_5: 0.0
   art_sys_corr_6: -1.63557318e-07
-  art_sys_corr_7: -0.0
-  art_sys_corr_8: -0.0
-  art_sys_corr_9: -0.0
+  art_sys_corr_7: 0.0
+  art_sys_corr_8: 0.0
+  art_sys_corr_9: 0.0
   art_sys_corr_10: 0.0
   art_sys_corr_11: 2.07026836e-05
-  art_sys_corr_12: -0.0
-  art_sys_corr_13: -0.0
+  art_sys_corr_12: 0.0
+  art_sys_corr_13: 0.0
   art_sys_corr_14: 0.0
   art_sys_corr_15: 0.0
-  art_sys_corr_16: -0.0
-  art_sys_corr_17: -0.0
+  art_sys_corr_16: 0.0
+  art_sys_corr_17: 0.0
   art_sys_corr_18: 0.0
   art_sys_corr_19: 0.0
   art_sys_corr_20: -2.27570841e-06
   art_sys_corr_21: 0.0
-  art_sys_corr_22: -0.0
+  art_sys_corr_22: 0.0
   art_sys_corr_23: 0.0
   art_sys_corr_24: 1.65253870e-04
   art_sys_corr_25: 0.0
   art_sys_corr_26: 0.0
   art_sys_corr_27: -1.00629630e-03
-  art_sys_corr_28: -0.0
+  art_sys_corr_28: 0.0
   art_sys_corr_29: 0.0
   art_sys_corr_30: 0.0
   art_sys_corr_31: 0.0
   art_sys_corr_32: 0.0
   art_sys_corr_33: 0.0
   art_sys_corr_34: -5.00800775e-06
-  art_sys_corr_35: -0.0
+  art_sys_corr_35: 0.0
   art_sys_corr_36: 0.0
   art_sys_corr_37: 1.84233505e-07
-  art_sys_corr_38: -0.0
+  art_sys_corr_38: 0.0
   art_sys_corr_39: 0.0
-  art_sys_corr_40: -0.0
+  art_sys_corr_40: 0.0
   art_sys_corr_41: -2.42882572e-09
-  art_sys_corr_42: -0.0
+  art_sys_corr_42: 0.0
   art_sys_corr_43: 0.0
   art_sys_corr_44: 0.0
-  art_sys_corr_45: -0.0
+  art_sys_corr_45: 0.0
   art_sys_corr_46: -8.73688670e-11
-  art_sys_corr_47: -0.0
+  art_sys_corr_47: 0.0
   art_sys_corr_48: -1.32278501e-12
   art_sys_corr_49: 0.0
   art_sys_corr_50: 0.0
   art_sys_corr_51: -3.58801357e-14
   art_sys_corr_52: 0.0
   art_sys_corr_53: 0.0
-  art_sys_corr_54: -0.0
+  art_sys_corr_54: 0.0
   Unfolding+: 0.0
   Unfolding-: 0.0
   JEC0-: -1.59523290e-03
@@ -1978,60 +1978,60 @@ bins:
   JEC13+: 5.31744299e-04
   luminosity_uncertainty: 1.65440000e-03
   bin_by_bin_uncertainty: 7.52000000e-04
-- art_sys_corr_1: -0.0
+- art_sys_corr_1: 0.0
   art_sys_corr_2: 4.97701687e-13
   art_sys_corr_3: 0.0
-  art_sys_corr_4: -0.0
+  art_sys_corr_4: 0.0
   art_sys_corr_5: 0.0
   art_sys_corr_6: 7.32338059e-12
-  art_sys_corr_7: -0.0
-  art_sys_corr_8: -0.0
-  art_sys_corr_9: -0.0
+  art_sys_corr_7: 0.0
+  art_sys_corr_8: 0.0
+  art_sys_corr_9: 0.0
   art_sys_corr_10: 0.0
   art_sys_corr_11: -4.57599179e-09
-  art_sys_corr_12: -0.0
-  art_sys_corr_13: -0.0
+  art_sys_corr_12: 0.0
+  art_sys_corr_13: 0.0
   art_sys_corr_14: 0.0
   art_sys_corr_15: 0.0
-  art_sys_corr_16: -0.0
-  art_sys_corr_17: -0.0
+  art_sys_corr_16: 0.0
+  art_sys_corr_17: 0.0
   art_sys_corr_18: 0.0
   art_sys_corr_19: 0.0
   art_sys_corr_20: -1.49749556e-06
   art_sys_corr_21: 0.0
-  art_sys_corr_22: -0.0
+  art_sys_corr_22: 0.0
   art_sys_corr_23: 0.0
   art_sys_corr_24: -2.83340428e-06
   art_sys_corr_25: 0.0
   art_sys_corr_26: 0.0
   art_sys_corr_27: 4.10009492e-05
-  art_sys_corr_28: -0.0
+  art_sys_corr_28: 0.0
   art_sys_corr_29: 0.0
   art_sys_corr_30: 0.0
   art_sys_corr_31: 0.0
   art_sys_corr_32: 0.0
   art_sys_corr_33: 0.0
   art_sys_corr_34: -1.23234751e-04
-  art_sys_corr_35: -0.0
+  art_sys_corr_35: 0.0
   art_sys_corr_36: 0.0
   art_sys_corr_37: 4.67295279e-06
-  art_sys_corr_38: -0.0
+  art_sys_corr_38: 0.0
   art_sys_corr_39: 0.0
-  art_sys_corr_40: -0.0
+  art_sys_corr_40: 0.0
   art_sys_corr_41: 1.05444010e-07
-  art_sys_corr_42: -0.0
+  art_sys_corr_42: 0.0
   art_sys_corr_43: 0.0
   art_sys_corr_44: 0.0
-  art_sys_corr_45: -0.0
+  art_sys_corr_45: 0.0
   art_sys_corr_46: 2.11090447e-09
-  art_sys_corr_47: -0.0
+  art_sys_corr_47: 0.0
   art_sys_corr_48: 2.95234041e-11
   art_sys_corr_49: 0.0
   art_sys_corr_50: 0.0
   art_sys_corr_51: 7.93922436e-13
   art_sys_corr_52: 0.0
   art_sys_corr_53: 0.0
-  art_sys_corr_54: -0.0
+  art_sys_corr_54: 0.0
   Unfolding+: -1.29400541e-04
   Unfolding-: 0.0
   JEC0-: -3.88201623e-04
@@ -2064,60 +2064,60 @@ bins:
   JEC13+: 1.29400541e-04
   luminosity_uncertainty: 4.02600000e-04
   bin_by_bin_uncertainty: 0.000183
-- art_sys_corr_1: -0.0
+- art_sys_corr_1: 0.0
   art_sys_corr_2: -1.84802623e-16
   art_sys_corr_3: 0.0
-  art_sys_corr_4: -0.0
+  art_sys_corr_4: 0.0
   art_sys_corr_5: 0.0
   art_sys_corr_6: 2.45730595e-13
-  art_sys_corr_7: -0.0
-  art_sys_corr_8: -0.0
-  art_sys_corr_9: -0.0
+  art_sys_corr_7: 0.0
+  art_sys_corr_8: 0.0
+  art_sys_corr_9: 0.0
   art_sys_corr_10: 0.0
   art_sys_corr_11: 3.01079257e-12
-  art_sys_corr_12: -0.0
-  art_sys_corr_13: -0.0
+  art_sys_corr_12: 0.0
+  art_sys_corr_13: 0.0
   art_sys_corr_14: 0.0
   art_sys_corr_15: 0.0
-  art_sys_corr_16: -0.0
-  art_sys_corr_17: -0.0
+  art_sys_corr_16: 0.0
+  art_sys_corr_17: 0.0
   art_sys_corr_18: 0.0
   art_sys_corr_19: 0.0
   art_sys_corr_20: 7.15831507e-09
   art_sys_corr_21: 0.0
-  art_sys_corr_22: -0.0
+  art_sys_corr_22: 0.0
   art_sys_corr_23: 0.0
   art_sys_corr_24: -5.86955357e-07
   art_sys_corr_25: 0.0
   art_sys_corr_26: 0.0
   art_sys_corr_27: -1.36164953e-07
-  art_sys_corr_28: -0.0
+  art_sys_corr_28: 0.0
   art_sys_corr_29: 0.0
   art_sys_corr_30: 0.0
   art_sys_corr_31: 0.0
   art_sys_corr_32: 0.0
   art_sys_corr_33: 0.0
   art_sys_corr_34: 1.00881433e-05
-  art_sys_corr_35: -0.0
+  art_sys_corr_35: 0.0
   art_sys_corr_36: 0.0
   art_sys_corr_37: 5.70828548e-05
-  art_sys_corr_38: -0.0
+  art_sys_corr_38: 0.0
   art_sys_corr_39: 0.0
-  art_sys_corr_40: -0.0
+  art_sys_corr_40: 0.0
   art_sys_corr_41: 1.84725714e-06
-  art_sys_corr_42: -0.0
+  art_sys_corr_42: 0.0
   art_sys_corr_43: 0.0
   art_sys_corr_44: 0.0
-  art_sys_corr_45: -0.0
+  art_sys_corr_45: 0.0
   art_sys_corr_46: 3.97623860e-08
-  art_sys_corr_47: -0.0
+  art_sys_corr_47: 0.0
   art_sys_corr_48: 5.63153019e-10
   art_sys_corr_49: 0.0
   art_sys_corr_50: 0.0
   art_sys_corr_51: 1.51653383e-11
   art_sys_corr_52: 0.0
   art_sys_corr_53: 0.0
-  art_sys_corr_54: -0.0
+  art_sys_corr_54: 0.0
   Unfolding+: -2.99106168e-05
   Unfolding-: 2.99106168e-05
   JEC0-: -1.19642467e-04
@@ -2150,60 +2150,60 @@ bins:
   JEC13+: 2.99106168e-05
   luminosity_uncertainty: 9.30600000e-05
   bin_by_bin_uncertainty: 4.23000000e-05
-- art_sys_corr_1: -0.0
+- art_sys_corr_1: 0.0
   art_sys_corr_2: 3.00618455e-20
   art_sys_corr_3: 0.0
-  art_sys_corr_4: -0.0
+  art_sys_corr_4: 0.0
   art_sys_corr_5: 0.0
   art_sys_corr_6: -1.04195712e-16
-  art_sys_corr_7: -0.0
-  art_sys_corr_8: -0.0
-  art_sys_corr_9: -0.0
+  art_sys_corr_7: 0.0
+  art_sys_corr_8: 0.0
+  art_sys_corr_9: 0.0
   art_sys_corr_10: 0.0
   art_sys_corr_11: 3.02110693e-13
-  art_sys_corr_12: -0.0
-  art_sys_corr_13: -0.0
+  art_sys_corr_12: 0.0
+  art_sys_corr_13: 0.0
   art_sys_corr_14: 0.0
   art_sys_corr_15: 0.0
-  art_sys_corr_16: -0.0
-  art_sys_corr_17: -0.0
+  art_sys_corr_16: 0.0
+  art_sys_corr_17: 0.0
   art_sys_corr_18: 0.0
   art_sys_corr_19: 0.0
   art_sys_corr_20: -6.73285385e-12
   art_sys_corr_21: 0.0
-  art_sys_corr_22: -0.0
+  art_sys_corr_22: 0.0
   art_sys_corr_23: 0.0
   art_sys_corr_24: 7.78336365e-09
   art_sys_corr_25: 0.0
   art_sys_corr_26: 0.0
   art_sys_corr_27: -2.58937693e-07
-  art_sys_corr_28: -0.0
+  art_sys_corr_28: 0.0
   art_sys_corr_29: 0.0
   art_sys_corr_30: 0.0
   art_sys_corr_31: 0.0
   art_sys_corr_32: 0.0
   art_sys_corr_33: 0.0
   art_sys_corr_34: -2.23000052e-07
-  art_sys_corr_35: -0.0
+  art_sys_corr_35: 0.0
   art_sys_corr_36: 0.0
   art_sys_corr_37: -4.17653582e-06
-  art_sys_corr_38: -0.0
+  art_sys_corr_38: 0.0
   art_sys_corr_39: 0.0
-  art_sys_corr_40: -0.0
+  art_sys_corr_40: 0.0
   art_sys_corr_41: 2.53475256e-05
-  art_sys_corr_42: -0.0
+  art_sys_corr_42: 0.0
   art_sys_corr_43: 0.0
   art_sys_corr_44: 0.0
-  art_sys_corr_45: -0.0
+  art_sys_corr_45: 0.0
   art_sys_corr_46: 6.57695681e-07
-  art_sys_corr_47: -0.0
+  art_sys_corr_47: 0.0
   art_sys_corr_48: 9.58993284e-09
   art_sys_corr_49: 0.0
   art_sys_corr_50: 0.0
   art_sys_corr_51: 2.59083967e-10
   art_sys_corr_52: 0.0
   art_sys_corr_53: 0.0
-  art_sys_corr_54: -0.0
+  art_sys_corr_54: 0.0
   Unfolding+: -6.80943830e-06
   Unfolding-: 6.80943830e-06
   JEC0-: -2.72377532e-05
@@ -2236,60 +2236,60 @@ bins:
   JEC13+: 6.80943830e-06
   luminosity_uncertainty: 2.11860000e-05
   bin_by_bin_uncertainty: 9.63e-06
-- art_sys_corr_1: -0.0
+- art_sys_corr_1: 0.0
   art_sys_corr_2: -1.66817469e-31
   art_sys_corr_3: 0.0
-  art_sys_corr_4: -0.0
+  art_sys_corr_4: 0.0
   art_sys_corr_5: 0.0
   art_sys_corr_6: 8.79844208e-27
-  art_sys_corr_7: -0.0
-  art_sys_corr_8: -0.0
-  art_sys_corr_9: -0.0
+  art_sys_corr_7: 0.0
+  art_sys_corr_8: 0.0
+  art_sys_corr_9: 0.0
   art_sys_corr_10: 0.0
   art_sys_corr_11: -5.84362375e-22
-  art_sys_corr_12: -0.0
-  art_sys_corr_13: -0.0
+  art_sys_corr_12: 0.0
+  art_sys_corr_13: 0.0
   art_sys_corr_14: 0.0
   art_sys_corr_15: 0.0
-  art_sys_corr_16: -0.0
-  art_sys_corr_17: -0.0
+  art_sys_corr_16: 0.0
+  art_sys_corr_17: 0.0
   art_sys_corr_18: 0.0
   art_sys_corr_19: 0.0
   art_sys_corr_20: 2.63418891e-18
   art_sys_corr_21: 0.0
-  art_sys_corr_22: -0.0
+  art_sys_corr_22: 0.0
   art_sys_corr_23: 0.0
   art_sys_corr_24: -4.84593698e-14
   art_sys_corr_25: 0.0
   art_sys_corr_26: 0.0
   art_sys_corr_27: 8.82773352e-12
-  art_sys_corr_28: -0.0
+  art_sys_corr_28: 0.0
   art_sys_corr_29: 0.0
   art_sys_corr_30: 0.0
   art_sys_corr_31: 0.0
   art_sys_corr_32: 0.0
   art_sys_corr_33: 0.0
   art_sys_corr_34: 5.09579126e-10
-  art_sys_corr_35: -0.0
+  art_sys_corr_35: 0.0
   art_sys_corr_36: 0.0
   art_sys_corr_37: 4.54977175e-08
-  art_sys_corr_38: -0.0
+  art_sys_corr_38: 0.0
   art_sys_corr_39: 0.0
-  art_sys_corr_40: -0.0
+  art_sys_corr_40: 0.0
   art_sys_corr_41: -1.62983996e-06
-  art_sys_corr_42: -0.0
+  art_sys_corr_42: 0.0
   art_sys_corr_43: 0.0
   art_sys_corr_44: 0.0
-  art_sys_corr_45: -0.0
+  art_sys_corr_45: 0.0
   art_sys_corr_46: 1.02698894e-05
-  art_sys_corr_47: -0.0
+  art_sys_corr_47: 0.0
   art_sys_corr_48: 1.75780731e-07
   art_sys_corr_49: 0.0
   art_sys_corr_50: 0.0
   art_sys_corr_51: 4.82808004e-09
   art_sys_corr_52: 0.0
   art_sys_corr_53: 0.0
-  art_sys_corr_54: -0.0
+  art_sys_corr_54: 0.0
   Unfolding+: -1.25157900e-06
   Unfolding-: 1.25157900e-06
   JEC0-: -6.25789501e-06
@@ -2322,60 +2322,60 @@ bins:
   JEC13+: 1.25157900e-06
   luminosity_uncertainty: 3.89400000e-06
   bin_by_bin_uncertainty: 1.77e-06
-- art_sys_corr_1: -0.0
+- art_sys_corr_1: 0.0
   art_sys_corr_2: 1.26793699e-43
   art_sys_corr_3: 0.0
-  art_sys_corr_4: -0.0
+  art_sys_corr_4: 0.0
   art_sys_corr_5: 0.0
   art_sys_corr_6: -1.01789359e-37
-  art_sys_corr_7: -0.0
-  art_sys_corr_8: -0.0
-  art_sys_corr_9: -0.0
+  art_sys_corr_7: 0.0
+  art_sys_corr_8: 0.0
+  art_sys_corr_9: 0.0
   art_sys_corr_10: 0.0
   art_sys_corr_11: 1.54944875e-31
-  art_sys_corr_12: -0.0
-  art_sys_corr_13: -0.0
+  art_sys_corr_12: 0.0
+  art_sys_corr_13: 0.0
   art_sys_corr_14: 0.0
   art_sys_corr_15: 0.0
-  art_sys_corr_16: -0.0
-  art_sys_corr_17: -0.0
+  art_sys_corr_16: 0.0
+  art_sys_corr_17: 0.0
   art_sys_corr_18: 0.0
   art_sys_corr_19: 0.0
   art_sys_corr_20: -1.41157423e-25
   art_sys_corr_21: 0.0
-  art_sys_corr_22: -0.0
+  art_sys_corr_22: 0.0
   art_sys_corr_23: 0.0
   art_sys_corr_24: 4.13228537e-20
   art_sys_corr_25: 0.0
   art_sys_corr_26: 0.0
   art_sys_corr_27: -4.12165733e-17
-  art_sys_corr_28: -0.0
+  art_sys_corr_28: 0.0
   art_sys_corr_29: 0.0
   art_sys_corr_30: 0.0
   art_sys_corr_31: 0.0
   art_sys_corr_32: 0.0
   art_sys_corr_33: 0.0
   art_sys_corr_34: -1.58489532e-13
-  art_sys_corr_35: -0.0
+  art_sys_corr_35: 0.0
   art_sys_corr_36: 0.0
   art_sys_corr_37: -6.59054738e-11
-  art_sys_corr_38: -0.0
+  art_sys_corr_38: 0.0
   art_sys_corr_39: 0.0
-  art_sys_corr_40: -0.0
+  art_sys_corr_40: 0.0
   art_sys_corr_41: 1.21918362e-08
-  art_sys_corr_42: -0.0
+  art_sys_corr_42: 0.0
   art_sys_corr_43: 0.0
   art_sys_corr_44: 0.0
-  art_sys_corr_45: -0.0
+  art_sys_corr_45: 0.0
   art_sys_corr_46: -5.21067838e-07
-  art_sys_corr_47: -0.0
+  art_sys_corr_47: 0.0
   art_sys_corr_48: 3.48047745e-06
   art_sys_corr_49: 0.0
   art_sys_corr_50: 0.0
   art_sys_corr_51: 7.08263570e-08
   art_sys_corr_52: 0.0
   art_sys_corr_53: 0.0
-  art_sys_corr_54: -0.0
+  art_sys_corr_54: 0.0
   Unfolding+: -1.55563492e-07
   Unfolding-: 1.55563492e-07
   JEC0-: -9.33380951e-07
@@ -2408,60 +2408,60 @@ bins:
   JEC13+: 1.55563492e-07
   luminosity_uncertainty: 4.84000000e-07
   bin_by_bin_uncertainty: 2.2e-07
-- art_sys_corr_1: -0.0
+- art_sys_corr_1: 0.0
   art_sys_corr_2: 3.54667690e-45
   art_sys_corr_3: 0.0
-  art_sys_corr_4: -0.0
+  art_sys_corr_4: 0.0
   art_sys_corr_5: 0.0
   art_sys_corr_6: -2.84725479e-39
-  art_sys_corr_7: -0.0
-  art_sys_corr_8: -0.0
-  art_sys_corr_9: -0.0
+  art_sys_corr_7: 0.0
+  art_sys_corr_8: 0.0
+  art_sys_corr_9: 0.0
   art_sys_corr_10: 0.0
   art_sys_corr_11: 4.33412238e-33
-  art_sys_corr_12: -0.0
-  art_sys_corr_13: -0.0
+  art_sys_corr_12: 0.0
+  art_sys_corr_13: 0.0
   art_sys_corr_14: 0.0
   art_sys_corr_15: 0.0
-  art_sys_corr_16: -0.0
-  art_sys_corr_17: -0.0
+  art_sys_corr_16: 0.0
+  art_sys_corr_17: 0.0
   art_sys_corr_18: 0.0
   art_sys_corr_19: 0.0
   art_sys_corr_20: -3.94845797e-27
   art_sys_corr_21: 0.0
-  art_sys_corr_22: -0.0
+  art_sys_corr_22: 0.0
   art_sys_corr_23: 0.0
   art_sys_corr_24: 1.15587746e-21
   art_sys_corr_25: 0.0
   art_sys_corr_26: 0.0
   art_sys_corr_27: -1.15287531e-18
-  art_sys_corr_28: -0.0
+  art_sys_corr_28: 0.0
   art_sys_corr_29: 0.0
   art_sys_corr_30: 0.0
   art_sys_corr_31: 0.0
   art_sys_corr_32: 0.0
   art_sys_corr_33: 0.0
   art_sys_corr_34: -4.42410272e-15
-  art_sys_corr_35: -0.0
+  art_sys_corr_35: 0.0
   art_sys_corr_36: 0.0
   art_sys_corr_37: -1.82579377e-12
-  art_sys_corr_38: -0.0
+  art_sys_corr_38: 0.0
   art_sys_corr_39: 0.0
-  art_sys_corr_40: -0.0
+  art_sys_corr_40: 0.0
   art_sys_corr_41: 3.24332440e-10
-  art_sys_corr_42: -0.0
+  art_sys_corr_42: 0.0
   art_sys_corr_43: 0.0
   art_sys_corr_44: 0.0
-  art_sys_corr_45: -0.0
+  art_sys_corr_45: 0.0
   art_sys_corr_46: -1.01582557e-08
-  art_sys_corr_47: -0.0
+  art_sys_corr_47: 0.0
   art_sys_corr_48: -1.95552396e-07
   art_sys_corr_49: 0.0
   art_sys_corr_50: 0.0
   art_sys_corr_51: 1.26493319e-06
   art_sys_corr_52: 0.0
   art_sys_corr_53: 0.0
-  art_sys_corr_54: -0.0
+  art_sys_corr_54: 0.0
   Unfolding+: -5.04874242e-08
   Unfolding-: 5.04874242e-08
   JEC0-: -1.76705985e-07
@@ -2494,60 +2494,60 @@ bins:
   JEC13+: 2.52437121e-08
   luminosity_uncertainty: 7.85400000e-08
   bin_by_bin_uncertainty: 3.57e-08
-- art_sys_corr_1: -0.0
+- art_sys_corr_1: 0.0
   art_sys_corr_2: 0.0
   art_sys_corr_3: 1.35976742e+00
-  art_sys_corr_4: -0.0
+  art_sys_corr_4: 0.0
   art_sys_corr_5: 0.0
-  art_sys_corr_6: -0.0
+  art_sys_corr_6: 0.0
   art_sys_corr_7: 2.51501189e-02
-  art_sys_corr_8: -0.0
-  art_sys_corr_9: -0.0
+  art_sys_corr_8: 0.0
+  art_sys_corr_9: 0.0
   art_sys_corr_10: 0.0
-  art_sys_corr_11: -0.0
-  art_sys_corr_12: -0.0
-  art_sys_corr_13: -0.0
+  art_sys_corr_11: 0.0
+  art_sys_corr_12: 0.0
+  art_sys_corr_13: 0.0
   art_sys_corr_14: 1.63768888e-04
   art_sys_corr_15: 7.05597548e-06
-  art_sys_corr_16: -0.0
-  art_sys_corr_17: -0.0
+  art_sys_corr_16: 0.0
+  art_sys_corr_17: 0.0
   art_sys_corr_18: 0.0
   art_sys_corr_19: 0.0
-  art_sys_corr_20: -0.0
+  art_sys_corr_20: 0.0
   art_sys_corr_21: 0.0
-  art_sys_corr_22: -0.0
+  art_sys_corr_22: 0.0
   art_sys_corr_23: 5.91670928e-08
   art_sys_corr_24: 0.0
   art_sys_corr_25: 0.0
   art_sys_corr_26: 0.0
-  art_sys_corr_27: -0.0
-  art_sys_corr_28: -0.0
+  art_sys_corr_27: 0.0
+  art_sys_corr_28: 0.0
   art_sys_corr_29: 0.0
   art_sys_corr_30: 1.22029158e-09
   art_sys_corr_31: 2.61528493e-11
   art_sys_corr_32: 0.0
   art_sys_corr_33: 0.0
-  art_sys_corr_34: -0.0
-  art_sys_corr_35: -0.0
+  art_sys_corr_34: 0.0
+  art_sys_corr_35: 0.0
   art_sys_corr_36: 0.0
-  art_sys_corr_37: -0.0
-  art_sys_corr_38: -0.0
+  art_sys_corr_37: 0.0
+  art_sys_corr_38: 0.0
   art_sys_corr_39: 8.91371123e-14
-  art_sys_corr_40: -0.0
+  art_sys_corr_40: 0.0
   art_sys_corr_41: 0.0
-  art_sys_corr_42: -0.0
+  art_sys_corr_42: 0.0
   art_sys_corr_43: 0.0
   art_sys_corr_44: 0.0
   art_sys_corr_45: 3.92880432e-15
-  art_sys_corr_46: -0.0
-  art_sys_corr_47: -0.0
+  art_sys_corr_46: 0.0
+  art_sys_corr_47: 0.0
   art_sys_corr_48: 0.0
   art_sys_corr_49: 5.35831782e-17
   art_sys_corr_50: 0.0
   art_sys_corr_51: 0.0
   art_sys_corr_52: 0.0
   art_sys_corr_53: 6.84072769e-19
-  art_sys_corr_54: -0.0
+  art_sys_corr_54: 0.0
   Unfolding+: -4.61740728e-01
   Unfolding-: 4.61740728e-01
   JEC0-: -9.23481456e-01
@@ -2580,60 +2580,60 @@ bins:
   JEC13+: 9.23481456e-01
   luminosity_uncertainty: 1.43660000e+00
   bin_by_bin_uncertainty: 0.653
-- art_sys_corr_1: -0.0
+- art_sys_corr_1: 0.0
   art_sys_corr_2: 0.0
   art_sys_corr_3: -8.09237518e-02
-  art_sys_corr_4: -0.0
+  art_sys_corr_4: 0.0
   art_sys_corr_5: 0.0
-  art_sys_corr_6: -0.0
+  art_sys_corr_6: 0.0
   art_sys_corr_7: 4.22296571e-01
-  art_sys_corr_8: -0.0
-  art_sys_corr_9: -0.0
+  art_sys_corr_8: 0.0
+  art_sys_corr_9: 0.0
   art_sys_corr_10: 0.0
-  art_sys_corr_11: -0.0
-  art_sys_corr_12: -0.0
-  art_sys_corr_13: -0.0
+  art_sys_corr_11: 0.0
+  art_sys_corr_12: 0.0
+  art_sys_corr_13: 0.0
   art_sys_corr_14: 4.11388956e-03
   art_sys_corr_15: -1.69511108e-04
-  art_sys_corr_16: -0.0
-  art_sys_corr_17: -0.0
+  art_sys_corr_16: 0.0
+  art_sys_corr_17: 0.0
   art_sys_corr_18: 0.0
   art_sys_corr_19: 0.0
-  art_sys_corr_20: -0.0
+  art_sys_corr_20: 0.0
   art_sys_corr_21: 0.0
-  art_sys_corr_22: -0.0
+  art_sys_corr_22: 0.0
   art_sys_corr_23: 3.48253374e-07
   art_sys_corr_24: 0.0
   art_sys_corr_25: 0.0
   art_sys_corr_26: 0.0
-  art_sys_corr_27: -0.0
-  art_sys_corr_28: -0.0
+  art_sys_corr_27: 0.0
+  art_sys_corr_28: 0.0
   art_sys_corr_29: 0.0
   art_sys_corr_30: 1.29058679e-08
   art_sys_corr_31: 6.31357501e-10
   art_sys_corr_32: 0.0
   art_sys_corr_33: 0.0
-  art_sys_corr_34: -0.0
-  art_sys_corr_35: -0.0
+  art_sys_corr_34: 0.0
+  art_sys_corr_35: 0.0
   art_sys_corr_36: 0.0
-  art_sys_corr_37: -0.0
-  art_sys_corr_38: -0.0
+  art_sys_corr_37: 0.0
+  art_sys_corr_38: 0.0
   art_sys_corr_39: -1.54844399e-13
-  art_sys_corr_40: -0.0
+  art_sys_corr_40: 0.0
   art_sys_corr_41: 0.0
-  art_sys_corr_42: -0.0
+  art_sys_corr_42: 0.0
   art_sys_corr_43: 0.0
   art_sys_corr_44: 0.0
   art_sys_corr_45: 2.72703763e-14
-  art_sys_corr_46: -0.0
-  art_sys_corr_47: -0.0
+  art_sys_corr_46: 0.0
+  art_sys_corr_47: 0.0
   art_sys_corr_48: 0.0
   art_sys_corr_49: 7.29474848e-16
   art_sys_corr_50: 0.0
   art_sys_corr_51: 0.0
   art_sys_corr_52: 0.0
   art_sys_corr_53: 7.94881040e-18
-  art_sys_corr_54: -0.0
+  art_sys_corr_54: 0.0
   Unfolding+: -8.48528137e-02
   Unfolding-: 8.48528137e-02
   JEC0-: -2.54558441e-01
@@ -2666,60 +2666,60 @@ bins:
   JEC13+: 1.69705627e-01
   luminosity_uncertainty: 0.264
   bin_by_bin_uncertainty: 0.12
-- art_sys_corr_1: -0.0
+- art_sys_corr_1: 0.0
   art_sys_corr_2: 0.0
   art_sys_corr_3: 1.26761489e-03
-  art_sys_corr_4: -0.0
+  art_sys_corr_4: 0.0
   art_sys_corr_5: 0.0
-  art_sys_corr_6: -0.0
+  art_sys_corr_6: 0.0
   art_sys_corr_7: -1.93695379e-02
-  art_sys_corr_8: -0.0
-  art_sys_corr_9: -0.0
+  art_sys_corr_8: 0.0
+  art_sys_corr_9: 0.0
   art_sys_corr_10: 0.0
-  art_sys_corr_11: -0.0
-  art_sys_corr_12: -0.0
-  art_sys_corr_13: -0.0
+  art_sys_corr_11: 0.0
+  art_sys_corr_12: 0.0
+  art_sys_corr_13: 0.0
   art_sys_corr_14: 8.98398781e-02
   art_sys_corr_15: -4.00130136e-03
-  art_sys_corr_16: -0.0
-  art_sys_corr_17: -0.0
+  art_sys_corr_16: 0.0
+  art_sys_corr_17: 0.0
   art_sys_corr_18: 0.0
   art_sys_corr_19: 0.0
-  art_sys_corr_20: -0.0
+  art_sys_corr_20: 0.0
   art_sys_corr_21: 0.0
-  art_sys_corr_22: -0.0
+  art_sys_corr_22: 0.0
   art_sys_corr_23: -6.00361195e-06
   art_sys_corr_24: 0.0
   art_sys_corr_25: 0.0
   art_sys_corr_26: 0.0
-  art_sys_corr_27: -0.0
-  art_sys_corr_28: -0.0
+  art_sys_corr_27: 0.0
+  art_sys_corr_28: 0.0
   art_sys_corr_29: 0.0
   art_sys_corr_30: 8.07109160e-08
   art_sys_corr_31: 7.63489025e-09
   art_sys_corr_32: 0.0
   art_sys_corr_33: 0.0
-  art_sys_corr_34: -0.0
-  art_sys_corr_35: -0.0
+  art_sys_corr_34: 0.0
+  art_sys_corr_35: 0.0
   art_sys_corr_36: 0.0
-  art_sys_corr_37: -0.0
-  art_sys_corr_38: -0.0
+  art_sys_corr_37: 0.0
+  art_sys_corr_38: 0.0
   art_sys_corr_39: -3.08114408e-11
-  art_sys_corr_40: -0.0
+  art_sys_corr_40: 0.0
   art_sys_corr_41: 0.0
-  art_sys_corr_42: -0.0
+  art_sys_corr_42: 0.0
   art_sys_corr_43: 0.0
   art_sys_corr_44: 0.0
   art_sys_corr_45: -2.33599885e-13
-  art_sys_corr_46: -0.0
-  art_sys_corr_47: -0.0
+  art_sys_corr_46: 0.0
+  art_sys_corr_47: 0.0
   art_sys_corr_48: 0.0
   art_sys_corr_49: 3.42376581e-15
   art_sys_corr_50: 0.0
   art_sys_corr_51: 0.0
   art_sys_corr_52: 0.0
   art_sys_corr_53: 1.93988957e-17
-  art_sys_corr_54: -0.0
+  art_sys_corr_54: 0.0
   Unfolding+: -1.96575685e-02
   Unfolding-: 1.96575685e-02
   JEC0-: -5.89727056e-02
@@ -2752,60 +2752,60 @@ bins:
   JEC13+: 3.93151370e-02
   luminosity_uncertainty: 6.11600000e-02
   bin_by_bin_uncertainty: 0.0278
-- art_sys_corr_1: -0.0
+- art_sys_corr_1: 0.0
   art_sys_corr_2: 0.0
   art_sys_corr_3: 4.30574430e-04
-  art_sys_corr_4: -0.0
+  art_sys_corr_4: 0.0
   art_sys_corr_5: 0.0
-  art_sys_corr_6: -0.0
+  art_sys_corr_6: 0.0
   art_sys_corr_7: 1.48277438e-04
-  art_sys_corr_8: -0.0
-  art_sys_corr_9: -0.0
+  art_sys_corr_8: 0.0
+  art_sys_corr_9: 0.0
   art_sys_corr_10: 0.0
-  art_sys_corr_11: -0.0
-  art_sys_corr_12: -0.0
-  art_sys_corr_13: -0.0
+  art_sys_corr_11: 0.0
+  art_sys_corr_12: 0.0
+  art_sys_corr_13: 0.0
   art_sys_corr_14: -8.49627373e-03
   art_sys_corr_15: -4.23536637e-02
-  art_sys_corr_16: -0.0
-  art_sys_corr_17: -0.0
+  art_sys_corr_16: 0.0
+  art_sys_corr_17: 0.0
   art_sys_corr_18: 0.0
   art_sys_corr_19: 0.0
-  art_sys_corr_20: -0.0
+  art_sys_corr_20: 0.0
   art_sys_corr_21: 0.0
-  art_sys_corr_22: -0.0
+  art_sys_corr_22: 0.0
   art_sys_corr_23: -1.14551651e-04
   art_sys_corr_24: 0.0
   art_sys_corr_25: 0.0
   art_sys_corr_26: 0.0
-  art_sys_corr_27: -0.0
-  art_sys_corr_28: -0.0
+  art_sys_corr_27: 0.0
+  art_sys_corr_28: 0.0
   art_sys_corr_29: 0.0
   art_sys_corr_30: -1.82970181e-06
   art_sys_corr_31: 8.24134506e-09
   art_sys_corr_32: 0.0
   art_sys_corr_33: 0.0
-  art_sys_corr_34: -0.0
-  art_sys_corr_35: -0.0
+  art_sys_corr_34: 0.0
+  art_sys_corr_35: 0.0
   art_sys_corr_36: 0.0
-  art_sys_corr_37: -0.0
-  art_sys_corr_38: -0.0
+  art_sys_corr_37: 0.0
+  art_sys_corr_38: 0.0
   art_sys_corr_39: -2.41201557e-10
-  art_sys_corr_40: -0.0
+  art_sys_corr_40: 0.0
   art_sys_corr_41: 0.0
-  art_sys_corr_42: -0.0
+  art_sys_corr_42: 0.0
   art_sys_corr_43: 0.0
   art_sys_corr_44: 0.0
   art_sys_corr_45: -7.25647563e-12
-  art_sys_corr_46: -0.0
-  art_sys_corr_47: -0.0
+  art_sys_corr_46: 0.0
+  art_sys_corr_47: 0.0
   art_sys_corr_48: 0.0
   art_sys_corr_49: -5.25425361e-14
   art_sys_corr_50: 0.0
   art_sys_corr_51: 0.0
   art_sys_corr_52: 0.0
   art_sys_corr_53: -8.49833123e-16
-  art_sys_corr_54: -0.0
+  art_sys_corr_54: 0.0
   Unfolding+: -4.97803174e-03
   Unfolding-: 4.97803174e-03
   JEC0-: -1.49340952e-02
@@ -2838,60 +2838,60 @@ bins:
   JEC13+: 9.95606348e-03
   luminosity_uncertainty: 1.54880000e-02
   bin_by_bin_uncertainty: 7.04000000e-03
-- art_sys_corr_1: -0.0
+- art_sys_corr_1: 0.0
   art_sys_corr_2: 0.0
   art_sys_corr_3: -1.81523752e-06
-  art_sys_corr_4: -0.0
+  art_sys_corr_4: 0.0
   art_sys_corr_5: 0.0
-  art_sys_corr_6: -0.0
+  art_sys_corr_6: 0.0
   art_sys_corr_7: 9.65040891e-05
-  art_sys_corr_8: -0.0
-  art_sys_corr_9: -0.0
+  art_sys_corr_8: 0.0
+  art_sys_corr_9: 0.0
   art_sys_corr_10: 0.0
-  art_sys_corr_11: -0.0
-  art_sys_corr_12: -0.0
-  art_sys_corr_13: -0.0
+  art_sys_corr_11: 0.0
+  art_sys_corr_12: 0.0
+  art_sys_corr_13: 0.0
   art_sys_corr_14: 1.70765464e-04
   art_sys_corr_15: 1.89873778e-03
-  art_sys_corr_16: -0.0
-  art_sys_corr_17: -0.0
+  art_sys_corr_16: 0.0
+  art_sys_corr_17: 0.0
   art_sys_corr_18: 0.0
   art_sys_corr_19: 0.0
-  art_sys_corr_20: -0.0
+  art_sys_corr_20: 0.0
   art_sys_corr_21: 0.0
-  art_sys_corr_22: -0.0
+  art_sys_corr_22: 0.0
   art_sys_corr_23: -2.56802720e-03
   art_sys_corr_24: 0.0
   art_sys_corr_25: 0.0
   art_sys_corr_26: 0.0
-  art_sys_corr_27: -0.0
-  art_sys_corr_28: -0.0
+  art_sys_corr_27: 0.0
+  art_sys_corr_28: 0.0
   art_sys_corr_29: 0.0
   art_sys_corr_30: -3.93989106e-05
   art_sys_corr_31: -1.30161527e-06
   art_sys_corr_32: 0.0
   art_sys_corr_33: 0.0
-  art_sys_corr_34: -0.0
-  art_sys_corr_35: -0.0
+  art_sys_corr_34: 0.0
+  art_sys_corr_35: 0.0
   art_sys_corr_36: 0.0
-  art_sys_corr_37: -0.0
-  art_sys_corr_38: -0.0
+  art_sys_corr_37: 0.0
+  art_sys_corr_38: 0.0
   art_sys_corr_39: -4.99728041e-09
-  art_sys_corr_40: -0.0
+  art_sys_corr_40: 0.0
   art_sys_corr_41: 0.0
-  art_sys_corr_42: -0.0
+  art_sys_corr_42: 0.0
   art_sys_corr_43: 0.0
   art_sys_corr_44: 0.0
   art_sys_corr_45: -1.57460001e-10
-  art_sys_corr_46: -0.0
-  art_sys_corr_47: -0.0
+  art_sys_corr_46: 0.0
+  art_sys_corr_47: 0.0
   art_sys_corr_48: 0.0
   art_sys_corr_49: -2.48217149e-12
   art_sys_corr_50: 0.0
   art_sys_corr_51: 0.0
   art_sys_corr_52: 0.0
   art_sys_corr_53: -3.02384496e-14
-  art_sys_corr_54: -0.0
+  art_sys_corr_54: 0.0
   Unfolding+: -1.07480231e-03
   Unfolding-: 1.07480231e-03
   JEC0-: -3.22440692e-03
@@ -2924,60 +2924,60 @@ bins:
   JEC13+: 1.07480231e-03
   luminosity_uncertainty: 3.34400000e-03
   bin_by_bin_uncertainty: 0.00152
-- art_sys_corr_1: -0.0
+- art_sys_corr_1: 0.0
   art_sys_corr_2: 0.0
   art_sys_corr_3: 1.30357077e-09
-  art_sys_corr_4: -0.0
+  art_sys_corr_4: 0.0
   art_sys_corr_5: 0.0
-  art_sys_corr_6: -0.0
+  art_sys_corr_6: 0.0
   art_sys_corr_7: -2.18042365e-07
-  art_sys_corr_8: -0.0
-  art_sys_corr_9: -0.0
+  art_sys_corr_8: 0.0
+  art_sys_corr_9: 0.0
   art_sys_corr_10: 0.0
-  art_sys_corr_11: -0.0
-  art_sys_corr_12: -0.0
-  art_sys_corr_13: -0.0
+  art_sys_corr_11: 0.0
+  art_sys_corr_12: 0.0
+  art_sys_corr_13: 0.0
   art_sys_corr_14: 2.25044831e-05
   art_sys_corr_15: 2.57821919e-06
-  art_sys_corr_16: -0.0
-  art_sys_corr_17: -0.0
+  art_sys_corr_16: 0.0
+  art_sys_corr_17: 0.0
   art_sys_corr_18: 0.0
   art_sys_corr_19: 0.0
-  art_sys_corr_20: -0.0
+  art_sys_corr_20: 0.0
   art_sys_corr_21: 0.0
-  art_sys_corr_22: -0.0
+  art_sys_corr_22: 0.0
   art_sys_corr_23: 1.41732331e-04
   art_sys_corr_24: 0.0
   art_sys_corr_25: 0.0
   art_sys_corr_26: 0.0
-  art_sys_corr_27: -0.0
-  art_sys_corr_28: -0.0
+  art_sys_corr_27: 0.0
+  art_sys_corr_28: 0.0
   art_sys_corr_29: 0.0
   art_sys_corr_30: -7.15368956e-04
   art_sys_corr_31: -2.33677470e-05
   art_sys_corr_32: 0.0
   art_sys_corr_33: 0.0
-  art_sys_corr_34: -0.0
-  art_sys_corr_35: -0.0
+  art_sys_corr_34: 0.0
+  art_sys_corr_35: 0.0
   art_sys_corr_36: 0.0
-  art_sys_corr_37: -0.0
-  art_sys_corr_38: -0.0
+  art_sys_corr_37: 0.0
+  art_sys_corr_38: 0.0
   art_sys_corr_39: 7.20074476e-08
-  art_sys_corr_40: -0.0
+  art_sys_corr_40: 0.0
   art_sys_corr_41: 0.0
-  art_sys_corr_42: -0.0
+  art_sys_corr_42: 0.0
   art_sys_corr_43: 0.0
   art_sys_corr_44: 0.0
   art_sys_corr_45: -6.00982293e-10
-  art_sys_corr_46: -0.0
-  art_sys_corr_47: -0.0
+  art_sys_corr_46: 0.0
+  art_sys_corr_47: 0.0
   art_sys_corr_48: 0.0
   art_sys_corr_49: -1.98446122e-11
   art_sys_corr_50: 0.0
   art_sys_corr_51: 0.0
   art_sys_corr_52: 0.0
   art_sys_corr_53: -2.13792784e-13
-  art_sys_corr_54: -0.0
+  art_sys_corr_54: 0.0
   Unfolding+: -2.60922402e-04
   Unfolding-: 2.60922402e-04
   JEC0-: -7.82767207e-04
@@ -3010,60 +3010,60 @@ bins:
   JEC13+: 2.60922402e-04
   luminosity_uncertainty: 8.11800000e-04
   bin_by_bin_uncertainty: 0.000369
-- art_sys_corr_1: -0.0
+- art_sys_corr_1: 0.0
   art_sys_corr_2: 0.0
   art_sys_corr_3: 9.38497263e-11
-  art_sys_corr_4: -0.0
+  art_sys_corr_4: 0.0
   art_sys_corr_5: 0.0
-  art_sys_corr_6: -0.0
+  art_sys_corr_6: 0.0
   art_sys_corr_7: 3.23606441e-10
-  art_sys_corr_8: -0.0
-  art_sys_corr_9: -0.0
+  art_sys_corr_8: 0.0
+  art_sys_corr_9: 0.0
   art_sys_corr_10: 0.0
-  art_sys_corr_11: -0.0
-  art_sys_corr_12: -0.0
-  art_sys_corr_13: -0.0
+  art_sys_corr_11: 0.0
+  art_sys_corr_12: 0.0
+  art_sys_corr_13: 0.0
   art_sys_corr_14: -4.21507041e-07
   art_sys_corr_15: -9.46507991e-06
-  art_sys_corr_16: -0.0
-  art_sys_corr_17: -0.0
+  art_sys_corr_16: 0.0
+  art_sys_corr_17: 0.0
   art_sys_corr_18: 0.0
   art_sys_corr_19: 0.0
-  art_sys_corr_20: -0.0
+  art_sys_corr_20: 0.0
   art_sys_corr_21: 0.0
-  art_sys_corr_22: -0.0
+  art_sys_corr_22: 0.0
   art_sys_corr_23: 6.77653709e-08
   art_sys_corr_24: 0.0
   art_sys_corr_25: 0.0
   art_sys_corr_26: 0.0
-  art_sys_corr_27: -0.0
-  art_sys_corr_28: -0.0
+  art_sys_corr_27: 0.0
+  art_sys_corr_28: 0.0
   art_sys_corr_29: 0.0
   art_sys_corr_30: 5.45691529e-05
   art_sys_corr_31: -3.07040736e-04
   art_sys_corr_32: 0.0
   art_sys_corr_33: 0.0
-  art_sys_corr_34: -0.0
-  art_sys_corr_35: -0.0
+  art_sys_corr_34: 0.0
+  art_sys_corr_35: 0.0
   art_sys_corr_36: 0.0
-  art_sys_corr_37: -0.0
-  art_sys_corr_38: -0.0
+  art_sys_corr_37: 0.0
+  art_sys_corr_38: 0.0
   art_sys_corr_39: 1.55672965e-06
-  art_sys_corr_40: -0.0
+  art_sys_corr_40: 0.0
   art_sys_corr_41: 0.0
-  art_sys_corr_42: -0.0
+  art_sys_corr_42: 0.0
   art_sys_corr_43: 0.0
   art_sys_corr_44: 0.0
   art_sys_corr_45: 2.20058517e-08
-  art_sys_corr_46: -0.0
-  art_sys_corr_47: -0.0
+  art_sys_corr_46: 0.0
+  art_sys_corr_47: 0.0
   art_sys_corr_48: 0.0
   art_sys_corr_49: -3.76433185e-11
   art_sys_corr_50: 0.0
   art_sys_corr_51: 0.0
   art_sys_corr_52: 0.0
   art_sys_corr_53: 7.81670980e-13
-  art_sys_corr_54: -0.0
+  art_sys_corr_54: 0.0
   Unfolding+: -6.42052957e-05
   Unfolding-: 6.42052957e-05
   JEC0-: -2.56821183e-04
@@ -3096,60 +3096,60 @@ bins:
   JEC13+: 6.42052957e-05
   luminosity_uncertainty: 1.99760000e-04
   bin_by_bin_uncertainty: 9.08e-05
-- art_sys_corr_1: -0.0
+- art_sys_corr_1: 0.0
   art_sys_corr_2: 0.0
   art_sys_corr_3: -3.81172533e-12
-  art_sys_corr_4: -0.0
+  art_sys_corr_4: 0.0
   art_sys_corr_5: 0.0
-  art_sys_corr_6: -0.0
+  art_sys_corr_6: 0.0
   art_sys_corr_7: -1.22641919e-11
-  art_sys_corr_8: -0.0
-  art_sys_corr_9: -0.0
+  art_sys_corr_8: 0.0
+  art_sys_corr_9: 0.0
   art_sys_corr_10: 0.0
-  art_sys_corr_11: -0.0
-  art_sys_corr_12: -0.0
-  art_sys_corr_13: -0.0
+  art_sys_corr_11: 0.0
+  art_sys_corr_12: 0.0
+  art_sys_corr_13: 0.0
   art_sys_corr_14: 1.71436015e-08
   art_sys_corr_15: 3.85963482e-07
-  art_sys_corr_16: -0.0
-  art_sys_corr_17: -0.0
+  art_sys_corr_16: 0.0
+  art_sys_corr_17: 0.0
   art_sys_corr_18: 0.0
   art_sys_corr_19: 0.0
-  art_sys_corr_20: -0.0
+  art_sys_corr_20: 0.0
   art_sys_corr_21: 0.0
-  art_sys_corr_22: -0.0
+  art_sys_corr_22: 0.0
   art_sys_corr_23: -6.52815759e-07
   art_sys_corr_24: 0.0
   art_sys_corr_25: 0.0
   art_sys_corr_26: 0.0
-  art_sys_corr_27: -0.0
-  art_sys_corr_28: -0.0
+  art_sys_corr_27: 0.0
+  art_sys_corr_28: 0.0
   art_sys_corr_29: 0.0
   art_sys_corr_30: -9.53026526e-07
   art_sys_corr_31: 1.35133579e-05
   art_sys_corr_32: 0.0
   art_sys_corr_33: 0.0
-  art_sys_corr_34: -0.0
-  art_sys_corr_35: -0.0
+  art_sys_corr_34: 0.0
+  art_sys_corr_35: 0.0
   art_sys_corr_36: 0.0
-  art_sys_corr_37: -0.0
-  art_sys_corr_38: -0.0
+  art_sys_corr_37: 0.0
+  art_sys_corr_38: 0.0
   art_sys_corr_39: 3.54913435e-05
-  art_sys_corr_40: -0.0
+  art_sys_corr_40: 0.0
   art_sys_corr_41: 0.0
-  art_sys_corr_42: -0.0
+  art_sys_corr_42: 0.0
   art_sys_corr_43: 0.0
   art_sys_corr_44: 0.0
   art_sys_corr_45: 5.19588964e-07
-  art_sys_corr_46: -0.0
-  art_sys_corr_47: -0.0
+  art_sys_corr_46: 0.0
+  art_sys_corr_47: 0.0
   art_sys_corr_48: 0.0
   art_sys_corr_49: 5.69080840e-09
   art_sys_corr_50: 0.0
   art_sys_corr_51: 0.0
   art_sys_corr_52: 0.0
   art_sys_corr_53: 7.63056009e-11
-  art_sys_corr_54: -0.0
+  art_sys_corr_54: 0.0
   Unfolding+: -1.30107648e-05
   Unfolding-: 1.30107648e-05
   JEC0-: -5.20430591e-05
@@ -3182,60 +3182,60 @@ bins:
   JEC13+: 1.30107648e-05
   luminosity_uncertainty: 4.04800000e-05
   bin_by_bin_uncertainty: 1.84e-05
-- art_sys_corr_1: -0.0
+- art_sys_corr_1: 0.0
   art_sys_corr_2: 0.0
   art_sys_corr_3: 5.49921356e-20
-  art_sys_corr_4: -0.0
+  art_sys_corr_4: 0.0
   art_sys_corr_5: 0.0
-  art_sys_corr_6: -0.0
+  art_sys_corr_6: 0.0
   art_sys_corr_7: -9.49614617e-17
-  art_sys_corr_8: -0.0
-  art_sys_corr_9: -0.0
+  art_sys_corr_8: 0.0
+  art_sys_corr_9: 0.0
   art_sys_corr_10: 0.0
-  art_sys_corr_11: -0.0
-  art_sys_corr_12: -0.0
-  art_sys_corr_13: -0.0
+  art_sys_corr_11: 0.0
+  art_sys_corr_12: 0.0
+  art_sys_corr_13: 0.0
   art_sys_corr_14: 2.15290375e-13
   art_sys_corr_15: 9.89337577e-14
-  art_sys_corr_16: -0.0
-  art_sys_corr_17: -0.0
+  art_sys_corr_16: 0.0
+  art_sys_corr_17: 0.0
   art_sys_corr_18: 0.0
   art_sys_corr_19: 0.0
-  art_sys_corr_20: -0.0
+  art_sys_corr_20: 0.0
   art_sys_corr_21: 0.0
-  art_sys_corr_22: -0.0
+  art_sys_corr_22: 0.0
   art_sys_corr_23: 1.67592753e-09
   art_sys_corr_24: 0.0
   art_sys_corr_25: 0.0
   art_sys_corr_26: 0.0
-  art_sys_corr_27: -0.0
-  art_sys_corr_28: -0.0
+  art_sys_corr_27: 0.0
+  art_sys_corr_28: 0.0
   art_sys_corr_29: 0.0
   art_sys_corr_30: -1.08148365e-07
   art_sys_corr_31: -2.73411234e-08
   art_sys_corr_32: 0.0
   art_sys_corr_33: 0.0
-  art_sys_corr_34: -0.0
-  art_sys_corr_35: -0.0
+  art_sys_corr_34: 0.0
+  art_sys_corr_35: 0.0
   art_sys_corr_36: 0.0
-  art_sys_corr_37: -0.0
-  art_sys_corr_38: -0.0
+  art_sys_corr_37: 0.0
+  art_sys_corr_38: 0.0
   art_sys_corr_39: -1.75088255e-06
-  art_sys_corr_40: -0.0
+  art_sys_corr_40: 0.0
   art_sys_corr_41: 0.0
-  art_sys_corr_42: -0.0
+  art_sys_corr_42: 0.0
   art_sys_corr_43: 0.0
   art_sys_corr_44: 0.0
   art_sys_corr_45: 1.05548103e-05
-  art_sys_corr_46: -0.0
-  art_sys_corr_47: -0.0
+  art_sys_corr_46: 0.0
+  art_sys_corr_47: 0.0
   art_sys_corr_48: 0.0
   art_sys_corr_49: 8.91159612e-08
   art_sys_corr_50: 0.0
   art_sys_corr_51: 0.0
   art_sys_corr_52: 0.0
   art_sys_corr_53: 1.37615235e-09
-  art_sys_corr_54: -0.0
+  art_sys_corr_54: 0.0
   Unfolding+: -1.76069589e-06
   Unfolding-: 1.76069589e-06
   JEC0-: -8.80347943e-06
@@ -3268,60 +3268,60 @@ bins:
   JEC13+: 1.76069589e-06
   luminosity_uncertainty: 5.47800000e-06
   bin_by_bin_uncertainty: 2.49e-06
-- art_sys_corr_1: -0.0
+- art_sys_corr_1: 0.0
   art_sys_corr_2: 0.0
   art_sys_corr_3: 4.64657677e-22
-  art_sys_corr_4: -0.0
+  art_sys_corr_4: 0.0
   art_sys_corr_5: 0.0
-  art_sys_corr_6: -0.0
+  art_sys_corr_6: 0.0
   art_sys_corr_7: 1.65713201e-20
-  art_sys_corr_8: -0.0
-  art_sys_corr_9: -0.0
+  art_sys_corr_8: 0.0
+  art_sys_corr_9: 0.0
   art_sys_corr_10: 0.0
-  art_sys_corr_11: -0.0
-  art_sys_corr_12: -0.0
-  art_sys_corr_13: -0.0
+  art_sys_corr_11: 0.0
+  art_sys_corr_12: 0.0
+  art_sys_corr_13: 0.0
   art_sys_corr_14: -4.74529547e-16
   art_sys_corr_15: -4.79497073e-14
-  art_sys_corr_16: -0.0
-  art_sys_corr_17: -0.0
+  art_sys_corr_16: 0.0
+  art_sys_corr_17: 0.0
   art_sys_corr_18: 0.0
   art_sys_corr_19: 0.0
-  art_sys_corr_20: -0.0
+  art_sys_corr_20: 0.0
   art_sys_corr_21: 0.0
-  art_sys_corr_22: -0.0
+  art_sys_corr_22: 0.0
   art_sys_corr_23: 2.02334703e-13
   art_sys_corr_24: 0.0
   art_sys_corr_25: 0.0
   art_sys_corr_26: 0.0
-  art_sys_corr_27: -0.0
-  art_sys_corr_28: -0.0
+  art_sys_corr_27: 0.0
+  art_sys_corr_28: 0.0
   art_sys_corr_29: 0.0
   art_sys_corr_30: 9.68952851e-10
   art_sys_corr_31: -2.97045136e-08
   art_sys_corr_32: 0.0
   art_sys_corr_33: 0.0
-  art_sys_corr_34: -0.0
-  art_sys_corr_35: -0.0
+  art_sys_corr_34: 0.0
+  art_sys_corr_35: 0.0
   art_sys_corr_36: 0.0
-  art_sys_corr_37: -0.0
-  art_sys_corr_38: -0.0
+  art_sys_corr_37: 0.0
+  art_sys_corr_38: 0.0
   art_sys_corr_39: -1.57542309e-08
-  art_sys_corr_40: -0.0
+  art_sys_corr_40: 0.0
   art_sys_corr_41: 0.0
-  art_sys_corr_42: -0.0
+  art_sys_corr_42: 0.0
   art_sys_corr_43: 0.0
   art_sys_corr_44: 0.0
   art_sys_corr_45: -3.24298060e-07
-  art_sys_corr_46: -0.0
-  art_sys_corr_47: -0.0
+  art_sys_corr_46: 0.0
+  art_sys_corr_47: 0.0
   art_sys_corr_48: 0.0
   art_sys_corr_49: 2.91169144e-06
   art_sys_corr_50: 0.0
   art_sys_corr_51: 0.0
   art_sys_corr_52: 0.0
   art_sys_corr_53: 2.55392945e-08
-  art_sys_corr_54: -0.0
+  art_sys_corr_54: 0.0
   Unfolding+: -3.15369624e-07
   Unfolding-: 3.15369624e-07
   JEC0-: -1.10379369e-06
@@ -3354,60 +3354,60 @@ bins:
   JEC13+: 1.57684812e-07
   luminosity_uncertainty: 4.90600000e-07
   bin_by_bin_uncertainty: 2.23e-07
-- art_sys_corr_1: -0.0
+- art_sys_corr_1: 0.0
   art_sys_corr_2: 0.0
   art_sys_corr_3: -2.67350195e-33
-  art_sys_corr_4: -0.0
+  art_sys_corr_4: 0.0
   art_sys_corr_5: 0.0
-  art_sys_corr_6: -0.0
+  art_sys_corr_6: 0.0
   art_sys_corr_7: 4.66625505e-29
-  art_sys_corr_8: -0.0
-  art_sys_corr_9: -0.0
+  art_sys_corr_8: 0.0
+  art_sys_corr_9: 0.0
   art_sys_corr_10: 0.0
-  art_sys_corr_11: -0.0
-  art_sys_corr_12: -0.0
-  art_sys_corr_13: -0.0
+  art_sys_corr_11: 0.0
+  art_sys_corr_12: 0.0
+  art_sys_corr_13: 0.0
   art_sys_corr_14: -2.31204627e-24
   art_sys_corr_15: 1.57375628e-24
-  art_sys_corr_16: -0.0
-  art_sys_corr_17: -0.0
+  art_sys_corr_16: 0.0
+  art_sys_corr_17: 0.0
   art_sys_corr_18: 0.0
   art_sys_corr_19: 0.0
-  art_sys_corr_20: -0.0
+  art_sys_corr_20: 0.0
   art_sys_corr_21: 0.0
-  art_sys_corr_22: -0.0
+  art_sys_corr_22: 0.0
   art_sys_corr_23: -2.23011181e-17
   art_sys_corr_24: 0.0
   art_sys_corr_25: 0.0
   art_sys_corr_26: 0.0
-  art_sys_corr_27: -0.0
-  art_sys_corr_28: -0.0
+  art_sys_corr_27: 0.0
+  art_sys_corr_28: 0.0
   art_sys_corr_29: 0.0
   art_sys_corr_30: 1.80157539e-14
   art_sys_corr_31: 1.00861682e-13
   art_sys_corr_32: 0.0
   art_sys_corr_33: 0.0
-  art_sys_corr_34: -0.0
-  art_sys_corr_35: -0.0
+  art_sys_corr_34: 0.0
+  art_sys_corr_35: 0.0
   art_sys_corr_36: 0.0
-  art_sys_corr_37: -0.0
-  art_sys_corr_38: -0.0
+  art_sys_corr_37: 0.0
+  art_sys_corr_38: 0.0
   art_sys_corr_39: 1.25094128e-10
-  art_sys_corr_40: -0.0
+  art_sys_corr_40: 0.0
   art_sys_corr_41: 0.0
-  art_sys_corr_42: -0.0
+  art_sys_corr_42: 0.0
   art_sys_corr_43: 0.0
   art_sys_corr_44: 0.0
   art_sys_corr_45: -7.67142202e-09
-  art_sys_corr_46: -0.0
-  art_sys_corr_47: -0.0
+  art_sys_corr_46: 0.0
+  art_sys_corr_47: 0.0
   art_sys_corr_48: 0.0
   art_sys_corr_49: -9.09549389e-08
   art_sys_corr_50: 0.0
   art_sys_corr_51: 0.0
   art_sys_corr_52: 0.0
   art_sys_corr_53: 8.18928771e-07
-  art_sys_corr_54: -0.0
+  art_sys_corr_54: 0.0
   Unfolding+: -3.20319372e-08
   Unfolding-: 3.20319372e-08
   JEC0-: -9.60958116e-08
@@ -3440,60 +3440,60 @@ bins:
   JEC13+: 2.13546248e-08
   luminosity_uncertainty: 3.32200000e-08
   bin_by_bin_uncertainty: 1.51e-08
-- art_sys_corr_1: -0.0
+- art_sys_corr_1: 0.0
   art_sys_corr_2: 0.0
   art_sys_corr_3: 0.0
   art_sys_corr_4: 1.00950799e+00
   art_sys_corr_5: 0.0
-  art_sys_corr_6: -0.0
-  art_sys_corr_7: -0.0
+  art_sys_corr_6: 0.0
+  art_sys_corr_7: 0.0
   art_sys_corr_8: 3.15201252e-02
-  art_sys_corr_9: -0.0
+  art_sys_corr_9: 0.0
   art_sys_corr_10: 0.0
-  art_sys_corr_11: -0.0
+  art_sys_corr_11: 0.0
   art_sys_corr_12: 3.06409918e-04
-  art_sys_corr_13: -0.0
+  art_sys_corr_13: 0.0
   art_sys_corr_14: 0.0
   art_sys_corr_15: 0.0
   art_sys_corr_16: 1.22600305e-05
-  art_sys_corr_17: -0.0
+  art_sys_corr_17: 0.0
   art_sys_corr_18: 6.56235748e-07
   art_sys_corr_19: 0.0
-  art_sys_corr_20: -0.0
+  art_sys_corr_20: 0.0
   art_sys_corr_21: 0.0
-  art_sys_corr_22: -0.0
+  art_sys_corr_22: 0.0
   art_sys_corr_23: 0.0
   art_sys_corr_24: 0.0
   art_sys_corr_25: 0.0
   art_sys_corr_26: 2.12566815e-09
-  art_sys_corr_27: -0.0
-  art_sys_corr_28: -0.0
+  art_sys_corr_27: 0.0
+  art_sys_corr_28: 0.0
   art_sys_corr_29: 0.0
   art_sys_corr_30: 0.0
   art_sys_corr_31: 0.0
   art_sys_corr_32: 7.45069838e-12
   art_sys_corr_33: 0.0
-  art_sys_corr_34: -0.0
-  art_sys_corr_35: -0.0
+  art_sys_corr_34: 0.0
+  art_sys_corr_35: 0.0
   art_sys_corr_36: 4.92304580e-13
-  art_sys_corr_37: -0.0
-  art_sys_corr_38: -0.0
+  art_sys_corr_37: 0.0
+  art_sys_corr_38: 0.0
   art_sys_corr_39: 0.0
   art_sys_corr_40: 5.50640981e-15
   art_sys_corr_41: 0.0
-  art_sys_corr_42: -0.0
+  art_sys_corr_42: 0.0
   art_sys_corr_43: 0.0
   art_sys_corr_44: 0.0
-  art_sys_corr_45: -0.0
-  art_sys_corr_46: -0.0
-  art_sys_corr_47: -0.0
+  art_sys_corr_45: 0.0
+  art_sys_corr_46: 0.0
+  art_sys_corr_47: 0.0
   art_sys_corr_48: 0.0
   art_sys_corr_49: 0.0
   art_sys_corr_50: 0.0
   art_sys_corr_51: 0.0
   art_sys_corr_52: 3.01566326e-18
   art_sys_corr_53: 0.0
-  art_sys_corr_54: -0.0
+  art_sys_corr_54: 0.0
   Unfolding+: -2.98399062e-01
   Unfolding-: 2.98399062e-01
   JEC0-: -8.95197185e-01
@@ -3526,60 +3526,60 @@ bins:
   JEC13+: 8.95197185e-01
   luminosity_uncertainty: 0.9284
   bin_by_bin_uncertainty: 4.22000000e-01
-- art_sys_corr_1: -0.0
+- art_sys_corr_1: 0.0
   art_sys_corr_2: 0.0
   art_sys_corr_3: 0.0
   art_sys_corr_4: -7.85801436e-02
   art_sys_corr_5: 0.0
-  art_sys_corr_6: -0.0
-  art_sys_corr_7: -0.0
+  art_sys_corr_6: 0.0
+  art_sys_corr_7: 0.0
   art_sys_corr_8: 4.04372697e-01
-  art_sys_corr_9: -0.0
+  art_sys_corr_9: 0.0
   art_sys_corr_10: 0.0
-  art_sys_corr_11: -0.0
+  art_sys_corr_11: 0.0
   art_sys_corr_12: 7.20172480e-03
-  art_sys_corr_13: -0.0
+  art_sys_corr_13: 0.0
   art_sys_corr_14: 0.0
   art_sys_corr_15: 0.0
   art_sys_corr_16: -1.34810132e-04
-  art_sys_corr_17: -0.0
+  art_sys_corr_17: 0.0
   art_sys_corr_18: 3.18856018e-06
   art_sys_corr_19: 0.0
-  art_sys_corr_20: -0.0
+  art_sys_corr_20: 0.0
   art_sys_corr_21: 0.0
-  art_sys_corr_22: -0.0
+  art_sys_corr_22: 0.0
   art_sys_corr_23: 0.0
   art_sys_corr_24: 0.0
   art_sys_corr_25: 0.0
   art_sys_corr_26: 2.22505585e-08
-  art_sys_corr_27: -0.0
-  art_sys_corr_28: -0.0
+  art_sys_corr_27: 0.0
+  art_sys_corr_28: 0.0
   art_sys_corr_29: 0.0
   art_sys_corr_30: 0.0
   art_sys_corr_31: 0.0
   art_sys_corr_32: 3.84637219e-10
   art_sys_corr_33: 0.0
-  art_sys_corr_34: -0.0
-  art_sys_corr_35: -0.0
+  art_sys_corr_34: 0.0
+  art_sys_corr_35: 0.0
   art_sys_corr_36: -7.26190798e-12
-  art_sys_corr_37: -0.0
-  art_sys_corr_38: -0.0
+  art_sys_corr_37: 0.0
+  art_sys_corr_38: 0.0
   art_sys_corr_39: 0.0
   art_sys_corr_40: -5.47073735e-14
   art_sys_corr_41: 0.0
-  art_sys_corr_42: -0.0
+  art_sys_corr_42: 0.0
   art_sys_corr_43: 0.0
   art_sys_corr_44: 0.0
-  art_sys_corr_45: -0.0
-  art_sys_corr_46: -0.0
-  art_sys_corr_47: -0.0
+  art_sys_corr_45: 0.0
+  art_sys_corr_46: 0.0
+  art_sys_corr_47: 0.0
   art_sys_corr_48: 0.0
   art_sys_corr_49: 0.0
   art_sys_corr_50: 0.0
   art_sys_corr_51: 0.0
   art_sys_corr_52: 3.57576202e-17
   art_sys_corr_53: 0.0
-  art_sys_corr_54: -0.0
+  art_sys_corr_54: 0.0
   Unfolding+: -6.08818939e-02
   Unfolding-: 6.08818939e-02
   JEC0-: -1.82645682e-01
@@ -3612,60 +3612,60 @@ bins:
   JEC13+: 1.82645682e-01
   luminosity_uncertainty: 1.89420000e-01
   bin_by_bin_uncertainty: 0.0861
-- art_sys_corr_1: -0.0
+- art_sys_corr_1: 0.0
   art_sys_corr_2: 0.0
   art_sys_corr_3: 0.0
   art_sys_corr_4: 1.98641599e-03
   art_sys_corr_5: 0.0
-  art_sys_corr_6: -0.0
-  art_sys_corr_7: -0.0
+  art_sys_corr_6: 0.0
+  art_sys_corr_7: 0.0
   art_sys_corr_8: -2.22756371e-02
-  art_sys_corr_9: -0.0
+  art_sys_corr_9: 0.0
   art_sys_corr_10: 0.0
-  art_sys_corr_11: -0.0
+  art_sys_corr_11: 0.0
   art_sys_corr_12: 1.31075564e-01
-  art_sys_corr_13: -0.0
+  art_sys_corr_13: 0.0
   art_sys_corr_14: 0.0
   art_sys_corr_15: 0.0
   art_sys_corr_16: -2.83615482e-03
-  art_sys_corr_17: -0.0
+  art_sys_corr_17: 0.0
   art_sys_corr_18: -5.37912793e-05
   art_sys_corr_19: 0.0
-  art_sys_corr_20: -0.0
+  art_sys_corr_20: 0.0
   art_sys_corr_21: 0.0
-  art_sys_corr_22: -0.0
+  art_sys_corr_22: 0.0
   art_sys_corr_23: 0.0
   art_sys_corr_24: 0.0
   art_sys_corr_25: 0.0
   art_sys_corr_26: 9.71563797e-08
-  art_sys_corr_27: -0.0
-  art_sys_corr_28: -0.0
+  art_sys_corr_27: 0.0
+  art_sys_corr_28: 0.0
   art_sys_corr_29: 0.0
   art_sys_corr_30: 0.0
   art_sys_corr_31: 0.0
   art_sys_corr_32: 4.18640190e-09
   art_sys_corr_33: 0.0
-  art_sys_corr_34: -0.0
-  art_sys_corr_35: -0.0
+  art_sys_corr_34: 0.0
+  art_sys_corr_35: 0.0
   art_sys_corr_36: -1.73991280e-10
-  art_sys_corr_37: -0.0
-  art_sys_corr_38: -0.0
+  art_sys_corr_37: 0.0
+  art_sys_corr_38: 0.0
   art_sys_corr_39: 0.0
   art_sys_corr_40: -1.58061854e-12
   art_sys_corr_41: 0.0
-  art_sys_corr_42: -0.0
+  art_sys_corr_42: 0.0
   art_sys_corr_43: 0.0
   art_sys_corr_44: 0.0
-  art_sys_corr_45: -0.0
-  art_sys_corr_46: -0.0
-  art_sys_corr_47: -0.0
+  art_sys_corr_45: 0.0
+  art_sys_corr_46: 0.0
+  art_sys_corr_47: 0.0
   art_sys_corr_48: 0.0
   art_sys_corr_49: 0.0
   art_sys_corr_50: 0.0
   art_sys_corr_51: 0.0
   art_sys_corr_52: 3.02581579e-17
   art_sys_corr_53: 0.0
-  art_sys_corr_54: -0.0
+  art_sys_corr_54: 0.0
   Unfolding+: -1.43542677e-02
   Unfolding-: 1.43542677e-02
   JEC0-: -4.30628030e-02
@@ -3698,60 +3698,60 @@ bins:
   JEC13+: 2.87085353e-02
   luminosity_uncertainty: 4.46600000e-02
   bin_by_bin_uncertainty: 0.0203
-- art_sys_corr_1: -0.0
+- art_sys_corr_1: 0.0
   art_sys_corr_2: 0.0
   art_sys_corr_3: 0.0
   art_sys_corr_4: 4.19316919e-04
   art_sys_corr_5: 0.0
-  art_sys_corr_6: -0.0
-  art_sys_corr_7: -0.0
+  art_sys_corr_6: 0.0
+  art_sys_corr_7: 0.0
   art_sys_corr_8: 2.28304877e-04
-  art_sys_corr_9: -0.0
+  art_sys_corr_9: 0.0
   art_sys_corr_10: 0.0
-  art_sys_corr_11: -0.0
+  art_sys_corr_11: 0.0
   art_sys_corr_12: -9.01688346e-03
-  art_sys_corr_13: -0.0
+  art_sys_corr_13: 0.0
   art_sys_corr_14: 0.0
   art_sys_corr_15: 0.0
   art_sys_corr_16: -4.13152142e-02
-  art_sys_corr_17: -0.0
+  art_sys_corr_17: 0.0
   art_sys_corr_18: -9.00517641e-04
   art_sys_corr_19: 0.0
-  art_sys_corr_20: -0.0
+  art_sys_corr_20: 0.0
   art_sys_corr_21: 0.0
-  art_sys_corr_22: -0.0
+  art_sys_corr_22: 0.0
   art_sys_corr_23: 0.0
   art_sys_corr_24: 0.0
   art_sys_corr_25: 0.0
   art_sys_corr_26: -1.91343628e-06
-  art_sys_corr_27: -0.0
-  art_sys_corr_28: -0.0
+  art_sys_corr_27: 0.0
+  art_sys_corr_28: 0.0
   art_sys_corr_29: 0.0
   art_sys_corr_30: 0.0
   art_sys_corr_31: 0.0
   art_sys_corr_32: 2.89885723e-08
   art_sys_corr_33: 0.0
-  art_sys_corr_34: -0.0
-  art_sys_corr_35: -0.0
+  art_sys_corr_34: 0.0
+  art_sys_corr_35: 0.0
   art_sys_corr_36: -1.76010447e-09
-  art_sys_corr_37: -0.0
-  art_sys_corr_38: -0.0
+  art_sys_corr_37: 0.0
+  art_sys_corr_38: 0.0
   art_sys_corr_39: 0.0
   art_sys_corr_40: -1.67034546e-11
   art_sys_corr_41: 0.0
-  art_sys_corr_42: -0.0
+  art_sys_corr_42: 0.0
   art_sys_corr_43: 0.0
   art_sys_corr_44: 0.0
-  art_sys_corr_45: -0.0
-  art_sys_corr_46: -0.0
-  art_sys_corr_47: -0.0
+  art_sys_corr_45: 0.0
+  art_sys_corr_46: 0.0
+  art_sys_corr_47: 0.0
   art_sys_corr_48: 0.0
   art_sys_corr_49: 0.0
   art_sys_corr_50: 0.0
   art_sys_corr_51: 0.0
   art_sys_corr_52: -1.72321730e-15
   art_sys_corr_53: 0.0
-  art_sys_corr_54: -0.0
+  art_sys_corr_54: 0.0
   Unfolding+: -3.98808225e-03
   Unfolding-: 3.98808225e-03
   JEC0-: -1.19642467e-02
@@ -3784,60 +3784,60 @@ bins:
   JEC13+: 7.97616449e-03
   luminosity_uncertainty: 1.24080000e-02
   bin_by_bin_uncertainty: 5.64000000e-03
-- art_sys_corr_1: -0.0
+- art_sys_corr_1: 0.0
   art_sys_corr_2: 0.0
   art_sys_corr_3: 0.0
   art_sys_corr_4: -4.83754616e-06
   art_sys_corr_5: 0.0
-  art_sys_corr_6: -0.0
-  art_sys_corr_7: -0.0
+  art_sys_corr_6: 0.0
+  art_sys_corr_7: 0.0
   art_sys_corr_8: 1.53559280e-04
-  art_sys_corr_9: -0.0
+  art_sys_corr_9: 0.0
   art_sys_corr_10: 0.0
-  art_sys_corr_11: -0.0
+  art_sys_corr_11: 0.0
   art_sys_corr_12: 7.38987073e-05
-  art_sys_corr_13: -0.0
+  art_sys_corr_13: 0.0
   art_sys_corr_14: 0.0
   art_sys_corr_15: 0.0
   art_sys_corr_16: 2.49020067e-03
-  art_sys_corr_17: -0.0
+  art_sys_corr_17: 0.0
   art_sys_corr_18: -1.49935914e-02
   art_sys_corr_19: 0.0
-  art_sys_corr_20: -0.0
+  art_sys_corr_20: 0.0
   art_sys_corr_21: 0.0
-  art_sys_corr_22: -0.0
+  art_sys_corr_22: 0.0
   art_sys_corr_23: 0.0
   art_sys_corr_24: 0.0
   art_sys_corr_25: 0.0
   art_sys_corr_26: -4.52986141e-05
-  art_sys_corr_27: -0.0
-  art_sys_corr_28: -0.0
+  art_sys_corr_27: 0.0
+  art_sys_corr_28: 0.0
   art_sys_corr_29: 0.0
   art_sys_corr_30: 0.0
   art_sys_corr_31: 0.0
   art_sys_corr_32: -4.85182382e-07
   art_sys_corr_33: 0.0
-  art_sys_corr_34: -0.0
-  art_sys_corr_35: -0.0
+  art_sys_corr_34: 0.0
+  art_sys_corr_35: 0.0
   art_sys_corr_36: -2.62936671e-09
-  art_sys_corr_37: -0.0
-  art_sys_corr_38: -0.0
+  art_sys_corr_37: 0.0
+  art_sys_corr_38: 0.0
   art_sys_corr_39: 0.0
   art_sys_corr_40: -5.33162248e-11
   art_sys_corr_41: 0.0
-  art_sys_corr_42: -0.0
+  art_sys_corr_42: 0.0
   art_sys_corr_43: 0.0
   art_sys_corr_44: 0.0
-  art_sys_corr_45: -0.0
-  art_sys_corr_46: -0.0
-  art_sys_corr_47: -0.0
+  art_sys_corr_45: 0.0
+  art_sys_corr_46: 0.0
+  art_sys_corr_47: 0.0
   art_sys_corr_48: 0.0
   art_sys_corr_49: 0.0
   art_sys_corr_50: 0.0
   art_sys_corr_51: 0.0
   art_sys_corr_52: -8.97444611e-14
   art_sys_corr_53: 0.0
-  art_sys_corr_54: -0.0
+  art_sys_corr_54: 0.0
   Unfolding+: -7.21248917e-04
   Unfolding-: 0.0
   JEC0-: -2.16374675e-03
@@ -3870,60 +3870,60 @@ bins:
   JEC13+: 1.44249783e-03
   luminosity_uncertainty: 0.002244
   bin_by_bin_uncertainty: 1.02000000e-03
-- art_sys_corr_1: -0.0
+- art_sys_corr_1: 0.0
   art_sys_corr_2: 0.0
   art_sys_corr_3: 0.0
   art_sys_corr_4: 6.70302582e-09
   art_sys_corr_5: 0.0
-  art_sys_corr_6: -0.0
-  art_sys_corr_7: -0.0
+  art_sys_corr_6: 0.0
+  art_sys_corr_7: 0.0
   art_sys_corr_8: -4.56982247e-07
-  art_sys_corr_9: -0.0
+  art_sys_corr_9: 0.0
   art_sys_corr_10: 0.0
-  art_sys_corr_11: -0.0
+  art_sys_corr_11: 0.0
   art_sys_corr_12: 2.48581254e-05
-  art_sys_corr_13: -0.0
+  art_sys_corr_13: 0.0
   art_sys_corr_14: 0.0
   art_sys_corr_15: 0.0
   art_sys_corr_16: -3.19438066e-05
-  art_sys_corr_17: -0.0
+  art_sys_corr_17: 0.0
   art_sys_corr_18: 6.31673214e-04
   art_sys_corr_19: 0.0
-  art_sys_corr_20: -0.0
+  art_sys_corr_20: 0.0
   art_sys_corr_21: 0.0
-  art_sys_corr_22: -0.0
+  art_sys_corr_22: 0.0
   art_sys_corr_23: 0.0
   art_sys_corr_24: 0.0
   art_sys_corr_25: 0.0
   art_sys_corr_26: -1.07782475e-03
-  art_sys_corr_27: -0.0
-  art_sys_corr_28: -0.0
+  art_sys_corr_27: 0.0
+  art_sys_corr_28: 0.0
   art_sys_corr_29: 0.0
   art_sys_corr_30: 0.0
   art_sys_corr_31: 0.0
   art_sys_corr_32: -1.20045158e-05
   art_sys_corr_33: 0.0
-  art_sys_corr_34: -0.0
-  art_sys_corr_35: -0.0
+  art_sys_corr_34: 0.0
+  art_sys_corr_35: 0.0
   art_sys_corr_36: 3.41644265e-07
-  art_sys_corr_37: -0.0
-  art_sys_corr_38: -0.0
+  art_sys_corr_37: 0.0
+  art_sys_corr_38: 0.0
   art_sys_corr_39: 0.0
   art_sys_corr_40: 2.90160241e-09
   art_sys_corr_41: 0.0
-  art_sys_corr_42: -0.0
+  art_sys_corr_42: 0.0
   art_sys_corr_43: 0.0
   art_sys_corr_44: 0.0
-  art_sys_corr_45: -0.0
-  art_sys_corr_46: -0.0
-  art_sys_corr_47: -0.0
+  art_sys_corr_45: 0.0
+  art_sys_corr_46: 0.0
+  art_sys_corr_47: 0.0
   art_sys_corr_48: 0.0
   art_sys_corr_49: 0.0
   art_sys_corr_50: 0.0
   art_sys_corr_51: 0.0
   art_sys_corr_52: -6.27778789e-13
   art_sys_corr_53: 0.0
-  art_sys_corr_54: -0.0
+  art_sys_corr_54: 0.0
   Unfolding+: -1.98697006e-04
   Unfolding-: 1.98697006e-04
   JEC0-: -7.94788022e-04
@@ -3956,60 +3956,60 @@ bins:
   JEC13+: 3.97394011e-04
   luminosity_uncertainty: 6.18200000e-04
   bin_by_bin_uncertainty: 0.000281
-- art_sys_corr_1: -0.0
+- art_sys_corr_1: 0.0
   art_sys_corr_2: 0.0
   art_sys_corr_3: 0.0
   art_sys_corr_4: 1.35456141e-10
   art_sys_corr_5: 0.0
-  art_sys_corr_6: -0.0
-  art_sys_corr_7: -0.0
+  art_sys_corr_6: 0.0
+  art_sys_corr_7: 0.0
   art_sys_corr_8: 4.58407709e-10
-  art_sys_corr_9: -0.0
+  art_sys_corr_9: 0.0
   art_sys_corr_10: 0.0
-  art_sys_corr_11: -0.0
+  art_sys_corr_11: 0.0
   art_sys_corr_12: -1.72563810e-07
-  art_sys_corr_13: -0.0
+  art_sys_corr_13: 0.0
   art_sys_corr_14: 0.0
   art_sys_corr_15: 0.0
   art_sys_corr_16: -7.94954447e-06
-  art_sys_corr_17: -0.0
+  art_sys_corr_17: 0.0
   art_sys_corr_18: -1.46590287e-06
   art_sys_corr_19: 0.0
-  art_sys_corr_20: -0.0
+  art_sys_corr_20: 0.0
   art_sys_corr_21: 0.0
-  art_sys_corr_22: -0.0
+  art_sys_corr_22: 0.0
   art_sys_corr_23: 0.0
   art_sys_corr_24: 0.0
   art_sys_corr_25: 0.0
   art_sys_corr_26: 5.06547918e-05
-  art_sys_corr_27: -0.0
-  art_sys_corr_28: -0.0
+  art_sys_corr_27: 0.0
+  art_sys_corr_28: 0.0
   art_sys_corr_29: 0.0
   art_sys_corr_30: 0.0
   art_sys_corr_31: 0.0
   art_sys_corr_32: -2.55794123e-04
   art_sys_corr_33: 0.0
-  art_sys_corr_34: -0.0
-  art_sys_corr_35: -0.0
+  art_sys_corr_34: 0.0
+  art_sys_corr_35: 0.0
   art_sys_corr_36: 7.68637795e-06
-  art_sys_corr_37: -0.0
-  art_sys_corr_38: -0.0
+  art_sys_corr_37: 0.0
+  art_sys_corr_38: 0.0
   art_sys_corr_39: 0.0
   art_sys_corr_40: 6.60065142e-08
   art_sys_corr_41: 0.0
-  art_sys_corr_42: -0.0
+  art_sys_corr_42: 0.0
   art_sys_corr_43: 0.0
   art_sys_corr_44: 0.0
-  art_sys_corr_45: -0.0
-  art_sys_corr_46: -0.0
-  art_sys_corr_47: -0.0
+  art_sys_corr_45: 0.0
+  art_sys_corr_46: 0.0
+  art_sys_corr_47: 0.0
   art_sys_corr_48: 0.0
   art_sys_corr_49: 0.0
   art_sys_corr_50: 0.0
   art_sys_corr_51: 0.0
   art_sys_corr_52: -1.39850218e-11
   art_sys_corr_53: 0.0
-  art_sys_corr_54: -0.0
+  art_sys_corr_54: 0.0
   Unfolding+: -4.45477272e-05
   Unfolding-: 4.45477272e-05
   JEC0-: -1.78190909e-04
@@ -4042,60 +4042,60 @@ bins:
   JEC13+: 8.90954544e-05
   luminosity_uncertainty: 1.38600000e-04
   bin_by_bin_uncertainty: 6.3e-05
-- art_sys_corr_1: -0.0
+- art_sys_corr_1: 0.0
   art_sys_corr_2: 0.0
   art_sys_corr_3: 0.0
   art_sys_corr_4: -1.59221987e-13
   art_sys_corr_5: 0.0
-  art_sys_corr_6: -0.0
-  art_sys_corr_7: -0.0
+  art_sys_corr_6: 0.0
+  art_sys_corr_7: 0.0
   art_sys_corr_8: 3.14067565e-11
-  art_sys_corr_9: -0.0
+  art_sys_corr_9: 0.0
   art_sys_corr_10: 0.0
-  art_sys_corr_11: -0.0
+  art_sys_corr_11: 0.0
   art_sys_corr_12: 1.42069349e-10
-  art_sys_corr_13: -0.0
+  art_sys_corr_13: 0.0
   art_sys_corr_14: 0.0
   art_sys_corr_15: 0.0
   art_sys_corr_16: 4.88633788e-08
-  art_sys_corr_17: -0.0
+  art_sys_corr_17: 0.0
   art_sys_corr_18: -2.24246028e-06
   art_sys_corr_19: 0.0
-  art_sys_corr_20: -0.0
+  art_sys_corr_20: 0.0
   art_sys_corr_21: 0.0
-  art_sys_corr_22: -0.0
+  art_sys_corr_22: 0.0
   art_sys_corr_23: 0.0
   art_sys_corr_24: 0.0
   art_sys_corr_25: 0.0
   art_sys_corr_26: -1.93978265e-07
-  art_sys_corr_27: -0.0
-  art_sys_corr_28: -0.0
+  art_sys_corr_27: 0.0
+  art_sys_corr_28: 0.0
   art_sys_corr_29: 0.0
   art_sys_corr_30: 0.0
   art_sys_corr_31: 0.0
   art_sys_corr_32: 1.79873790e-05
   art_sys_corr_33: 0.0
-  art_sys_corr_34: -0.0
-  art_sys_corr_35: -0.0
+  art_sys_corr_34: 0.0
+  art_sys_corr_35: 0.0
   art_sys_corr_36: 1.09503843e-04
-  art_sys_corr_37: -0.0
-  art_sys_corr_38: -0.0
+  art_sys_corr_37: 0.0
+  art_sys_corr_38: 0.0
   art_sys_corr_39: 0.0
   art_sys_corr_40: 1.13748324e-06
   art_sys_corr_41: 0.0
-  art_sys_corr_42: -0.0
+  art_sys_corr_42: 0.0
   art_sys_corr_43: 0.0
   art_sys_corr_44: 0.0
-  art_sys_corr_45: -0.0
-  art_sys_corr_46: -0.0
-  art_sys_corr_47: -0.0
+  art_sys_corr_45: 0.0
+  art_sys_corr_46: 0.0
+  art_sys_corr_47: 0.0
   art_sys_corr_48: 0.0
   art_sys_corr_49: 0.0
   art_sys_corr_50: 0.0
   art_sys_corr_51: 0.0
   art_sys_corr_52: 4.33063895e-10
   art_sys_corr_53: 0.0
-  art_sys_corr_54: -0.0
+  art_sys_corr_54: 0.0
   Unfolding+: -9.19238816e-06
   Unfolding-: 9.19238816e-06
   JEC0-: -4.59619408e-05
@@ -4128,60 +4128,60 @@ bins:
   JEC13+: 1.83847763e-05
   luminosity_uncertainty: 2.86000000e-05
   bin_by_bin_uncertainty: 1.3e-05
-- art_sys_corr_1: -0.0
+- art_sys_corr_1: 0.0
   art_sys_corr_2: 0.0
   art_sys_corr_3: 0.0
   art_sys_corr_4: 6.97440472e-23
   art_sys_corr_5: 0.0
-  art_sys_corr_6: -0.0
-  art_sys_corr_7: -0.0
+  art_sys_corr_6: 0.0
+  art_sys_corr_7: 0.0
   art_sys_corr_8: -8.54809575e-20
-  art_sys_corr_9: -0.0
+  art_sys_corr_9: 0.0
   art_sys_corr_10: 0.0
-  art_sys_corr_11: -0.0
+  art_sys_corr_11: 0.0
   art_sys_corr_12: -3.68510641e-18
-  art_sys_corr_13: -0.0
+  art_sys_corr_13: 0.0
   art_sys_corr_14: 0.0
   art_sys_corr_15: 0.0
   art_sys_corr_16: -1.27496538e-14
-  art_sys_corr_17: -0.0
+  art_sys_corr_17: 0.0
   art_sys_corr_18: 4.45581474e-12
   art_sys_corr_19: 0.0
-  art_sys_corr_20: -0.0
+  art_sys_corr_20: 0.0
   art_sys_corr_21: 0.0
-  art_sys_corr_22: -0.0
+  art_sys_corr_22: 0.0
   art_sys_corr_23: 0.0
   art_sys_corr_24: 0.0
   art_sys_corr_25: 0.0
   art_sys_corr_26: 7.47452265e-11
-  art_sys_corr_27: -0.0
-  art_sys_corr_28: -0.0
+  art_sys_corr_27: 0.0
+  art_sys_corr_28: 0.0
   art_sys_corr_29: 0.0
   art_sys_corr_30: 0.0
   art_sys_corr_31: 0.0
   art_sys_corr_32: -1.24157322e-07
   art_sys_corr_33: 0.0
-  art_sys_corr_34: -0.0
-  art_sys_corr_35: -0.0
+  art_sys_corr_34: 0.0
+  art_sys_corr_35: 0.0
   art_sys_corr_36: -4.37762124e-06
-  art_sys_corr_37: -0.0
-  art_sys_corr_38: -0.0
+  art_sys_corr_37: 0.0
+  art_sys_corr_38: 0.0
   art_sys_corr_39: 0.0
   art_sys_corr_40: 2.85662517e-05
   art_sys_corr_41: 0.0
-  art_sys_corr_42: -0.0
+  art_sys_corr_42: 0.0
   art_sys_corr_43: 0.0
   art_sys_corr_44: 0.0
-  art_sys_corr_45: -0.0
-  art_sys_corr_46: -0.0
-  art_sys_corr_47: -0.0
+  art_sys_corr_45: 0.0
+  art_sys_corr_46: 0.0
+  art_sys_corr_47: 0.0
   art_sys_corr_48: 0.0
   art_sys_corr_49: 0.0
   art_sys_corr_50: 0.0
   art_sys_corr_51: 0.0
   art_sys_corr_52: 1.68248704e-08
   art_sys_corr_53: 0.0
-  art_sys_corr_54: -0.0
+  art_sys_corr_54: 0.0
   Unfolding+: -9.54594155e-07
   Unfolding-: 9.54594155e-07
   JEC0-: -5.72756493e-06
@@ -4214,60 +4214,60 @@ bins:
   JEC13+: 1.90918831e-06
   luminosity_uncertainty: 2.97e-06
   bin_by_bin_uncertainty: 1.35e-06
-- art_sys_corr_1: -0.0
+- art_sys_corr_1: 0.0
   art_sys_corr_2: 0.0
   art_sys_corr_3: 0.0
   art_sys_corr_4: 3.65145448e-22
   art_sys_corr_5: 0.0
-  art_sys_corr_6: -0.0
-  art_sys_corr_7: -0.0
+  art_sys_corr_6: 0.0
+  art_sys_corr_7: 0.0
   art_sys_corr_8: 8.13381571e-21
-  art_sys_corr_9: -0.0
+  art_sys_corr_9: 0.0
   art_sys_corr_10: 0.0
-  art_sys_corr_11: -0.0
+  art_sys_corr_11: 0.0
   art_sys_corr_12: -2.75545062e-17
-  art_sys_corr_13: -0.0
+  art_sys_corr_13: 0.0
   art_sys_corr_14: 0.0
   art_sys_corr_15: 0.0
   art_sys_corr_16: -1.27109469e-14
-  art_sys_corr_17: -0.0
+  art_sys_corr_17: 0.0
   art_sys_corr_18: -4.12908814e-14
   art_sys_corr_19: 0.0
-  art_sys_corr_20: -0.0
+  art_sys_corr_20: 0.0
   art_sys_corr_21: 0.0
-  art_sys_corr_22: -0.0
+  art_sys_corr_22: 0.0
   art_sys_corr_23: 0.0
   art_sys_corr_24: 0.0
   art_sys_corr_25: 0.0
   art_sys_corr_26: 1.19764010e-10
-  art_sys_corr_27: -0.0
-  art_sys_corr_28: -0.0
+  art_sys_corr_27: 0.0
+  art_sys_corr_28: 0.0
   art_sys_corr_29: 0.0
   art_sys_corr_30: 0.0
   art_sys_corr_31: 0.0
   art_sys_corr_32: -1.00685047e-08
   art_sys_corr_33: 0.0
-  art_sys_corr_34: -0.0
-  art_sys_corr_35: -0.0
+  art_sys_corr_34: 0.0
+  art_sys_corr_35: 0.0
   art_sys_corr_36: 2.85590941e-08
-  art_sys_corr_37: -0.0
-  art_sys_corr_38: -0.0
+  art_sys_corr_37: 0.0
+  art_sys_corr_38: 0.0
   art_sys_corr_39: 0.0
   art_sys_corr_40: -5.21678728e-07
   art_sys_corr_41: 0.0
-  art_sys_corr_42: -0.0
+  art_sys_corr_42: 0.0
   art_sys_corr_43: 0.0
   art_sys_corr_44: 0.0
-  art_sys_corr_45: -0.0
-  art_sys_corr_46: -0.0
-  art_sys_corr_47: -0.0
+  art_sys_corr_45: 0.0
+  art_sys_corr_46: 0.0
+  art_sys_corr_47: 0.0
   art_sys_corr_48: 0.0
   art_sys_corr_49: 0.0
   art_sys_corr_50: 0.0
   art_sys_corr_51: 0.0
   art_sys_corr_52: 9.22244162e-07
   art_sys_corr_53: 0.0
-  art_sys_corr_54: -0.0
+  art_sys_corr_54: 0.0
   Unfolding+: -6.33567676e-08
   Unfolding-: 6.33567676e-08
   JEC0-: -3.16783838e-07
@@ -4300,60 +4300,60 @@ bins:
   JEC13+: 9.50351514e-08
   luminosity_uncertainty: 9.85600000e-08
   bin_by_bin_uncertainty: 4.48000000e-08
-- art_sys_corr_1: -0.0
+- art_sys_corr_1: 0.0
   art_sys_corr_2: 0.0
   art_sys_corr_3: 0.0
-  art_sys_corr_4: -0.0
+  art_sys_corr_4: 0.0
   art_sys_corr_5: 0.0
-  art_sys_corr_6: -0.0
-  art_sys_corr_7: -0.0
-  art_sys_corr_8: -0.0
+  art_sys_corr_6: 0.0
+  art_sys_corr_7: 0.0
+  art_sys_corr_8: 0.0
   art_sys_corr_9: 2.91765973e-01
   art_sys_corr_10: 0.0
-  art_sys_corr_11: -0.0
-  art_sys_corr_12: -0.0
+  art_sys_corr_11: 0.0
+  art_sys_corr_12: 0.0
   art_sys_corr_13: 1.16878002e-02
   art_sys_corr_14: 0.0
   art_sys_corr_15: 0.0
-  art_sys_corr_16: -0.0
+  art_sys_corr_16: 0.0
   art_sys_corr_17: 1.10366717e-04
   art_sys_corr_18: 0.0
   art_sys_corr_19: 2.26042094e-06
-  art_sys_corr_20: -0.0
+  art_sys_corr_20: 0.0
   art_sys_corr_21: 0.0
   art_sys_corr_22: 1.02525719e-07
   art_sys_corr_23: 0.0
   art_sys_corr_24: 0.0
   art_sys_corr_25: 0.0
   art_sys_corr_26: 0.0
-  art_sys_corr_27: -0.0
+  art_sys_corr_27: 0.0
   art_sys_corr_28: 2.16671687e-09
   art_sys_corr_29: 0.0
   art_sys_corr_30: 0.0
   art_sys_corr_31: 0.0
   art_sys_corr_32: 0.0
   art_sys_corr_33: 5.63778884e-12
-  art_sys_corr_34: -0.0
-  art_sys_corr_35: -0.0
+  art_sys_corr_34: 0.0
+  art_sys_corr_35: 0.0
   art_sys_corr_36: 0.0
-  art_sys_corr_37: -0.0
-  art_sys_corr_38: -0.0
+  art_sys_corr_37: 0.0
+  art_sys_corr_38: 0.0
   art_sys_corr_39: 0.0
-  art_sys_corr_40: -0.0
+  art_sys_corr_40: 0.0
   art_sys_corr_41: 0.0
-  art_sys_corr_42: -0.0
+  art_sys_corr_42: 0.0
   art_sys_corr_43: 8.44952456e-15
   art_sys_corr_44: 0.0
-  art_sys_corr_45: -0.0
-  art_sys_corr_46: -0.0
-  art_sys_corr_47: -0.0
+  art_sys_corr_45: 0.0
+  art_sys_corr_46: 0.0
+  art_sys_corr_47: 0.0
   art_sys_corr_48: 0.0
   art_sys_corr_49: 0.0
   art_sys_corr_50: 0.0
   art_sys_corr_51: 0.0
   art_sys_corr_52: 0.0
   art_sys_corr_53: 0.0
-  art_sys_corr_54: -0.0
+  art_sys_corr_54: 0.0
   Unfolding+: -3.52139177e-02
   Unfolding-: 3.52139177e-02
   JEC0-: -1.05641753e-01
@@ -4386,60 +4386,60 @@ bins:
   JEC13+: 1.05641753e-01
   luminosity_uncertainty: 0.10956
   bin_by_bin_uncertainty: 4.98000000e-02
-- art_sys_corr_1: -0.0
+- art_sys_corr_1: 0.0
   art_sys_corr_2: 0.0
   art_sys_corr_3: 0.0
-  art_sys_corr_4: -0.0
+  art_sys_corr_4: 0.0
   art_sys_corr_5: 0.0
-  art_sys_corr_6: -0.0
-  art_sys_corr_7: -0.0
-  art_sys_corr_8: -0.0
+  art_sys_corr_6: 0.0
+  art_sys_corr_7: 0.0
+  art_sys_corr_8: 0.0
   art_sys_corr_9: -2.70008258e-02
   art_sys_corr_10: 0.0
-  art_sys_corr_11: -0.0
-  art_sys_corr_12: -0.0
+  art_sys_corr_11: 0.0
+  art_sys_corr_12: 0.0
   art_sys_corr_13: 1.26126208e-01
   art_sys_corr_14: 0.0
   art_sys_corr_15: 0.0
-  art_sys_corr_16: -0.0
+  art_sys_corr_16: 0.0
   art_sys_corr_17: 2.03311702e-03
   art_sys_corr_18: 0.0
   art_sys_corr_19: -3.83791140e-05
-  art_sys_corr_20: -0.0
+  art_sys_corr_20: 0.0
   art_sys_corr_21: 0.0
   art_sys_corr_22: 4.51752524e-07
   art_sys_corr_23: 0.0
   art_sys_corr_24: 0.0
   art_sys_corr_25: 0.0
   art_sys_corr_26: 0.0
-  art_sys_corr_27: -0.0
+  art_sys_corr_27: 0.0
   art_sys_corr_28: 1.77660046e-08
   art_sys_corr_29: 0.0
   art_sys_corr_30: 0.0
   art_sys_corr_31: 0.0
   art_sys_corr_32: 0.0
   art_sys_corr_33: 2.12552135e-10
-  art_sys_corr_34: -0.0
-  art_sys_corr_35: -0.0
+  art_sys_corr_34: 0.0
+  art_sys_corr_35: 0.0
   art_sys_corr_36: 0.0
-  art_sys_corr_37: -0.0
-  art_sys_corr_38: -0.0
+  art_sys_corr_37: 0.0
+  art_sys_corr_38: 0.0
   art_sys_corr_39: 0.0
-  art_sys_corr_40: -0.0
+  art_sys_corr_40: 0.0
   art_sys_corr_41: 0.0
-  art_sys_corr_42: -0.0
+  art_sys_corr_42: 0.0
   art_sys_corr_43: -1.63369068e-13
   art_sys_corr_44: 0.0
-  art_sys_corr_45: -0.0
-  art_sys_corr_46: -0.0
-  art_sys_corr_47: -0.0
+  art_sys_corr_45: 0.0
+  art_sys_corr_46: 0.0
+  art_sys_corr_47: 0.0
   art_sys_corr_48: 0.0
   art_sys_corr_49: 0.0
   art_sys_corr_50: 0.0
   art_sys_corr_51: 0.0
   art_sys_corr_52: 0.0
   art_sys_corr_53: 0.0
-  art_sys_corr_54: -0.0
+  art_sys_corr_54: 0.0
   Unfolding+: -8.34386002e-03
   Unfolding-: 8.34386002e-03
   JEC0-: -2.50315801e-02
@@ -4472,60 +4472,60 @@ bins:
   JEC13+: 2.50315801e-02
   luminosity_uncertainty: 2.59600000e-02
   bin_by_bin_uncertainty: 0.0118
-- art_sys_corr_1: -0.0
+- art_sys_corr_1: 0.0
   art_sys_corr_2: 0.0
   art_sys_corr_3: 0.0
-  art_sys_corr_4: -0.0
+  art_sys_corr_4: 0.0
   art_sys_corr_5: 0.0
-  art_sys_corr_6: -0.0
-  art_sys_corr_7: -0.0
-  art_sys_corr_8: -0.0
+  art_sys_corr_6: 0.0
+  art_sys_corr_7: 0.0
+  art_sys_corr_8: 0.0
   art_sys_corr_9: 6.40333407e-04
   art_sys_corr_10: 0.0
-  art_sys_corr_11: -0.0
-  art_sys_corr_12: -0.0
+  art_sys_corr_11: 0.0
+  art_sys_corr_12: 0.0
   art_sys_corr_13: -7.17955466e-03
   art_sys_corr_14: 0.0
   art_sys_corr_15: 0.0
-  art_sys_corr_16: -0.0
+  art_sys_corr_16: 0.0
   art_sys_corr_17: 3.58751358e-02
   art_sys_corr_18: 0.0
   art_sys_corr_19: -7.60604300e-04
-  art_sys_corr_20: -0.0
+  art_sys_corr_20: 0.0
   art_sys_corr_21: 0.0
   art_sys_corr_22: -8.98437757e-06
   art_sys_corr_23: 0.0
   art_sys_corr_24: 0.0
   art_sys_corr_25: 0.0
   art_sys_corr_26: 0.0
-  art_sys_corr_27: -0.0
+  art_sys_corr_27: 0.0
   art_sys_corr_28: 1.03385238e-07
   art_sys_corr_29: 0.0
   art_sys_corr_30: 0.0
   art_sys_corr_31: 0.0
   art_sys_corr_32: 0.0
   art_sys_corr_33: 2.68456569e-09
-  art_sys_corr_34: -0.0
-  art_sys_corr_35: -0.0
+  art_sys_corr_34: 0.0
+  art_sys_corr_35: 0.0
   art_sys_corr_36: 0.0
-  art_sys_corr_37: -0.0
-  art_sys_corr_38: -0.0
+  art_sys_corr_37: 0.0
+  art_sys_corr_38: 0.0
   art_sys_corr_39: 0.0
-  art_sys_corr_40: -0.0
+  art_sys_corr_40: 0.0
   art_sys_corr_41: 0.0
-  art_sys_corr_42: -0.0
+  art_sys_corr_42: 0.0
   art_sys_corr_43: -4.11893602e-12
   art_sys_corr_44: 0.0
-  art_sys_corr_45: -0.0
-  art_sys_corr_46: -0.0
-  art_sys_corr_47: -0.0
+  art_sys_corr_45: 0.0
+  art_sys_corr_46: 0.0
+  art_sys_corr_47: 0.0
   art_sys_corr_48: 0.0
   art_sys_corr_49: 0.0
   art_sys_corr_50: 0.0
   art_sys_corr_51: 0.0
   art_sys_corr_52: 0.0
   art_sys_corr_53: 0.0
-  art_sys_corr_54: -0.0
+  art_sys_corr_54: 0.0
   Unfolding+: -2.14960461e-03
   Unfolding-: 2.14960461e-03
   JEC0-: -8.59841846e-03
@@ -4558,60 +4558,60 @@ bins:
   JEC13+: 6.44881384e-03
   luminosity_uncertainty: 6.68800000e-03
   bin_by_bin_uncertainty: 0.00304
-- art_sys_corr_1: -0.0
+- art_sys_corr_1: 0.0
   art_sys_corr_2: 0.0
   art_sys_corr_3: 0.0
-  art_sys_corr_4: -0.0
+  art_sys_corr_4: 0.0
   art_sys_corr_5: 0.0
-  art_sys_corr_6: -0.0
-  art_sys_corr_7: -0.0
-  art_sys_corr_8: -0.0
+  art_sys_corr_6: 0.0
+  art_sys_corr_7: 0.0
+  art_sys_corr_8: 0.0
   art_sys_corr_9: 1.10687833e-04
   art_sys_corr_10: 0.0
-  art_sys_corr_11: -0.0
-  art_sys_corr_12: -0.0
+  art_sys_corr_11: 0.0
+  art_sys_corr_12: 0.0
   art_sys_corr_13: 6.07793800e-05
   art_sys_corr_14: 0.0
   art_sys_corr_15: 0.0
-  art_sys_corr_16: -0.0
+  art_sys_corr_16: 0.0
   art_sys_corr_17: -2.50650526e-03
   art_sys_corr_18: 0.0
   art_sys_corr_19: -1.09141717e-02
-  art_sys_corr_20: -0.0
+  art_sys_corr_20: 0.0
   art_sys_corr_21: 0.0
   art_sys_corr_22: -1.49449793e-04
   art_sys_corr_23: 0.0
   art_sys_corr_24: 0.0
   art_sys_corr_25: 0.0
   art_sys_corr_26: 0.0
-  art_sys_corr_27: -0.0
+  art_sys_corr_27: 0.0
   art_sys_corr_28: -2.50808246e-06
   art_sys_corr_29: 0.0
   art_sys_corr_30: 0.0
   art_sys_corr_31: 0.0
   art_sys_corr_32: 0.0
   art_sys_corr_33: 1.81471721e-08
-  art_sys_corr_34: -0.0
-  art_sys_corr_35: -0.0
+  art_sys_corr_34: 0.0
+  art_sys_corr_35: 0.0
   art_sys_corr_36: 0.0
-  art_sys_corr_37: -0.0
-  art_sys_corr_38: -0.0
+  art_sys_corr_37: 0.0
+  art_sys_corr_38: 0.0
   art_sys_corr_39: 0.0
-  art_sys_corr_40: -0.0
+  art_sys_corr_40: 0.0
   art_sys_corr_41: 0.0
-  art_sys_corr_42: -0.0
+  art_sys_corr_42: 0.0
   art_sys_corr_43: -4.05572701e-11
   art_sys_corr_44: 0.0
-  art_sys_corr_45: -0.0
-  art_sys_corr_46: -0.0
-  art_sys_corr_47: -0.0
+  art_sys_corr_45: 0.0
+  art_sys_corr_46: 0.0
+  art_sys_corr_47: 0.0
   art_sys_corr_48: 0.0
   art_sys_corr_49: 0.0
   art_sys_corr_50: 0.0
   art_sys_corr_51: 0.0
   art_sys_corr_52: 0.0
   art_sys_corr_53: 0.0
-  art_sys_corr_54: -0.0
+  art_sys_corr_54: 0.0
   Unfolding+: -4.43355952e-04
   Unfolding-: 4.43355952e-04
   JEC0-: -1.77342381e-03
@@ -4644,60 +4644,60 @@ bins:
   JEC13+: 1.33006786e-03
   luminosity_uncertainty: 1.37940000e-03
   bin_by_bin_uncertainty: 6.27000000e-04
-- art_sys_corr_1: -0.0
+- art_sys_corr_1: 0.0
   art_sys_corr_2: 0.0
   art_sys_corr_3: 0.0
-  art_sys_corr_4: -0.0
+  art_sys_corr_4: 0.0
   art_sys_corr_5: 0.0
-  art_sys_corr_6: -0.0
-  art_sys_corr_7: -0.0
-  art_sys_corr_8: -0.0
+  art_sys_corr_6: 0.0
+  art_sys_corr_7: 0.0
+  art_sys_corr_8: 0.0
   art_sys_corr_9: -1.37367497e-06
   art_sys_corr_10: 0.0
-  art_sys_corr_11: -0.0
-  art_sys_corr_12: -0.0
+  art_sys_corr_11: 0.0
+  art_sys_corr_12: 0.0
   art_sys_corr_13: 3.40704566e-05
   art_sys_corr_14: 0.0
   art_sys_corr_15: 0.0
-  art_sys_corr_16: -0.0
+  art_sys_corr_16: 0.0
   art_sys_corr_17: 1.64315142e-05
   art_sys_corr_18: 0.0
   art_sys_corr_19: 4.91631061e-04
-  art_sys_corr_20: -0.0
+  art_sys_corr_20: 0.0
   art_sys_corr_21: 0.0
   art_sys_corr_22: -3.33343321e-03
   art_sys_corr_23: 0.0
   art_sys_corr_24: 0.0
   art_sys_corr_25: 0.0
   art_sys_corr_26: 0.0
-  art_sys_corr_27: -0.0
+  art_sys_corr_27: 0.0
   art_sys_corr_28: -4.46004211e-05
   art_sys_corr_29: 0.0
   art_sys_corr_30: 0.0
   art_sys_corr_31: 0.0
   art_sys_corr_32: 0.0
   art_sys_corr_33: -2.80516869e-07
-  art_sys_corr_34: -0.0
-  art_sys_corr_35: -0.0
+  art_sys_corr_34: 0.0
+  art_sys_corr_35: 0.0
   art_sys_corr_36: 0.0
-  art_sys_corr_37: -0.0
-  art_sys_corr_38: -0.0
+  art_sys_corr_37: 0.0
+  art_sys_corr_38: 0.0
   art_sys_corr_39: 0.0
-  art_sys_corr_40: -0.0
+  art_sys_corr_40: 0.0
   art_sys_corr_41: 0.0
-  art_sys_corr_42: -0.0
+  art_sys_corr_42: 0.0
   art_sys_corr_43: -1.67403754e-10
   art_sys_corr_44: 0.0
-  art_sys_corr_45: -0.0
-  art_sys_corr_46: -0.0
-  art_sys_corr_47: -0.0
+  art_sys_corr_45: 0.0
+  art_sys_corr_46: 0.0
+  art_sys_corr_47: 0.0
   art_sys_corr_48: 0.0
   art_sys_corr_49: 0.0
   art_sys_corr_50: 0.0
   art_sys_corr_51: 0.0
   art_sys_corr_52: 0.0
   art_sys_corr_53: 0.0
-  art_sys_corr_54: -0.0
+  art_sys_corr_54: 0.0
   Unfolding+: -5.44472222e-05
   Unfolding-: 5.44472222e-05
   JEC0-: -2.17788889e-04
@@ -4730,60 +4730,60 @@ bins:
   JEC13+: 1.63341666e-04
   luminosity_uncertainty: 1.69400000e-04
   bin_by_bin_uncertainty: 7.7e-05
-- art_sys_corr_1: -0.0
+- art_sys_corr_1: 0.0
   art_sys_corr_2: 0.0
   art_sys_corr_3: 0.0
-  art_sys_corr_4: -0.0
+  art_sys_corr_4: 0.0
   art_sys_corr_5: 0.0
-  art_sys_corr_6: -0.0
-  art_sys_corr_7: -0.0
-  art_sys_corr_8: -0.0
+  art_sys_corr_6: 0.0
+  art_sys_corr_7: 0.0
+  art_sys_corr_8: 0.0
   art_sys_corr_9: 2.47670358e-09
   art_sys_corr_10: 0.0
-  art_sys_corr_11: -0.0
-  art_sys_corr_12: -0.0
+  art_sys_corr_11: 0.0
+  art_sys_corr_12: 0.0
   art_sys_corr_13: -1.57341302e-07
   art_sys_corr_14: 0.0
   art_sys_corr_15: 0.0
-  art_sys_corr_16: -0.0
+  art_sys_corr_16: 0.0
   art_sys_corr_17: 9.87210719e-06
   art_sys_corr_18: 0.0
   art_sys_corr_19: 5.58093856e-06
-  art_sys_corr_20: -0.0
+  art_sys_corr_20: 0.0
   art_sys_corr_21: 0.0
   art_sys_corr_22: 1.58291797e-04
   art_sys_corr_23: 0.0
   art_sys_corr_24: 0.0
   art_sys_corr_25: 0.0
   art_sys_corr_26: 0.0
-  art_sys_corr_27: -0.0
+  art_sys_corr_27: 0.0
   art_sys_corr_28: -9.41705709e-04
   art_sys_corr_29: 0.0
   art_sys_corr_30: 0.0
   art_sys_corr_31: 0.0
   art_sys_corr_32: 0.0
   art_sys_corr_33: -5.51677253e-06
-  art_sys_corr_34: -0.0
-  art_sys_corr_35: -0.0
+  art_sys_corr_34: 0.0
+  art_sys_corr_35: 0.0
   art_sys_corr_36: 0.0
-  art_sys_corr_37: -0.0
-  art_sys_corr_38: -0.0
+  art_sys_corr_37: 0.0
+  art_sys_corr_38: 0.0
   art_sys_corr_39: 0.0
-  art_sys_corr_40: -0.0
+  art_sys_corr_40: 0.0
   art_sys_corr_41: 0.0
-  art_sys_corr_42: -0.0
+  art_sys_corr_42: 0.0
   art_sys_corr_43: 5.87294804e-09
   art_sys_corr_44: 0.0
-  art_sys_corr_45: -0.0
-  art_sys_corr_46: -0.0
-  art_sys_corr_47: -0.0
+  art_sys_corr_45: 0.0
+  art_sys_corr_46: 0.0
+  art_sys_corr_47: 0.0
   art_sys_corr_48: 0.0
   art_sys_corr_49: 0.0
   art_sys_corr_50: 0.0
   art_sys_corr_51: 0.0
   art_sys_corr_52: 0.0
   art_sys_corr_53: 0.0
-  art_sys_corr_54: -0.0
+  art_sys_corr_54: 0.0
   Unfolding+: -1.74655375e-05
   Unfolding-: 1.74655375e-05
   JEC0-: -8.73276875e-05
@@ -4816,60 +4816,60 @@ bins:
   JEC13+: 5.23966125e-05
   luminosity_uncertainty: 5.43400000e-05
   bin_by_bin_uncertainty: 2.47e-05
-- art_sys_corr_1: -0.0
+- art_sys_corr_1: 0.0
   art_sys_corr_2: 0.0
   art_sys_corr_3: 0.0
-  art_sys_corr_4: -0.0
+  art_sys_corr_4: 0.0
   art_sys_corr_5: 0.0
-  art_sys_corr_6: -0.0
-  art_sys_corr_7: -0.0
-  art_sys_corr_8: -0.0
+  art_sys_corr_6: 0.0
+  art_sys_corr_7: 0.0
+  art_sys_corr_8: 0.0
   art_sys_corr_9: 3.96362127e-11
   art_sys_corr_10: 0.0
-  art_sys_corr_11: -0.0
-  art_sys_corr_12: -0.0
+  art_sys_corr_11: 0.0
+  art_sys_corr_12: 0.0
   art_sys_corr_13: 1.06465351e-10
   art_sys_corr_14: 0.0
   art_sys_corr_15: 0.0
-  art_sys_corr_16: -0.0
+  art_sys_corr_16: 0.0
   art_sys_corr_17: -5.96231273e-08
   art_sys_corr_18: 0.0
   art_sys_corr_19: -2.81356255e-06
-  art_sys_corr_20: -0.0
+  art_sys_corr_20: 0.0
   art_sys_corr_21: 0.0
   art_sys_corr_22: 4.49263235e-07
   art_sys_corr_23: 0.0
   art_sys_corr_24: 0.0
   art_sys_corr_25: 0.0
   art_sys_corr_26: 0.0
-  art_sys_corr_27: -0.0
+  art_sys_corr_27: 0.0
   art_sys_corr_28: 3.97276723e-05
   art_sys_corr_29: 0.0
   art_sys_corr_30: 0.0
   art_sys_corr_31: 0.0
   art_sys_corr_32: 0.0
   art_sys_corr_33: -1.31082297e-04
-  art_sys_corr_34: -0.0
-  art_sys_corr_35: -0.0
+  art_sys_corr_34: 0.0
+  art_sys_corr_35: 0.0
   art_sys_corr_36: 0.0
-  art_sys_corr_37: -0.0
-  art_sys_corr_38: -0.0
+  art_sys_corr_37: 0.0
+  art_sys_corr_38: 0.0
   art_sys_corr_39: 0.0
-  art_sys_corr_40: -0.0
+  art_sys_corr_40: 0.0
   art_sys_corr_41: 0.0
-  art_sys_corr_42: -0.0
+  art_sys_corr_42: 0.0
   art_sys_corr_43: 1.48471771e-07
   art_sys_corr_44: 0.0
-  art_sys_corr_45: -0.0
-  art_sys_corr_46: -0.0
-  art_sys_corr_47: -0.0
+  art_sys_corr_45: 0.0
+  art_sys_corr_46: 0.0
+  art_sys_corr_47: 0.0
   art_sys_corr_48: 0.0
   art_sys_corr_49: 0.0
   art_sys_corr_50: 0.0
   art_sys_corr_51: 0.0
   art_sys_corr_52: 0.0
   art_sys_corr_53: 0.0
-  art_sys_corr_54: -0.0
+  art_sys_corr_54: 0.0
   Unfolding+: -4.44063059e-06
   Unfolding-: 4.44063059e-06
   JEC0-: -3.10844141e-05
@@ -4902,60 +4902,60 @@ bins:
   JEC13+: 1.33218918e-05
   luminosity_uncertainty: 1.38160000e-05
   bin_by_bin_uncertainty: 6.28e-06
-- art_sys_corr_1: -0.0
+- art_sys_corr_1: 0.0
   art_sys_corr_2: 0.0
   art_sys_corr_3: 0.0
-  art_sys_corr_4: -0.0
+  art_sys_corr_4: 0.0
   art_sys_corr_5: 0.0
-  art_sys_corr_6: -0.0
-  art_sys_corr_7: -0.0
-  art_sys_corr_8: -0.0
+  art_sys_corr_6: 0.0
+  art_sys_corr_7: 0.0
+  art_sys_corr_8: 0.0
   art_sys_corr_9: -6.73992499e-15
   art_sys_corr_10: 0.0
-  art_sys_corr_11: -0.0
-  art_sys_corr_12: -0.0
+  art_sys_corr_11: 0.0
+  art_sys_corr_12: 0.0
   art_sys_corr_13: 8.91661256e-13
   art_sys_corr_14: 0.0
   art_sys_corr_15: 0.0
-  art_sys_corr_16: -0.0
+  art_sys_corr_16: 0.0
   art_sys_corr_17: 5.34433474e-12
   art_sys_corr_18: 0.0
   art_sys_corr_19: 1.73150339e-09
-  art_sys_corr_20: -0.0
+  art_sys_corr_20: 0.0
   art_sys_corr_21: 0.0
   art_sys_corr_22: -1.25843652e-07
   art_sys_corr_23: 0.0
   art_sys_corr_24: 0.0
   art_sys_corr_25: 0.0
   art_sys_corr_26: 0.0
-  art_sys_corr_27: -0.0
+  art_sys_corr_27: 0.0
   art_sys_corr_28: -3.02753776e-08
   art_sys_corr_29: 0.0
   art_sys_corr_30: 0.0
   art_sys_corr_31: 0.0
   art_sys_corr_32: 0.0
   art_sys_corr_33: 1.57211833e-06
-  art_sys_corr_34: -0.0
-  art_sys_corr_35: -0.0
+  art_sys_corr_34: 0.0
+  art_sys_corr_35: 0.0
   art_sys_corr_36: 0.0
-  art_sys_corr_37: -0.0
-  art_sys_corr_38: -0.0
+  art_sys_corr_37: 0.0
+  art_sys_corr_38: 0.0
   art_sys_corr_39: 0.0
-  art_sys_corr_40: -0.0
+  art_sys_corr_40: 0.0
   art_sys_corr_41: 0.0
-  art_sys_corr_42: -0.0
+  art_sys_corr_42: 0.0
   art_sys_corr_43: 1.24000681e-05
   art_sys_corr_44: 0.0
-  art_sys_corr_45: -0.0
-  art_sys_corr_46: -0.0
-  art_sys_corr_47: -0.0
+  art_sys_corr_45: 0.0
+  art_sys_corr_46: 0.0
+  art_sys_corr_47: 0.0
   art_sys_corr_48: 0.0
   art_sys_corr_49: 0.0
   art_sys_corr_50: 0.0
   art_sys_corr_51: 0.0
   art_sys_corr_52: 0.0
   art_sys_corr_53: 0.0
-  art_sys_corr_54: -0.0
+  art_sys_corr_54: 0.0
   Unfolding+: -1.71119841e-07
   Unfolding-: 1.71119841e-07
   JEC0-: -9.41159126e-07

--- a/nnpdf_data/nnpdf_data/filter_utils/utils.py
+++ b/nnpdf_data/nnpdf_data/filter_utils/utils.py
@@ -106,6 +106,7 @@ def cormat_to_covmat(err_list, cormat_list):
         covmat_list.append(cormat_list[i] * err_list[a] * err_list[b])
     return covmat_list
 
+
 def sort_eigenvalues(evals, evecs):
     r"""Defines ordering of the eigenvalues and eigenvectors such
     that eigenvalues are given in decreasing order and the first
@@ -118,18 +119,19 @@ def sort_eigenvalues(evals, evecs):
     -------
     evacs_sorted, evecs_sorted : ordered eigen- values and vectors,
     as defined above
-    
+
     """
-    idx = evals.argsort()[::-1]   
+    idx = evals.argsort()[::-1]
     evals_sorted = evals[idx]
-    evecs_sorted = evecs[:,idx]
+    evecs_sorted = evecs[:, idx]
     for i in range(len(evecs_sorted)):
         j = 0
-        while evecs_sorted[j,i] == 0:
+        while evecs_sorted[j, i] == 0:
             j += 1
-        if evecs_sorted[j,i] < 0:
+        if evecs_sorted[j, i] < 0:
             evecs_sorted[:, i] *= -1
     return evals_sorted, evecs_sorted
+
 
 def covmat_to_artunc(ndata, covmat_list, no_of_norm_mat=0):
     r"""Convert the covariance matrix to a matrix of
@@ -444,6 +446,9 @@ def prettify_float(dumper, value):
 
     must be called to use this function.
     """
+    # Ensure that both -0 and 0 are represented as just 0
+    if value == 0.0:
+        value = 0.0
 
     ret = dumper.represent_float(value)
     if len(ret.value) > 8:


### PR DESCRIPTION
I've noticed that quite a few data-changing commits are just a dance of `0.0` and `-0.0`, an information that is dumped to the yaml file.

See e.g., https://github.com/NNPDF/nnpdf/commit/092ac304b221c73f80a4843a70b77f865d590fd8 

This just uses the prettify float to eliminate the sign from 0.
The only change in this PR is that of the first commit.

tbf, there are way too many 0s in the commondata for yaml files to be an efficient representation. Luckily electricity, storage and memory are free so this is not a problem at all and not expected to become a problem any time soon.