### PR TITLE
Include log contributions in jupyter notebook for pineappl grids

### DIFF
--- a/validphys2/examples/API_extension_Pineappl.ipynb
+++ b/validphys2/examples/API_extension_Pineappl.ipynb
@@ -93,7 +93,7 @@
     "\n",
     "        # Take only the QCD corerctions\n",
     "        all_ord = self._grid.orders()\n",
-    "        mask_nnlo = pineappl.boc.Order.create_mask(all_ord, 3, 0, False)\n",
+    "        mask_nnlo = pineappl.boc.Order.create_mask(all_ord, 3, 0, True)\n",
     "\n",
     "        for _, member in enumerate(pdf.members):\n",
     "            tmp = self._grid.convolve(\n",
@@ -411,9 +411,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "nnpdf",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "nnpdf"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -425,7 +425,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.5"
+   "version": "3.13.15"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The jupyter notebook to use validphys with pineappl grids was masking out the logs contributions, which essentially means (if i understand it correctly, cc @Radonirinaunimi) that the scale variations were only taking into account the alpha_s term, missing the log(muR/mu)-like terms. Thanks @ecole41 for noticing