### PR TITLE
Extend HyperOpt backend to support the `itwinai` interface

### DIFF
--- a/n3fit/src/n3fit/backends/keras_backend/MetaModel.py
+++ b/n3fit/src/n3fit/backends/keras_backend/MetaModel.py
@@ -350,7 +350,10 @@ class MetaModel(Model):
 
     def get_layer_re(self, regex):
         """Get all layers matching the given regular expression"""
-        check = lambda x: re.match(regex, x.name)
+
+        def check(x):
+            return re.match(regex, x.name)
+
         return list(filter(check, self.layers))
 
     def get_replica_weights(self, i_replica):
@@ -534,7 +537,7 @@ def set_layer_replica_weights(layer, weights, i_replica: int):
         layer.get_layer(f"{NN_PREFIX}_{i_replica}").set_weights(weights)
         return
 
-    full_weights = [w.numpy() for w in layer.weights]
+    full_weights = [ops.variable_to_numpy(w) for w in layer.weights]
     for w_old, w_new in zip(full_weights, weights):
         w_old[i_replica : i_replica + 1] = w_new
 

--- a/n3fit/src/n3fit/backends/keras_backend/internal_state.py
+++ b/n3fit/src/n3fit/backends/keras_backend/internal_state.py
@@ -40,6 +40,13 @@ if (kback := K.backend()) == "torch":
         log.info("Setting max number of threads to: %d", threads)
         torch.set_num_threads(threads)
 
+    def enable_op_determinism():
+        torch.use_deterministic_algorithms(True)
+
+    def get_physical_gpus():
+        """Return one entry per CUDA device visible to PyTorch."""
+        return list(range(torch.cuda.device_count()))
+
 elif K.backend() == "tensorflow":
     import tensorflow as tf
     from tensorflow.python.framework import ops
@@ -69,7 +76,7 @@ elif K.backend() == "tensorflow":
                 "Could not set tensorflow parallelism settings from n3fit, maybe tensorflow is already initialized by a third program"
             )
 
-    def _internal_backend_clear():
+    def _internal_backend_clear():  # noqa: F811 (override of the top-level no-op default)
         """TensorFlow saves the gradient of the custom models we create as custom gradients.
         These are not followed by keras and are thus not cleared during the clear_backend call."""
         try:
@@ -83,6 +90,13 @@ elif K.backend() == "tensorflow":
             )
             raise e
 
+    def enable_op_determinism():
+        tf.config.experimental.enable_op_determinism()
+
+    def get_physical_gpus():
+        """Retrieve a list of all physical GPU devices available in the system."""
+        return tf.config.list_physical_devices('GPU')
+
 elif K.backend() == "jax":
 
     import jax
@@ -92,6 +106,13 @@ elif K.backend() == "jax":
 
     def set_threading(threads, core, double_precision=False):
         pass
+
+    def enable_op_determinism():
+        pass
+
+    def get_physical_gpus():
+        """Return the GPU devices JAX can see."""
+        return [d for d in jax.devices() if d.platform == "gpu"]
 
 else:
     # Keras should've failed by now, if it doesn't it could be a new backend that works ootb?
@@ -202,7 +223,7 @@ def set_initial_state(debug=False, external_seed=None, max_cores=None, double_pr
     if debug and max_cores is None:
         keras.utils.set_random_seed(7331)
         threads = 1
-        tf.config.experimental.enable_op_determinism()
+        enable_op_determinism()
     set_number_of_cores(max_cores=max_cores, max_threads=threads, double_precision=double_precision)
 
     # Once again, if in debug mode or external_seed set, set also the TF seed
@@ -212,14 +233,3 @@ def set_initial_state(debug=False, external_seed=None, max_cores=None, double_pr
             tf.random.set_seed(use_seed)
         else:
             keras.utils.set_random_seed(use_seed)
-
-
-def get_physical_gpus():
-    """
-    Retrieve a list of all physical GPU devices available in the system.
-
-    Returns
-    -------
-        list: A list of TensorFlow physical devices of type 'GPU'.
-    """
-    return tf.config.list_physical_devices('GPU')

--- a/n3fit/src/n3fit/backends/keras_backend/operations.py
+++ b/n3fit/src/n3fit/backends/keras_backend/operations.py
@@ -76,7 +76,7 @@ elif K.backend() == "tensorflow":
     decorator_compiler = tf.function
 
 dict_to_numpy_or_python = lambda ret: {k: tensor_to_numpy_or_python(i) for k, i in ret.items()}
-variable_to_numpy = lambda x: x.numpy()
+variable_to_numpy = lambda x: tensor_to_numpy_or_python(x.value)
 
 
 def as_layer(operation, op_args=None, op_kwargs=None, **kwargs):

--- a/n3fit/src/n3fit/hyper_optimization/hyper_scan.py
+++ b/n3fit/src/n3fit/hyper_optimization/hyper_scan.py
@@ -50,6 +50,7 @@ log = logging.getLogger(__name__)
 HYPEROPT_STATUSES = {True: "ok", False: "fail"}
 HYPEROPT_SEED = int(os.environ.get("HYPEROPT_SEED", 42))
 
+
 def _run_trial_in_subprocess(objective, params):
     """Running a hyperparameter scan leaks memory trial by trial.
     In order to ensure that the memory associated to one trial is eliminated once it has finished,
@@ -245,6 +246,33 @@ def hyper_scan_wrapper(replica_path_set, model_trainer, hyperscanner, max_evals=
             hyperopt.fmin(**fmin_args, show_progressbar=False, trials_save_file=trials.pkl_file)
 
 
+def get_scan_wrapper(backend):
+    """
+    Returns the callable to be used to drive the hyperparameter scan for the
+    requested `backend`. The returned callable must accept the same signature
+    as :func:`hyper_scan_wrapper`.
+
+    Parameters
+    ----------
+        `backend`: str
+            name of the backend, as set in ``hyperscan_config.backend`` in the runcard.
+    """
+    if backend == "hyperopt":
+        return hyper_scan_wrapper
+    if backend == "ray":
+        try:
+            from itwinai.plugins.nnpdf.ray_scan import ray_hyper_scan_wrapper
+        except ModuleNotFoundError as err:
+            raise ModuleNotFoundError(
+                "The 'ray' hyperopt backend was requested but the nnpdf itwinai "
+                "plugin is not installed. Install it "
+                "(https://github.com/interTwin-eu/nnpdf-plugin) or set 'backend: "
+                "hyperopt' (the default) in the runcard's hyperscan_config."
+            ) from err
+        return ray_hyper_scan_wrapper
+    raise ValueError(f"Unknown hyperopt backend '{backend}'.")
+
+
 class ActivationStr:
     """
     Upon call this class returns an array where the activation function
@@ -287,16 +315,28 @@ class HyperScanner:
             the `hyperscan` dictionary of the NNPDF runcard defining the search space of the scan
         `steps`: int
             when taking discrete steps between two parameters, number of steps to take
+        `backend`: str
+            name of the hyperoptimization backend to use, see :func:`get_scan_wrapper`.
+            Defaults to ``"hyperopt"``, which preserves the historical behaviour.
 
     """
 
     def __init__(
-        self, parameters, sampling_dict, steps=5, db_host=None, db_port=None, db_path=None
+        self,
+        parameters,
+        sampling_dict,
+        steps=5,
+        db_host=None,
+        db_port=None,
+        db_path=None,
+        backend="hyperopt",
     ):
         self._original_parameters = parameters
         self.parameter_keys = parameters.keys()
         self.parameters = copy.deepcopy(parameters)
         self.steps = steps
+        self.backend = backend
+        self.sampling_dict = sampling_dict
 
         # adding extra options for parallel execution
         self._db_path = db_path

--- a/n3fit/src/n3fit/hyper_optimization/rewards.py
+++ b/n3fit/src/n3fit/hyper_optimization/rewards.py
@@ -437,7 +437,7 @@ def _set_central_value(n3pdf, model):
     # Get the input x
     for key, grid in model.x_in.items():
         if key != "xgrid_integration":
-            input_x = grid.numpy()
+            input_x = op.tensor_to_numpy_or_python(grid)
             break
 
     # Compute the central value of the PDF

--- a/n3fit/src/n3fit/layers/losses.py
+++ b/n3fit/src/n3fit/layers/losses.py
@@ -1,10 +1,10 @@
 """
-    Module containg the losses to be apply to the models as layers
+Module containg the losses to be apply to the models as layers
 
-    The layer take the input from the model and acts on it producing a score function.
-    For instance, in the case of the chi2 (``LossInvcovmat``) the function takes only
-    the prediction of the model and, during instantiation, took the real data to compare with
-    and the covmat.
+The layer take the input from the model and acts on it producing a score function.
+For instance, in the case of the chi2 (``LossInvcovmat``) the function takes only
+the prediction of the model and, during instantiation, took the real data to compare with
+and the covmat.
 
 """
 
@@ -218,4 +218,4 @@ class LossHyperopt:
 
     def __call__(self, chi2):
         loss = op.elu(chi2 - self.chi2ref, alpha=self.alpha)
-        return self.c * loss.numpy()
+        return self.c * op.tensor_to_numpy_or_python(loss)

--- a/n3fit/src/n3fit/model_trainer.py
+++ b/n3fit/src/n3fit/model_trainer.py
@@ -841,7 +841,7 @@ class ModelTrainer:
 
         return filtered_datagroupspec
 
-    def hyperparametrizable(self, params):
+    def hyperparametrizable(self, params, report_fn=None):
         """
         Wrapper around all the functions defining the fit.
 
@@ -857,6 +857,14 @@ class ModelTrainer:
             - ``stopping_delta``: minimum improvement to consider it a new minimum
 
         All other parameters are passed to the corresponding functions
+
+        Parameters
+        ----------
+            `report_fn`: Callable, optional
+                if given, called right after the loss for each k-fold is computed
+                (only in hyperopt mode). This is a pure reporting side-channel used
+                by external hyperoptimization backends (e.g. to feed early-stopping
+                schedulers such as ASHA).
         """
         # Reset the internal state of the backend every time this function is called
         print("")
@@ -1108,6 +1116,9 @@ class ModelTrainer:
                 trvl_logp_per_fold.append(hyper_metrics.logp)
                 pdfs_per_fold.append(pdf_model)
                 exp_models.append(models["experimental"])
+
+                if report_fn is not None:
+                    report_fn(fold_idx=k, hyper_loss=hyper_loss)
 
                 if hyper_loss > self.hyper_threshold:
                     log.info(

--- a/n3fit/src/n3fit/performfit.py
+++ b/n3fit/src/n3fit/performfit.py
@@ -219,14 +219,14 @@ def performfit(
         # this block                                                           #
         ########################################################################
         if hyperopt:
-            from n3fit.hyper_optimization.hyper_scan import hyper_scan_wrapper
+            from n3fit.hyper_optimization.hyper_scan import get_scan_wrapper
+
+            scan_wrapper = get_scan_wrapper(hyperscanner.backend)
 
             # TODO: save everything to a hyperopt folder instead
             # Save everything to replica_1 regardless of which replicas are we running
             replica_path_set = replica_path / "replica_1"
-            hyper_scan_wrapper(
-                replica_path_set, the_model_trainer, hyperscanner, max_evals=hyperopt
-            )
+            scan_wrapper(replica_path_set, the_model_trainer, hyperscanner, max_evals=hyperopt)
             log.info("The hyperparameter scan is successfully finished.")
             # In general after we do the hyperoptimization we do not care about the fit
             # so just let this die here

--- a/n3fit/src/n3fit/scripts/n3fit_exec.py
+++ b/n3fit/src/n3fit/scripts/n3fit_exec.py
@@ -255,10 +255,10 @@ class N3FitConfig(Config):
         # This needs to be imported here because it needs Tensorflow and n3fit
         from n3fit.hyper_optimization.hyper_scan import HyperScanner
 
-        extra_args = {}
-
         if hyperscan_config is None or hyperopt is None:
             return None
+
+        extra_args = {"backend": hyperscan_config.pop("backend", "hyperopt")}
 
         if self.environment.parallel_hyperopt:
             hyperscan_config.update({'parallel': 'true'})
@@ -266,11 +266,13 @@ class N3FitConfig(Config):
             db_path = (
                 self.environment.output_path / "nnfit" / "replica_1" / self.environment.db_name
             )
-            extra_args = {
-                "db_host": self.environment.db_host,
-                "db_port": self.environment.db_port,
-                "db_path": db_path,
-            }
+            extra_args.update(
+                {
+                    "db_host": self.environment.db_host,
+                    "db_port": self.environment.db_port,
+                    "db_path": db_path,
+                }
+            )
         return HyperScanner(parameters, hyperscan_config, **extra_args)
 
     def parse_trial_specs(self, trial_specs):

--- a/n3fit/src/n3fit/vpinterface.py
+++ b/n3fit/src/n3fit/vpinterface.py
@@ -279,6 +279,7 @@ class N3PDF(PDF):
 
         # Keep the import here to avoid loading the backend when it is not necessary
         from n3fit.backends import PREPROCESSING_LAYER_ALL_REPLICAS
+        from n3fit.backends import operations as op
 
         preprocessing_layer = self._models[replica - 1].get_layer(PREPROCESSING_LAYER_ALL_REPLICAS)
 
@@ -290,9 +291,9 @@ class N3PDF(PDF):
                 alpha = preprocessing_layer.get_weight_by_name(f"alpha_{flavour}")
                 beta = preprocessing_layer.get_weight_by_name(f"beta_{flavour}")
                 if alpha is not None:
-                    alpha = float(alpha.numpy().squeeze())
+                    alpha = float(op.variable_to_numpy(alpha).squeeze())
                 if beta is not None:
-                    beta = float(beta.numpy().squeeze())
+                    beta = float(op.variable_to_numpy(beta).squeeze())
                 output_dictionaries.append(
                     {
                         "fl": flavour,
@@ -527,7 +528,7 @@ def compute_hyperopt_metrics(n3pdf, experimental_data) -> HyperoptMetrics:
     # Compute the chi2
     total_covmat_chol = la.cholesky(total_covmat, lower=True)
     chi2 = calc_chi2(sqrtcov=total_covmat_chol, diffs=diffs)
-    
+
     # Compute the experimental chi2
     exp_covmat_chol = la.cholesky(exp_cov, lower=True)
     chi2exp = calc_chi2(sqrtcov=exp_covmat_chol, diffs=diffs)


### PR DESCRIPTION
This extends the hyperopt backend in view of interfacing with [itwinai](https://itwinai.readthedocs.io/stable/index.html#). Such an interface will provide several advantages as this will allow us to:

- run distributed HPO on a Ray cluster without mongoDB
- use some of the Ray Tune search algorithms
- use advanced scheduler such as SHA (Successive Halving Algorithm) for example to stop unpromising trials early
- have a genuine memory isolation that'd have fully prevented https://github.com/NNPDF/nnpdf/pull/2511
- a true automatic resume of crashed/interrupted trials
- have live-monitoring through which one can see trials-status and resource usages
- ...

These minor changes are sufficient for the [plugin](https://itwinai.readthedocs.io/stable/getting-started/plugins.html) (to be hosted in separate repo) while still allowing the old hyperopt to run exactly as before.